### PR TITLE
fix(walker): skip non-regular paths during repository scan

### DIFF
--- a/gitnexus/src/core/ingestion/filesystem-walker.ts
+++ b/gitnexus/src/core/ingestion/filesystem-walker.ts
@@ -42,6 +42,7 @@ export const walkRepositoryPaths = async (
   const entries: ScannedFile[] = [];
   let processed = 0;
   let skippedLarge = 0;
+  let skippedNonRegular = 0;
 
   for (let start = 0; start < filtered.length; start += READ_CONCURRENCY) {
     const batch = filtered.slice(start, start + READ_CONCURRENCY);
@@ -49,6 +50,10 @@ export const walkRepositoryPaths = async (
       batch.map(async relativePath => {
         const fullPath = path.join(repoPath, relativePath);
         const stat = await fs.stat(fullPath);
+        if (!stat.isFile()) {
+          skippedNonRegular++;
+          return null;
+        }
         if (stat.size > MAX_FILE_SIZE) {
           skippedLarge++;
           return null;
@@ -70,6 +75,9 @@ export const walkRepositoryPaths = async (
 
   if (skippedLarge > 0) {
     console.warn(`  Skipped ${skippedLarge} large files (>${MAX_FILE_SIZE / 1024}KB, likely generated/vendored)`);
+  }
+  if (skippedNonRegular > 0) {
+    console.warn(`  Skipped ${skippedNonRegular} non-regular paths (pipes/sockets/devices)`);
   }
 
   return entries;

--- a/gitnexus/test/integration/filesystem-walker.test.ts
+++ b/gitnexus/test/integration/filesystem-walker.test.ts
@@ -65,6 +65,30 @@ describe('filesystem-walker', () => {
       }
     });
 
+    it('skips non-regular paths reported by stat', async () => {
+      const originalStat = fs.stat.bind(fs);
+      const statSpy = vi.spyOn(fs, 'stat');
+
+      statSpy.mockImplementation(async (targetPath: any) => {
+        const normalized = String(targetPath).replace(/\\/g, '/');
+        if (normalized.endsWith('/src/index.ts')) {
+          return {
+            isFile: () => false,
+            size: 0,
+          } as any;
+        }
+        return originalStat(targetPath);
+      });
+
+      try {
+        const files = await walkRepositoryPaths(tmpDir);
+        const paths = files.map(f => f.path.replace(/\\/g, '/'));
+        expect(paths.some(p => p.endsWith('src/index.ts'))).toBe(false);
+      } finally {
+        statSpy.mockRestore();
+      }
+    });
+
     it('calls progress callback', async () => {
       const onProgress = vi.fn();
       await walkRepositoryPaths(tmpDir, onProgress);


### PR DESCRIPTION
# Summary
This PR fixes gitnexus analyze hanging when the repository contains non-regular filesystem entries (for example, FIFO pipes created by tests).

The scanner now skips non-regular paths during repository walk, so these entries never enter the ingestion pipeline and cannot block file reads later.

# Root Cause
walkRepositoryPaths was including paths returned by glob without checking file type.
If a path was a FIFO/socket/device, downstream read operations could block and make analyze appear stuck (commonly around the CSV streaming phase).

# Changes
Update repository scanner to ignore non-regular paths:
check stat.isFile() before accepting a scanned entry
skip and count non-regular entries
Add a warning summary when non-regular paths are skipped:
Skipped X non-regular paths (pipes/sockets/devices)
Add integration coverage for this behavior:
simulate a stat result where a discovered path is non-regular
verify the path is excluded from scan results

# Why this is safe
Only affects path filtering in scan phase.
No schema/query/graph semantics changed.
Existing behavior for regular files is unchanged.

# Validation
npx vitest run test/integration/filesystem-walker.test.ts
npm run build
detect_changes(scope=staged, repo=GitNexus) reports low risk and only expected files/symbols.