### PR TITLE
fix: surface server JSON error message on failed server connection

### DIFF
--- a/gitnexus-web/src/services/server-connection.ts
+++ b/gitnexus-web/src/services/server-connection.ts
@@ -67,7 +67,12 @@ export async function fetchRepoInfo(baseUrl: string, repoName?: string): Promise
   const url = repoName ? `${baseUrl}/repo?repo=${encodeURIComponent(repoName)}` : `${baseUrl}/repo`;
   const response = await fetch(url);
   if (!response.ok) {
-    throw new Error(`Server returned ${response.status}: ${response.statusText}`);
+    let message = `Server returned ${response.status}: ${response.statusText}`;
+    try {
+      const body = await response.json();
+      if (body?.error) message = body.error;
+    } catch { /* ignore parse errors */ }
+    throw new Error(message);
   }
   const data = await response.json();
   // npm gitnexus@1.3.3 returns "path"; git HEAD returns "repoPath"

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -156,7 +156,7 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
     try {
       const entry = await resolveRepo(requestedRepo(req));
       if (!entry) {
-        res.status(404).json({ error: 'Repository not found. Run: gitnexus analyze' });
+        res.status(404).json({ error: 'No repository indexed. Run `gitnexus analyze` in your project directory first, then restart the server.' });
         return;
       }
       const meta = await loadMeta(entry.storagePath);


### PR DESCRIPTION
## Summary

Fixes #158

- **server-connection.ts**: On non-ok responses, parse the JSON body and use body.error as the error message, falling back to HTTP status text if parsing fails.
- **api.ts**: Expand the 404 error message to also hint at restarting the server after running gitnexus analyze.

## Problem

When gitnexus serve has no indexed repo, GET /api/repo returns a 404 with a helpful JSON body but the client was discarding it, showing the user a cryptic *Server returned 404: Not Found* instead of the actionable message.

## Result

User now sees: *No repository indexed. Run gitnexus analyze in your project directory first, then restart the server.*