### PR TITLE
fix: correct file path matching and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ claude mcp add gitnexus -- npx -y gitnexus@latest mcp
 gitnexus setup                    # Configure MCP for your editors (one-time)
 gitnexus analyze [path]           # Index a repository (or update stale index)
 gitnexus analyze --force          # Force full re-index
-gitnexus analyze --skip-embeddings  # Skip embedding generation (faster)
+gitnexus analyze --embeddings       # Enable embedding generation (off by default)
 gitnexus mcp                     # Start MCP server (stdio) — serves all indexed repos
 gitnexus serve                   # Start local HTTP server (multi-repo) for web UI connection
 gitnexus list                    # List all indexed repositories

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -284,8 +284,8 @@ export const analyzeCommand = async (
       files: pipelineResult.totalFileCount,
       nodes: stats.nodes,
       edges: stats.edges,
-      communities: pipelineResult.communityResult?.stats.totalCommunities,
-      processes: pipelineResult.processResult?.stats.totalProcesses,
+      communities: pipelineResult.communityResult?.stats.totalCommunities || 0,
+      processes: pipelineResult.processResult?.stats.totalProcesses || 0,
     },
   };
   await saveMeta(storagePath, meta);
@@ -307,9 +307,9 @@ export const analyzeCommand = async (
     files: pipelineResult.totalFileCount,
     nodes: stats.nodes,
     edges: stats.edges,
-    communities: pipelineResult.communityResult?.stats.totalCommunities,
+    communities: pipelineResult.communityResult?.stats.totalCommunities || 0,
     clusters: aggregatedClusterCount,
-    processes: pipelineResult.processResult?.stats.totalProcesses,
+    processes: pipelineResult.processResult?.stats.totalProcesses || 0,
   });
 
   await closeKuzu();

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -846,7 +846,7 @@ export class LocalBackend {
       let whereClause: string;
       let queryParams: Record<string, any>;
       if (file_path) {
-        whereClause = `WHERE n.name = $symName AND n.filePath CONTAINS $filePath`;
+        whereClause = `WHERE n.name = $symName AND n.filePath ENDS WITH $filePath`;
         queryParams = { symName: name!, filePath: file_path };
       } else if (isQualified) {
         whereClause = `WHERE n.id = $symName OR n.name = $symName`;
@@ -1089,7 +1089,7 @@ export class LocalBackend {
       const normalizedFile = file.replace(/\\/g, '/');
       try {
         const symbols = await executeParameterized(repo.id, `
-          MATCH (n) WHERE n.filePath CONTAINS $filePath
+          MATCH (n) WHERE n.filePath = $filePath
           RETURN n.id AS id, n.name AS name, labels(n)[0] AS type, n.filePath AS filePath
           LIMIT 20
         `, { filePath: normalizedFile });


### PR DESCRIPTION
## Summary

- **Fixed false-positive path matching in `detect_changes`**: The tool used `CONTAINS` for matching file paths against graph nodes, which caused unrelated files to be flagged as changed (e.g. querying `src/auth.ts` would also match `src/auth-backup.ts` or `src/authentication.ts`). Changed to exact match (`=`) since git diff output uses the same relative path format as stored in the graph.

- **Fixed path matching in `context` tool**: Same `CONTAINS` issue when disambiguating symbols by file path. Changed to `ENDS WITH` since users may pass partial paths here.

- **Fixed incorrect CLI flag in README**: Documentation referenced `--skip-embeddings` but the actual CLI option is `--embeddings` (to enable, not skip). Users following the docs would get "Unknown option" errors.

- **Added missing fallback values in analyze output**: `communities` and `processes` stats could be `undefined` when pipeline results were partial, causing inconsistent metadata. Added `|| 0` fallback to match the pattern already used in the summary output.

## Test plan

- [ ] Run `gitnexus analyze` on a repo and verify stats output shows `0` instead of `undefined` when community/process detection is skipped
- [ ] Run `detect_changes` on a repo with similarly-named files and verify only exact matches are returned
- [ ] Verify `context` tool with partial file paths still resolves correctly