### PR TITLE
feat: add AWS Bedrock integration for LLM chat

### DIFF
--- a/gitnexus-web/package-lock.json
+++ b/gitnexus-web/package-lock.json
@@ -19,6 +19,7 @@
         "@langchain/openai": "^1.2.2",
         "@sigma/edge-curve": "^3.1.0",
         "@tailwindcss/vite": "^4.1.18",
+        "aws4fetch": "^1.0.20",
         "axios": "^1.13.2",
         "buffer": "^6.0.3",
         "comlink": "^4.4.2",
@@ -50,7 +51,8 @@
         "vite-plugin-top-level-await": "^1.6.0",
         "vite-plugin-wasm": "^3.5.0",
         "web-tree-sitter": "^0.20.8",
-        "zod": "^3.25.76"
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.24.5"
       },
       "devDependencies": {
         "@babel/types": "^7.28.5",
@@ -3718,6 +3720,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
     },
     "node_modules/axios": {
       "version": "1.13.2",
@@ -10186,6 +10194,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/gitnexus-web/package.json
+++ b/gitnexus-web/package.json
@@ -19,6 +19,7 @@
     "@langchain/openai": "^1.2.2",
     "@sigma/edge-curve": "^3.1.0",
     "@tailwindcss/vite": "^4.1.18",
+    "aws4fetch": "^1.0.20",
     "axios": "^1.13.2",
     "buffer": "^6.0.3",
     "comlink": "^4.4.2",
@@ -51,7 +52,8 @@
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.5.0",
     "web-tree-sitter": "^0.20.8",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.24.5"
   },
   "devDependencies": {
     "@babel/types": "^7.28.5",

--- a/gitnexus-web/src/components/SettingsPanel.tsx
+++ b/gitnexus-web/src/components/SettingsPanel.tsx
@@ -7,6 +7,7 @@ import {
   fetchOpenRouterModels,
 } from '../core/llm/settings-service';
 import type { LLMSettings, LLMProvider } from '../core/llm/types';
+import { testBedrockConnection, getBackendUrl } from '../services/backend';
 
 interface SettingsPanelProps {
   isOpen: boolean;
@@ -222,6 +223,9 @@ export const SettingsPanel = ({ isOpen, onClose, onSettingsSaved, backendUrl, is
   // OpenRouter models state
   const [openRouterModels, setOpenRouterModels] = useState<Array<{ id: string; name: string }>>([]);
   const [isLoadingModels, setIsLoadingModels] = useState(false);
+  // Bedrock connection test state
+  const [bedrockTestStatus, setBedrockTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
+  const [bedrockTestMessage, setBedrockTestMessage] = useState('');
 
   // Load settings when panel opens
   useEffect(() => {
@@ -281,7 +285,7 @@ export const SettingsPanel = ({ isOpen, onClose, onSettingsSaved, backendUrl, is
 
   if (!isOpen) return null;
 
-  const providers: LLMProvider[] = ['openai', 'gemini', 'anthropic', 'azure-openai', 'ollama', 'openrouter'];
+  const providers: LLMProvider[] = ['openai', 'gemini', 'anthropic', 'azure-openai', 'ollama', 'openrouter', 'bedrock'];
 
 
   return (
@@ -366,7 +370,7 @@ export const SettingsPanel = ({ isOpen, onClose, onSettingsSaved, backendUrl, is
                     w-8 h-8 rounded-lg flex items-center justify-center text-lg
                     ${settings.activeProvider === provider ? 'bg-accent/20' : 'bg-surface'}
                   `}>
-                    {provider === 'openai' ? '🤖' : provider === 'gemini' ? '💎' : provider === 'anthropic' ? '🧠' : provider === 'ollama' ? '🦙' : provider === 'openrouter' ? '🌐' : '☁️'}
+                    {provider === 'openai' ? '🤖' : provider === 'gemini' ? '💎' : provider === 'anthropic' ? '🧠' : provider === 'ollama' ? '🦙' : provider === 'openrouter' ? '🌐' : provider === 'bedrock' ? '🔶' : '☁️'}
                   </div>
                   <span className="font-medium">{getProviderDisplayName(provider)}</span>
                 </button>
@@ -815,6 +819,202 @@ export const SettingsPanel = ({ isOpen, onClose, onSettingsSaved, backendUrl, is
           )}
 
 
+
+          {/* AWS Bedrock Settings */}
+          {settings.activeProvider === 'bedrock' && (
+            <div className="space-y-4 animate-fade-in">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <label className="flex items-center gap-2 text-sm font-medium text-text-secondary">
+                    <Key className="w-4 h-4" />
+                    Access Key ID
+                  </label>
+                  <div className="relative">
+                    <input
+                      type={showApiKey['bedrock-access'] ? 'text' : 'password'}
+                      value={settings.bedrock?.accessKeyId ?? ''}
+                      onChange={e => setSettings(prev => ({ ...prev, bedrock: { ...prev.bedrock!, accessKeyId: e.target.value } }))}
+                      placeholder="AKIAIOSFODNN7EXAMPLE"
+                      className="w-full px-4 py-3 pr-10 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all font-mono text-xs"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => toggleApiKeyVisibility('bedrock-access')}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-text-muted hover:text-text-primary transition-colors"
+                    >
+                      {showApiKey['bedrock-access'] ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                    </button>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="flex items-center gap-2 text-sm font-medium text-text-secondary">
+                    <Key className="w-4 h-4" />
+                    Secret Access Key
+                  </label>
+                  <div className="relative">
+                    <input
+                      type={showApiKey['bedrock-secret'] ? 'text' : 'password'}
+                      value={settings.bedrock?.secretAccessKey ?? ''}
+                      onChange={e => setSettings(prev => ({ ...prev, bedrock: { ...prev.bedrock!, secretAccessKey: e.target.value } }))}
+                      placeholder="wJalrXUtnFEMI/K7MDENG"
+                      className="w-full px-4 py-3 pr-10 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all font-mono text-xs"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => toggleApiKeyVisibility('bedrock-secret')}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-text-muted hover:text-text-primary transition-colors"
+                    >
+                      {showApiKey['bedrock-secret'] ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-text-secondary">
+                  Session Token <span className="text-text-muted font-normal">(optional — for STS temporary credentials)</span>
+                </label>
+                <input
+                  type="text"
+                  value={settings.bedrock?.sessionToken ?? ''}
+                  onChange={e => setSettings(prev => ({ ...prev, bedrock: { ...prev.bedrock!, sessionToken: e.target.value } }))}
+                  placeholder="Leave empty for long-term credentials"
+                  className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all font-mono text-xs"
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-text-secondary">Region</label>
+                  <input
+                    type="text"
+                    list="aws-regions"
+                    value={settings.bedrock?.region ?? 'us-east-1'}
+                    onChange={e => setSettings(prev => ({ ...prev, bedrock: { ...prev.bedrock!, region: e.target.value } }))}
+                    placeholder="e.g. us-east-1"
+                    className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all font-mono text-xs"
+                  />
+                  <datalist id="aws-regions">
+                    <option value="us-east-1">N. Virginia</option>
+                    <option value="us-east-2">Ohio</option>
+                    <option value="us-west-1">N. California</option>
+                    <option value="us-west-2">Oregon</option>
+                    <option value="eu-west-1">Ireland</option>
+                    <option value="eu-west-2">London</option>
+                    <option value="eu-west-3">Paris</option>
+                    <option value="eu-central-1">Frankfurt</option>
+                    <option value="eu-central-2">Zurich</option>
+                    <option value="eu-north-1">Stockholm</option>
+                    <option value="eu-south-1">Milan</option>
+                    <option value="eu-south-2">Spain</option>
+                    <option value="ap-southeast-1">Singapore</option>
+                    <option value="ap-southeast-2">Sydney</option>
+                    <option value="ap-southeast-3">Jakarta</option>
+                    <option value="ap-northeast-1">Tokyo</option>
+                    <option value="ap-northeast-2">Seoul</option>
+                    <option value="ap-northeast-3">Osaka</option>
+                    <option value="ap-south-1">Mumbai</option>
+                    <option value="ap-south-2">Hyderabad</option>
+                    <option value="ap-east-1">Hong Kong</option>
+                    <option value="sa-east-1">São Paulo</option>
+                    <option value="ca-central-1">Canada</option>
+                    <option value="me-south-1">Bahrain</option>
+                    <option value="me-central-1">UAE</option>
+                    <option value="af-south-1">Cape Town</option>
+                    <option value="il-central-1">Tel Aviv</option>
+                  </datalist>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-text-secondary">Model</label>
+                  <input
+                    type="text"
+                    value={settings.bedrock?.model ?? 'anthropic.claude-3-5-sonnet-20241022-v2:0'}
+                    onChange={e => setSettings(prev => ({ ...prev, bedrock: { ...prev.bedrock!, model: e.target.value } }))}
+                    placeholder="e.g. anthropic.claude-3-5-sonnet-20241022-v2:0"
+                    className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all font-mono text-xs"
+                  />
+                </div>
+              </div>
+
+              <p className="text-xs text-text-muted">
+                Make sure Bedrock model access is enabled in your{' '}
+                <a
+                  href="https://console.aws.amazon.com/bedrock/home#/modelaccess"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-accent hover:underline"
+                >
+                  AWS Console
+                </a>
+              </p>
+
+              {/* Bedrock Health Check */}
+              <div className="space-y-2">
+                <button
+                  type="button"
+                  disabled={
+                    !settings.bedrock?.accessKeyId?.trim() ||
+                    !settings.bedrock?.secretAccessKey?.trim() ||
+                    !settings.bedrock?.model?.trim() ||
+                    bedrockTestStatus === 'testing'
+                  }
+                  onClick={async () => {
+                    setBedrockTestStatus('testing');
+                    setBedrockTestMessage('');
+                    try {
+                      const result = await testBedrockConnection({
+                        region: settings.bedrock?.region || 'us-east-1',
+                        accessKeyId: settings.bedrock?.accessKeyId || '',
+                        secretAccessKey: settings.bedrock?.secretAccessKey || '',
+                        sessionToken: settings.bedrock?.sessionToken || undefined,
+                        model: settings.bedrock?.model || '',
+                      });
+                      if (result.ok) {
+                        setBedrockTestStatus('success');
+                        setBedrockTestMessage(`Connected — ${result.model} in ${result.region}`);
+                      } else {
+                        setBedrockTestStatus('error');
+                        setBedrockTestMessage(result.error || 'Connection failed');
+                      }
+                    } catch (err: any) {
+                      setBedrockTestStatus('error');
+                      setBedrockTestMessage(err.message || 'Failed to reach backend server');
+                    }
+                  }}
+                  className="flex items-center gap-2 px-4 py-2 bg-accent/20 text-accent rounded-lg hover:bg-accent/30 transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-sm font-medium"
+                >
+                  {bedrockTestStatus === 'testing' ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <Server className="w-4 h-4" />
+                  )}
+                  Test Connection
+                </button>
+
+                {bedrockTestStatus === 'success' && (
+                  <div className="flex items-start gap-2 p-3 bg-green-500/10 border border-green-500/20 rounded-lg">
+                    <Check className="w-4 h-4 text-green-400 flex-shrink-0 mt-0.5" />
+                    <span className="text-xs text-green-400">{bedrockTestMessage}</span>
+                  </div>
+                )}
+
+                {bedrockTestStatus === 'error' && (
+                  <div className="flex items-start gap-2 p-3 bg-red-500/10 border border-red-500/20 rounded-lg">
+                    <AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+                    <span className="text-xs text-red-400 break-all">{bedrockTestMessage}</span>
+                  </div>
+                )}
+
+                {!getBackendUrl() && (
+                  <p className="text-xs text-yellow-400/80">
+                    Bedrock requires the local server running (<code className="bg-elevated px-1 rounded">gitnexus serve</code>) to proxy API calls and bypass browser CORS restrictions.
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
 
           {/* Privacy Note */}
           <div className="p-4 bg-elevated/50 border border-border-subtle rounded-xl">

--- a/gitnexus-web/src/core/llm/agent.ts
+++ b/gitnexus-web/src/core/llm/agent.ts
@@ -11,6 +11,7 @@ import { ChatOpenAI, AzureChatOpenAI } from '@langchain/openai';
 import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { ChatOllama } from '@langchain/ollama';
+import { ChatBedrockBrowser } from './bedrock-browser';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { createGraphRAGTools } from './tools';
 import type { 
@@ -21,6 +22,7 @@ import type {
   AnthropicConfig,
   OllamaConfig,
   OpenRouterConfig,
+  AWSBedrockConfig,
   AgentStreamChunk,
 } from './types';
 import { 
@@ -226,6 +228,23 @@ export const createChatModel = (config: ProviderConfig): BaseChatModel => {
       });
     }
     
+    case 'bedrock': {
+      const bedrockConfig = config as AWSBedrockConfig;
+      return new ChatBedrockBrowser({
+        region: bedrockConfig.region,
+        credentials: {
+          accessKeyId: bedrockConfig.accessKeyId,
+          secretAccessKey: bedrockConfig.secretAccessKey,
+          sessionToken: bedrockConfig.sessionToken,
+        },
+        model: bedrockConfig.model,
+        temperature: bedrockConfig.temperature ?? 0.1,
+        maxTokens: bedrockConfig.maxTokens,
+        streaming: true,
+        proxyBaseUrl: bedrockConfig.proxyBaseUrl,
+      }) as BaseChatModel;
+    }
+
     default:
       throw new Error(`Unsupported provider: ${(config as any).provider}`);
   }

--- a/gitnexus-web/src/core/llm/bedrock-browser.ts
+++ b/gitnexus-web/src/core/llm/bedrock-browser.ts
@@ -1,0 +1,506 @@
+/**
+ * Browser-native AWS Bedrock Chat Model
+ *
+ * Uses aws4fetch for SigV4 request signing (no Node.js deps) and calls
+ * the Bedrock Converse / Converse-Stream API directly via fetch.
+ *
+ * Supports:
+ * - Streaming (AWS Event Stream binary format parsed inline)
+ * - Tool calls (Bedrock Converse API toolUse/toolResult format)
+ * - All Bedrock models that implement the Converse API
+ */
+
+import { AwsClient } from 'aws4fetch';
+import { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import type { BaseChatModelCallOptions } from '@langchain/core/language_models/chat_models';
+import {
+  BaseMessage,
+  AIMessage,
+  AIMessageChunk,
+  ToolMessage,
+  SystemMessage,
+} from '@langchain/core/messages';
+import type { ChatResult } from '@langchain/core/outputs';
+import { ChatGenerationChunk } from '@langchain/core/outputs';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+interface BedrockCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
+interface ChatBedrockBrowserParams {
+  region: string;
+  credentials: BedrockCredentials;
+  model: string;
+  temperature?: number;
+  maxTokens?: number;
+  streaming?: boolean;
+  proxyBaseUrl?: string;  // when set, routes calls through backend to bypass CORS
+}
+
+interface BedrockTool {
+  toolSpec: {
+    name: string;
+    description: string;
+    inputSchema: { json: object };
+  };
+}
+
+// ─── Message format conversion ──────────────────────────────────────────────
+
+function toBedrockMessages(messages: BaseMessage[]): {
+  system: Array<{ text: string }>;
+  messages: any[];
+} {
+  const system: Array<{ text: string }> = [];
+  const out: any[] = [];
+
+  for (const msg of messages) {
+    const type = msg._getType();
+
+    if (type === 'system') {
+      system.push({ text: String(msg.content) });
+      continue;
+    }
+
+    if (type === 'human') {
+      const textBlock = { text: String(msg.content) };
+      const last = out[out.length - 1];
+      if (last?.role === 'user') {
+        // Merge into the previous user turn — Bedrock requires strictly alternating roles.
+        // Consecutive user messages occur when a prior turn failed before producing an assistant reply.
+        last.content.push(textBlock);
+      } else {
+        out.push({ role: 'user', content: [textBlock] });
+      }
+      continue;
+    }
+
+    if (type === 'ai') {
+      const ai = msg as AIMessage;
+      const content: any[] = [];
+
+      // Text part
+      if (ai.content && typeof ai.content === 'string' && ai.content.trim()) {
+        content.push({ text: ai.content });
+      }
+
+      // Tool calls → nested toolUse blocks (Converse API format)
+      for (const tc of ai.tool_calls ?? []) {
+        content.push({
+          toolUse: {
+            toolUseId: tc.id,
+            name: tc.name,
+            input: tc.args,
+          },
+        });
+      }
+
+      if (content.length > 0) {
+        out.push({ role: 'assistant', content });
+      }
+      continue;
+    }
+
+    if (type === 'tool') {
+      const tm = msg as ToolMessage;
+      // Bedrock expects tool results as a user message with nested toolResult blocks
+      const last = out[out.length - 1];
+      const resultBlock = {
+        toolResult: {
+          toolUseId: tm.tool_call_id,
+          content: [{ text: String(tm.content) }],
+        },
+      };
+      if (last?.role === 'user') {
+        last.content.push(resultBlock);
+      } else {
+        out.push({ role: 'user', content: [resultBlock] });
+      }
+    }
+  }
+
+  return { system, messages: out };
+}
+
+function toBedrockTools(tools: StructuredToolInterface[]): BedrockTool[] {
+  return tools.map((t) => ({
+    toolSpec: {
+      name: t.name,
+      description: t.description,
+      inputSchema: {
+        json: t.schema instanceof z.ZodType
+          ? zodToJsonSchema(t.schema, { $refStrategy: 'none' })
+          : t.schema,
+      },
+    },
+  }));
+}
+
+function fromBedrockMessage(msg: any): AIMessage {
+  let text = '';
+  const tool_calls: any[] = [];
+
+  for (const block of msg.content ?? []) {
+    // Converse API uses nested format: { text: '...' } or { toolUse: { ... } }
+    if (block.text) text += block.text;
+    if (block.toolUse) {
+      tool_calls.push({
+        id: block.toolUse.toolUseId,
+        name: block.toolUse.name,
+        args: block.toolUse.input,
+        type: 'tool_call' as const,
+      });
+    }
+  }
+
+  return new AIMessage({ content: text, tool_calls });
+}
+
+// ─── AWS Event Stream parser (binary) ────────────────────────────────────────
+// Binary framing: [4B totalLen][4B headersLen][4B preludeCRC][headers][payload][4B msgCRC]
+// Extracts :event-type from binary headers and wraps the JSON payload:
+//   {"contentBlockDelta": { "delta": {"text":"..."}, "contentBlockIndex": 0 }}
+// Used for direct Bedrock calls (no proxy).
+
+function parseEventStreamHeaders(buf: Uint8Array, start: number, end: number): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const decoder = new TextDecoder();
+  let offset = start;
+  while (offset < end) {
+    const nameLen = buf[offset]; offset += 1;
+    const name = decoder.decode(buf.slice(offset, offset + nameLen)); offset += nameLen;
+    const valueType = buf[offset]; offset += 1;
+    if (valueType === 7) { // string
+      const valLen = (buf[offset] << 8) | buf[offset + 1]; offset += 2;
+      headers[name] = decoder.decode(buf.slice(offset, offset + valLen)); offset += valLen;
+    } else if (valueType === 6) { // bytes
+      const valLen = (buf[offset] << 8) | buf[offset + 1]; offset += 2;
+      offset += valLen;
+    } else if (valueType === 0 || valueType === 1) { // bool
+      // no value bytes
+    } else if (valueType === 2) { offset += 1;  // byte
+    } else if (valueType === 3) { offset += 2;  // short
+    } else if (valueType === 4) { offset += 4;  // int
+    } else if (valueType === 5 || valueType === 8) { offset += 8; // long / timestamp
+    } else {
+      break; // unknown type
+    }
+  }
+  return headers;
+}
+
+async function* parseEventStream(
+  stream: ReadableStream<Uint8Array>
+): AsyncGenerator<Record<string, any>> {
+  const reader = stream.getReader();
+  let buf = new Uint8Array(0);
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const merged = new Uint8Array(buf.length + value.length);
+      merged.set(buf);
+      merged.set(value, buf.length);
+      buf = merged;
+
+      while (buf.length >= 12) {
+        const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+        const totalLen = view.getUint32(0);
+        if (buf.length < totalLen) break;
+
+        const headersLen = view.getUint32(4);
+        const payloadStart = 12 + headersLen;
+        const payloadLen = totalLen - headersLen - 16; // prelude(12) + trailingCRC(4)
+
+        // Extract event type from binary headers
+        const headers = parseEventStreamHeaders(buf, 12, 12 + headersLen);
+        const eventType = headers[':event-type'] || '';
+
+        if (payloadLen > 0) {
+          const payload = buf.slice(payloadStart, payloadStart + payloadLen);
+          try {
+            const data = JSON.parse(new TextDecoder().decode(payload));
+            // Wrap with event type to match SDK format
+            yield eventType ? { [eventType]: data } : data;
+          } catch { /* skip malformed frame */ }
+        }
+
+        buf = buf.slice(totalLen);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+// ─── NDJSON parser ───────────────────────────────────────────────────────────
+// Used when going through the proxy (which converts binary event stream → NDJSON).
+
+async function* parseNDJSON(
+  stream: ReadableStream<Uint8Array>
+): AsyncGenerator<Record<string, any>> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || ''; // keep incomplete line in buffer
+
+      for (const line of lines) {
+        if (line.trim()) {
+          try {
+            const parsed = JSON.parse(line);
+            // Handle error frames forwarded by the proxy server
+            if (parsed.__error) {
+              throw new Error(`Bedrock: ${parsed.__error.message || parsed.__error.type || 'stream error'}`);
+            }
+            yield parsed;
+          } catch (e) {
+            // Re-throw Bedrock errors, skip malformed JSON
+            if (e instanceof Error && e.message.startsWith('Bedrock:')) throw e;
+          }
+        }
+      }
+    }
+
+    // Process any remaining data
+    if (buffer.trim()) {
+      try {
+        const parsed = JSON.parse(buffer);
+        if (parsed.__error) {
+          throw new Error(`Bedrock: ${parsed.__error.message || parsed.__error.type || 'stream error'}`);
+        }
+        yield parsed;
+      } catch (e) {
+        if (e instanceof Error && e.message.startsWith('Bedrock:')) throw e;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+// ─── ChatBedrockBrowser ──────────────────────────────────────────────────────
+
+export class ChatBedrockBrowser extends BaseChatModel {
+  private aws: AwsClient;
+  private region: string;
+  private modelId: string;
+  private temperature: number;
+  private maxTokens?: number;
+  private credentials: BedrockCredentials;
+  private proxyBaseUrl?: string;
+  readonly streaming: boolean;
+
+  constructor(params: ChatBedrockBrowserParams) {
+    super({});
+    this.credentials = params.credentials;
+    this.proxyBaseUrl = params.proxyBaseUrl;
+    this.aws = new AwsClient({
+      accessKeyId: params.credentials.accessKeyId,
+      secretAccessKey: params.credentials.secretAccessKey,
+      sessionToken: params.credentials.sessionToken,
+      region: params.region,
+      service: 'bedrock',
+    });
+    this.region = params.region;
+    this.modelId = params.model;
+    this.temperature = params.temperature ?? 0.1;
+    this.maxTokens = params.maxTokens;
+    this.streaming = params.streaming ?? true;
+  }
+
+  _llmType(): string {
+    return 'bedrock';
+  }
+
+  bindTools(tools: StructuredToolInterface[]) {
+    return this.withConfig({ tools: toBedrockTools(tools) } as any);
+  }
+
+  private buildBody(messages: BaseMessage[], tools?: BedrockTool[]): string {
+    const { system, messages: bedrockMessages } = toBedrockMessages(messages);
+    const body: any = {
+      messages: bedrockMessages,
+      inferenceConfig: {
+        temperature: this.temperature,
+        ...(this.maxTokens ? { maxTokens: this.maxTokens } : {}),
+      },
+    };
+    if (system.length > 0) body.system = system;
+    if (tools && tools.length > 0) {
+      body.toolConfig = { tools };
+    }
+    return JSON.stringify(body);
+  }
+
+  private async proxyFetch(endpoint: 'converse' | 'converse-stream', bodyJson: string): Promise<Response> {
+    // Timeout for getting initial response headers (not the stream body)
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 180_000); // 3 minutes
+    try {
+      const resp = await fetch(`${this.proxyBaseUrl}/api/bedrock/${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          region: this.region,
+          credentials: this.credentials,
+          model: this.modelId,
+          body: JSON.parse(bodyJson),
+        }),
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+      return resp;
+    } catch (err: any) {
+      clearTimeout(timeout);
+      if (err.name === 'AbortError') throw new Error('Bedrock proxy request timed out');
+      throw err;
+    }
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+    options: BaseChatModelCallOptions,
+    _runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    const tools = (options as any).tools as BedrockTool[] | undefined;
+    const bodyJson = this.buildBody(messages, tools);
+    let resp: Response;
+
+    if (this.proxyBaseUrl) {
+      resp = await this.proxyFetch('converse', bodyJson);
+    } else {
+      const url = `https://bedrock-runtime.${this.region}.amazonaws.com/model/${encodeURIComponent(this.modelId)}/converse`;
+      resp = await this.aws.fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: bodyJson,
+      });
+    }
+
+    if (!resp.ok) {
+      const err = await resp.text();
+      throw new Error(`Bedrock error ${resp.status}: ${err}`);
+    }
+
+    const data = (await resp.json()) as any;
+    const message = fromBedrockMessage(data.output?.message ?? { content: [] });
+
+    return {
+      generations: [{ text: message.content as string, message }],
+      llmOutput: { usage: data.usage },
+    };
+  }
+
+  async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: BaseChatModelCallOptions,
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    const tools = (options as any).tools as BedrockTool[] | undefined;
+    const bodyJson = this.buildBody(messages, tools);
+    let resp: Response;
+
+    if (this.proxyBaseUrl) {
+      resp = await this.proxyFetch('converse-stream', bodyJson);
+    } else {
+      const url = `https://bedrock-runtime.${this.region}.amazonaws.com/model/${encodeURIComponent(this.modelId)}/converse-stream`;
+      resp = await this.aws.fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: bodyJson,
+      });
+    }
+
+    if (!resp.ok) {
+      const err = await resp.text();
+      throw new Error(`Bedrock error ${resp.status}: ${err}`);
+    }
+
+    if (!resp.body) throw new Error('Bedrock: no response body');
+
+    // Accumulate tool use inputs per content block index
+    const toolAccumulator: Record<number, { id: string; name: string; input: string }> = {};
+
+    // Proxy returns NDJSON (text), direct calls return AWS Event Stream (binary)
+    const eventSource = this.proxyBaseUrl ? parseNDJSON(resp.body) : parseEventStream(resp.body);
+
+    for await (const event of eventSource) {
+      if (event.contentBlockDelta?.delta?.text) {
+        const text: string = event.contentBlockDelta.delta.text;
+        await runManager?.handleLLMNewToken(text);
+        yield new ChatGenerationChunk({ text, message: new AIMessageChunk({ content: text }) });
+
+      } else if (event.contentBlockStart?.start?.toolUse) {
+        const { contentBlockIndex } = event.contentBlockStart;
+        const { toolUseId, name } = event.contentBlockStart.start.toolUse;
+        toolAccumulator[contentBlockIndex] = { id: toolUseId, name, input: '' };
+
+      } else if (event.contentBlockDelta?.delta?.toolUse?.input != null) {
+        const idx = event.contentBlockDelta.contentBlockIndex;
+        if (toolAccumulator[idx]) {
+          toolAccumulator[idx].input += event.contentBlockDelta.delta.toolUse.input;
+        }
+
+      } else if (event.contentBlockStop != null) {
+        const idx = event.contentBlockStop.contentBlockIndex;
+        const acc = toolAccumulator[idx];
+        if (acc) {
+          // Use tool_call_chunks (not tool_calls) so AIMessageChunk.concat() preserves them.
+          // tool_call_chunks use string args; the constructor converts to parsed tool_calls.
+          const tool_call_chunks = [{
+            id: acc.id,
+            name: acc.name,
+            args: acc.input,
+            index: idx,
+            type: 'tool_call_chunk' as const,
+          }];
+          const toolChunk = new ChatGenerationChunk({
+            text: '',
+            message: new AIMessageChunk({ content: '', tool_call_chunks }),
+          });
+          await runManager?.handleLLMNewToken('', undefined, undefined, undefined, undefined, { chunk: toolChunk });
+          yield toolChunk;
+          delete toolAccumulator[idx];
+        }
+
+      } else if (
+        event.internalServerException ||
+        event.modelStreamErrorException ||
+        event.validationException ||
+        event.throttlingException ||
+        event.serviceUnavailableException ||
+        event.modelNotReadyException
+      ) {
+        // In-band Bedrock error — surface as a real error so the caller sees the message
+        // instead of silently swallowing it and causing "Received empty response" from LangChain.
+        const msg =
+          event.internalServerException?.message ||
+          event.modelStreamErrorException?.message ||
+          event.validationException?.message ||
+          event.throttlingException?.message ||
+          event.serviceUnavailableException?.message ||
+          event.modelNotReadyException?.message ||
+          'Bedrock stream error';
+        throw new Error(`Bedrock: ${msg}`);
+      }
+    }
+  }
+}

--- a/gitnexus-web/src/core/llm/settings-service.ts
+++ b/gitnexus-web/src/core/llm/settings-service.ts
@@ -15,6 +15,7 @@ import {
   AnthropicConfig,
   OllamaConfig,
   OpenRouterConfig,
+  AWSBedrockConfig,
   ProviderConfig,
 } from './types';
 
@@ -60,6 +61,10 @@ export const loadSettings = (): LLMSettings => {
         ...DEFAULT_LLM_SETTINGS.openrouter,
         ...parsed.openrouter,
       },
+      bedrock: {
+        ...DEFAULT_LLM_SETTINGS.bedrock,
+        ...parsed.bedrock,
+      },
     };
   } catch (error) {
     console.warn('Failed to load LLM settings:', error);
@@ -89,6 +94,7 @@ export const updateProviderSettings = <T extends LLMProvider>(
     T extends 'gemini' ? Partial<Omit<GeminiConfig, 'provider'>> :
     T extends 'anthropic' ? Partial<Omit<AnthropicConfig, 'provider'>> :
     T extends 'ollama' ? Partial<Omit<OllamaConfig, 'provider'>> :
+    T extends 'bedrock' ? Partial<Omit<AWSBedrockConfig, 'provider'>> :
     never
   >
 ): LLMSettings => {
@@ -157,6 +163,17 @@ export const updateProviderSettings = <T extends LLMProvider>(
         openrouter: {
           ...(current.openrouter ?? {}),
           ...(updates as Partial<Omit<OpenRouterConfig, 'provider'>>),
+        },
+      };
+      saveSettings(updated);
+      return updated;
+    }
+    case 'bedrock': {
+      const updated: LLMSettings = {
+        ...current,
+        bedrock: {
+          ...(current.bedrock ?? {}),
+          ...(updates as Partial<Omit<AWSBedrockConfig, 'provider'>>),
         },
       };
       saveSettings(updated);
@@ -245,7 +262,16 @@ export const getActiveProviderConfig = (): ProviderConfig | null => {
         temperature: settings.openrouter.temperature,
         maxTokens: settings.openrouter.maxTokens,
       } as OpenRouterConfig;
-      
+
+    case 'bedrock':
+      if (!settings.bedrock?.accessKeyId || !settings.bedrock?.secretAccessKey) {
+        return null;
+      }
+      return {
+        provider: 'bedrock',
+        ...settings.bedrock,
+      } as AWSBedrockConfig;
+
     default:
       return null;
   }
@@ -282,6 +308,8 @@ export const getProviderDisplayName = (provider: LLMProvider): string => {
       return 'Ollama (Local)';
     case 'openrouter':
       return 'OpenRouter';
+    case 'bedrock':
+      return 'AWS Bedrock';
     default:
       return provider;
   }
@@ -303,6 +331,16 @@ export const getAvailableModels = (provider: LLMProvider): string[] => {
       return ['claude-sonnet-4-20250514', 'claude-3-5-sonnet-20241022', 'claude-3-5-haiku-20241022', 'claude-3-opus-20240229'];
     case 'ollama':
       return ['llama3.2', 'llama3.1', 'mistral', 'codellama', 'deepseek-coder'];
+    case 'bedrock':
+      return [
+        'anthropic.claude-sonnet-4-20250514-v1:0',
+        'anthropic.claude-opus-4-20250514-v1:0',
+        'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        'anthropic.claude-3-5-haiku-20241022-v1:0',
+        'anthropic.claude-3-opus-20240229-v1:0',
+        'meta.llama3-70b-instruct-v1:0',
+        'mistral.mistral-large-2402-v1:0',
+      ];
     default:
       return [];
   }

--- a/gitnexus-web/src/core/llm/types.ts
+++ b/gitnexus-web/src/core/llm/types.ts
@@ -8,7 +8,7 @@
 /**
  * Supported LLM providers
  */
-export type LLMProvider = 'openai' | 'azure-openai' | 'gemini' | 'anthropic' | 'ollama' | 'openrouter';
+export type LLMProvider = 'openai' | 'azure-openai' | 'gemini' | 'anthropic' | 'ollama' | 'openrouter' | 'bedrock';
 
 /**
  * Base configuration shared by all providers
@@ -79,9 +79,22 @@ export interface OpenRouterConfig extends BaseProviderConfig {
 }
 
 /**
+ * AWS Bedrock configuration
+ */
+export interface AWSBedrockConfig extends BaseProviderConfig {
+  provider: 'bedrock';
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;  // for temporary STS credentials
+  region: string;
+  model: string;
+  proxyBaseUrl?: string;  // when set, routes API calls through backend to bypass CORS
+}
+
+/**
  * Union type for all provider configurations
  */
-export type ProviderConfig = OpenAIConfig | AzureOpenAIConfig | GeminiConfig | AnthropicConfig | OllamaConfig | OpenRouterConfig;
+export type ProviderConfig = OpenAIConfig | AzureOpenAIConfig | GeminiConfig | AnthropicConfig | OllamaConfig | OpenRouterConfig | AWSBedrockConfig;
 
 /**
  * Stored settings (what goes to localStorage)
@@ -98,6 +111,7 @@ export interface LLMSettings {
   anthropic?: Partial<Omit<AnthropicConfig, 'provider'>>;
   ollama?: Partial<Omit<OllamaConfig, 'provider'>>;
   openrouter?: Partial<Omit<OpenRouterConfig, 'provider'>>;
+  bedrock?: Partial<Omit<AWSBedrockConfig, 'provider'>>;
 
   // Intelligent Clustering Settings
   intelligentClustering: boolean;
@@ -146,6 +160,13 @@ export const DEFAULT_LLM_SETTINGS: LLMSettings = {
     apiKey: '',
     model: '',
     baseUrl: 'https://openrouter.ai/api/v1',
+    temperature: 0.1,
+  },
+  bedrock: {
+    accessKeyId: '',
+    secretAccessKey: '',
+    region: 'us-east-1',
+    model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
     temperature: 0.1,
   },
 };

--- a/gitnexus-web/src/services/backend.ts
+++ b/gitnexus-web/src/services/backend.ts
@@ -228,3 +228,25 @@ export const fetchClusterDetail = async (
   await assertOk(response);
   return response.json();
 };
+
+/**
+ * Test AWS Bedrock connection by making a minimal API call through the backend proxy.
+ */
+export const testBedrockConnection = async (config: {
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  model: string;
+}): Promise<{ ok: boolean; error?: string; model?: string; region?: string }> => {
+  const response = await fetchWithTimeout(
+    `${backendUrl}/api/bedrock/test`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(config),
+    },
+    15_000, // Bedrock cold start can be slow
+  );
+  return response.json() as Promise<{ ok: boolean; error?: string; model?: string; region?: string }>;
+};

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "gitnexus",
-  "version": "1.4.0",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.4.0",
+      "version": "1.4.6",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",
         "@ladybugdb/core": "^0.15.1",
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "aws4fetch": "^1.0.20",
         "cli-progress": "^3.12.0",
         "commander": "^12.0.0",
         "cors": "^2.8.5",
@@ -36,7 +37,6 @@
         "tree-sitter-python": "^0.21.0",
         "tree-sitter-ruby": "^0.23.1",
         "tree-sitter-rust": "^0.21.0",
-        "tree-sitter-swift": "^0.6.0",
         "tree-sitter-typescript": "^0.21.0",
         "uuid": "^13.0.0"
       },
@@ -2430,6 +2430,12 @@
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
       }
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -49,6 +49,7 @@
     "prepack": "npm run build && chmod +x dist/cli/index.js"
   },
   "dependencies": {
+    "aws4fetch": "^1.0.20",
     "@huggingface/transformers": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "cli-progress": "^3.12.0",

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -12,6 +12,7 @@ import express from 'express';
 import cors from 'cors';
 import path from 'path';
 import fs from 'fs/promises';
+import { AwsClient } from 'aws4fetch';
 import { loadMeta, listRegisteredRepos } from '../storage/repo-manager.js';
 import { executeQuery, closeLbug, withLbugDb } from '../core/lbug/lbug-adapter.js';
 import { NODE_TABLES } from '../core/lbug/schema.js';
@@ -334,6 +335,255 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
       res.json(result);
     } catch (err: any) {
       res.status(statusFromError(err)).json({ error: err.message || 'Failed to query cluster detail' });
+    }
+  });
+
+  /** Health check — minimal Converse call to validate credentials + model access */
+  app.post('/api/bedrock/test', async (req, res) => {
+    try {
+      const { region, accessKeyId, secretAccessKey, sessionToken, model } = req.body;
+      if (!region || !accessKeyId || !secretAccessKey || !model) {
+        res.status(400).json({ ok: false, error: 'Missing required fields: region, accessKeyId, secretAccessKey, model' });
+        return;
+      }
+
+      const aws = new AwsClient({
+        accessKeyId,
+        secretAccessKey,
+        sessionToken: sessionToken || undefined,
+        region,
+        service: 'bedrock',
+      });
+
+      const url = `https://bedrock-runtime.${region}.amazonaws.com/model/${encodeURIComponent(model)}/converse`;
+      const resp = await aws.fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+          inferenceConfig: { maxTokens: 1, temperature: 0 },
+        }),
+      });
+
+      if (!resp.ok) {
+        const errBody = await resp.text();
+        res.json({ ok: false, error: `${resp.status}: ${errBody}` });
+        return;
+      }
+
+      res.json({ ok: true, model, region });
+    } catch (err: any) {
+      res.json({ ok: false, error: err.message || 'Unknown error' });
+    }
+  });
+
+  /** Non-streaming Converse proxy */
+  app.post('/api/bedrock/converse', async (req, res) => {
+    try {
+      const { region, credentials, model, body } = req.body;
+      if (!region || !credentials?.accessKeyId || !credentials?.secretAccessKey || !model || !body) {
+        res.status(400).json({ error: 'Missing required fields' });
+        return;
+      }
+
+      const aws = new AwsClient({
+        accessKeyId: credentials.accessKeyId,
+        secretAccessKey: credentials.secretAccessKey,
+        sessionToken: credentials.sessionToken || undefined,
+        region,
+        service: 'bedrock',
+      });
+
+      const url = `https://bedrock-runtime.${region}.amazonaws.com/model/${encodeURIComponent(model)}/converse`;
+      const awsResp = await aws.fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!awsResp.ok) {
+        const errBody = await awsResp.text();
+        res.status(awsResp.status).json({ error: errBody });
+        return;
+      }
+
+      const data = await awsResp.json();
+      res.json(data);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message || 'Bedrock converse failed' });
+    }
+  });
+
+  /** Streaming Converse proxy — parses AWS Event Stream binary and forwards as NDJSON */
+  app.post('/api/bedrock/converse-stream', async (req, res) => {
+    let aborted = false;
+    let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
+    // Detect client disconnect — abort the AWS stream immediately
+    res.on('close', () => {
+      if (!res.writableEnded) {
+        aborted = true;
+        try { reader?.cancel(); } catch { /* already closed */ }
+      }
+    });
+
+    try {
+      const { region, credentials, model, body } = req.body;
+      if (!region || !credentials?.accessKeyId || !credentials?.secretAccessKey || !model || !body) {
+        res.status(400).json({ error: 'Missing required fields' });
+        return;
+      }
+
+      const aws = new AwsClient({
+        accessKeyId: credentials.accessKeyId,
+        secretAccessKey: credentials.secretAccessKey,
+        sessionToken: credentials.sessionToken || undefined,
+        region,
+        service: 'bedrock',
+      });
+
+      const url = `https://bedrock-runtime.${region}.amazonaws.com/model/${encodeURIComponent(model)}/converse-stream`;
+
+      // Timeout for the initial AWS response (model may take time to start generating)
+      const fetchTimeout = 120_000; // 2 minutes
+      const awsRespPromise = aws.fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Bedrock request timed out')), fetchTimeout)
+      );
+      const awsResp = await Promise.race([awsRespPromise, timeoutPromise]) as Response;
+
+      if (aborted) return;
+
+      if (!awsResp.ok) {
+        const errBody = await awsResp.text();
+        if (!res.headersSent) res.status(awsResp.status).json({ error: errBody });
+        return;
+      }
+
+      if (!awsResp.body) {
+        if (!res.headersSent) res.status(502).json({ error: 'No response body from Bedrock' });
+        return;
+      }
+
+      // Stream as NDJSON — parse AWS Event Stream binary server-side,
+      // extract event type from binary headers and wrap the payload.
+      // Output format matches what boto3/SDKs return: {"eventType": {payload}}
+      res.setHeader('Content-Type', 'application/x-ndjson');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('X-Accel-Buffering', 'no'); // disable nginx buffering if present
+      res.flushHeaders();
+
+      reader = (awsResp.body as ReadableStream<Uint8Array>).getReader();
+      const decoder = new TextDecoder();
+      let buf = new Uint8Array(0);
+
+      // Timeout for individual chunk reads — if Bedrock goes silent for too long, abort
+      const CHUNK_TIMEOUT = 120_000; // 2 minutes between chunks
+
+      try {
+        while (!aborted) {
+          // Race reader.read() against a timeout
+          const chunkTimeoutPromise = new Promise<{ done: true; value: undefined }>((_, reject) =>
+            setTimeout(() => reject(new Error('Bedrock stream chunk timed out')), CHUNK_TIMEOUT)
+          );
+          const { done, value } = await Promise.race([reader.read(), chunkTimeoutPromise]);
+          if (done || aborted) break;
+
+          const merged = new Uint8Array(buf.length + value!.length);
+          merged.set(buf);
+          merged.set(value!, buf.length);
+          buf = merged;
+
+          // Parse complete AWS Event Stream frames
+          // Binary framing: [4B totalLen][4B headersLen][4B preludeCRC][headers][payload][4B msgCRC]
+          while (buf.length >= 12) {
+            const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+            const totalLen = view.getUint32(0);
+            if (totalLen < 16 || totalLen > 16 * 1024 * 1024) {
+              // Invalid frame — corrupted stream, skip remaining buffer
+              buf = new Uint8Array(0);
+              break;
+            }
+            if (buf.length < totalLen) break;
+
+            const headersLen = view.getUint32(4);
+            const headersStart = 12;
+            const payloadStart = 12 + headersLen;
+            const payloadLen = totalLen - headersLen - 16;
+
+            // Parse binary headers to extract :event-type, :message-type, :exception-type
+            let eventType = '';
+            let messageType = '';
+            let exceptionType = '';
+            let offset = headersStart;
+            const headersEnd = headersStart + headersLen;
+            while (offset < headersEnd) {
+              const nameLen = buf[offset]; offset += 1;
+              const name = decoder.decode(buf.slice(offset, offset + nameLen)); offset += nameLen;
+              const valueType = buf[offset]; offset += 1;
+              if (valueType === 7) { // string
+                const valLen = (buf[offset] << 8) | buf[offset + 1]; offset += 2;
+                const val = decoder.decode(buf.slice(offset, offset + valLen)); offset += valLen;
+                if (name === ':event-type') eventType = val;
+                else if (name === ':message-type') messageType = val;
+                else if (name === ':exception-type') exceptionType = val;
+              } else if (valueType === 6) { // bytes
+                const valLen = (buf[offset] << 8) | buf[offset + 1]; offset += 2;
+                offset += valLen;
+              } else if (valueType === 0 || valueType === 1) { // bool
+                // no value bytes
+              } else if (valueType === 2) { offset += 1;  // byte
+              } else if (valueType === 3) { offset += 2;  // short
+              } else if (valueType === 4) { offset += 4;  // int
+              } else if (valueType === 5 || valueType === 8) { offset += 8; // long / timestamp
+              } else {
+                break; // unknown type, stop parsing headers
+              }
+            }
+
+            if (payloadLen > 0 && !aborted) {
+              const payload = buf.slice(payloadStart, payloadStart + payloadLen);
+              try {
+                const data = JSON.parse(decoder.decode(payload));
+
+                // Handle exception frames — forward as NDJSON error and stop
+                if (messageType === 'exception' || exceptionType) {
+                  const errMsg = data.message || data.Message || exceptionType || 'Bedrock stream exception';
+                  res.write(JSON.stringify({ __error: { type: exceptionType || eventType, message: errMsg } }) + '\n');
+                  aborted = true;
+                  break;
+                }
+
+                // Wrap payload with event type to match SDK format:
+                // {"contentBlockDelta": {"delta": {"text": "..."}, "contentBlockIndex": 0}}
+                const wrapped = eventType ? { [eventType]: data } : data;
+                res.write(JSON.stringify(wrapped) + '\n');
+              } catch { /* skip malformed frame */ }
+            }
+
+            buf = buf.slice(totalLen);
+          }
+        }
+      } finally {
+        try { reader.releaseLock(); } catch { /* already released */ }
+      }
+
+      if (!res.writableEnded) res.end();
+    } catch (err: any) {
+      if (aborted) return; // client already gone
+      if (!res.headersSent) {
+        res.status(500).json({ error: err.message || 'Bedrock stream failed' });
+      } else {
+        // Stream already started — send error as NDJSON so client can see it
+        try {
+          res.write(JSON.stringify({ __error: { type: 'proxy_error', message: err.message || 'Bedrock stream failed' } }) + '\n');
+        } catch { /* write failed, client gone */ }
+        if (!res.writableEnded) res.end();
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

Adds AWS Bedrock as an LLM provider for the chat interface, enabling users to use Claude, Titan, and other Bedrock-hosted models directly from GitNexus.

- **Bedrock browser client** with SigV4 signing via `aws4fetch`
- **Server proxy endpoints**: `/api/bedrock/test`, `/api/bedrock/converse`, `/api/bedrock/converse-stream`
- **Settings panel**: Bedrock provider configuration (AWS credentials, region, model selector, test connection)
- **Streaming SSE** support for real-time responses

## Changes

| Area | Files | What |
|------|-------|------|
| Backend | `api.ts`, `package.json` | Bedrock proxy endpoints, `aws4fetch` dep |
| Web LLM | `bedrock-browser.ts`, `types.ts`, `agent.ts`, `settings-service.ts` | Bedrock client, provider type, model factory |
| Web UI | `SettingsPanel.tsx`, `backend.ts` | Bedrock config section, test connection |
| Web deps | `package.json` | `aws4fetch`, `zod-to-json-schema` |

## Test plan

- [ ] Configure Bedrock credentials in Settings > LLM Provider > Bedrock
- [ ] Test connection button validates credentials
- [ ] Send a chat message using Bedrock provider
- [ ] Verify streaming responses work

🤖 Generated with [Claude Code](https://claude.com/claude-code)