### PR TITLE
fix: always force-exit after analyze to avoid KuzuDB destructor crash

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -357,10 +357,8 @@ export const analyzeCommand = async (
 
   console.log('');
 
-  // ONNX Runtime registers native atexit hooks that segfault during process
-  // shutdown on macOS (#38) and some Linux configs (#40). Force-exit to
-  // bypass them when embeddings were loaded.
-  if (!embeddingSkipped) {
-    process.exit(0);
-  }
+  // KuzuDB 0.11.3 and ONNX Runtime register native atexit hooks that
+  // segfault / double-free during process shutdown on Node 22+ (and
+  // macOS for ONNX — see #38, #40).  Force-exit to bypass them.
+  process.exit(0);
 };


### PR DESCRIPTION
## Summary

- `npx gitnexus analyze` crashes under some circumstances with "double free or corruption (out)" or "munmap_chunk(): invalid pointer" on **Node 22+**
- KuzuDB 0.11.3's native `atexit` hooks corrupt the heap during natural process shutdown
- The existing `process.exit(0)` workaround was conditional on `--embeddings` being enabled; without it (the default), the process exits naturally and hits the crash

## Fix

Always call `process.exit(0)` after successful completion, since KuzuDB is always loaded. One-line change (removes the `if (!embeddingSkipped)` guard).

## Root cause analysis

KuzuDB 0.11.3's C++ destructors registered via `atexit` conflict with Node 22's V8 shutdown sequence. Minimal reproducer:

\`\`\`js
const kuzu = require('kuzu');
const db = new kuzu.Database('/tmp/test');
const conn = new kuzu.Connection(db);
await conn.query('CREATE NODE TABLE IF NOT EXISTS T(id STRING, PRIMARY KEY(id))');
await conn.close();
await db.close();
// Process exits naturally → segfault
\`\`\`

This happens regardless of tree-sitter or worker threads — it's purely KuzuDB 0.11.3 + Node 22.

## Test plan

- [x] \`gitnexus analyze --force\` completes cleanly on Node 22.22.0 (exit code 0, no crash)
- [x] Worker pool path works (15.6s vs 50s sequential)
- [x] Verified crash does not occur with \`process.exit(0)\`
- [x] Verified \`embeddingSkipped\` variable is still used in summary output (no unused var)

🤖 Generated with [Claude Code](https://claude.com/claude-code)