### PR TITLE
doc: fix opencode mcp config

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ codex mcp add gitnexus -- npx -y gitnexus@latest mcp
 }
 ```
 
-**OpenCode** (`~/.config/opencode/config.json`):
+**OpenCode** (`~/.config/opencode/opencode.json`):
 
 ```json
 {


### PR DESCRIPTION
opencode config file name is `opencode.json`

mcp config requrie `local` and `command` field, there is no `args`

opencode config file:

https://opencode.ai/docs/config/#precedence-order

MCP config doc:

https://opencode.ai/docs/mcp-servers/