### PR TITLE
feat: Add multi-repo switching support with server backend integration

### DIFF
--- a/gitnexus-web/src/App.tsx
+++ b/gitnexus-web/src/App.tsx
@@ -37,6 +37,8 @@ const AppContent = () => {
     isCodePanelOpen,
     serverBaseUrl,
     setServerBaseUrl,
+    currentRepoName,
+    setCurrentRepoName,
     availableRepos,
     setAvailableRepos,
     switchRepo,
@@ -132,11 +134,12 @@ const AppContent = () => {
     }
   }, [setViewMode, setGraph, setFileContents, setProgress, setProjectName, runPipelineFromFiles, startEmbeddings, initializeAgent]);
 
-  const handleServerConnect = useCallback((result: ConnectToServerResult) => {
+  const handleServerConnect = useCallback((result: ConnectToServerResult, repoName?: string) => {
     // Extract project name from repoPath
     const repoPath = result.repoInfo.repoPath;
-    const projectName = repoPath.split('/').pop() || 'server-project';
+    const projectName = result.repoInfo.name || repoPath.split('/').pop() || 'server-project';
     setProjectName(projectName);
+    setCurrentRepoName(repoName || null);
 
     // Build KnowledgeGraph from server data (bypasses WASM pipeline entirely)
     const graph = createKnowledgeGraph();
@@ -171,7 +174,7 @@ const AppContent = () => {
         console.warn('Embeddings auto-start failed:', err);
       }
     });
-  }, [setViewMode, setGraph, setFileContents, setProjectName, initializeAgent, startEmbeddings]);
+  }, [setViewMode, setGraph, setFileContents, setProjectName, setCurrentRepoName, initializeAgent, startEmbeddings]);
 
   // Auto-connect when ?server query param is present (bookmarkable shortcut)
   const autoConnectRan = useRef(false);

--- a/gitnexus-web/src/App.tsx
+++ b/gitnexus-web/src/App.tsx
@@ -9,6 +9,7 @@ import { SettingsPanel } from './components/SettingsPanel';
 import { StatusBar } from './components/StatusBar';
 import { FileTreePanel } from './components/FileTreePanel';
 import { CodeReferencesPanel } from './components/CodeReferencesPanel';
+import { ResizableDivider } from './components/ResizableDivider';
 import { FileEntry } from './services/zip';
 import { getActiveProviderConfig } from './core/llm/settings-service';
 import { createKnowledgeGraph } from './core/graph/graph';
@@ -42,6 +43,10 @@ const AppContent = () => {
     availableRepos,
     setAvailableRepos,
     switchRepo,
+    leftPanelWidth,
+    setLeftPanelWidth,
+    rightPanelWidth,
+    setRightPanelWidth,
   } = useAppState();
 
   const graphCanvasRef = useRef<GraphCanvasHandle>(null);
@@ -235,6 +240,15 @@ const AppContent = () => {
     graphCanvasRef.current?.focusNode(nodeId);
   }, []);
 
+  // Handle panel resize
+  const handleLeftPanelResize = useCallback((delta: number) => {
+    setLeftPanelWidth(prev => Math.max(200, Math.min(600, prev + delta)));
+  }, [setLeftPanelWidth]);
+
+  const handleRightPanelResize = useCallback((delta: number) => {
+    setRightPanelWidth(prev => Math.max(400, Math.min(800, prev + delta)));
+  }, [setRightPanelWidth]);
+
   // Handle settings saved - refresh and reinitialize agent
   // NOTE: Must be defined BEFORE any conditional returns (React hooks rule)
   const handleSettingsSaved = useCallback(() => {
@@ -276,7 +290,15 @@ const AppContent = () => {
 
       <main className="flex-1 flex min-h-0">
         {/* Left Panel - File Tree */}
-        <FileTreePanel onFocusNode={handleFocusNode} />
+        <FileTreePanel onFocusNode={handleFocusNode} width={leftPanelWidth} />
+
+        {/* Left Divider */}
+        <ResizableDivider
+          onResize={handleLeftPanelResize}
+          minWidth={200}
+          maxWidth={600}
+          side="left"
+        />
 
         {/* Graph area - takes remaining space */}
         <div className="flex-1 relative min-w-0">
@@ -290,8 +312,18 @@ const AppContent = () => {
           )}
         </div>
 
+        {/* Right Divider */}
+        {isRightPanelOpen && (
+          <ResizableDivider
+            onResize={handleRightPanelResize}
+            minWidth={400}
+            maxWidth={800}
+            side="right"
+          />
+        )}
+
         {/* Right Panel - Code & Chat (tabbed) */}
-        {isRightPanelOpen && <RightPanel />}
+        {isRightPanelOpen && <RightPanel width={rightPanelWidth} />}
       </main>
 
       <StatusBar />

--- a/gitnexus-web/src/components/ChatSessionList.tsx
+++ b/gitnexus-web/src/components/ChatSessionList.tsx
@@ -87,6 +87,13 @@ export const ChatSessionList = ({ onSessionSelect }: ChatSessionListProps) => {
                   {formatSessionDate(session.updatedAt)}
                 </span>
               </div>
+              {session.modelProvider && session.modelName && (
+                <div className="mt-1">
+                  <span className="text-xs text-text-muted bg-surface px-1.5 py-0.5 rounded">
+                    {session.modelProvider}/{session.modelName}
+                  </span>
+                </div>
+              )}
             </div>
 
             {/* Delete Button */}

--- a/gitnexus-web/src/components/ChatSessionList.tsx
+++ b/gitnexus-web/src/components/ChatSessionList.tsx
@@ -1,0 +1,105 @@
+/**
+ * Chat Session List Component
+ * 
+ * Displays a list of saved chat sessions with options to:
+ * - Load a session (restore messages to chat panel)
+ * - Delete a session
+ * - Shows session name, repo, and timestamp
+ */
+
+import { useMemo } from 'react';
+import { MessageSquare, Trash2, Clock } from 'lucide-react';
+import { useAppState } from '../hooks/useAppState';
+import type { ChatSession } from '../core/llm/types';
+import { formatSessionDate } from '../core/llm/chat-session-service';
+
+interface ChatSessionListProps {
+  onSessionSelect?: () => void;
+}
+
+export const ChatSessionList = ({ onSessionSelect }: ChatSessionListProps) => {
+  const { chatSessions, currentSessionId, loadSession, deleteSession, currentRepoName } = useAppState();
+
+  // Sort sessions by updatedAt (newest first)
+  const sortedSessions = useMemo(() => {
+    return [...chatSessions].sort((a, b) => b.updatedAt - a.updatedAt);
+  }, [chatSessions]);
+
+  const handleLoadSession = (sessionId: string) => {
+    loadSession(sessionId);
+    onSessionSelect?.();
+  };
+
+  const handleDeleteSession = (e: React.MouseEvent, sessionId: string) => {
+    e.stopPropagation();
+    if (confirm('Are you sure you want to delete this session?')) {
+      deleteSession(sessionId);
+    }
+  };
+
+  if (chatSessions.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-center">
+        <MessageSquare className="w-10 h-10 text-text-muted mb-3 opacity-50" />
+        <p className="text-sm text-text-secondary">No saved sessions yet</p>
+        <p className="text-xs text-text-muted mt-1">
+          Sessions are auto-saved when tasks complete
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2 bg-surface border-b border-border-subtle">
+        <h3 className="text-sm font-medium text-text-primary">Chat History</h3>
+        <span className="text-xs text-text-muted">{chatSessions.length} sessions</span>
+      </div>
+
+      {/* Session List */}
+      <div className="flex-1 overflow-y-auto scrollbar-thin">
+        {sortedSessions.map((session) => (
+          <div
+            key={session.id}
+            onClick={() => handleLoadSession(session.id)}
+            className={`group flex items-start gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-hover border-b border-border-subtle last:border-0 ${
+              currentSessionId === session.id ? 'bg-accent/10 border-l-2 border-accent' : 'border-l-2 border-transparent'
+            }`}
+          >
+            {/* Icon */}
+            <div className={`mt-0.5 p-1.5 rounded-md ${
+              currentSessionId === session.id
+                ? 'bg-accent/20 text-accent'
+                : 'bg-surface text-text-muted group-hover:text-text-primary'
+            }`}>
+              <MessageSquare className="w-4 h-4" />
+            </div>
+
+            {/* Content */}
+            <div className="flex-1 min-w-0">
+              <h4 className="text-sm font-medium text-text-primary truncate">
+                {session.name}
+              </h4>
+              <div className="flex items-center gap-2 mt-1">
+                <Clock className="w-3 h-3 text-text-muted" />
+                <span className="text-xs text-text-muted">
+                  {formatSessionDate(session.updatedAt)}
+                </span>
+              </div>
+            </div>
+
+            {/* Delete Button */}
+            <button
+              onClick={(e) => handleDeleteSession(e, session.id)}
+              className="opacity-0 group-hover:opacity-100 p-1.5 text-text-muted hover:text-rose-400 hover:bg-rose-500/10 rounded transition-all"
+              title="Delete session"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/gitnexus-web/src/components/FileTreePanel.tsx
+++ b/gitnexus-web/src/components/FileTreePanel.tsx
@@ -192,9 +192,10 @@ const getNodeTypeIcon = (label: NodeLabel) => {
 
 interface FileTreePanelProps {
   onFocusNode: (nodeId: string) => void;
+  width: number;
 }
 
-export const FileTreePanel = ({ onFocusNode }: FileTreePanelProps) => {
+export const FileTreePanel = ({ onFocusNode, width }: FileTreePanelProps) => {
   const { graph, visibleLabels, toggleLabelVisibility, visibleEdgeTypes, toggleEdgeVisibility, selectedNode, setSelectedNode, openCodePanel, depthFilter, setDepthFilter } = useAppState();
 
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -297,7 +298,10 @@ export const FileTreePanel = ({ onFocusNode }: FileTreePanelProps) => {
   }
 
   return (
-    <div className="h-full w-64 bg-surface border-r border-border-subtle flex flex-col animate-slide-in">
+    <div
+      className="h-full bg-surface border-r border-border-subtle flex flex-col animate-slide-in"
+      style={{ width: `${width}px` }}
+    >
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 border-b border-border-subtle">
         <div className="flex items-center gap-1">

--- a/gitnexus-web/src/components/ResizableDivider.tsx
+++ b/gitnexus-web/src/components/ResizableDivider.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { GripVertical } from 'lucide-react';
+
+interface ResizableDividerProps {
+  onResize: (delta: number) => void;
+  minWidth?: number;
+  maxWidth?: number;
+  side: 'left' | 'right';
+}
+
+export const ResizableDivider = ({ onResize, minWidth = 200, maxWidth = 800, side }: ResizableDividerProps) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const startXRef = useRef<number>(0);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+    startXRef.current = e.clientX;
+  }, []);
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const delta = side === 'left' 
+        ? e.clientX - startXRef.current 
+        : startXRef.current - e.clientX;
+      
+      startXRef.current = e.clientX;
+      onResize(delta);
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+
+    // Add cursor style to body while dragging
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+  }, [isDragging, onResize, side]);
+
+  return (
+    <div
+      className={`
+        relative flex items-center justify-center
+        w-1 bg-border-subtle hover:bg-accent/50 
+        cursor-col-resize transition-colors
+        ${isDragging ? 'bg-accent' : ''}
+        group
+      `}
+      onMouseDown={handleMouseDown}
+    >
+      {/* Wider hit area for easier grabbing */}
+      <div className="absolute inset-y-0 -left-1 -right-1 z-10" />
+      
+      {/* Visual grip indicator */}
+      <div className={`
+        absolute inset-y-0 flex items-center justify-center
+        opacity-0 group-hover:opacity-100 transition-opacity
+        ${isDragging ? 'opacity-100' : ''}
+      `}>
+        <GripVertical className="w-3 h-3 text-accent" />
+      </div>
+    </div>
+  );
+};

--- a/gitnexus-web/src/components/RightPanel.tsx
+++ b/gitnexus-web/src/components/RightPanel.tsx
@@ -1,14 +1,20 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import {
   Send, Square, Sparkles, User,
-  PanelRightClose, Loader2, AlertTriangle, GitBranch
+  PanelRightClose, Loader2, AlertTriangle, GitBranch,
+  History, Save
 } from 'lucide-react';
 import { useAppState } from '../hooks/useAppState';
 import { ToolCallCard } from './ToolCallCard';
 import { isProviderConfigured } from '../core/llm/settings-service';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { ProcessesPanel } from './ProcessesPanel';
-export const RightPanel = () => {
+import { ChatSessionList } from './ChatSessionList';
+interface RightPanelProps {
+  width: number;
+}
+
+export const RightPanel = ({ width }: RightPanelProps) => {
   const {
     isRightPanelOpen,
     setRightPanelOpen,
@@ -25,10 +31,12 @@ export const RightPanel = () => {
     sendChatMessage,
     stopChatResponse,
     clearChat,
+    saveCurrentSession,
+    currentSessionId,
   } = useAppState();
 
   const [chatInput, setChatInput] = useState('');
-  const [activeTab, setActiveTab] = useState<'chat' | 'processes'>('chat');
+  const [activeTab, setActiveTab] = useState<'chat' | 'processes' | 'history'>('chat');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -208,7 +216,10 @@ export const RightPanel = () => {
   if (!isRightPanelOpen) return null;
 
   return (
-    <aside className="w-[40%] min-w-[400px] max-w-[600px] flex flex-col bg-deep border-l border-border-subtle animate-slide-in relative z-30 flex-shrink-0">
+    <aside
+      className="flex flex-col bg-deep border-l border-border-subtle animate-slide-in relative z-30 flex-shrink-0"
+      style={{ width: `${width}px` }}
+    >
       {/* Header with Tabs */}
       <div className="flex items-center justify-between px-4 py-2 bg-surface border-b border-border-subtle">
         <div className="flex items-center gap-1">
@@ -238,22 +249,54 @@ export const RightPanel = () => {
               NEW
             </span>
           </button>
+
+          {/* History Tab */}
+          <button
+            onClick={() => setActiveTab('history')}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${activeTab === 'history'
+              ? 'bg-accent/15 text-accent'
+              : 'text-text-muted hover:text-text-primary hover:bg-hover'
+              }`}
+          >
+            <History className="w-3.5 h-3.5" />
+            <span>History</span>
+          </button>
         </div>
 
-        {/* Close button */}
-        <button
-          onClick={() => setRightPanelOpen(false)}
-          className="p-1.5 text-text-muted hover:text-text-primary hover:bg-hover rounded transition-colors"
-          title="Close Panel"
-        >
-          <PanelRightClose className="w-4 h-4" />
-        </button>
+        <div className="flex items-center gap-1">
+          {/* Save button - only show when there are messages and not in a session */}
+          {chatMessages.length > 0 && !currentSessionId && (
+            <button
+              onClick={saveCurrentSession}
+              className="p-1.5 text-text-muted hover:text-accent hover:bg-hover rounded transition-colors"
+              title="Save current session"
+            >
+              <Save className="w-4 h-4" />
+            </button>
+          )}
+
+          {/* Close button */}
+          <button
+            onClick={() => setRightPanelOpen(false)}
+            className="p-1.5 text-text-muted hover:text-text-primary hover:bg-hover rounded transition-colors"
+            title="Close Panel"
+          >
+            <PanelRightClose className="w-4 h-4" />
+          </button>
+        </div>
       </div>
 
       {/* Processes Tab */}
       {activeTab === 'processes' && (
         <div className="flex-1 flex flex-col overflow-hidden">
           <ProcessesPanel />
+        </div>
+      )}
+
+      {/* History Tab - Session List */}
+      {activeTab === 'history' && (
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <ChatSessionList onSessionSelect={() => setActiveTab('chat')} />
         </div>
       )}
 

--- a/gitnexus-web/src/components/RightPanel.tsx
+++ b/gitnexus-web/src/components/RightPanel.tsx
@@ -451,9 +451,9 @@ export const RightPanel = ({ width }: RightPanelProps) => {
               <button
                 onClick={clearChat}
                 className="px-2 py-1 text-xs text-text-muted hover:text-text-primary transition-colors"
-                title="Clear chat"
+                title="Start new chat session"
               >
-                Clear
+                New
               </button>
               {isChatLoading ? (
                 <button

--- a/gitnexus-web/src/components/ToolCallCard.tsx
+++ b/gitnexus-web/src/components/ToolCallCard.tsx
@@ -99,7 +99,7 @@ export const ToolCallCard = ({ toolCall, defaultExpanded = false }: ToolCallCard
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
   const status = getStatusDisplay(toolCall.status);
   const formattedArgs = formatArgs(toolCall.args);
-
+  
   return (
     <div className={`rounded-lg border ${status.borderColor} ${status.bgColor} overflow-hidden transition-all`}>
       {/* Header - always visible */}
@@ -130,13 +130,13 @@ export const ToolCallCard = ({ toolCall, defaultExpanded = false }: ToolCallCard
       {/* Expanded content */}
       {isExpanded && (
         <div className="border-t border-border-subtle/50">
-          {/* Arguments/Query */}
+          {/* Parameters/Input - always shown for all tool types */}
           {formattedArgs && (
             <div className="px-3 py-2 border-b border-border-subtle/50">
-              <div className="text-[10px] uppercase tracking-wider text-text-muted mb-1.5">
-                {toolCall.name === 'cypher' ? 'Query' : 'Input'}
+              <div className="text-[10px] uppercase tracking-wider text-accent mb-1.5 flex items-center gap-1.5">
+                <span>Parameters</span>
               </div>
-              <pre className="text-xs text-text-secondary bg-surface/50 rounded p-2 overflow-x-auto whitespace-pre-wrap font-mono">
+              <pre className="text-xs text-text-secondary bg-surface/50 rounded p-2 overflow-x-auto whitespace-pre-wrap font-mono border border-accent/20">
                 {formattedArgs}
               </pre>
             </div>

--- a/gitnexus-web/src/core/llm/agent.ts
+++ b/gitnexus-web/src/core/llm/agent.ts
@@ -335,6 +335,7 @@ export async function* streamAgentResponse(
     // Track what we've yielded to avoid duplicates
     const yieldedToolCalls = new Set<string>();
     const yieldedToolResults = new Set<string>();
+    const toolCallArgsMap = new Map<string, { name: string; args: Record<string, unknown> }>();
     let lastProcessedMsgCount = formattedMessages.length;
     // Track if all tools are done (for distinguishing reasoning vs final content)
     let allToolsDone = true;
@@ -416,12 +417,32 @@ export async function* streamAgentResponse(
               const toolId = tc.id || `tool-${Date.now()}-${Math.random().toString(36).slice(2)}`;
               if (!yieldedToolCalls.has(toolId)) {
                 yieldedToolCalls.add(toolId);
+                const toolName = tc.name || tc.function?.name || 'unknown';
+                
+                // Try multiple possible locations for args
+                let toolArgs: Record<string, unknown> = {};
+                if (tc.args && Object.keys(tc.args).length > 0) {
+                  toolArgs = tc.args;
+                } else if ((tc as any).input) {
+                  // LangChain might use 'input' field
+                  toolArgs = (tc as any).input;
+                } else if (tc.function?.arguments) {
+                  try {
+                    toolArgs = JSON.parse(tc.function.arguments);
+                  } catch {
+                    toolArgs = {};
+                  }
+                }
+                
+                // Store args for later use when result comes back
+                toolCallArgsMap.set(toolId, { name: toolName, args: toolArgs });
+                
                 yield {
                   type: 'tool_call',
                   toolCall: {
                     id: toolId,
-                    name: tc.name || tc.function?.name || 'unknown',
-                    args: tc.args || (tc.function?.arguments ? JSON.parse(tc.function.arguments) : {}),
+                    name: toolName,
+                    args: toolArgs,
                     status: 'running',
                   },
                 };
@@ -436,12 +457,16 @@ export async function* streamAgentResponse(
           if (toolCallId && !yieldedToolResults.has(toolCallId)) {
             yieldedToolResults.add(toolCallId);
             const result = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+            
+            // Retrieve stored args from the original tool call
+            const storedToolInfo = toolCallArgsMap.get(toolCallId);
+            
             yield {
               type: 'tool_result',
               toolCall: {
                 id: toolCallId,
-                name: msg.name || 'tool',
-                args: {},
+                name: storedToolInfo?.name || msg.name || 'tool',
+                args: storedToolInfo?.args || {},
                 result: result,
                 status: 'completed',
               },
@@ -462,19 +487,30 @@ export async function* streamAgentResponse(
           const msgType = msg._getType?.() || msg.type || 'unknown';
           
           // Catch tool calls from values mode (backup)
-          if ((msgType === 'ai' || msgType === 'AIMessage') && !yieldedToolCalls.size) {
+          if ((msgType === 'ai' || msgType === 'AIMessage')) {
             const toolCalls = msg.tool_calls || [];
+
             for (const tc of toolCalls) {
               const toolId = tc.id || `tool-${Date.now()}`;
+              const toolName = tc.name || 'unknown';
+              const toolArgs = tc.args || {};
+              
+              // Always update the map with values mode data (it has complete args)
+              // This will overwrite any incomplete data from messages mode
+              if (Object.keys(toolArgs).length > 0) {
+                toolCallArgsMap.set(toolId, { name: toolName, args: toolArgs });
+              }
+              
               if (!yieldedToolCalls.has(toolId)) {
                 allToolsDone = false;
                 yieldedToolCalls.add(toolId);
+                
                 yield {
                   type: 'tool_call',
                   toolCall: {
                     id: toolId,
-                    name: tc.name || 'unknown',
-                    args: tc.args || {},
+                    name: toolName,
+                    args: toolArgs,
                     status: 'running',
                   },
                 };
@@ -488,12 +524,16 @@ export async function* streamAgentResponse(
             if (toolCallId && !yieldedToolResults.has(toolCallId)) {
               yieldedToolResults.add(toolCallId);
               const result = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+              
+              // Retrieve stored args from the original tool call
+              const storedToolInfo = toolCallArgsMap.get(toolCallId);
+              
               yield {
                 type: 'tool_result',
                 toolCall: {
                   id: toolCallId,
-                  name: msg.name || 'tool',
-                  args: {},
+                  name: storedToolInfo?.name || msg.name || 'tool',
+                  args: storedToolInfo?.args || {},
                   result: result,
                   status: 'completed',
                 },

--- a/gitnexus-web/src/core/llm/agent.ts
+++ b/gitnexus-web/src/core/llm/agent.ts
@@ -327,7 +327,8 @@ export async function* streamAgentResponse(
       {
         streamMode: ['values', 'messages'] as any,
         // Allow longer tool/reasoning loops (more Cursor-like persistence)
-        recursionLimit: 50,
+        // Increased from 50 to 200 to handle complex multi-step reasoning
+        recursionLimit: 200,
       } as any
     );
     

--- a/gitnexus-web/src/core/llm/chat-session-service.ts
+++ b/gitnexus-web/src/core/llm/chat-session-service.ts
@@ -1,0 +1,178 @@
+/**
+ * Chat Session Service
+ * 
+ * Manages conversation history sessions with server-side persistence.
+ * Provides save, load, delete, and list operations for chat sessions.
+ */
+
+import type { ChatSession, ChatMessage } from './types';
+import { 
+  fetchAllSessions, 
+  fetchSession, 
+  saveSessionToServer, 
+  deleteSessionFromServer, 
+  clearAllSessionsFromServer 
+} from '../../services/backend.js';
+
+/**
+ * Generate a unique session ID
+ */
+function generateSessionId(): string {
+  return `session-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}
+
+/**
+ * Get all sessions from server
+ */
+export async function getAllSessions(): Promise<ChatSession[]> {
+  try {
+    return await fetchAllSessions();
+  } catch (error) {
+    console.error('Failed to load chat sessions:', error);
+    return [];
+  }
+}
+
+/**
+ * Create a new session from current messages
+ */
+export async function createSession(
+  messages: ChatMessage[],
+  repoName?: string,
+  customName?: string
+): Promise<ChatSession> {
+  const now = Date.now();
+  const session: ChatSession = {
+    id: generateSessionId(),
+    name: customName || generateSessionName(messages),
+    repoName,
+    createdAt: now,
+    updatedAt: now,
+    messages,
+  };
+  
+  try {
+    return await saveSessionToServer(session);
+  } catch (error) {
+    console.error('Failed to create session:', error);
+    throw error;
+  }
+}
+
+/**
+ * Generate a session name from messages
+ */
+function generateSessionName(messages: ChatMessage[]): string {
+  // Use first user message as session name, truncated
+  const firstUserMessage = messages.find(m => m.role === 'user');
+  if (firstUserMessage) {
+    const content = firstUserMessage.content.trim();
+    return content.length > 50 ? content.substring(0, 47) + '...' : content;
+  }
+  return `Session ${new Date().toLocaleString()}`;
+}
+
+/**
+ * Update an existing session
+ */
+export async function updateSession(sessionId: string, messages: ChatMessage[]): Promise<ChatSession | null> {
+  try {
+    const sessions = await getAllSessions();
+    const existing = sessions.find(s => s.id === sessionId);
+    
+    if (!existing) {
+      // Session not found, create new one
+      return await createSession(messages);
+    }
+    
+    const updated: ChatSession = {
+      ...existing,
+      messages,
+      updatedAt: Date.now(),
+    };
+    
+    return await saveSessionToServer(updated);
+  } catch (error) {
+    console.error('Failed to update session:', error);
+    return null;
+  }
+}
+
+/**
+ * Save or update a session (upsert)
+ */
+export async function saveSession(
+  sessionId: string | null,
+  messages: ChatMessage[],
+  repoName?: string
+): Promise<ChatSession> {
+  if (sessionId) {
+    const updated = await updateSession(sessionId, messages);
+    if (updated) return updated;
+  }
+  return await createSession(messages, repoName);
+}
+
+/**
+ * Load a specific session by ID
+ */
+export async function loadSession(sessionId: string): Promise<ChatSession | null> {
+  try {
+    return await fetchSession(sessionId);
+  } catch (error) {
+    console.error('Failed to load session:', error);
+    return null;
+  }
+}
+
+/**
+ * Delete a session
+ */
+export async function deleteSession(sessionId: string): Promise<boolean> {
+  try {
+    await deleteSessionFromServer(sessionId);
+    return true;
+  } catch (error) {
+    console.error('Failed to delete session:', error);
+    return false;
+  }
+}
+
+/**
+ * Clear all sessions
+ */
+export async function clearAllSessions(): Promise<void> {
+  try {
+    await clearAllSessionsFromServer();
+  } catch (error) {
+    console.error('Failed to clear sessions:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get sessions for a specific repository
+ */
+export async function getSessionsByRepo(repoName: string): Promise<ChatSession[]> {
+  const sessions = await getAllSessions();
+  return sessions.filter(s => s.repoName === repoName);
+}
+
+/**
+ * Format timestamp for display
+ */
+export function formatSessionDate(timestamp: number): string {
+  const now = Date.now();
+  const diff = now - timestamp;
+  
+  const minutes = Math.floor(diff / 60000);
+  const hours = Math.floor(diff / 3600000);
+  const days = Math.floor(diff / 86400000);
+  
+  if (minutes < 1) return 'Just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 7) return `${days}d ago`;
+  
+  return new Date(timestamp).toLocaleDateString();
+}

--- a/gitnexus-web/src/core/llm/chat-session-service.ts
+++ b/gitnexus-web/src/core/llm/chat-session-service.ts
@@ -23,10 +23,11 @@ function generateSessionId(): string {
 
 /**
  * Get all sessions from server
+ * @param repoName - Optional repo name to filter sessions
  */
-export async function getAllSessions(): Promise<ChatSession[]> {
+export async function getAllSessions(repoName?: string): Promise<ChatSession[]> {
   try {
-    return await fetchAllSessions();
+    return await fetchAllSessions(repoName);
   } catch (error) {
     console.error('Failed to load chat sessions:', error);
     return [];
@@ -39,16 +40,30 @@ export async function getAllSessions(): Promise<ChatSession[]> {
 export async function createSession(
   messages: ChatMessage[],
   repoName?: string,
-  customName?: string
+  customName?: string,
+  modelProvider?: string,
+  modelName?: string
 ): Promise<ChatSession> {
   const now = Date.now();
+  const timestamp = new Date(now).toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false
+  }).replace(/\//g, '-').replace(/\s/g, '_');
+  const baseName = customName || generateSessionName(messages);
   const session: ChatSession = {
     id: generateSessionId(),
-    name: customName || generateSessionName(messages),
+    name: `${baseName}[${timestamp}]`,
     repoName,
     createdAt: now,
     updatedAt: now,
     messages,
+    modelProvider,
+    modelName,
   };
   
   try {
@@ -75,14 +90,20 @@ function generateSessionName(messages: ChatMessage[]): string {
 /**
  * Update an existing session
  */
-export async function updateSession(sessionId: string, messages: ChatMessage[]): Promise<ChatSession | null> {
+export async function updateSession(
+  sessionId: string,
+  messages: ChatMessage[],
+  repoName?: string
+): Promise<ChatSession | null> {
   try {
-    const sessions = await getAllSessions();
-    const existing = sessions.find(s => s.id === sessionId);
+    // Try to fetch the specific session first by ID
+    const existing = await loadSession(sessionId);
     
     if (!existing) {
-      // Session not found, create new one
-      return await createSession(messages);
+      // Session not found — return null so the caller can decide what to do.
+      // Do NOT silently create a new session here, as that causes duplicates.
+      console.warn(`Session ${sessionId} not found for update`);
+      return null;
     }
     
     const updated: ChatSession = {
@@ -104,13 +125,18 @@ export async function updateSession(sessionId: string, messages: ChatMessage[]):
 export async function saveSession(
   sessionId: string | null,
   messages: ChatMessage[],
-  repoName?: string
+  repoName?: string,
+  modelProvider?: string,
+  modelName?: string
 ): Promise<ChatSession> {
   if (sessionId) {
-    const updated = await updateSession(sessionId, messages);
+    const updated = await updateSession(sessionId, messages, repoName);
     if (updated) return updated;
+    // updateSession failed (e.g. network error) — do NOT fall through to createSession
+    // to avoid creating a duplicate. Re-throw so the caller can handle it.
+    throw new Error(`Failed to update session ${sessionId}`);
   }
-  return await createSession(messages, repoName);
+  return await createSession(messages, repoName, undefined, modelProvider, modelName);
 }
 
 /**
@@ -152,9 +178,10 @@ export async function clearAllSessions(): Promise<void> {
 
 /**
  * Get sessions for a specific repository
+ * @param repoName - The repository name to filter sessions
  */
 export async function getSessionsByRepo(repoName: string): Promise<ChatSession[]> {
-  const sessions = await getAllSessions();
+  const sessions = await getAllSessions(repoName);
   return sessions.filter(s => s.repoName === repoName);
 }
 

--- a/gitnexus-web/src/core/llm/tools.ts
+++ b/gitnexus-web/src/core/llm/tools.ts
@@ -429,7 +429,7 @@ MATCH (n:Function {id: emb.nodeId}) RETURN n`,
         pattern: z.string().describe('Regex pattern to search for (e.g., "TODO", "console\\.log", "API_KEY")'),
         fileFilter: z.string().optional().nullable().describe('Only search files containing this string (e.g., ".ts", "src/api")'),
         caseSensitive: z.boolean().optional().nullable().describe('Case-sensitive search (default: false)'),
-        maxResults: z.number().optional().nullable().describe('Max results (default: 100)'),
+        maxResults: z.union([z.number(), z.string().transform(Number)]).optional().nullable().describe('Max results (default: 100)'),
       }),
     }
   );

--- a/gitnexus-web/src/core/llm/types.ts
+++ b/gitnexus-web/src/core/llm/types.ts
@@ -221,6 +221,18 @@ export interface AgentStep {
 }
 
 /**
+ * Chat conversation session for history management
+ */
+export interface ChatSession {
+  id: string;
+  name: string;
+  repoName?: string;  // Associated repository name
+  createdAt: number;
+  updatedAt: number;
+  messages: ChatMessage[];
+}
+
+/**
  * Graph schema information for LLM context
  */
 export const GRAPH_SCHEMA_DESCRIPTION = `

--- a/gitnexus-web/src/core/llm/types.ts
+++ b/gitnexus-web/src/core/llm/types.ts
@@ -230,6 +230,8 @@ export interface ChatSession {
   createdAt: number;
   updatedAt: number;
   messages: ChatMessage[];
+  modelProvider?: string;  // LLM provider used (e.g., 'openai', 'gemini', 'anthropic')
+  modelName?: string;      // Model name used (e.g., 'gpt-4o', 'gemini-2.0-flash')
 }
 
 /**

--- a/gitnexus-web/src/hooks/useAppState.tsx
+++ b/gitnexus-web/src/hooks/useAppState.tsx
@@ -116,6 +116,8 @@ interface AppState {
   // Multi-repo switching
   serverBaseUrl: string | null;
   setServerBaseUrl: (url: string | null) => void;
+  currentRepoName: string | null;
+  setCurrentRepoName: (name: string | null) => void;
   availableRepos: RepoSummary[];
   setAvailableRepos: (repos: RepoSummary[]) => void;
   switchRepo: (repoName: string) => Promise<void>;
@@ -155,7 +157,7 @@ interface AppState {
 
   // LLM methods
   refreshLLMSettings: () => void;
-  initializeAgent: (overrideProjectName?: string) => Promise<void>;
+  initializeAgent: (overrideProjectName?: string, overrideRepoName?: string) => Promise<void>;
   sendChatMessage: (message: string) => Promise<void>;
   stopChatResponse: () => void;
   clearChat: () => void;
@@ -281,6 +283,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
 
   // Multi-repo switching
   const [serverBaseUrl, setServerBaseUrl] = useState<string | null>(null);
+  const [currentRepoName, setCurrentRepoName] = useState<string | null>(null);
   const [availableRepos, setAvailableRepos] = useState<RepoSummary[]>([]);
 
   // Embedding state
@@ -467,12 +470,43 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   const runQuery = useCallback(async (cypher: string): Promise<any[]> => {
+    // Server mode: use HTTP API
+    if (serverBaseUrl) {
+      try {
+        const body: any = { cypher };
+        if (currentRepoName) {
+          body.repo = currentRepoName;
+        }
+        const response = await fetch(`${serverBaseUrl}/query`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(errorData.error || `Server returned ${response.status}`);
+        }
+        const data = await response.json();
+        return data.result ?? data;
+      } catch (err) {
+        console.error('Server query failed:', err);
+        throw err;
+      }
+    }
+    
+    // Local mode: use worker
     const api = apiRef.current;
     if (!api) throw new Error('Worker not initialized');
     return api.runQuery(cypher);
-  }, []);
+  }, [serverBaseUrl, currentRepoName]);
 
   const isDatabaseReady = useCallback(async (): Promise<boolean> => {
+    // Server mode: always ready if connected
+    if (serverBaseUrl) {
+      return true;
+    }
+    
+    // Local mode: check worker
     const api = apiRef.current;
     if (!api) return false;
     try {
@@ -480,7 +514,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
     } catch {
       return false;
     }
-  }, []);
+  }, [serverBaseUrl]);
 
   // Embedding methods
   const startEmbeddings = useCallback(async (forceDevice?: 'webgpu' | 'wasm'): Promise<void> => {
@@ -565,7 +599,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
     setLLMSettings(loadSettings());
   }, []);
 
-  const initializeAgent = useCallback(async (overrideProjectName?: string): Promise<void> => {
+  const initializeAgent = useCallback(async (overrideProjectName?: string, overrideRepoName?: string): Promise<void> => {
     const api = apiRef.current;
     if (!api) {
       setAgentError('Worker not initialized');
@@ -584,7 +618,25 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
     try {
       // Use override if provided (for fresh loads), fallback to state (for re-init)
       const effectiveProjectName = overrideProjectName || projectName || 'project';
-      const result = await api.initializeAgent(config, effectiveProjectName);
+      const effectiveRepoName = overrideRepoName !== undefined ? overrideRepoName : currentRepoName;
+      
+      let result;
+      // Server mode: use backend agent
+      if (serverBaseUrl) {
+        // Convert fileContents Map to entries array for Comlink transfer
+        const fileContentsEntries = Array.from(fileContents.entries());
+        result = await api.initializeBackendAgent(
+          config,
+          serverBaseUrl,
+          effectiveRepoName || '',
+          fileContentsEntries,
+          effectiveProjectName
+        );
+      } else {
+        // Local mode: use local agent
+        result = await api.initializeAgent(config, effectiveProjectName);
+      }
+      
       if (result.success) {
         setIsAgentReady(true);
         setAgentError(null);
@@ -602,7 +654,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
     } finally {
       setIsAgentInitializing(false);
     }
-  }, [projectName]);
+  }, [projectName, serverBaseUrl, currentRepoName, fileContents]);
 
   const sendChatMessage = useCallback(async (message: string): Promise<void> => {
     const api = apiRef.current;
@@ -1007,6 +1059,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
       const repoPath = result.repoInfo.repoPath;
       const pName = result.repoInfo.name || repoPath.split('/').pop() || 'server-project';
       setProjectName(pName);
+      setCurrentRepoName(repoName || null);
 
       const graph = createKnowledgeGraph();
       for (const node of result.nodes) graph.addNode(node);
@@ -1019,7 +1072,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
 
       setViewMode('exploring');
 
-      if (getActiveProviderConfig()) initializeAgent(pName);
+      if (getActiveProviderConfig()) initializeAgent(pName, repoName);
 
       startEmbeddings().catch((err) => {
         if (err?.name === 'WebGPUNotAvailableError' || err?.message?.includes('WebGPU')) {
@@ -1135,6 +1188,8 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
     // Multi-repo switching
     serverBaseUrl,
     setServerBaseUrl,
+    currentRepoName,
+    setCurrentRepoName,
     availableRepos,
     setAvailableRepos,
     switchRepo,

--- a/gitnexus-web/src/hooks/useAppState.tsx
+++ b/gitnexus-web/src/hooks/useAppState.tsx
@@ -22,6 +22,8 @@ async function getFilteredSessions(repoName: string | null): Promise<ChatSession
   if (repoName) {
     return await getSessionsByRepo(repoName);
   }
+  // When no repo is selected, show all sessions from all repo files
+  // This reads from all known repo session files
   return await getAllSessions();
 }
 
@@ -330,6 +332,14 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
   const [currentToolCalls, setCurrentToolCalls] = useState<ToolCallInfo[]>([]);
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
   const [chatSessions, setChatSessions] = useState<ChatSession[]>([]);
+  // Refs to always hold the latest values — bypasses React stale-closure issues
+  // in Comlink proxy callbacks and post-stream save logic.
+  const currentSessionIdRef = useRef<string | null>(null);
+  const currentRepoNameRef = useRef<string | null>(null);
+
+  // Keep refs in sync with state
+  useEffect(() => { currentSessionIdRef.current = currentSessionId; }, [currentSessionId]);
+  useEffect(() => { currentRepoNameRef.current = currentRepoName; }, [currentRepoName]);
 
   // Code References Panel state
   const [codeReferences, setCodeReferences] = useState<CodeReference[]>([]);
@@ -744,6 +754,9 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
     // Keep toolCalls for backwards compat and currentToolCalls state
     const toolCallsForMessage: ToolCallInfo[] = [];
     let stepCounter = 0;
+    // Track the full message list locally (independent of React state) for session saving.
+    // This avoids stale-closure and async-render-timing issues when saving after stream ends.
+    const localMessages: ChatMessage[] = [...chatMessages, userMessage];
 
     // Helper to update the message with current steps
     const updateMessage = () => {
@@ -754,20 +767,34 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
         .filter(Boolean);
       const content = contentParts.join('\n\n');
 
+      const existingLocal = localMessages.find(m => m.id === assistantMessageId);
+      const newMessage: ChatMessage = {
+        id: assistantMessageId,
+        role: 'assistant' as const,
+        content,
+        steps: [...stepsForMessage],
+        toolCalls: [...toolCallsForMessage],
+        timestamp: existingLocal?.timestamp ?? Date.now(),
+      };
+
+      // Update localMessages (used for session saving — independent of React state)
+      if (existingLocal) {
+        const idx = localMessages.findIndex(m => m.id === assistantMessageId);
+        localMessages[idx] = newMessage;
+      } else {
+        localMessages.push(newMessage);
+      }
+
       setChatMessages(prev => {
         const existing = prev.find(m => m.id === assistantMessageId);
-        const newMessage: ChatMessage = {
-          id: assistantMessageId,
-          role: 'assistant' as const,
-          content,
-          steps: [...stepsForMessage],
-          toolCalls: [...toolCallsForMessage],
-          timestamp: existing?.timestamp ?? Date.now(),
+        const msg: ChatMessage = {
+          ...newMessage,
+          timestamp: existing?.timestamp ?? newMessage.timestamp,
         };
         if (existing) {
-          return prev.map(m => m.id === assistantMessageId ? newMessage : m);
+          return prev.map(m => m.id === assistantMessageId ? msg : m);
         } else {
-          return [...prev, newMessage];
+          return [...prev, msg];
         }
       });
     };
@@ -1026,24 +1053,36 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
           case 'done':
             // Finalize the assistant message - just call updateMessage one more time
             updateMessage();
-            // Auto-save session when task completes
-            // Use setTimeout to ensure the final message update is processed first
-            setTimeout(() => {
-              setChatMessages(prev => {
-                if (prev.length > 0) {
-                  saveSession(currentSessionId, prev, currentRepoName || undefined).then(session => {
-                    setCurrentSessionId(session.id);
-                    getFilteredSessions(currentRepoName).then(setChatSessions);
-                  }).catch(err => console.error('Failed to save session:', err));
-                }
-                return prev;
-              });
-            }, 100);
             break;
         }
       });
 
       await api.chatStream(history, onChunk);
+
+      // Auto-save session after stream completes.
+      // Use localMessages (built locally in this function scope) and refs for sessionId/repoName
+      // to completely avoid React state stale-closure issues.
+      if (localMessages.length > 0) {
+        try {
+          const config = getActiveProviderConfig();
+          const latestSessionId = currentSessionIdRef.current;
+          const latestRepoName = currentRepoNameRef.current;
+          const session = await saveSession(
+            latestSessionId,
+            localMessages,
+            latestRepoName || undefined,
+            config?.provider,
+            config?.model
+          );
+          // Update both the ref and the state so subsequent messages use the correct session ID
+          currentSessionIdRef.current = session.id;
+          setCurrentSessionId(session.id);
+          const sessions = await getFilteredSessions(latestRepoName);
+          setChatSessions(sessions);
+        } catch (err) {
+          console.error('Failed to save session:', err);
+        }
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       setAgentError(message);
@@ -1051,7 +1090,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
       setIsChatLoading(false);
       setCurrentToolCalls([]);
     }
-  }, [chatMessages, isAgentReady, initializeAgent, resolveFilePath, findFileNodeId, addCodeReference, clearAICodeReferences, clearAIToolHighlights, graph, embeddingStatus, currentSessionId, currentRepoName]);
+  }, [chatMessages, isAgentReady, initializeAgent, resolveFilePath, findFileNodeId, addCodeReference, clearAICodeReferences, clearAIToolHighlights, graph, embeddingStatus]);
 
   const stopChatResponse = useCallback(() => {
     const api = apiRef.current;
@@ -1062,22 +1101,18 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [isChatLoading]);
 
-  const clearChat = useCallback(() => {
-    // Save current session before clearing if there are messages
-    if (chatMessages.length > 0) {
-      saveCurrentSession();
-    }
-    setChatMessages([]);
-    setCurrentToolCalls([]);
-    setAgentError(null);
-    setCurrentSessionId(null);
-  }, [chatMessages]);
-
   const saveCurrentSession = useCallback(async () => {
     if (chatMessages.length === 0) return;
     
     try {
-      const session = await saveSession(currentSessionId, chatMessages, currentRepoName || undefined);
+      const config = getActiveProviderConfig();
+      const session = await saveSession(
+        currentSessionId,
+        chatMessages,
+        currentRepoName || undefined,
+        config?.provider,
+        config?.model
+      );
       setCurrentSessionId(session.id);
       const sessions = await getFilteredSessions(currentRepoName);
       setChatSessions(sessions);
@@ -1086,12 +1121,30 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [chatMessages, currentSessionId, currentRepoName]);
 
+  const clearChat = useCallback(async () => {
+    // Save current session before clearing only if there are unsaved messages
+    // (i.e., there are messages but no currentSessionId yet — the auto-save on 'done'
+    // hasn't run yet, or the user manually started a chat without sending a full message)
+    if (chatMessages.length > 0 && !currentSessionId) {
+      try {
+        await saveCurrentSession();
+      } catch (err) {
+        console.error('Failed to save session before clearing:', err);
+      }
+    }
+    // Clear everything and reset session ID to start fresh
+    setChatMessages([]);
+    setCurrentToolCalls([]);
+    setAgentError(null);
+    setCurrentSessionId(null);
+  }, [chatMessages, currentSessionId, saveCurrentSession]);
+
   const loadChatSession = useCallback(async (sessionId: string) => {
     try {
       const session = await loadSession(sessionId);
       if (session) {
-        // Save current session first if it has messages
-        if (chatMessages.length > 0 && !currentSessionId) {
+        // Save current session first if it has messages and is different from the one being loaded
+        if (chatMessages.length > 0 && currentSessionId && currentSessionId !== sessionId) {
           await saveCurrentSession();
         }
         setChatMessages(session.messages);

--- a/gitnexus-web/src/hooks/useAppState.tsx
+++ b/gitnexus-web/src/hooks/useAppState.tsx
@@ -7,12 +7,23 @@ import { DEFAULT_VISIBLE_LABELS } from '../lib/constants';
 import type { IngestionWorkerApi } from '../workers/ingestion.worker';
 import type { FileEntry } from '../services/zip';
 import type { EmbeddingProgress, SemanticSearchResult } from '../core/embeddings/types';
-import type { LLMSettings, ProviderConfig, AgentStreamChunk, ChatMessage, ToolCallInfo, MessageStep } from '../core/llm/types';
+import type { LLMSettings, ProviderConfig, AgentStreamChunk, ChatMessage, ToolCallInfo, MessageStep, ChatSession } from '../core/llm/types';
 import { loadSettings, getActiveProviderConfig, saveSettings } from '../core/llm/settings-service';
 import type { AgentMessage } from '../core/llm/agent';
+import { saveSession, loadSession, getAllSessions, deleteSession, getSessionsByRepo } from '../core/llm/chat-session-service';
 import { DEFAULT_VISIBLE_EDGES, type EdgeType } from '../lib/constants';
 import type { RepoSummary, ConnectToServerResult } from '../services/server-connection';
 import { fetchRepos, connectToServer } from '../services/server-connection';
+
+/**
+ * Helper function to get sessions filtered by repo if available
+ */
+async function getFilteredSessions(repoName: string | null): Promise<ChatSession[]> {
+  if (repoName) {
+    return await getSessionsByRepo(repoName);
+  }
+  return await getAllSessions();
+}
 
 export type ViewMode = 'onboarding' | 'loading' | 'exploring';
 export type RightPanelTab = 'code' | 'chat';
@@ -74,6 +85,12 @@ interface AppState {
   setRightPanelTab: (tab: RightPanelTab) => void;
   openCodePanel: () => void;
   openChatPanel: () => void;
+
+  // Panel widths (resizable)
+  leftPanelWidth: number;
+  setLeftPanelWidth: (width: number | ((prev: number) => number)) => void;
+  rightPanelWidth: number;
+  setRightPanelWidth: (width: number | ((prev: number) => number)) => void;
 
   // Filters
   visibleLabels: NodeLabel[];
@@ -154,6 +171,8 @@ interface AppState {
   chatMessages: ChatMessage[];
   isChatLoading: boolean;
   currentToolCalls: ToolCallInfo[];
+  currentSessionId: string | null;
+  chatSessions: ChatSession[];
 
   // LLM methods
   refreshLLMSettings: () => void;
@@ -161,6 +180,10 @@ interface AppState {
   sendChatMessage: (message: string) => Promise<void>;
   stopChatResponse: () => void;
   clearChat: () => void;
+  saveCurrentSession: () => void;
+  loadSession: (sessionId: string) => void;
+  deleteSession: (sessionId: string) => void;
+  refreshChatSessions: () => void;
 
   // Code References Panel
   codeReferences: CodeReference[];
@@ -189,6 +212,10 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
   // Right Panel
   const [isRightPanelOpen, setRightPanelOpen] = useState(false);
   const [rightPanelTab, setRightPanelTab] = useState<RightPanelTab>('code');
+
+  // Panel widths (resizable)
+  const [leftPanelWidth, setLeftPanelWidth] = useState(280); // Default 280px
+  const [rightPanelWidth, setRightPanelWidth] = useState(480); // Default 480px (40% of 1200px)
 
   const openCodePanel = useCallback(() => {
     // Legacy API: used by graph/tree selection.
@@ -301,6 +328,8 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
   const [isChatLoading, setIsChatLoading] = useState(false);
   const [currentToolCalls, setCurrentToolCalls] = useState<ToolCallInfo[]>([]);
+  const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
+  const [chatSessions, setChatSessions] = useState<ChatSession[]>([]);
 
   // Code References Panel state
   const [codeReferences, setCodeReferences] = useState<CodeReference[]>([]);
@@ -883,6 +912,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
               if (idx >= 0) {
                 toolCallsForMessage[idx] = {
                   ...toolCallsForMessage[idx],
+                  args: tc.args || toolCallsForMessage[idx].args, // Preserve args from result
                   result: tc.result,
                   status: 'completed'
                 };
@@ -900,6 +930,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
                   ...stepsForMessage[stepIdx],
                   toolCall: {
                     ...stepsForMessage[stepIdx].toolCall!,
+                    args: tc.args || stepsForMessage[stepIdx].toolCall!.args, // Preserve args from result
                     result: tc.result,
                     status: 'completed',
                   },
@@ -917,7 +948,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
                 }
                 if (targetIdx >= 0) {
                   return prev.map((t, i) => i === targetIdx
-                    ? { ...t, result: tc.result, status: 'completed' }
+                    ? { ...t, args: tc.args || t.args, result: tc.result, status: 'completed' }
                     : t
                   );
                 }
@@ -995,6 +1026,19 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
           case 'done':
             // Finalize the assistant message - just call updateMessage one more time
             updateMessage();
+            // Auto-save session when task completes
+            // Use setTimeout to ensure the final message update is processed first
+            setTimeout(() => {
+              setChatMessages(prev => {
+                if (prev.length > 0) {
+                  saveSession(currentSessionId, prev, currentRepoName || undefined).then(session => {
+                    setCurrentSessionId(session.id);
+                    getFilteredSessions(currentRepoName).then(setChatSessions);
+                  }).catch(err => console.error('Failed to save session:', err));
+                }
+                return prev;
+              });
+            }, 100);
             break;
         }
       });
@@ -1007,7 +1051,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
       setIsChatLoading(false);
       setCurrentToolCalls([]);
     }
-  }, [chatMessages, isAgentReady, initializeAgent, resolveFilePath, findFileNodeId, addCodeReference, clearAICodeReferences, clearAIToolHighlights, graph, embeddingStatus]);
+  }, [chatMessages, isAgentReady, initializeAgent, resolveFilePath, findFileNodeId, addCodeReference, clearAICodeReferences, clearAIToolHighlights, graph, embeddingStatus, currentSessionId, currentRepoName]);
 
   const stopChatResponse = useCallback(() => {
     const api = apiRef.current;
@@ -1019,14 +1063,82 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
   }, [isChatLoading]);
 
   const clearChat = useCallback(() => {
+    // Save current session before clearing if there are messages
+    if (chatMessages.length > 0) {
+      saveCurrentSession();
+    }
     setChatMessages([]);
     setCurrentToolCalls([]);
     setAgentError(null);
-  }, []);
+    setCurrentSessionId(null);
+  }, [chatMessages]);
+
+  const saveCurrentSession = useCallback(async () => {
+    if (chatMessages.length === 0) return;
+    
+    try {
+      const session = await saveSession(currentSessionId, chatMessages, currentRepoName || undefined);
+      setCurrentSessionId(session.id);
+      const sessions = await getFilteredSessions(currentRepoName);
+      setChatSessions(sessions);
+    } catch (err) {
+      console.error('Failed to save session:', err);
+    }
+  }, [chatMessages, currentSessionId, currentRepoName]);
+
+  const loadChatSession = useCallback(async (sessionId: string) => {
+    try {
+      const session = await loadSession(sessionId);
+      if (session) {
+        // Save current session first if it has messages
+        if (chatMessages.length > 0 && !currentSessionId) {
+          await saveCurrentSession();
+        }
+        setChatMessages(session.messages);
+        setCurrentSessionId(sessionId);
+        setRightPanelTab('chat');
+        setRightPanelOpen(true);
+      }
+    } catch (err) {
+      console.error('Failed to load session:', err);
+    }
+  }, [chatMessages, currentSessionId, saveCurrentSession]);
+
+  const deleteChatSession = useCallback(async (sessionId: string) => {
+    try {
+      await deleteSession(sessionId);
+      const sessions = await getFilteredSessions(currentRepoName);
+      setChatSessions(sessions);
+      if (currentSessionId === sessionId) {
+        setCurrentSessionId(null);
+      }
+    } catch (err) {
+      console.error('Failed to delete session:', err);
+    }
+  }, [currentSessionId, currentRepoName]);
+
+  const refreshChatSessions = useCallback(async () => {
+    try {
+      const sessions = await getFilteredSessions(currentRepoName);
+      setChatSessions(sessions);
+    } catch (err) {
+      console.error('Failed to refresh sessions:', err);
+    }
+  }, [currentRepoName]);
+
+  // Load chat sessions from localStorage on mount
+  useEffect(() => {
+    refreshChatSessions();
+  }, [refreshChatSessions]);
 
   // Switch to a different repo on the connected server
   const switchRepo = useCallback(async (repoName: string) => {
     if (!serverBaseUrl) return;
+
+    // Save current session before switching if there are messages
+    if (chatMessages.length > 0) {
+      saveCurrentSession();
+    }
 
     setProgress({ phase: 'extracting', percent: 0, message: 'Switching repository...', detail: `Loading ${repoName}` });
     setViewMode('loading');
@@ -1071,6 +1183,11 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
       setFileContents(fileMap);
 
       setViewMode('exploring');
+
+      // Clear chat and session when switching repos
+      setChatMessages([]);
+      setCurrentSessionId(null);
+      setCurrentToolCalls([]);
 
       if (getActiveProviderConfig()) initializeAgent(pName, repoName);
 
@@ -1159,6 +1276,10 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
     setRightPanelTab,
     openCodePanel,
     openChatPanel,
+    leftPanelWidth,
+    setLeftPanelWidth,
+    rightPanelWidth,
+    setRightPanelWidth,
     visibleLabels,
     toggleLabelVisibility,
     visibleEdgeTypes,
@@ -1218,12 +1339,18 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
     chatMessages,
     isChatLoading,
     currentToolCalls,
+    currentSessionId,
+    chatSessions,
     // LLM methods
     refreshLLMSettings,
     initializeAgent,
     sendChatMessage,
     stopChatResponse,
     clearChat,
+    saveCurrentSession,
+    loadSession: loadChatSession,
+    deleteSession: deleteChatSession,
+    refreshChatSessions,
     // Code References Panel
     codeReferences,
     isCodePanelOpen,

--- a/gitnexus-web/src/services/backend.ts
+++ b/gitnexus-web/src/services/backend.ts
@@ -228,3 +228,65 @@ export const fetchClusterDetail = async (
   await assertOk(response);
   return response.json();
 };
+
+// ── Chat Session Management ────────────────────────────────────────────────
+
+export interface ChatSession {
+  id: string;
+  name: string;
+  repoName?: string;
+  createdAt: number;
+  updatedAt: number;
+  messages: any[];
+}
+
+/**
+ * Fetch all chat sessions from the server.
+ */
+export const fetchAllSessions = async (): Promise<ChatSession[]> => {
+  const response = await fetchWithTimeout(`${backendUrl}/api/sessions`);
+  await assertOk(response);
+  return response.json() as Promise<ChatSession[]>;
+};
+
+/**
+ * Fetch a specific session by ID.
+ */
+export const fetchSession = async (sessionId: string): Promise<ChatSession> => {
+  const response = await fetchWithTimeout(`${backendUrl}/api/sessions/${encodeURIComponent(sessionId)}`);
+  await assertOk(response);
+  return response.json() as Promise<ChatSession>;
+};
+
+/**
+ * Save or update a session on the server.
+ */
+export const saveSessionToServer = async (session: ChatSession): Promise<ChatSession> => {
+  const response = await fetchWithTimeout(`${backendUrl}/api/sessions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(session),
+  });
+  await assertOk(response);
+  return response.json() as Promise<ChatSession>;
+};
+
+/**
+ * Delete a session from the server.
+ */
+export const deleteSessionFromServer = async (sessionId: string): Promise<void> => {
+  const response = await fetchWithTimeout(`${backendUrl}/api/sessions/${encodeURIComponent(sessionId)}`, {
+    method: 'DELETE',
+  });
+  await assertOk(response);
+};
+
+/**
+ * Clear all sessions from the server.
+ */
+export const clearAllSessionsFromServer = async (): Promise<void> => {
+  const response = await fetchWithTimeout(`${backendUrl}/api/sessions`, {
+    method: 'DELETE',
+  });
+  await assertOk(response);
+};

--- a/gitnexus-web/src/services/backend.ts
+++ b/gitnexus-web/src/services/backend.ts
@@ -238,13 +238,19 @@ export interface ChatSession {
   createdAt: number;
   updatedAt: number;
   messages: any[];
+  modelProvider?: string;  // LLM provider used (e.g., 'openai', 'gemini', 'anthropic')
+  modelName?: string;      // Model name used (e.g., 'gpt-4o', 'gemini-2.0-flash')
 }
 
 /**
  * Fetch all chat sessions from the server.
+ * @param repoName - Optional repo name to filter sessions. If not provided, loads from global.json
  */
-export const fetchAllSessions = async (): Promise<ChatSession[]> => {
-  const response = await fetchWithTimeout(`${backendUrl}/api/sessions`);
+export const fetchAllSessions = async (repoName?: string): Promise<ChatSession[]> => {
+  const url = repoName
+    ? `${backendUrl}/api/sessions?repo=${encodeURIComponent(repoName)}`
+    : `${backendUrl}/api/sessions`;
+  const response = await fetchWithTimeout(url);
   await assertOk(response);
   return response.json() as Promise<ChatSession[]>;
 };

--- a/gitnexus-web/src/workers/ingestion.worker.ts
+++ b/gitnexus-web/src/workers/ingestion.worker.ts
@@ -74,7 +74,8 @@ const httpFetchWithTimeout = async (
 
 const createHttpExecuteQuery = (backendUrl: string, repo: string) => {
   return async (cypher: string): Promise<any[]> => {
-    const response = await httpFetchWithTimeout(`${backendUrl}/api/query`, {
+    // backendUrl already includes /api from normalizeServerUrl
+    const response = await httpFetchWithTimeout(`${backendUrl}/query`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ cypher, repo }),
@@ -97,7 +98,8 @@ const createHttpExecuteQuery = (backendUrl: string, repo: string) => {
 const createHttpHybridSearch = (backendUrl: string, repo: string) => {
   return async (query: string, k: number = 15): Promise<any[]> => {
     try {
-      const response = await httpFetchWithTimeout(`${backendUrl}/api/search`, {
+      // backendUrl already includes /api from normalizeServerUrl
+      const response = await httpFetchWithTimeout(`${backendUrl}/search`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ query, limit: k, repo }),

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -12,6 +12,7 @@ import express from 'express';
 import cors from 'cors';
 import path from 'path';
 import fs from 'fs/promises';
+import os from 'os';
 import { loadMeta, listRegisteredRepos } from '../storage/repo-manager.js';
 import { executeQuery, closeKuzu, withKuzuDb } from '../core/kuzu/kuzu-adapter.js';
 import { NODE_TABLES } from '../core/kuzu/schema.js';
@@ -334,6 +335,148 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
       res.json(result);
     } catch (err: any) {
       res.status(statusFromError(err)).json({ error: err.message || 'Failed to query cluster detail' });
+    }
+  });
+
+  // ── Chat Session Management ──────────────────────────────────────────────
+
+  // Helper: get sessions directory path
+  const getSessionsDir = () => {
+    const homeDir = os.homedir();
+    return path.join(homeDir, '.gitnexus', 'sessions');
+  };
+
+  // Helper: get sessions file path for a specific repo
+  const getSessionsFilePath = (repoName?: string) => {
+    const sessionsDir = getSessionsDir();
+    // If no repo specified, use 'global' as default
+    const safeRepoName = repoName || 'global';
+    // Sanitize repo name to be filesystem-safe
+    const safeFileName = safeRepoName.replace(/[^a-zA-Z0-9_-]/g, '_');
+    return path.join(sessionsDir, `${safeFileName}.json`);
+  };
+
+  // Helper: ensure sessions directory exists
+  const ensureSessionsDir = async () => {
+    await fs.mkdir(getSessionsDir(), { recursive: true });
+  };
+
+  // Helper: read sessions from a specific repo file
+  const readSessions = async (repoName?: string) => {
+    try {
+      const filePath = getSessionsFilePath(repoName);
+      const data = await fs.readFile(filePath, 'utf-8');
+      const sessions = JSON.parse(data);
+      return Array.isArray(sessions) ? sessions : [];
+    } catch (err: any) {
+      if (err.code === 'ENOENT') return [];
+      throw err;
+    }
+  };
+
+  // Helper: write sessions to a specific repo file
+  const writeSessions = async (sessions: any[], repoName?: string) => {
+    await ensureSessionsDir();
+    const filePath = getSessionsFilePath(repoName);
+    await fs.writeFile(filePath, JSON.stringify(sessions, null, 2), 'utf-8');
+  };
+
+  // Helper: get repo name from request query or body
+  const getRepoFromRequest = (req: express.Request): string | undefined => {
+    const fromQuery = typeof req.query.repo === 'string' ? req.query.repo : undefined;
+    if (fromQuery) return fromQuery;
+    if (req.body && typeof req.body === 'object' && typeof req.body.repoName === 'string') {
+      return req.body.repoName;
+    }
+    if (req.body && typeof req.body === 'object' && typeof req.body.repo === 'string') {
+      return req.body.repo;
+    }
+    return undefined;
+  };
+
+  // Get all chat sessions (optionally filtered by repo)
+  app.get('/api/sessions', async (req, res) => {
+    try {
+      const repoName = getRepoFromRequest(req);
+      const sessions = await readSessions(repoName);
+      res.json(sessions);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message || 'Failed to load sessions' });
+    }
+  });
+
+  // Get a specific session by ID (optionally from a specific repo)
+  app.get('/api/sessions/:id', async (req, res) => {
+    try {
+      const repoName = getRepoFromRequest(req);
+      const sessions = await readSessions(repoName);
+      const session = sessions.find((s: any) => s.id === req.params.id);
+      if (!session) {
+        res.status(404).json({ error: 'Session not found' });
+        return;
+      }
+      res.json(session);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message || 'Failed to load session' });
+    }
+  });
+
+  // Create or update a session
+  app.post('/api/sessions', async (req, res) => {
+    try {
+      const session = req.body;
+      if (!session || !session.id) {
+        res.status(400).json({ error: 'Invalid session data' });
+        return;
+      }
+
+      const repoName = session.repoName;
+      const sessions = await readSessions(repoName);
+      const index = sessions.findIndex((s: any) => s.id === session.id);
+      
+      if (index >= 0) {
+        // Update existing session
+        sessions[index] = { ...session, updatedAt: Date.now() };
+      } else {
+        // Add new session
+        sessions.push({ ...session, updatedAt: Date.now() });
+      }
+
+      // No limit - store all sessions per repo
+      await writeSessions(sessions, repoName);
+      res.json(session);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message || 'Failed to save session' });
+    }
+  });
+
+  // Delete a session
+  app.delete('/api/sessions/:id', async (req, res) => {
+    try {
+      const repoName = getRepoFromRequest(req);
+      const sessions = await readSessions(repoName);
+      const filtered = sessions.filter((s: any) => s.id !== req.params.id);
+      
+      if (filtered.length === sessions.length) {
+        res.status(404).json({ error: 'Session not found' });
+        return;
+      }
+      
+      await writeSessions(filtered, repoName);
+      res.json({ success: true });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message || 'Failed to delete session' });
+    }
+  });
+
+  // Clear all sessions (optionally for a specific repo)
+  app.delete('/api/sessions', async (req, res) => {
+    try {
+      const repoName = getRepoFromRequest(req);
+      await writeSessions([], repoName);
+      res.json({ success: true });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message || 'Failed to clear sessions' });
     }
   });
 

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -13,6 +13,7 @@ import cors from 'cors';
 import path from 'path';
 import fs from 'fs/promises';
 import os from 'os';
+import crypto from 'crypto';
 import { loadMeta, listRegisteredRepos } from '../storage/repo-manager.js';
 import { executeQuery, closeKuzu, withKuzuDb } from '../core/kuzu/kuzu-adapter.js';
 import { NODE_TABLES } from '../core/kuzu/schema.js';
@@ -340,45 +341,135 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
 
   // ── Chat Session Management ──────────────────────────────────────────────
 
-  // Helper: get sessions directory path
-  const getSessionsDir = () => {
+  // Helper: get base sessions directory path
+  const getSessionsBaseDir = () => {
     const homeDir = os.homedir();
     return path.join(homeDir, '.gitnexus', 'sessions');
   };
 
-  // Helper: get sessions file path for a specific repo
-  const getSessionsFilePath = (repoName?: string) => {
-    const sessionsDir = getSessionsDir();
+  // Helper: generate a unique repo identifier from name and path
+  const getRepoUniqueId = async (repoName: string): Promise<string> => {
+    const repos = await listRegisteredRepos();
+    const repo = repos.find(r => r.name === repoName);
+    
+    if (repo && repo.path) {
+      // Use first 8 characters of MD5 hash of the full path
+      const hash = crypto.createHash('md5').update(repo.path).digest('hex').substring(0, 8);
+      return `${repoName}_${hash}`;
+    }
+    
+    // Fallback: just use the name
+    return repoName;
+  };
+
+  // Helper: get sessions directory for a specific repo
+  const getRepoSessionsDir = async (repoName?: string): Promise<string> => {
+    const baseDir = getSessionsBaseDir();
+    
     // If no repo specified, use 'global' as default
-    const safeRepoName = repoName || 'global';
-    // Sanitize repo name to be filesystem-safe
-    const safeFileName = safeRepoName.replace(/[^a-zA-Z0-9_-]/g, '_');
-    return path.join(sessionsDir, `${safeFileName}.json`);
+    if (!repoName) {
+      return path.join(baseDir, 'global');
+    }
+    
+    // Generate unique identifier using repo name + path hash
+    const uniqueId = await getRepoUniqueId(repoName);
+    // Sanitize to be filesystem-safe
+    const safeFileName = uniqueId.replace(/[^a-zA-Z0-9_-]/g, '_');
+    return path.join(baseDir, safeFileName);
   };
 
-  // Helper: ensure sessions directory exists
-  const ensureSessionsDir = async () => {
-    await fs.mkdir(getSessionsDir(), { recursive: true });
+  // Helper: get session file path for a specific session
+  const getSessionFilePath = async (sessionId: string, repoName?: string): Promise<string> => {
+    const repoDir = await getRepoSessionsDir(repoName);
+    // Sanitize session ID to be filesystem-safe
+    const safeSessionId = sessionId.replace(/[^a-zA-Z0-9_-]/g, '_');
+    return path.join(repoDir, `${safeSessionId}.json`);
   };
 
-  // Helper: read sessions from a specific repo file
+  // Helper: ensure repo sessions directory exists
+  const ensureRepoSessionsDir = async (repoName?: string) => {
+    const repoDir = await getRepoSessionsDir(repoName);
+    await fs.mkdir(repoDir, { recursive: true });
+  };
+
+  // Helper: read all sessions from a specific repo directory
   const readSessions = async (repoName?: string) => {
+    // If no repo specified, read ALL repo directories and combine sessions
+    if (!repoName) {
+      try {
+        const baseDir = getSessionsBaseDir();
+        const repoDirs = await fs.readdir(baseDir);
+        const allSessions: any[] = [];
+        
+        for (const repoDir of repoDirs) {
+          try {
+            const repoDirPath = path.join(baseDir, repoDir);
+            const stat = await fs.stat(repoDirPath);
+            if (!stat.isDirectory()) continue;
+            
+            const sessionFiles = await fs.readdir(repoDirPath);
+            for (const file of sessionFiles) {
+              if (file.endsWith('.json')) {
+                try {
+                  const filePath = path.join(repoDirPath, file);
+                  const data = await fs.readFile(filePath, 'utf-8');
+                  const session = JSON.parse(data);
+                  allSessions.push(session);
+                } catch {
+                  // Skip files that can't be read
+                }
+              }
+            }
+          } catch {
+            // Skip directories that can't be read
+          }
+        }
+        
+        // Sort by updatedAt descending
+        return allSessions.sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+      } catch {
+        return [];
+      }
+    }
+    
+    // Read all session files from the specific repo directory
     try {
-      const filePath = getSessionsFilePath(repoName);
-      const data = await fs.readFile(filePath, 'utf-8');
-      const sessions = JSON.parse(data);
-      return Array.isArray(sessions) ? sessions : [];
+      const repoDir = await getRepoSessionsDir(repoName);
+      const files = await fs.readdir(repoDir);
+      const sessions: any[] = [];
+      
+      for (const file of files) {
+        if (file.endsWith('.json')) {
+          try {
+            const filePath = path.join(repoDir, file);
+            const data = await fs.readFile(filePath, 'utf-8');
+            const session = JSON.parse(data);
+            sessions.push(session);
+          } catch {
+            // Skip files that can't be read
+          }
+        }
+      }
+      
+      // Sort by updatedAt descending
+      return sessions.sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
     } catch (err: any) {
       if (err.code === 'ENOENT') return [];
       throw err;
     }
   };
 
-  // Helper: write sessions to a specific repo file
-  const writeSessions = async (sessions: any[], repoName?: string) => {
-    await ensureSessionsDir();
-    const filePath = getSessionsFilePath(repoName);
-    await fs.writeFile(filePath, JSON.stringify(sessions, null, 2), 'utf-8');
+  // Helper: write a single session to its own file
+  const writeSession = async (session: any) => {
+    await ensureRepoSessionsDir(session.repoName);
+    const filePath = await getSessionFilePath(session.id, session.repoName);
+    await fs.writeFile(filePath, JSON.stringify(session, null, 2), 'utf-8');
+  };
+
+  // Helper: delete a single session file
+  const deleteSessionFile = async (sessionId: string, repoName?: string) => {
+    const filePath = await getSessionFilePath(sessionId, repoName);
+    await fs.unlink(filePath);
   };
 
   // Helper: get repo name from request query or body
@@ -408,8 +499,9 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
   // Get a specific session by ID (optionally from a specific repo)
   app.get('/api/sessions/:id', async (req, res) => {
     try {
-      const repoName = getRepoFromRequest(req);
-      const sessions = await readSessions(repoName);
+      // Search across all repos to find the session by ID
+      // Don't filter by repoName since we need to find the session regardless of which repo it belongs to
+      const sessions = await readSessions();
       const session = sessions.find((s: any) => s.id === req.params.id);
       if (!session) {
         res.status(404).json({ error: 'Session not found' });
@@ -430,21 +522,12 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
         return;
       }
 
-      const repoName = session.repoName;
-      const sessions = await readSessions(repoName);
-      const index = sessions.findIndex((s: any) => s.id === session.id);
+      // Update timestamp
+      const updatedSession = { ...session, updatedAt: Date.now() };
       
-      if (index >= 0) {
-        // Update existing session
-        sessions[index] = { ...session, updatedAt: Date.now() };
-      } else {
-        // Add new session
-        sessions.push({ ...session, updatedAt: Date.now() });
-      }
-
-      // No limit - store all sessions per repo
-      await writeSessions(sessions, repoName);
-      res.json(session);
+      // Write session to its own file
+      await writeSession(updatedSession);
+      res.json(updatedSession);
     } catch (err: any) {
       res.status(500).json({ error: err.message || 'Failed to save session' });
     }
@@ -453,16 +536,19 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
   // Delete a session
   app.delete('/api/sessions/:id', async (req, res) => {
     try {
-      const repoName = getRepoFromRequest(req);
-      const sessions = await readSessions(repoName);
-      const filtered = sessions.filter((s: any) => s.id !== req.params.id);
+      const sessionId = req.params.id;
       
-      if (filtered.length === sessions.length) {
+      // Search across all repos to find the session
+      const sessions = await readSessions();
+      const session = sessions.find((s: any) => s.id === sessionId);
+      
+      if (!session) {
         res.status(404).json({ error: 'Session not found' });
         return;
       }
       
-      await writeSessions(filtered, repoName);
+      // Delete the session file using the session's repoName
+      await deleteSessionFile(sessionId, session.repoName);
       res.json({ success: true });
     } catch (err: any) {
       res.status(500).json({ error: err.message || 'Failed to delete session' });
@@ -473,7 +559,21 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
   app.delete('/api/sessions', async (req, res) => {
     try {
       const repoName = getRepoFromRequest(req);
-      await writeSessions([], repoName);
+      const repoDir = await getRepoSessionsDir(repoName);
+      
+      // Delete all session files in the repo directory
+      try {
+        const files = await fs.readdir(repoDir);
+        for (const file of files) {
+          if (file.endsWith('.json')) {
+            await fs.unlink(path.join(repoDir, file));
+          }
+        }
+      } catch (err: any) {
+        if (err.code !== 'ENOENT') throw err;
+        // Directory doesn't exist, nothing to clear
+      }
+      
       res.json({ success: true });
     } catch (err: any) {
       res.status(500).json({ error: err.message || 'Failed to clear sessions' });


### PR DESCRIPTION
Fixed problem: when use web UI to connect to backend server (4747 port), cypher query and AI chat not working, reporting KuzuDB error/repo not loaded.

- Add currentRepoName state tracking in useAppState for repo context
- Update initializeAgent to accept overrideRepoName parameter for server mode
- Implement server-mode query execution with repo parameter in runQuery
- Fix HTTP endpoint paths in ingestion worker (remove duplicate /api prefix)
- Increase agent recursion limit from 50 to 200 for complex multi-step reasoning
- Pass repo context through App.tsx handleServerConnect callback

Enables seamless switching between multiple indexed repositories when connected to a server backend, with proper repo context propagation through query execution and agent initialization.