### PR TITLE
fix: escape backticks in html-viewer.ts to prevent script syntax error in wiki index.html

### DIFF
--- a/gitnexus/src/core/wiki/html-viewer.ts
+++ b/gitnexus/src/core/wiki/html-viewer.ts
@@ -67,9 +67,9 @@ function buildHTML(
   meta: Record<string, unknown> | null,
 ): string {
   // Embed data as JSON inside the HTML
-  const pagesJSON = JSON.stringify(pages);
-  const treeJSON = JSON.stringify(moduleTree);
-  const metaJSON = JSON.stringify(meta);
+  const pagesJSON = JSON.stringify(pages).replace(/`/g, '\\`');
+  const treeJSON = JSON.stringify(moduleTree).replace(/`/g, '\\`');
+  const metaJSON = meta ? JSON.stringify(meta).replace(/`/g, '\\`') : 'null';
 
   const parts: string[] = [];
 


### PR DESCRIPTION
JSON.stringify() does not escape backticks, which breaks JavaScript parsing when the output is embedded in a <script> tag. Added backtick escaping at lines 70-72 in html-viewer.ts.