### PR TITLE
fix(hooks): pass augment pattern after end-of-options marker

### DIFF
--- a/gitnexus-cursor-integration/hooks/augment-shell.sh
+++ b/gitnexus-cursor-integration/hooks/augment-shell.sh
@@ -37,7 +37,7 @@ if [ -z "$PATTERN" ] || [ ${#PATTERN} -lt 3 ]; then
 fi
 
 # Run gitnexus augment
-RESULT=$(npx -y gitnexus augment "$PATTERN" 2>/dev/null)
+RESULT=$(npx -y gitnexus augment -- "$PATTERN" 2>/dev/null)
 
 if [ -n "$RESULT" ]; then
   # Escape for JSON

--- a/gitnexus/hooks/claude/pre-tool-use.sh
+++ b/gitnexus/hooks/claude/pre-tool-use.sh
@@ -64,7 +64,7 @@ fi
 
 # Run gitnexus augment — must be fast (<500ms target)
 # augment writes to stderr (KuzuDB captures stdout at OS level), so capture stderr and discard stdout
-RESULT=$(cd "$CWD" && npx -y gitnexus augment "$PATTERN" 2>&1 1>/dev/null)
+RESULT=$(cd "$CWD" && npx -y gitnexus augment -- "$PATTERN" 2>&1 1>/dev/null)
 
 if [ -n "$RESULT" ]; then
   ESCAPED=$(echo "$RESULT" | jq -Rs .)


### PR DESCRIPTION
### Summary
This PR fixes a hook regression where search patterns starting with `--` (for example `--cheap|cheap mode`) were interpreted as CLI flags when invoking `gitnexus augment`.

### Root Cause
Hook scripts passed the extracted pattern directly as the next CLI argument:
- `gitnexus augment "$PATTERN"`

Because the CLI uses Commander, patterns beginning with `--` were parsed as options instead of positional input.

### What Changed
Added the end-of-options separator (`--`) before the pattern in all active hook call paths:

1. `gitnexus/hooks/claude/gitnexus-hook.cjs`
- direct CLI path: `[cliPath, 'augment', '--', pattern]`
- npx fallback path: `['-y', 'gitnexus', 'augment', '--', pattern]`

2. `gitnexus-claude-plugin/hooks/gitnexus-hook.js`
- direct binary path: `['augment', '--', pattern]`
- npx fallback path: `['-y', 'gitnexus', 'augment', '--', pattern]`

3. `gitnexus/hooks/claude/pre-tool-use.sh`
- `npx -y gitnexus augment -- "$PATTERN"`

4. `gitnexus-cursor-integration/hooks/augment-shell.sh`
- `npx -y gitnexus augment -- "$PATTERN"`

### Why This Is Safe
- Behavior is unchanged for normal patterns.
- Only argument parsing is disambiguated for edge cases where the pattern begins with `-` or `--`.
- `--` is standard POSIX/CLI end-of-options handling.

### Validation Performed
#### Reproduction checks
- Before fix: `gitnexus augment '--cheap'` -> `error: unknown option '--cheap'`
- Control: `gitnexus augment -- '--cheap'` -> success (exit `0`)

#### Hook-level checks
- Simulated Claude/Cursor hook invocations with `pattern="--cheap"`
- Confirmed hooks no longer surface the `unknown option` error after applying `--`

#### Static/syntax checks
- `node --check gitnexus/hooks/claude/gitnexus-hook.cjs`
- `node --check gitnexus-claude-plugin/hooks/gitnexus-hook.js`
- `bash -n gitnexus/hooks/claude/pre-tool-use.sh`
- `bash -n gitnexus-cursor-integration/hooks/augment-shell.sh`

#### GitNexus impact/change analysis
- `impact` run for edited targets: `LOW` risk
- `detect_changes(scope: staged)` summary:
  - `changed_files: 4`
  - `risk_level: low`
  - `affected_processes: []`

### Tests
- Full project CI test suites were **not** run locally in this session (`tsc`, unit, integration).
- Validation was focused on direct bug reproduction and hook invocation paths.