### PR TITLE
refactor(skills): unify installation in setup, auto-discover from disk

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,17 +1,17 @@
 {
-  "name": "gitnexus-marketplace",
+  "name": "gitnexus",
   "owner": {
     "name": "GitNexus",
     "email": "nico@gitnexus.dev"
   },
   "metadata": {
     "description": "Code intelligence powered by a knowledge graph — execution flows, blast radius, and semantic search",
-    "homepage": "https://github.com/nicosxt/gitnexus"
+    "homepage": "https://github.com/abhigyanpatwari/GitNexus"
   },
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.3.3",
+      "version": "1.3.6",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/README.md
+++ b/README.md
@@ -104,11 +104,13 @@ npx gitnexus analyze
 
 That's it. This indexes the codebase, installs agent skills, registers Claude Code hooks, and creates `AGENTS.md` / `CLAUDE.md` context files — all in one command.
 
-To configure MCP for your editor, run `npx gitnexus setup` once — or set it up manually below.
+To configure MCP, install agent skills, and register hooks for your editor, run `npx gitnexus setup` once — or set it up manually below.
+
+> **Claude Code plugin users:** If you installed GitNexus as a [Claude Code plugin](https://docs.anthropic.com/en/docs/claude-code/plugins), you can skip `gitnexus setup` entirely — the plugin bundles MCP, skills, and hooks automatically. Just run `gitnexus analyze` to index your repos.
 
 ### MCP Setup
 
-`gitnexus setup` auto-detects your editors and writes the correct global MCP config. You only need to run it once.
+`gitnexus setup` auto-detects your editors and writes the correct global MCP config, installs agent skills, and registers hooks. You only need to run it once.
 
 ### Editor Support
 

--- a/gitnexus/src/cli/ai-context.ts
+++ b/gitnexus/src/cli/ai-context.ts
@@ -8,12 +8,7 @@
 
 import fs from 'fs/promises';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import { type GeneratedSkillInfo } from './skill-gen.js';
-
-// ESM equivalent of __dirname
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 interface RepoStats {
   files?: number;
@@ -213,88 +208,6 @@ async function upsertGitNexusSection(
 }
 
 /**
- * Install GitNexus skills to .claude/skills/gitnexus/
- * Works natively with Claude Code, Cursor, and GitHub Copilot
- */
-async function installSkills(repoPath: string): Promise<string[]> {
-  const skillsDir = path.join(repoPath, '.claude', 'skills', 'gitnexus');
-  const installedSkills: string[] = [];
-
-  // Skill definitions bundled with the package
-  const skills = [
-    {
-      name: 'gitnexus-exploring',
-      description:
-        'Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of the codebase. Examples: "How does X work?", "What calls this function?", "Show me the auth flow"',
-    },
-    {
-      name: 'gitnexus-debugging',
-      description:
-        'Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: "Why is X failing?", "Where does this error come from?", "Trace this bug"',
-    },
-    {
-      name: 'gitnexus-impact-analysis',
-      description:
-        'Use when the user wants to know what will break if they change something, or needs safety analysis before editing code. Examples: "Is it safe to change X?", "What depends on this?", "What will break?"',
-    },
-    {
-      name: 'gitnexus-refactoring',
-      description:
-        'Use when the user wants to rename, extract, split, move, or restructure code safely. Examples: "Rename this function", "Extract this into a module", "Refactor this class", "Move this to a separate file"',
-    },
-    {
-      name: 'gitnexus-guide',
-      description:
-        'Use when the user asks about GitNexus itself — available tools, how to query the knowledge graph, MCP resources, graph schema, or workflow reference. Examples: "What GitNexus tools are available?", "How do I use GitNexus?"',
-    },
-    {
-      name: 'gitnexus-cli',
-      description:
-        'Use when the user needs to run GitNexus CLI commands like analyze/index a repo, check status, clean the index, generate a wiki, or list indexed repos. Examples: "Index this repo", "Reanalyze the codebase", "Generate a wiki"',
-    },
-  ];
-
-  for (const skill of skills) {
-    const skillDir = path.join(skillsDir, skill.name);
-    const skillPath = path.join(skillDir, 'SKILL.md');
-
-    try {
-      // Create skill directory
-      await fs.mkdir(skillDir, { recursive: true });
-
-      // Try to read from package skills directory
-      const packageSkillPath = path.join(__dirname, '..', '..', 'skills', `${skill.name}.md`);
-      let skillContent: string;
-
-      try {
-        skillContent = await fs.readFile(packageSkillPath, 'utf-8');
-      } catch {
-        // Fallback: generate minimal skill content
-        skillContent = `---
-name: ${skill.name}
-description: ${skill.description}
----
-
-# ${skill.name.charAt(0).toUpperCase() + skill.name.slice(1)}
-
-${skill.description}
-
-Use GitNexus tools to accomplish this task.
-`;
-      }
-
-      await fs.writeFile(skillPath, skillContent, 'utf-8');
-      installedSkills.push(skill.name);
-    } catch (err) {
-      // Skip on error, don't fail the whole process
-      console.warn(`Warning: Could not install skill ${skill.name}:`, err);
-    }
-  }
-
-  return installedSkills;
-}
-
-/**
  * Generate AI context files after indexing
  */
 export async function generateAIContextFiles(
@@ -321,12 +234,6 @@ export async function generateAIContextFiles(
   } else {
     createdFiles.push('AGENTS.md (skipped via --skip-agents-md)');
     createdFiles.push('CLAUDE.md (skipped via --skip-agents-md)');
-  }
-
-  // Install skills to .claude/skills/gitnexus/
-  const installedSkills = await installSkills(repoPath);
-  if (installedSkills.length > 0) {
-    createdFiles.push(`.claude/skills/gitnexus/ (${installedSkills.length} skills)`);
   }
 
   return { files: createdFiles };

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -40,6 +40,26 @@ function ensureHeap(): boolean {
   return true;
 }
 
+/**
+ * Check for stale project-local skills left by a previous `analyze` run.
+ * Prints a deprecation notice but does NOT delete — cleanup is handled by `setup`.
+ */
+export async function checkStaleProjectSkills(repoPath: string): Promise<boolean> {
+  const skillsDir = path.join(repoPath, '.claude', 'skills', 'gitnexus');
+  try {
+    const stat = await fs.stat(skillsDir);
+    if (stat.isDirectory()) {
+      console.log(
+        `  Note: Skills are no longer installed by analyze. Run 'gitnexus setup' to manage skills globally.`,
+      );
+      return true;
+    }
+  } catch {
+    // Directory doesn't exist — nothing to warn about
+  }
+  return false;
+}
+
 export interface AnalyzeOptions {
   force?: boolean;
   embeddings?: boolean;
@@ -193,6 +213,8 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
       console.warn = origWarn;
       console.error = origError;
       bar.stop();
+      // Keep migration notice visible even on no-op analyze runs
+      await checkStaleProjectSkills(repoPath);
       console.log('  Already up to date\n');
       // Safe to return without process.exit(0) — the early-return path in
       // runFullAnalysis never opens LadybugDB, so no native handles prevent exit.
@@ -268,10 +290,15 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
     );
     console.log(`  ${repoPath}`);
 
+    // Warn if stale project-local skills exist from a previous analyze run
+    await checkStaleProjectSkills(repoPath);
+
     try {
       await fs.access(getGlobalRegistryPath());
     } catch {
-      console.log('\n  Tip: Run `gitnexus setup` to configure MCP for your editor.');
+      console.log(
+        '\n  Tip: Run `gitnexus setup` to configure MCP and install agent skills for your editor.',
+      );
     }
 
     console.log('');

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -438,6 +438,56 @@ async function installCodexSkills(result: SetupResult): Promise<void> {
   }
 }
 
+// ─── Project-local skill cleanup ───────────────────────────────────
+
+/**
+ * Find the nearest git repository root by walking upward and checking for
+ * a .git marker (directory for standard repos, file for worktrees/submodules).
+ */
+async function findRepoRoot(startPath: string): Promise<string | null> {
+  let current = path.resolve(startPath);
+  const root = path.parse(current).root;
+
+  while (true) {
+    const gitMarker = path.join(current, '.git');
+    try {
+      const stat = await fs.stat(gitMarker);
+      if (stat.isDirectory() || stat.isFile()) {
+        return current;
+      }
+    } catch {
+      // Keep walking up
+    }
+
+    if (current === root) return null;
+    current = path.dirname(current);
+  }
+}
+
+/**
+ * Remove stale project-local skills left by previous `analyze` runs.
+ * Cleans up at repo root and supports both .git directories and files.
+ */
+async function cleanupProjectLocalSkills(result: SetupResult): Promise<void> {
+  const repoRoot = await findRepoRoot(process.cwd());
+  if (!repoRoot) return; // Not inside a git repo
+
+  const localSkillsDir = path.join(repoRoot, '.claude', 'skills', 'gitnexus');
+  try {
+    const stat = await fs.stat(localSkillsDir);
+    if (!stat.isDirectory()) return;
+  } catch {
+    return; // No project-local skills
+  }
+
+  try {
+    await fs.rm(localSkillsDir, { recursive: true, force: true });
+    result.configured.push('Removed project-local skills (now installed globally)');
+  } catch (err: any) {
+    result.errors.push(`Project-local skill cleanup: ${err.message}`);
+  }
+}
+
 // ─── Main command ──────────────────────────────────────────────────
 
 export const setupCommand = async () => {
@@ -468,6 +518,9 @@ export const setupCommand = async () => {
   await installCursorSkills(result);
   await installOpenCodeSkills(result);
   await installCodexSkills(result);
+
+  // Clean up stale project-local skills left by previous `analyze` runs
+  await cleanupProjectLocalSkills(result);
 
   // Print results
   if (result.configured.length > 0) {

--- a/gitnexus/test/unit/ai-context.test.ts
+++ b/gitnexus/test/unit/ai-context.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
@@ -8,13 +8,13 @@ describe('generateAIContextFiles', () => {
   let tmpDir: string;
   let storagePath: string;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-ai-ctx-test-'));
     storagePath = path.join(tmpDir, '.gitnexus');
     await fs.mkdir(storagePath, { recursive: true });
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     try {
       await fs.rm(tmpDir, { recursive: true, force: true });
     } catch {
@@ -66,18 +66,51 @@ describe('generateAIContextFiles', () => {
     expect(starts).toBe(1);
   });
 
-  it('installs skills files', async () => {
+  it('does NOT install skills after refactor', async () => {
+    const stats = { nodes: 10 };
+    await generateAIContextFiles(tmpDir, storagePath, 'TestProject', stats);
+
+    const skillsDir = path.join(tmpDir, '.claude', 'skills', 'gitnexus');
+    await expect(fs.stat(skillsDir)).rejects.toThrow();
+  });
+
+  it('return value does not mention skills after refactor', async () => {
     const stats = { nodes: 10 };
     const result = await generateAIContextFiles(tmpDir, storagePath, 'TestProject', stats);
+    const skillFiles = result.files.filter((f) => f.includes('skills'));
+    expect(skillFiles).toHaveLength(0);
+  });
 
-    // Should have installed skill files
-    const skillsDir = path.join(tmpDir, '.claude', 'skills', 'gitnexus');
-    try {
-      const entries = await fs.readdir(skillsDir, { recursive: true });
-      expect(entries.length).toBeGreaterThan(0);
-    } catch {
-      // Skills dir may not be created if skills source doesn't exist in test context
-    }
+  it('preserves existing CLAUDE.md content', async () => {
+    const claudePath = path.join(tmpDir, 'CLAUDE.md');
+    await fs.writeFile(claudePath, '# My Custom Instructions\n\nDo not remove this.\n', 'utf-8');
+
+    const stats = { nodes: 10 };
+    await generateAIContextFiles(tmpDir, storagePath, 'TestProject', stats);
+
+    const content = await fs.readFile(claudePath, 'utf-8');
+    expect(content).toContain('My Custom Instructions');
+    expect(content).toContain('Do not remove this.');
+    expect(content).toContain('gitnexus:start');
+  });
+
+  it('existing CLAUDE.md with gitnexus section but no skills dir works', async () => {
+    const claudePath = path.join(tmpDir, 'CLAUDE.md');
+    await fs.writeFile(
+      claudePath,
+      '<!-- gitnexus:start -->\nold content\n<!-- gitnexus:end -->\n',
+      'utf-8',
+    );
+
+    const stats = { nodes: 99 };
+    await generateAIContextFiles(tmpDir, storagePath, 'UpdatedProject', stats);
+
+    const content = await fs.readFile(claudePath, 'utf-8');
+    expect(content).not.toContain('old content');
+    expect(content).toContain('99 symbols');
+    const starts = (content.match(/gitnexus:start/g) || []).length;
+    expect(starts).toBe(1);
+    await expect(fs.stat(path.join(tmpDir, '.claude', 'skills', 'gitnexus'))).rejects.toThrow();
   });
 
   it('preserves manual AGENTS.md and CLAUDE.md edits when skipAgentsMd is enabled', async () => {

--- a/gitnexus/test/unit/analyze-skills-notice.test.ts
+++ b/gitnexus/test/unit/analyze-skills-notice.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+/**
+ * Contract tests for analyze stale-skills notice.
+ * These verify that analyze exports and uses checkStaleProjectSkills().
+ */
+
+async function getCheckStaleProjectSkills(): Promise<(repoPath: string) => Promise<boolean>> {
+  const analyzeModule = await import('../../src/cli/analyze.js');
+  const candidate = (analyzeModule as any).checkStaleProjectSkills;
+  expect(
+    typeof candidate,
+    'analyze.ts must export checkStaleProjectSkills(repoPath) for unit testing',
+  ).toBe('function');
+  return candidate as (repoPath: string) => Promise<boolean>;
+}
+
+describe('analyze — stale project-local skills notice', () => {
+  let tmpDir: string;
+  let consoleOutput: string[];
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-analyze-notice-test-'));
+    consoleOutput = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: any[]) => {
+      consoleOutput.push(args.map(String).join(' '));
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    try {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  it('prints deprecation notice when .claude/skills/gitnexus/ exists', async () => {
+    const skillSubDir = path.join(tmpDir, '.claude', 'skills', 'gitnexus', 'gitnexus-exploring');
+    await fs.mkdir(skillSubDir, { recursive: true });
+    await fs.writeFile(path.join(skillSubDir, 'SKILL.md'), 'stale');
+
+    const checkStaleProjectSkills = await getCheckStaleProjectSkills();
+    const detected = await checkStaleProjectSkills(tmpDir);
+
+    expect(detected).toBe(true);
+    const notice = consoleOutput.find((line) => line.includes('no longer installed by analyze'));
+    expect(notice).toBeDefined();
+  });
+
+  it('prints no notice when .claude/skills/gitnexus/ does not exist', async () => {
+    const checkStaleProjectSkills = await getCheckStaleProjectSkills();
+    const detected = await checkStaleProjectSkills(tmpDir);
+
+    expect(detected).toBe(false);
+    const notice = consoleOutput.find((line) => line.includes('no longer installed by analyze'));
+    expect(notice).toBeUndefined();
+  });
+
+  it('does NOT delete the directory — only warns', async () => {
+    const skillsDir = path.join(tmpDir, '.claude', 'skills', 'gitnexus');
+    await fs.mkdir(skillsDir, { recursive: true });
+
+    const checkStaleProjectSkills = await getCheckStaleProjectSkills();
+    await checkStaleProjectSkills(tmpDir);
+
+    // Directory must still exist
+    const stat = await fs.stat(skillsDir);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it('handles .claude dir existing without skills/gitnexus/', async () => {
+    await fs.mkdir(path.join(tmpDir, '.claude'), { recursive: true });
+
+    const checkStaleProjectSkills = await getCheckStaleProjectSkills();
+    const detected = await checkStaleProjectSkills(tmpDir);
+    expect(detected).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

### Summary

- Removes skill installation from `analyze` (was a side effect of indexing)
- Makes `setup` the single owner of skill installation (global only)
- Auto-discovers skill names from the `skills/` directory instead of hardcoding them
- Adds migration handling for users with stale project-local skills

### Problem

When users run both `gitnexus setup` and `gitnexus analyze`, the same skills get installed to two locations:

| Location | Installed by |
|----------|-------------|
| `~/.claude/skills/gitnexus-exploring/SKILL.md` | `setup` (global) |
| `<repo>/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` | `analyze` (project-local) |

This triggers [Claude Code bug #25209](https://github.com/anthropics/claude-code/issues/25209) — both copies appear in the skill list instead of one shadowing the other. Users see every GitNexus skill listed twice.

Beyond the duplication bug, skills are static markdown files that don't depend on the repository index. Installing them on every `analyze` run is unnecessary work in the wrong place. There were also two separate implementations of the same install logic.

### Solution

**Single owner:** `setup` installs skills globally to `~/.claude/skills/`, `~/.cursor/skills/`, and `~/.config/opencode/skill/`. `analyze` no longer touches skills.

**Migration:** `analyze` prints a deprecation notice if stale project-local skills exist. `setup` cleans them up after installing globally.

**Auto-discovery:** Skill names are discovered from the `skills/` source directory at install time instead of being hardcoded. This automatically picks up `gitnexus-pr-review` (previously missing) and prevents future breakage when skills are added or renamed.

### Changes

| File | What changed |
|------|-------------|
| `gitnexus/src/cli/ai-context.ts` | Removed `installSkills()` function and its call; cleaned up unused imports |
| `gitnexus/src/cli/analyze.ts` | Added `checkStaleProjectSkills()` deprecation notice; updated setup tip to mention skills |
| `gitnexus/src/cli/setup.ts` | Added `discoverSkillNames()` replacing hardcoded list; added `cleanupProjectLocalSkills()` with worktree/submodule support |
| `gitnexus/test/unit/ai-context.test.ts` | Acceptance tests: `analyze` no longer installs skills; regression guards for dynamic context generation |
| `gitnexus/test/unit/setup-skills.test.ts` | `installSkillsTo` tests, `setupCommand` cleanup tests, `discoverSkillNames` discovery tests |
| `gitnexus/test/unit/analyze-skills-notice.test.ts` | Contract tests for `checkStaleProjectSkills` export and behavior |
| `README.md` | Fixed skill count (4 -> 7), corrected command responsibility descriptions |

### Design decisions

1. **Why not keep both locations?** Adds complexity to work around a bug that shouldn't exist in our code. Skills are static config — one canonical location is cleaner.

2. **Why doesn't `analyze` delete stale skills?** After the refactor, `analyze` no longer owns skills. Deleting them would cross the responsibility boundary. It warns; `setup` cleans up.

3. **Why auto-discover instead of hardcode?** The hardcoded `SKILL_NAMES` list was the root cause of `gitnexus-pr-review` being silently excluded. Discovery from disk means adding a new skill is just dropping a file — no code change required.

4. **Worktree/submodule support:** `cleanupProjectLocalSkills` walks upward to find the repo root, handling `.git` as either a directory (standard) or a file (worktrees/submodules).

### Test plan

- [x] `analyze` no longer creates `.claude/skills/gitnexus/` (acceptance tests 1-2)
- [x] `analyze` prints deprecation notice when stale skills exist (15-17)
- [x] `analyze` shows notice even on "Already up to date" early return
- [x] `setup` installs all 7 discovered skills with non-empty SKILL.md (7-9)
- [x] `setup` removes project-local skills in git repos (11-12)
- [x] `setup` handles nested dirs, worktrees, non-git dirs, empty dirs (13-14, nested/worktree tests)
- [x] `discoverSkillNames` discovers flat files, directories, mixed layouts (27-33)
- [x] `discoverSkillNames` filters to `gitnexus-*` prefix only (28)
- [x] `discoverSkillNames` ignores directories without SKILL.md (33)
- [x] `discoverSkillNames` documents collision behavior for same-name flat+directory entries (34)
- [x] `discoverSkillNames` propagates errors: missing root (`ENOENT`), permission failure (`EACCES`) (35-36)
- [x] `SKILL_NAMES` lazy-population contract: starts empty, populated after first install (37)
- [x] All existing tests unaffected — **874/874 passing**