### PR TITLE
feat: cross-lingual query support (smart mode)

### DIFF
--- a/gitnexus/src/core/search/cross-lingual.ts
+++ b/gitnexus/src/core/search/cross-lingual.ts
@@ -1,0 +1,110 @@
+/**
+ * Cross-Lingual Query Translation
+ *
+ * Detects non-English queries and translates them to English code keywords
+ * using an LLM (OpenAI-compatible API: OpenRouter, Ollama, etc.)
+ *
+ * Opt-in via `smart: true` parameter on the query tool.
+ * Reuses the existing LLM client from wiki generation.
+ *
+ * Addresses: https://github.com/abhigyanpatwari/GitNexus/issues/160
+ */
+
+import { resolveLLMConfig, callLLM, type LLMConfig } from '../wiki/llm-client.js';
+
+/** Simple cache to avoid repeated LLM calls for the same query */
+const translationCache = new Map<string, string>();
+const CACHE_MAX_SIZE = 200;
+
+/**
+ * Detect if a query is primarily non-ASCII (likely non-English).
+ * Returns true if >30% of non-whitespace characters are non-ASCII.
+ */
+export function isNonEnglishQuery(query: string): boolean {
+  const chars = query.replace(/\s/g, '');
+  if (chars.length === 0) return false;
+  const nonAscii = chars.replace(/[\x00-\x7F]/g, '').length;
+  return nonAscii / chars.length > 0.3;
+}
+
+/**
+ * Translate a non-English query to English code keywords.
+ * Uses the same LLM config as wiki generation (env vars, ~/.gitnexus/config.json).
+ *
+ * @param query - The original non-English query
+ * @param configOverrides - Optional LLM config overrides
+ * @returns English keyword translation, or original query if translation fails
+ */
+export async function translateQuery(
+  query: string,
+  configOverrides?: Partial<LLMConfig>,
+): Promise<{ translated: string; original: string; wasTranslated: boolean }> {
+  // Check cache first
+  const cached = translationCache.get(query);
+  if (cached) {
+    return { translated: cached, original: query, wasTranslated: true };
+  }
+
+  try {
+    const config = await resolveLLMConfig({
+      maxTokens: 200,
+      temperature: 0,
+      ...configOverrides,
+    });
+
+    if (!config.apiKey) {
+      // No LLM configured — return original query
+      return { translated: query, original: query, wasTranslated: false };
+    }
+
+    const result = await callLLM(
+      query,
+      config,
+      `You are a code search query translator. The user gives you a query in any language about code/software concepts. Translate it into English code keywords that would match function names, class names, variable names, and file names in a codebase.
+
+Rules:
+- Output ONLY the English keywords, space-separated
+- Use common programming naming conventions (snake_case, camelCase fragments)
+- Include both full words and common abbreviations
+- Do NOT explain, do NOT add quotes or punctuation
+- Keep it concise: 3-8 keywords maximum
+
+Examples:
+- "收盘评分链可靠性改进" → "closing score pipeline reliability signal scorer"
+- "ユーザー認証フロー" → "user authentication auth flow login validate"
+- "데이터베이스 연결 풀링" → "database connection pool db connect"`,
+    );
+
+    const translated = result.content.trim();
+
+    // Cache the result
+    if (translationCache.size >= CACHE_MAX_SIZE) {
+      // Evict oldest entry
+      const firstKey = translationCache.keys().next().value;
+      if (firstKey) translationCache.delete(firstKey);
+    }
+    translationCache.set(query, translated);
+
+    return { translated, original: query, wasTranslated: true };
+  } catch {
+    // Translation failed — fall back to original query silently
+    return { translated: query, original: query, wasTranslated: false };
+  }
+}
+
+/**
+ * Process a query with optional cross-lingual translation.
+ * If smart=true and the query is non-English, translates first.
+ * Returns both the search query to use and metadata about translation.
+ */
+export async function processSmartQuery(
+  query: string,
+  smart: boolean,
+  configOverrides?: Partial<LLMConfig>,
+): Promise<{ searchQuery: string; original: string; wasTranslated: boolean }> {
+  if (!smart || !isNonEnglishQuery(query)) {
+    return { searchQuery: query, original: query, wasTranslated: false };
+  }
+  const result = await translateQuery(query, configOverrides);
+  return { searchQuery: result.translated, original: result.original, wasTranslated: result.wasTranslated };
+}

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -338,17 +338,29 @@ export class LocalBackend {
     limit?: number;
     max_symbols?: number;
     include_content?: boolean;
+    smart?: boolean;
   }): Promise<any> {
     if (!params.query?.trim()) {
       return { error: 'query parameter is required and cannot be empty.' };
     }
-    
+
     await this.ensureInitialized(repo.id);
-    
+
     const processLimit = params.limit || 5;
     const maxSymbolsPerProcess = params.max_symbols || 10;
     const includeContent = params.include_content ?? false;
-    const searchQuery = params.query.trim();
+
+    // Cross-lingual support: translate non-English queries when smart=true
+    let searchQuery = params.query.trim();
+    let translationNote = '';
+    if (params.smart) {
+      const { processSmartQuery } = await import('../../core/search/cross-lingual.js');
+      const result = await processSmartQuery(searchQuery, true);
+      if (result.wasTranslated) {
+        translationNote = `Translated: "${result.original}" → "${result.searchQuery}"\n\n`;
+        searchQuery = result.searchQuery;
+      }
+    }
     
     // Step 1: Run hybrid search to get matching symbols
     const searchLimit = processLimit * maxSymbolsPerProcess; // fetch enough raw results
@@ -526,6 +538,7 @@ export class LocalBackend {
     });
     
     return {
+      ...(translationNote ? { translation: translationNote.trim() } : {}),
       processes,
       process_symbols: dedupedSymbols,
       definitions: definitions.slice(0, 20), // cap standalone definitions

--- a/gitnexus/src/mcp/tools.ts
+++ b/gitnexus/src/mcp/tools.ts
@@ -63,6 +63,7 @@ Hybrid ranking: BM25 keyword + semantic vector search, ranked by Reciprocal Rank
         max_symbols: { type: 'number', description: 'Max symbols per process (default: 10)', default: 10 },
         include_content: { type: 'boolean', description: 'Include full symbol source code (default: false)', default: false },
         repo: { type: 'string', description: 'Repository name or path. Omit if only one repo is indexed.' },
+        smart: { type: 'boolean', description: 'Enable cross-lingual search: auto-translates non-English queries (Chinese, Japanese, Korean, etc.) to English code keywords via LLM. Requires LLM API key configured. Default: false.', default: false },
       },
       required: ['query'],
     },


### PR DESCRIPTION
## Summary
- Adds `smart: true` parameter to the `query` tool for cross-lingual search
- Auto-detects non-English queries (Chinese, Japanese, Korean, etc.) and translates to English code keywords via LLM
- Reuses existing LLM client infrastructure (OpenRouter/Ollama/OpenAI-compatible)
- Opt-in only: `smart` defaults to false, zero breaking changes

## How it works
```
query({ query: "收盘评分链可靠性改进", smart: true })
  → detects non-ASCII input (>30% threshold)
  → LLM translates → "closing score pipeline reliability signal scorer"
  → runs normal hybrid search (BM25 + semantic)
  → returns results with translation metadata
```

## Files changed
- `gitnexus/src/core/search/cross-lingual.ts` — new module: detection, translation, LRU cache (200 entries)
- `gitnexus/src/mcp/local/local-backend.ts` — integrated smart translation into query method
- `gitnexus/src/mcp/tools.ts` — added `smart` parameter to query tool schema

Addresses #160

## Design decisions
- **Opt-in** (`smart: true`) — no LLM dependency for normal queries
- **Reuses wiki LLM config** — same env vars (`GITNEXUS_API_KEY`, `GITNEXUS_LLM_BASE_URL`, `GITNEXUS_MODEL`)
- **Graceful fallback** — if no API key or LLM fails, silently uses original query
- **Translation caching** — avoids repeated LLM calls for same query
- **Transparent** — response includes `translation` field showing what was translated

## Test plan
- [ ] `query({ query: "user auth", smart: true })` — English query passes through unchanged
- [ ] `query({ query: "用户认证流程", smart: true })` — Chinese query gets translated
- [ ] `query({ query: "用户认证流程" })` — without smart flag, no translation
- [ ] No API key configured — falls back to original query silently
- [ ] Repeated same query — uses cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)