### PR TITLE
fix: add --no-hooks and --no-skills flags to setup

### DIFF
--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -19,6 +19,8 @@ program
 program
   .command('setup')
   .description('One-time setup: configure MCP for Cursor, Claude Code, OpenCode')
+  .option('--no-hooks', 'Skip installing PreToolUse/PostToolUse hooks')
+  .option('--no-skills', 'Skip installing skills to editor config directories')
   .action(createLazyAction(() => import('./setup.js'), 'setupCommand'));
 
 program

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -343,7 +343,10 @@ async function installOpenCodeSkills(result: SetupResult): Promise<void> {
 
 // ─── Main command ──────────────────────────────────────────────────
 
-export const setupCommand = async () => {
+export const setupCommand = async (options?: { hooks?: boolean; skills?: boolean }) => {
+  const installHooks = options?.hooks !== false;
+  const installSkills = options?.skills !== false;
+
   console.log('');
   console.log('  GitNexus Setup');
   console.log('  ==============');
@@ -365,10 +368,22 @@ export const setupCommand = async () => {
   await setupOpenCode(result);
   
   // Install global skills for platforms that support them
-  await installClaudeCodeSkills(result);
-  await installClaudeCodeHooks(result);
-  await installCursorSkills(result);
-  await installOpenCodeSkills(result);
+  if (installSkills) {
+    await installClaudeCodeSkills(result);
+    await installCursorSkills(result);
+    await installOpenCodeSkills(result);
+  } else {
+    result.skipped.push('Skills (--no-skills)');
+  }
+
+  if (installHooks) {
+    console.log('  Installing hooks to ~/.claude/settings.json (PreToolUse, PostToolUse)');
+    console.log('  Use --no-hooks to skip this step.');
+    console.log('');
+    await installClaudeCodeHooks(result);
+  } else {
+    result.skipped.push('Hooks (--no-hooks)');
+  }
 
   // Print results
   if (result.configured.length > 0) {


### PR DESCRIPTION
## Summary
- Adds `--no-hooks` flag to skip PreToolUse/PostToolUse hook installation
- Adds `--no-skills` flag to skip skill directory installation
- Prints explicit console output when hooks are being written to `~/.claude/settings.json`
- Skipped components are reported in the setup results

Addresses #168

## Usage
```bash
# Full setup (existing behavior)
gitnexus setup

# Skip hooks (don't modify ~/.claude/settings.json hooks)
gitnexus setup --no-hooks

# Skip skills (don't write to ~/.claude/skills/, ~/.config/opencode/skill/, etc.)
gitnexus setup --no-skills

# MCP config only, no hooks or skills
gitnexus setup --no-hooks --no-skills
```

## Files changed
- `gitnexus/src/cli/index.ts` — added `--no-hooks` and `--no-skills` options to setup command
- `gitnexus/src/cli/setup.ts` — gated hook/skill installation behind flags, added transparency output

## Test plan
- [ ] `gitnexus setup` — default behavior unchanged
- [ ] `gitnexus setup --no-hooks` — hooks skipped, skills installed
- [ ] `gitnexus setup --no-skills` — skills skipped, hooks installed
- [ ] `gitnexus setup --no-hooks --no-skills` — only MCP config

🤖 Generated with [Claude Code](https://claude.com/claude-code)