### PR TITLE
fix: skip unavailable parsers in sequential parsing

### DIFF
--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -1,11 +1,11 @@
 import { KnowledgeGraph, GraphNode, GraphRelationship } from '../graph/types.js';
 import Parser from 'tree-sitter';
-import { loadParser, loadLanguage } from '../tree-sitter/parser-loader.js';
+import { isLanguageAvailable, loadParser, loadLanguage } from '../tree-sitter/parser-loader.js';
 import { LANGUAGE_QUERIES } from './tree-sitter-queries.js';
 import { generateId } from '../../lib/utils.js';
 import { SymbolTable } from './symbol-table.js';
 import { ASTCache } from './ast-cache.js';
-import { getLanguageFromFilename, yieldToEventLoop, DEFINITION_CAPTURE_KEYS, getDefinitionNodeFromCaptures, findEnclosingClassId, extractMethodSignature } from './utils.js';
+import { getLanguageFromFilename, isVerboseIngestionEnabled, yieldToEventLoop, DEFINITION_CAPTURE_KEYS, getDefinitionNodeFromCaptures, findEnclosingClassId, extractMethodSignature } from './utils.js';
 import { isNodeExported } from './export-detection.js';
 import { detectFrameworkFromAST } from './framework-detection.js';
 import { typeConfigs } from './type-extractors/index.js';
@@ -110,6 +110,8 @@ const processParsingSequential = async (
 ) => {
   const parser = await loadParser();
   const total = files.length;
+  const logSkipped = isVerboseIngestionEnabled();
+  const skippedByLang = logSkipped ? new Map<string, number>() : null;
 
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
@@ -121,6 +123,12 @@ const processParsingSequential = async (
     const language = getLanguageFromFilename(file.path);
 
     if (!language) continue;
+    if (!isLanguageAvailable(language)) {
+      if (skippedByLang) {
+        skippedByLang.set(language, (skippedByLang.get(language) ?? 0) + 1);
+      }
+      continue;
+    }
 
     // Skip files larger than the max tree-sitter buffer (32 MB)
     if (file.content.length > TREE_SITTER_MAX_BUFFER) continue;
@@ -131,7 +139,7 @@ const processParsingSequential = async (
       continue;  // parser unavailable — already warned in pipeline
     }
 
-    let tree;
+    let tree: Parser.Tree;
     try {
       tree = parser.parse(file.content, undefined, { bufferSize: getTreeSitterBufferSize(file.content.length) });
     } catch (parseError) {
@@ -146,8 +154,8 @@ const processParsingSequential = async (
       continue;
     }
 
-    let query;
-    let matches;
+    let query: Parser.Query;
+    let matches: Parser.QueryMatch[];
     try {
       const language = parser.getLanguage();
       query = new Parser.Query(language, queryString);
@@ -285,6 +293,14 @@ const processParsingSequential = async (
         });
       }
     });
+  }
+
+  if (skippedByLang && skippedByLang.size > 0) {
+    for (const [lang, count] of skippedByLang.entries()) {
+      console.warn(
+        `[ingestion] Skipped ${count} ${lang} file(s) in parsing processing — ${lang} parser not available.`,
+      );
+    }
   }
 };
 

--- a/gitnexus/test/unit/sequential-language-availability.test.ts
+++ b/gitnexus/test/unit/sequential-language-availability.test.ts
@@ -11,9 +11,11 @@ vi.mock('../../src/core/tree-sitter/parser-loader.js', () => ({
 
 import { createKnowledgeGraph } from '../../src/core/graph/graph.js';
 import { createASTCache } from '../../src/core/ingestion/ast-cache.js';
+import { processParsing } from '../../src/core/ingestion/parsing-processor.js';
 import { processImports } from '../../src/core/ingestion/import-processor.js';
 import { processCalls } from '../../src/core/ingestion/call-processor.js';
 import { processHeritage } from '../../src/core/ingestion/heritage-processor.js';
+import { createSymbolTable } from '../../src/core/ingestion/symbol-table.js';
 import { createResolutionContext } from '../../src/core/ingestion/resolution-context.js';
 import * as parserLoader from '../../src/core/tree-sitter/parser-loader.js';
 
@@ -133,6 +135,44 @@ describe('sequential native parser availability', () => {
 
     expect(warnSpy).toHaveBeenCalledWith(
       '[ingestion] Skipped 1 swift file(s) in heritage processing — swift parser not available.'
+    );
+
+    warnSpy.mockRestore();
+    if (previous === undefined) {
+      delete process.env.GITNEXUS_VERBOSE;
+    } else {
+      process.env.GITNEXUS_VERBOSE = previous;
+    }
+  });
+
+  it('skips Swift files in processParsing when the native parser is unavailable', async () => {
+    vi.mocked(parserLoader.isLanguageAvailable).mockReturnValue(false);
+
+    await expect(processParsing(
+      createKnowledgeGraph(),
+      [{ path: 'App.swift', content: 'class AppViewController: UIViewController {}' }],
+      createSymbolTable(),
+      createASTCache(),
+    )).resolves.toBeNull();
+
+    expect(parserLoader.loadLanguage).not.toHaveBeenCalled();
+  });
+
+  it('warns when processParsing skips files in verbose mode', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const previous = process.env.GITNEXUS_VERBOSE;
+    process.env.GITNEXUS_VERBOSE = '1';
+    vi.mocked(parserLoader.isLanguageAvailable).mockReturnValue(false);
+
+    await processParsing(
+      createKnowledgeGraph(),
+      [{ path: 'App.swift', content: 'class AppViewController: UIViewController {}' }],
+      createSymbolTable(),
+      createASTCache(),
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[ingestion] Skipped 1 swift file(s) in parsing processing — swift parser not available.',
     );
 
     warnSpy.mockRestore();


### PR DESCRIPTION
## Summary

- make `processParsingSequential()` honor `isLanguageAvailable()` before trying `loadLanguage()`, matching the existing import/call/heritage processors
- add focused unit coverage proving sequential parsing skips unsupported Swift files and emits the verbose skipped-language warning
- keep the patch independent from the open framework-detection and worker-pool warning PRs

## Validation

- `cd gitnexus && npx vitest run test/unit/sequential-language-availability.test.ts`
- `lsp_diagnostics` clean on `gitnexus/src/core/ingestion/parsing-processor.ts`
- `lsp_diagnostics` clean on `gitnexus/test/unit/sequential-language-availability.test.ts`

## Notes

- `npx gitnexus status` / `impact` are still blocked in this checkout because local indexing fails while loading `tree-sitter-kotlin` native bindings; this PR keeps the requested best-effort check record without expanding scope into dependency/toolchain repair