### PR TITLE
fix(embeddings): force CPU execution providers to avoid ONNX crash: Fixes #288

### DIFF
--- a/gitnexus/src/core/embeddings/embedder.ts
+++ b/gitnexus/src/core/embeddings/embedder.ts
@@ -144,15 +144,22 @@ export const initEmbedder = async (
             console.log('🔧 Using WASM backend (slower)...');
           }
 
+          // Build pipeline options - force CPU providers when using CPU device to avoid
+          // CUDA provider bridge crash (#288). When using GPU, let ONNX pick the provider.
+          const pipelineOptions: any = {
+            device: device,
+            dtype: 'fp32',
+            progress_callback: progressCallback,
+            session_options: { logSeverityLevel: 3 },
+          };
+          if (device === 'cpu' || device === 'wasm') {
+            pipelineOptions.executionProviders = ['cpu'];
+          }
+
           embedderInstance = await (pipeline as any)(
             'feature-extraction',
             finalConfig.modelId,
-            {
-              device: device,
-              dtype: 'fp32',
-              progress_callback: progressCallback,
-              session_options: { logSeverityLevel: 3 },
-            }
+            pipelineOptions
           );
           currentDevice = device;
 


### PR DESCRIPTION
**Problem**
The embeddings feature crashes on Node.js v20.x with the error:

Assertion failed: (!providers.empty() || !"No execution providers available")

This occurs in provider_bridge_ort.cc when ONNX Runtime tries to initialize execution providers, particularly in WASM environments or when CUDA is not available.

**Root Cause**
When using CPU/WASM device, the code was not explicitly specifying CPU as an execution provider, causing ONNX Runtime to fail when no providers were available.

**Solution**
Add executionProviders: ['cpu'] when initializing ONNX Runtime with CPU/WASM device. CUDA is still attempted first if available (via webgpu/cuda), with CPU as fallback.

**Changes**
- Modified gitnexus/src/core/embeddings/embedder.ts to explicitly include CPU execution provider
- The fix maintains CUDA priority when available but ensures graceful fallback to CPU
- 
**Testing**
- Verified the fix works on Node.js v20.x
- Embeddings now load successfully without crashing


```
- Add executionProviders: ['cpu'] when using CPU/WASM device
- This prevents provider_bridge_ort.cc crash on Node.js v20.x
- CUDA is still attempted first if available, falls back to CPU with fix
```

Fixes #288