### PR TITLE
fix: detect React component paths before lowercasing

### DIFF
--- a/gitnexus/src/core/ingestion/framework-detection.ts
+++ b/gitnexus/src/core/ingestion/framework-detection.ts
@@ -34,10 +34,12 @@ export interface FrameworkHint {
  */
 export function detectFrameworkFromPath(filePath: string): FrameworkHint | null {
   // Normalize path separators and ensure leading slash for consistent matching
-  let p = filePath.toLowerCase().replace(/\\/g, '/');
+  const originalPath = filePath.replace(/\\/g, '/');
+  let p = originalPath.toLowerCase();
   if (!p.startsWith('/')) {
     p = '/' + p; // Add leading slash so patterns like '/app/' match 'app/...'
   }
+  const originalPathWithLeadingSlash = originalPath.startsWith('/') ? originalPath : `/${originalPath}`;
 
   // ========== JAVASCRIPT / TYPESCRIPT FRAMEWORKS ==========
 
@@ -128,7 +130,7 @@ export function detectFrameworkFromPath(filePath: string): FrameworkHint | null 
     (p.endsWith('.tsx') || p.endsWith('.jsx'))
   ) {
     // Only boost if PascalCase filename (likely a component, not util)
-    const fileName = p.split('/').pop() || '';
+    const fileName = originalPathWithLeadingSlash.split('/').pop() || '';
     if (/^[A-Z]/.test(fileName)) {
       return { framework: 'react', entryPointMultiplier: 1.5, reason: 'react-component' };
     }

--- a/gitnexus/src/core/ingestion/framework-detection.ts
+++ b/gitnexus/src/core/ingestion/framework-detection.ts
@@ -39,7 +39,9 @@ export function detectFrameworkFromPath(filePath: string): FrameworkHint | null 
   if (!p.startsWith('/')) {
     p = '/' + p; // Add leading slash so patterns like '/app/' match 'app/...'
   }
-  const originalPathWithLeadingSlash = originalPath.startsWith('/') ? originalPath : `/${originalPath}`;
+  const originalPathWithLeadingSlash = originalPath.startsWith('/')
+    ? originalPath
+    : `/${originalPath}`;
 
   // ========== JAVASCRIPT / TYPESCRIPT FRAMEWORKS ==========
 

--- a/gitnexus/test/unit/framework-detection.test.ts
+++ b/gitnexus/test/unit/framework-detection.test.ts
@@ -90,12 +90,11 @@ describe('detectFrameworkFromPath', () => {
 
   describe('React', () => {
     it('has React component detection rule for views/components folders', () => {
-      // Note: The current implementation lowercases the path before checking
-      // PascalCase, so PascalCase detection currently can't match.
-      // This test documents the current behavior.
       const result = detectFrameworkFromPath('views/Button.tsx');
-      // Returns null because path is lowercased before PascalCase regex check
-      expect(result).toBeNull();
+      expect(result).not.toBeNull();
+      expect(result!.framework).toBe('react');
+      expect(result!.entryPointMultiplier).toBe(1.5);
+      expect(result!.reason).toBe('react-component');
     });
   });
 


### PR DESCRIPTION
## Summary

- preserve original filename casing in `detectFrameworkFromPath()` so PascalCase React component files under `views/` and `components/` can actually match the React heuristic
- update the existing unit test to assert the intended React framework hint instead of documenting the broken null result
- keep the patch isolated to framework detection, independent from the open docs PR `#255`

## Validation

- direct tsx verification confirmed `detectFrameworkFromPath('views/Button.tsx')` now returns `{ framework: 'react', entryPointMultiplier: 1.5, reason: 'react-component' }`
- `lsp_diagnostics` clean on `gitnexus/src/core/ingestion/framework-detection.ts`
- `lsp_diagnostics` clean on `gitnexus/test/unit/framework-detection.test.ts`

## Notes

- `npx vitest run test/unit/framework-detection.test.ts` is currently blocked by a pre-existing `kuzu` package resolution problem in the repo's `test/global-setup.ts`, so this PR uses direct module verification instead of the broken global test bootstrap
- `npx gitnexus impact detectFrameworkFromPath --direction upstream` was attempted, but the local GitNexus index was not usable in this checkout, so no blast-radius graph was returned