### PR TITLE
fix: use OpenCode-compatible MCP config format

### DIFF
--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -230,7 +230,13 @@ async function setupOpenCode(result: SetupResult): Promise<void> {
     const existing = await readJsonFile(configPath);
     const config = existing || {};
     if (!config.mcp) config.mcp = {};
-    config.mcp.gitnexus = getMcpEntry();
+    // OpenCode expects { type: "local", command: ["cmd", "arg1", ...] } format
+    // which differs from the standard MCP { command, args } format (#219)
+    const entry = getMcpEntry();
+    config.mcp.gitnexus = {
+      type: 'local',
+      command: [entry.command, ...entry.args],
+    };
     await writeJsonFile(configPath, config);
     result.configured.push('OpenCode');
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- Fix `gitnexus setup` generating invalid OpenCode MCP config format
- OpenCode expects `{ type: "local", command: ["cmd", "arg1", ...] }` instead of `{ command, args }`
- The old format caused "Invalid input mcp.gitnexus" errors on startup

Fixes #219

## Test plan
- [ ] Run `gitnexus setup` with OpenCode installed, verify `~/.config/opencode/config.json` has correct format
- [ ] Verify OpenCode starts without MCP config errors
- [ ] Verify Cursor/Claude Code configs still use the standard format

🤖 Generated with [Claude Code](https://claude.com/claude-code)