### PR TITLE
feat(wiki): add --language option for multilingual wiki generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ gitnexus clean --all --force     # Delete all indexes
 gitnexus wiki [path]             # Generate repository wiki from knowledge graph
 gitnexus wiki --model <model>    # Wiki with custom LLM model (default: gpt-4o-mini)
 gitnexus wiki --base-url <url>   # Wiki with custom LLM API base URL
+gitnexus wiki --language zh-CN   # Wiki in Chinese (or ja, ko, etc.)
 ```
 
 ### What Your AI Agent Gets
@@ -447,6 +448,10 @@ gitnexus wiki --base-url https://api.anthropic.com/v1
 
 # Force full regeneration
 gitnexus wiki --force
+
+# Generate wiki in a specific language
+gitnexus wiki --language zh-CN
+gitnexus wiki --language ja
 ```
 
 The wiki generator reads the indexed graph structure, groups files into modules via LLM, generates per-module documentation pages, and creates an overview page — all with cross-references to the knowledge graph.

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -74,6 +74,7 @@ program
   .option('--base-url <url>', 'LLM API base URL (default: OpenAI)')
   .option('--api-key <key>', 'LLM API key (saved to ~/.gitnexus/config.json)')
   .option('--concurrency <n>', 'Parallel LLM calls (default: 3)', '3')
+  .option('--language <lang>', 'Output language for wiki (e.g. zh-CN, ja, ko)')
   .option('--gist', 'Publish wiki as a public GitHub Gist after generation')
   .action(wikiCommand);
 

--- a/gitnexus/src/cli/wiki.ts
+++ b/gitnexus/src/cli/wiki.ts
@@ -20,6 +20,7 @@ export interface WikiCommandOptions {
   baseUrl?: string;
   apiKey?: string;
   concurrency?: string;
+  language?: string;
   gist?: boolean;
 }
 
@@ -242,6 +243,7 @@ export const wikiCommand = async (
     model: options?.model,
     baseUrl: options?.baseUrl,
     concurrency: options?.concurrency ? parseInt(options.concurrency, 10) : undefined,
+    language: options?.language,
   };
 
   const generator = new WikiGenerator(

--- a/gitnexus/src/core/wiki/generator.ts
+++ b/gitnexus/src/core/wiki/generator.ts
@@ -63,6 +63,7 @@ export interface WikiOptions {
   apiKey?: string;
   maxTokensPerModule?: number;
   concurrency?: number;
+  language?: string;
 }
 
 export interface WikiMeta {
@@ -97,6 +98,7 @@ export class WikiGenerator {
   private llmConfig: LLMConfig;
   private maxTokensPerModule: number;
   private concurrency: number;
+  private language?: string;
   private options: WikiOptions;
   private onProgress: ProgressCallback;
   private failedModules: string[] = [];
@@ -116,6 +118,7 @@ export class WikiGenerator {
     this.options = options;
     this.llmConfig = llmConfig;
     this.maxTokensPerModule = options.maxTokensPerModule ?? DEFAULT_MAX_TOKENS_PER_MODULE;
+    this.language = options.language;
     this.concurrency = options.concurrency ?? 3;
     const progressFn = onProgress || (() => {});
     this.onProgress = (phase, percent, detail) => {
@@ -488,7 +491,7 @@ export class WikiGenerator {
     });
 
     const response = await callLLM(
-      prompt, this.llmConfig, MODULE_SYSTEM_PROMPT,
+      prompt, this.llmConfig, this.withLanguage(MODULE_SYSTEM_PROMPT),
       this.streamOpts(node.name),
     );
 
@@ -531,7 +534,7 @@ export class WikiGenerator {
     });
 
     const response = await callLLM(
-      prompt, this.llmConfig, PARENT_SYSTEM_PROMPT,
+      prompt, this.llmConfig, this.withLanguage(PARENT_SYSTEM_PROMPT),
       this.streamOpts(node.name),
     );
 
@@ -578,7 +581,7 @@ export class WikiGenerator {
     });
 
     const response = await callLLM(
-      prompt, this.llmConfig, OVERVIEW_SYSTEM_PROMPT,
+      prompt, this.llmConfig, this.withLanguage(OVERVIEW_SYSTEM_PROMPT),
       this.streamOpts('Generating overview', 88),
     );
 
@@ -907,6 +910,14 @@ export class WikiGenerator {
       }
     }
     return null;
+  }
+
+  /**
+   * Append a language instruction to the system prompt when --language is set.
+   */
+  private withLanguage(systemPrompt: string): string {
+    if (!this.language) return systemPrompt;
+    return `${systemPrompt}\n\nIMPORTANT: Write ALL documentation output in ${this.language}. Use ${this.language} for headings, descriptions, and explanations. Keep code identifiers, file paths, and Mermaid node labels in their original form.`;
   }
 
   private slugify(name: string): string {


### PR DESCRIPTION
## Summary

Closes #95

Adds a `--language <lang>` flag to the wiki command so users can generate documentation in their preferred language.

```bash
gitnexus wiki --language zh-CN    # Chinese
gitnexus wiki --language ja       # Japanese
gitnexus wiki --language ko       # Korean
```

## How it works

When `--language` is set, a language instruction is appended to the LLM system prompts for module pages, parent pages, and the overview page. The grouping step is unaffected since it must output structured JSON.

Code identifiers, file paths, and Mermaid diagram labels stay in their original form — only the prose (headings, descriptions, explanations) is written in the target language.

## Changes

- `cli/index.ts` — register `--language <lang>` CLI option
- `cli/wiki.ts` — pass `language` through `WikiCommandOptions` → `WikiOptions`
- `core/wiki/generator.ts` — `withLanguage()` helper appends language instruction to system prompts; applied to leaf, parent, and overview generation
- `README.md` — document the new flag

## Test plan

- [ ] `gitnexus wiki --help` shows the new `--language` option
- [ ] `gitnexus wiki` without `--language` works as before (no change to prompts)
- [ ] `gitnexus wiki --language zh-CN` generates Chinese documentation with original code identifiers preserved