### PR TITLE
fix: serve resolves repo from cwd instead of defaulting to first

### DIFF
--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -130,12 +130,22 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
   await backend.init();
   const cleanupMcp = mountMCPEndpoints(app, backend);
 
-  // Helper: resolve a repo by name from the global registry, or default to first
+  // Helper: resolve a repo by name from the global registry.
+  // When no repo is specified, prefer the repo matching cwd (#139).
   const resolveRepo = async (repoName?: string) => {
     const repos = await listRegisteredRepos();
     if (repos.length === 0) return null;
     if (repoName) return repos.find(r => r.name === repoName) || null;
-    return repos[0]; // default to first
+
+    // Match the repo whose path matches the current working directory
+    const cwd = path.resolve(process.cwd());
+    const cwdMatch = repos.find(r => path.resolve(r.path) === cwd);
+    if (cwdMatch) return cwdMatch;
+
+    // Fall back to first repo only if there's exactly one
+    if (repos.length === 1) return repos[0];
+
+    return null;
   };
 
   // List all registered repos


### PR DESCRIPTION
## Summary
- `gitnexus serve` now matches the current working directory against indexed repos
- Previously always returned data from the first repo in `registry.json`, regardless of cwd
- Falls back to first repo only when exactly one is indexed; returns 404 with guidance otherwise

Fixes #139

## Test plan
- [ ] Index two repos, run `gitnexus serve` in each — verify correct repo data returned
- [ ] Run `gitnexus serve` outside any indexed repo — verify 404 response
- [ ] Run with `?repo=name` param — verify explicit selection still works
- [ ] Single indexed repo — verify fallback still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)