### PR TITLE
fix(mcp): detect stale DB after re-indexing and reconnect

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -16,6 +16,7 @@ import { initLbug, executeQuery, executeParameterized, closeLbug, isLbugReady } 
 import {
   listRegisteredRepos,
   cleanupOldKuzuFiles,
+  loadMeta,
   type RegistryEntry,
 } from '../../storage/repo-manager.js';
 // AI context generation is CLI-only (gitnexus analyze)
@@ -82,6 +83,7 @@ interface RepoHandle {
   indexedAt: string;
   lastCommit: string;
   stats?: RegistryEntry['stats'];
+  loadedAt?: string;   // meta.indexedAt when DB was opened — for staleness detection
 }
 
 export class LocalBackend {
@@ -247,7 +249,24 @@ export class LocalBackend {
 
   private async ensureInitialized(repoId: string): Promise<void> {
     // Always check the actual pool — the idle timer may have evicted the connection
-    if (this.initializedRepos.has(repoId) && isLbugReady(repoId)) return;
+    if (this.initializedRepos.has(repoId) && isLbugReady(repoId)) {
+      // Staleness check: did `gitnexus analyze` rebuild the DB since we opened it?
+      const handle = this.repos.get(repoId);
+      if (handle?.loadedAt) {
+        const meta = await loadMeta(handle.storagePath);
+        if (meta?.indexedAt && meta.indexedAt !== handle.loadedAt) {
+          // DB was rebuilt — close stale connection and fall through to re-init
+          await closeLbug(repoId);
+          this.initializedRepos.delete(repoId);
+          this.contextCache.delete(repoId);
+          handle.loadedAt = undefined;
+        } else {
+          return; // Still fresh
+        }
+      } else {
+        return; // No loadedAt tracked yet (first run)
+      }
+    }
 
     const handle = this.repos.get(repoId);
     if (!handle) throw new Error(`Unknown repo: ${repoId}`);
@@ -255,6 +274,10 @@ export class LocalBackend {
     try {
       await initLbug(repoId, handle.lbugPath);
       this.initializedRepos.add(repoId);
+
+      // Record when we loaded so we can detect staleness later
+      const meta = await loadMeta(handle.storagePath);
+      handle.loadedAt = meta?.indexedAt;
     } catch (err: any) {
       // If lock error, mark as not initialized so next call retries
       this.initializedRepos.delete(repoId);

--- a/gitnexus/test/integration/augmentation.test.ts
+++ b/gitnexus/test/integration/augmentation.test.ts
@@ -54,6 +54,7 @@ const AUGMENT_FTS_INDEXES = [
 // Mock repo-manager so augment() finds our test DB
 vi.mock('../../src/storage/repo-manager.js', () => ({
   listRegisteredRepos: vi.fn(),
+  loadMeta: vi.fn().mockResolvedValue(null),
 }));
 
 let augment: (pattern: string, cwd?: string) => Promise<string>;

--- a/gitnexus/test/integration/local-backend-calltool.test.ts
+++ b/gitnexus/test/integration/local-backend-calltool.test.ts
@@ -14,6 +14,7 @@ import { LOCAL_BACKEND_SEED_DATA, LOCAL_BACKEND_FTS_INDEXES } from '../fixtures/
 vi.mock('../../src/storage/repo-manager.js', () => ({
   listRegisteredRepos: vi.fn().mockResolvedValue([]),
   cleanupOldKuzuFiles: vi.fn().mockResolvedValue({ found: false, needsReindex: false }),
+  loadMeta: vi.fn().mockResolvedValue(null),
 }));
 
 // ─── Block 2: callTool dispatch tests ────────────────────────────────

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -21,6 +21,7 @@ vi.mock('../../src/mcp/core/lbug-adapter.js', () => ({
 vi.mock('../../src/storage/repo-manager.js', () => ({
   listRegisteredRepos: vi.fn().mockResolvedValue([]),
   cleanupOldKuzuFiles: vi.fn().mockResolvedValue({ found: false, needsReindex: false }),
+  loadMeta: vi.fn().mockResolvedValue(null),
 }));
 
 // Also mock the search modules to avoid loading onnxruntime


### PR DESCRIPTION
## Summary

Fixes #297 — MCP server returns stale data after `gitnexus analyze` re-indexes a repo.

- `ensureInitialized()` now reads `meta.json` on each tool call to compare `indexedAt` against a stored `loadedAt` timestamp on the `RepoHandle`
- When the index has been rebuilt, the stale LadybugDB pool entry is closed and a fresh connection is opened automatically
- Lightweight check: one small `fs.readFile` per tool call, no background polling or file watchers

## Test plan

- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] Unit tests pass: `calltool-dispatch` (52 tests), `local-backend` (31 tests)
- [x] Integration tests pass: `local-backend-calltool` (11 tests), `augmentation` (8 tests)
- [x] Updated 3 test mocks to include `loadMeta` in `repo-manager.js` mock
- [ ] Manual: start MCP server → query symbol → run `gitnexus analyze` → query again → verify fresh data