### PR TITLE
feat: add TUI wizards, interactive modes, and embed CLI

### DIFF
--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -1,0 +1,178 @@
+# Embeddings Guide
+
+GitNexus supports semantic search via vector embeddings. When enabled, code symbols (functions, classes, methods, interfaces, files) are embedded into vectors and stored alongside the graph, enabling similarity-based search beyond keyword matching.
+
+## Quick Start
+
+```bash
+# Local provider (default) — no API key needed
+gitnexus analyze --embeddings
+
+# Check it works
+gitnexus mcp  # semantic search is now available in query results
+```
+
+## Providers
+
+### Local (default)
+
+Uses [transformers.js](https://huggingface.co/docs/transformers.js) with the `Snowflake/snowflake-arctic-embed-xs` model (22M parameters, 384 dimensions, ~90MB download).
+
+```bash
+gitnexus analyze --embeddings
+```
+
+- **GPU acceleration**: Automatically tries CUDA (Linux) or DirectML (Windows), falls back to CPU
+- **First run**: Downloads the model (~90MB), cached for subsequent runs
+- **No external dependencies**: Everything runs in-process
+
+### Ollama
+
+Uses [Ollama's](https://ollama.com) HTTP embedding API. Ollama must be running.
+
+```bash
+# Default endpoint is http://localhost:11434
+gitnexus analyze --embeddings \
+  --embed-provider ollama \
+  --embed-model nomic-embed-text \
+  --embed-dims 768
+
+# Custom endpoint (remote Ollama server)
+gitnexus analyze --embeddings \
+  --embed-provider ollama \
+  --embed-model nomic-embed-text \
+  --embed-dims 768 \
+  --embed-endpoint http://my-server:11434
+```
+
+Make sure the model is pulled first:
+```bash
+ollama pull nomic-embed-text
+```
+
+Common Ollama embedding models:
+
+| Model | Dimensions |
+|-------|-----------|
+| `nomic-embed-text` | 768 |
+| `mxbai-embed-large` | 1024 |
+| `all-minilm` | 384 |
+| `snowflake-arctic-embed` | 1024 |
+
+### OpenAI
+
+Works with OpenAI and any OpenAI-compatible API (LiteLLM, vLLM, Ollama `/v1`).
+
+```bash
+gitnexus analyze --embeddings \
+  --embed-provider openai \
+  --embed-model text-embedding-3-small \
+  --embed-dims 1536 \
+  --embed-api-key sk-xxx
+```
+
+The API key is read in this order:
+1. `--embed-api-key` flag
+2. `GITNEXUS_EMBED_API_KEY` environment variable
+3. `OPENAI_API_KEY` environment variable
+
+Default endpoint is `https://api.openai.com/v1`. Override with `--embed-endpoint` for proxies or compatible APIs:
+
+```bash
+# LiteLLM proxy
+gitnexus analyze --embeddings \
+  --embed-provider openai \
+  --embed-model text-embedding-3-small \
+  --embed-dims 1536 \
+  --embed-endpoint http://localhost:4000/v1 \
+  --embed-api-key sk-xxx
+```
+
+OpenAI embedding models:
+
+| Model | Dimensions | Notes |
+|-------|-----------|-------|
+| `text-embedding-3-small` | 1536 | Cheapest, good quality |
+| `text-embedding-3-large` | 3072 | Best quality |
+| `text-embedding-ada-002` | 1536 | Legacy |
+
+### Cohere
+
+```bash
+gitnexus analyze --embeddings \
+  --embed-provider cohere \
+  --embed-model embed-english-light-v3.0 \
+  --embed-dims 384 \
+  --embed-api-key xxx
+```
+
+The API key is read in this order:
+1. `--embed-api-key` flag
+2. `GITNEXUS_EMBED_API_KEY` environment variable
+3. `COHERE_API_KEY` environment variable
+
+Cohere embedding models:
+
+| Model | Dimensions | Notes |
+|-------|-----------|-------|
+| `embed-english-light-v3.0` | 384 | Fast, English only |
+| `embed-english-v3.0` | 1024 | Best English quality |
+| `embed-multilingual-v3.0` | 1024 | Multilingual |
+| `embed-multilingual-light-v3.0` | 384 | Fast, multilingual |
+
+## CLI Flags Reference
+
+| Flag | Environment Variable | Default | Description |
+|------|---------------------|---------|-------------|
+| `--embeddings` | — | off | Enable embedding generation |
+| `--embed-provider <type>` | `GITNEXUS_EMBED_PROVIDER` | `local` | Provider: `local`, `ollama`, `openai`, `cohere` |
+| `--embed-model <model>` | `GITNEXUS_EMBED_MODEL` | Per-provider default | Model name |
+| `--embed-dims <n>` | `GITNEXUS_EMBED_DIMS` | `384` | Vector dimensions |
+| `--embed-endpoint <url>` | `GITNEXUS_EMBED_ENDPOINT` | Per-provider default | API endpoint URL |
+| `--embed-api-key <key>` | `GITNEXUS_EMBED_API_KEY` | — | API key |
+
+Priority: CLI flags > environment variables > defaults.
+
+## Environment Variables Example
+
+```bash
+# .env or shell profile
+export GITNEXUS_EMBED_PROVIDER=ollama
+export GITNEXUS_EMBED_MODEL=nomic-embed-text
+export GITNEXUS_EMBED_DIMS=768
+export GITNEXUS_EMBED_ENDPOINT=http://localhost:11434
+
+# Then just:
+gitnexus analyze --embeddings
+```
+
+## Embedding Caching
+
+GitNexus caches embeddings across re-indexes. When you run `gitnexus analyze` again (without `--force`):
+
+1. Existing embeddings are extracted from the current index
+2. The graph is rebuilt
+3. Cached embeddings are re-inserted for symbols that still exist
+4. Only new/changed symbols need fresh embedding
+
+This makes incremental re-indexing much faster. Use `--force` to regenerate all embeddings from scratch.
+
+If you change the embedding provider or model, cached embeddings are automatically discarded and regenerated.
+
+## What Gets Embedded
+
+These node types are embedded for semantic search:
+
+- **Function** — function/method bodies and signatures
+- **Class** — class definitions
+- **Method** — class method bodies
+- **Interface** — interface definitions
+- **File** — file-level summaries
+
+Each node's embedding text includes its name, file path, and a code snippet (up to 500 characters).
+
+## Limitations
+
+- **Neptune**: Embeddings are not supported with the Neptune backend (v1). Use KuzuDB.
+- **Large codebases**: Embedding generation adds time proportional to the number of embeddable symbols. The `local` provider processes ~16 symbols per batch on CPU.
+- **Dimensions must match**: Setting `--embed-dims` to a value that doesn't match the model's actual output will produce incorrect results. Always check the model's documentation.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -1,0 +1,525 @@
+# GitNexus TUI — Interfaccia Terminale Interattiva
+
+La TUI (Terminal User Interface) di GitNexus offre wizard guidati, tabelle formattate, barre di progresso multi-fase e prompt interattivi direttamente nel terminale. Si attiva automaticamente quando i comandi vengono eseguiti in un terminale TTY senza flag espliciti.
+
+---
+
+## Installazione
+
+### Da npm (consigliato)
+
+```bash
+npm install -g gitnexus
+```
+
+### Da sorgente locale
+
+```bash
+cd gitnexus/
+npm install
+npm run build
+npm install -g .
+```
+
+### Verifica installazione
+
+```bash
+gitnexus --version   # Deve mostrare la versione (es. 1.4.0)
+gitnexus --help      # Mostra tutti i comandi disponibili
+```
+
+### Requisiti
+
+- **Node.js** >= 18
+- **Git** — il repository da analizzare deve essere un repo git
+- **Terminale TTY** — la TUI richiede un terminale interattivo (non funziona in pipe o CI)
+
+### Dipendenze TUI
+
+La TUI utilizza internamente:
+
+| Libreria | Versione | Uso |
+|----------|----------|-----|
+| `@clack/prompts` | 1.1.0 | Prompt interattivi (select, confirm, text, password) |
+| `cli-progress` | 3.12.0 | Barre di progresso multi-fase |
+| `picocolors` | 1.1.1 | Colorazione output (non richiede configurazione) |
+
+Tutte le dipendenze sono incluse nel pacchetto — nessuna installazione aggiuntiva necessaria.
+
+---
+
+## Quando si attiva la TUI
+
+La TUI si attiva **automaticamente** quando:
+
+1. Lo stdout è un terminale TTY
+2. Non si è in ambiente CI (`CI` non è `true` o `1`)
+3. Non sono stati passati flag espliciti (es. `--force`, `--db`, ecc.)
+4. Non è stato passato `--yes` / `-y`
+5. Non ci sono variabili d'ambiente di configurazione (`GITNEXUS_DB_TYPE`, `GITNEXUS_NEPTUNE_ENDPOINT`, ecc.)
+
+### Disattivare la TUI
+
+Per saltare i prompt interattivi e usare i valori predefiniti:
+
+```bash
+gitnexus analyze --yes          # Salta la TUI, usa i default
+gitnexus analyze --force        # Qualsiasi flag esplicito disattiva la TUI
+gitnexus analyze --db kuzu      # Flag esplicito → niente wizard
+GITNEXUS_DB_TYPE=kuzu gitnexus analyze   # Variabile d'ambiente → niente wizard
+```
+
+---
+
+## Comandi e wizard interattivi
+
+### `gitnexus setup` — Configurazione iniziale
+
+Configura automaticamente MCP per i tuoi editor. Da eseguire una sola volta.
+
+```bash
+gitnexus setup
+```
+
+**Flusso interattivo:**
+
+1. Rileva gli editor installati (Cursor, Claude Code, OpenCode)
+2. Mostra quelli trovati (con segno di spunta verde) e quelli non trovati
+3. Chiede per quali editor configurare MCP (selezione multipla con checkbox)
+4. Chiede conferma prima di scrivere i file di configurazione
+5. Scrive la configurazione MCP per ogni editor selezionato
+
+**Esempio output:**
+
+```
+◇  GitNexus Setup
+
+  Detected editors:
+    ✓ Cursor       ~/.cursor/mcp.json
+    ✓ Claude Code  ~/.claude/mcp.json
+    · OpenCode     (not found)
+
+◆  Configure MCP for:
+│  ◻ Cursor
+│  ◻ Claude Code
+└
+```
+
+**Modalità non interattiva:**
+
+```bash
+gitnexus setup --yes    # Configura tutti gli editor rilevati automaticamente
+```
+
+---
+
+### `gitnexus analyze [path]` — Indicizzazione repository
+
+Indicizza un repository costruendo il knowledge graph completo.
+
+```bash
+gitnexus analyze              # Indicizza il repo corrente (con wizard)
+gitnexus analyze /path/repo   # Indicizza un percorso specifico
+```
+
+**Flusso del wizard interattivo:**
+
+1. Conferma il percorso del repository
+2. Scelta del database backend:
+   - **KuzuDB** (locale, zero-config) — predefinito
+   - **AWS Neptune** (cloud)
+3. Se Neptune: endpoint, regione AWS, porta HTTP
+4. Abilitazione embeddings per ricerca semantica (predefinito: no)
+5. Se embeddings: provider (Local/Ollama/OpenAI/Cohere), modello, dimensioni, chiave API
+6. Se il repo è già indicizzato: conferma re-indicizzazione forzata
+7. Abilitazione log verbosi (predefinito: no)
+8. Riepilogo configurazione in una box formattata
+9. Conferma finale prima di avviare
+
+**Esempio riepilogo configurazione:**
+
+```
+┌─ Configuration ────────────────────────┐
+│ Repository     my-project              │
+│ Path           /home/user/my-project   │
+│ Database       KuzuDB (local)          │
+│ Embeddings     off                     │
+│ Force          no                      │
+│ Verbose        no                      │
+└────────────────────────────────────────┘
+```
+
+**Barra di progresso multi-fase:**
+
+Durante l'analisi, una barra di progresso mostra l'avanzamento attraverso 5 fasi:
+
+```
+  ████████████████░░░░░░░░░░░░░░ 53% | Running pipeline | 3,245 files · 12,340 symbols | 45s
+  ✓ Pipeline                                                                          42.3s
+  ██████░░░░░░░░░░░░░░░░░░░░░░░░ 68% | Loading into KuzuDB | 12,340 nodes
+```
+
+Le fasi sono:
+1. **Pipeline** (60%) — scansione file, parsing, risoluzione dipendenze
+2. **DB** (25%) — caricamento nel database (KuzuDB o Neptune)
+3. **FTS** (5%) — creazione indici di ricerca full-text
+4. **Embeddings** (8%) — generazione embeddings (se abilitati)
+5. **Finalize** (2%) — finalizzazione
+
+**Modalità non interattiva:**
+
+```bash
+gitnexus analyze --yes                    # Default: KuzuDB, no embeddings
+gitnexus analyze --force --embeddings     # Re-indicizza con embeddings
+gitnexus analyze --db neptune \
+  --neptune-endpoint host.amazonaws.com \
+  --neptune-region us-east-1              # Neptune diretto, niente wizard
+```
+
+---
+
+### `gitnexus wiki [path]` — Generazione wiki
+
+Genera documentazione automatica dal knowledge graph usando un LLM.
+
+```bash
+gitnexus wiki             # Wiki del repo corrente (con wizard)
+gitnexus wiki /path/repo  # Wiki di un percorso specifico
+```
+
+**Flusso del wizard interattivo:**
+
+1. Verifica che il repo sia indicizzato (suggerisce `gitnexus analyze` se necessario)
+2. Scelta del provider LLM:
+   - **OpenAI** (api.openai.com) — predefinito
+   - **OpenRouter** (openrouter.ai — accesso a molti modelli)
+   - **Custom endpoint** (qualsiasi API compatibile OpenAI)
+3. Se custom: URL base dell'endpoint
+4. Nome del modello (predefiniti: `gpt-4o-mini` per OpenAI, `minimax/minimax-m2.5` per OpenRouter)
+5. Chiave API (input mascherato, rileva chiavi salvate o da variabili d'ambiente)
+6. Concorrenza: numero di chiamate LLM parallele (1-10, predefinito: 3)
+7. Se la wiki esiste già: conferma rigenerazione forzata
+8. Riepilogo configurazione
+9. Conferma finale
+10. Salva la configurazione in `~/.gitnexus/config.json` per sessioni future
+
+**Modalità non interattiva:**
+
+```bash
+gitnexus wiki --yes                                    # Usa config salvata
+gitnexus wiki --model gpt-4o-mini --api-key sk-xxx     # Flag espliciti
+```
+
+---
+
+### `gitnexus query [ricerca]` — Ricerca nel knowledge graph
+
+Cerca flussi di esecuzione correlati a un concetto.
+
+```bash
+gitnexus query                    # Modalità interattiva
+gitnexus query "authentication"   # Ricerca diretta
+```
+
+**Modalità interattiva (senza argomenti):**
+
+1. Selezione repository (se più di uno indicizzato)
+2. Input della query di ricerca (es. "authentication flow", "error handling")
+3. Contesto opzionale (es. "sto lavorando sul login")
+
+**Output:**
+
+```
+  Query Results (5 flows)
+
+  #  Process              Relevance  Symbols
+  ── ──────────────────── ────────── ────────
+  1  UserAuthFlow         0.92       12
+  2  TokenValidation      0.87       8
+  3  PermissionCheck      0.81       6
+```
+
+---
+
+### `gitnexus context [nome]` — Vista 360° di un simbolo
+
+Mostra callers, callees e partecipazione ai processi di un simbolo.
+
+```bash
+gitnexus context                    # Modalità interattiva
+gitnexus context "validateUser"     # Ricerca diretta
+```
+
+**Modalità interattiva:**
+
+1. Selezione repository
+2. Input del nome del simbolo (es. "validateUser", "AuthService")
+
+**Output:**
+
+```
+┌─ Symbol Context ───────────────────────┐
+│ Name               validateUser        │
+│ Type               Function            │
+│ File               src/auth.ts         │
+│ Callers            5                   │
+│ Callees            3                   │
+│ Processes          2                   │
+└────────────────────────────────────────┘
+
+  Callers:
+    ← loginHandler (src/routes.ts)
+    ← apiMiddleware (src/app.ts)
+
+  Callees:
+    → hashPassword (src/crypto.ts)
+    → findUser (src/db.ts)
+```
+
+---
+
+### `gitnexus impact [target]` — Analisi blast radius
+
+Analizza cosa si rompe se modifichi un simbolo.
+
+```bash
+gitnexus impact                     # Modalità interattiva
+gitnexus impact "AuthService"       # Analisi diretta
+```
+
+**Modalità interattiva:**
+
+1. Selezione repository
+2. Input del simbolo target
+3. Scelta direzione: **upstream** (chi dipende da me) o **downstream** (da chi dipendo)
+
+**Output con livelli di rischio colorati:**
+
+```
+  Impact Analysis (8 affected)
+
+  Symbol               Type       Depth  Risk          File
+  ──────────────────── ────────── ────── ──────────── ──────────
+  loginHandler         Function   1      WILL BREAK   auth.ts
+  requestMiddleware    Function   1      WILL BREAK   app.ts
+  tokenValidator       Function   2      LIKELY       utils.ts
+  cacheService         Class      3      MAY          cache.ts
+```
+
+| Profondità | Rischio | Colore | Significato |
+|------------|---------|--------|-------------|
+| d=1 | WILL BREAK | Rosso | Dipendenti diretti — si romperanno sicuramente |
+| d=2 | LIKELY | Giallo | Dipendenze indirette — probabilmente impattate |
+| d=3 | MAY | Verde | Dipendenze transitive — da testare se percorso critico |
+
+---
+
+### `gitnexus cypher [query]` — Console Cypher
+
+Esegui query Cypher raw contro il knowledge graph.
+
+```bash
+gitnexus cypher                                              # Modalità interattiva
+gitnexus cypher "MATCH (n:Function) RETURN n.name LIMIT 10"  # Query diretta
+```
+
+**Modalità interattiva:**
+
+1. Selezione repository
+2. Input della query Cypher
+
+**Output:** Tabella dinamica con colonne auto-rilevate dal risultato.
+
+```
+  Results (10 rows)
+
+  name                type       file
+  ──────────────────── ────────── ──────────
+  validateUser        Function   auth.ts
+  hashPassword        Function   crypto.ts
+```
+
+---
+
+### `gitnexus list` — Lista repository indicizzati
+
+```bash
+gitnexus list
+```
+
+**Output:**
+
+```
+  Indexed Repositories (3)
+
+  Name        Path                        Indexed      Commit   Symbols   Edges
+  ─────────── ─────────────────────────── ──────────── ──────── ───────── ─────────
+  my-project  /home/user/projects/my-p... 14/3/2026    a1b2c3d  1,245     6,789
+  api-server  /home/user/projects/api-... 12/3/2026    def456e  892       3,421
+```
+
+---
+
+### `gitnexus status` — Stato del repository corrente
+
+```bash
+gitnexus status
+```
+
+**Output:**
+
+```
+┌─ Repository Status ────────────────────┐
+│ Repository         my-project          │
+│ Indexed            14/3/2026 14:30     │
+│ Indexed commit     a1b2c3d             │
+│ Current commit     a1b2c3d             │
+│ Status             Up to date          │
+│ Files              245                 │
+│ Symbols            1,245               │
+│ Edges              6,789               │
+│ Communities        42                  │
+│ Processes          18                  │
+└────────────────────────────────────────┘
+```
+
+Lo stato è verde se "Up to date", giallo se "Stale" (il commit corrente non corrisponde a quello indicizzato).
+
+---
+
+### `gitnexus clean` — Eliminazione indice
+
+```bash
+gitnexus clean              # Elimina l'indice del repo corrente (con conferma)
+gitnexus clean --all        # Elimina tutti gli indici (con conferma)
+gitnexus clean --force      # Senza conferma
+gitnexus clean --all --yes  # Tutti, senza conferma
+```
+
+**Conferma distruttiva (operazione irreversibile):**
+
+```
+WARNING: Delete GitNexus indexes for 2 repo(s)?
+  • my-project (/home/user/.gitnexus/storage/my-project)
+  • api-server (/home/user/.gitnexus/storage/api-server)
+
+◆  Are you sure?
+│  ○ Yes  / ● No
+└
+```
+
+Dopo l'eliminazione:
+
+```
+  ✓ Deleted: my-project
+  ✓ Deleted: api-server
+```
+
+---
+
+### `gitnexus serve` — Server web locale
+
+```bash
+gitnexus serve                  # Porta predefinita 4747
+gitnexus serve --port 8080      # Porta personalizzata
+gitnexus serve --host 0.0.0.0   # Accessibile dalla rete
+```
+
+**Banner di avvio:**
+
+```
+  ◊ GitNexus Web Server ◊
+  ℹ Listening at http://127.0.0.1:4747
+  ℹ Press Ctrl+C to stop
+```
+
+---
+
+## Componenti TUI riutilizzabili
+
+La TUI è costruita con componenti modulari in `gitnexus/src/cli/tui/`:
+
+### Struttura directory
+
+```
+src/cli/tui/
+├── index.ts                  # Re-export di tutti i componenti
+├── shared.ts                 # Logica di attivazione TUI e serializzazione env
+├── components/
+│   ├── repo-picker.ts        # Selettore repository interattivo
+│   ├── multi-progress.ts     # Barra di progresso multi-fase
+│   ├── formatted-table.ts    # Tabelle ASCII formattate
+│   ├── summary-box.ts        # Box riepilogo chiave-valore
+│   ├── confirm-destructive.ts # Conferma per operazioni distruttive
+│   ├── config-display.ts     # Visualizzazione configurazione
+│   └── log-panel.ts          # Pannello log con contatori errori/warning
+├── formatters/
+│   ├── list-formatter.ts     # Output del comando `list`
+│   ├── status-formatter.ts   # Output del comando `status`
+│   ├── clean-tui.ts          # Flusso interattivo del comando `clean`
+│   ├── serve-banner.ts       # Banner di avvio del server
+│   └── ai-context-tui.ts     # Output contesto AI
+├── interactive/
+│   ├── query-tui.ts          # TUI interattiva per `query`
+│   ├── context-tui.ts        # TUI interattiva per `context`
+│   ├── impact-tui.ts         # TUI interattiva per `impact`
+│   ├── cypher-tui.ts         # TUI interattiva per `cypher`
+│   └── augment-tui.ts        # TUI per `augment`
+└── wizards/
+    ├── analyze-wizard.ts     # Wizard multi-step per `analyze`
+    ├── wiki-wizard.ts        # Wizard multi-step per `wiki`
+    └── setup-wizard.ts       # Wizard configurazione iniziale
+```
+
+### Componenti principali
+
+| Componente | Import | Descrizione |
+|------------|--------|-------------|
+| `pickRepo` | `tui/components/repo-picker` | Selettore repository con auto-selezione se uno solo |
+| `createMultiProgress` | `tui/components/multi-progress` | Barra progresso con fasi pesate e tempo trascorso |
+| `renderTable` | `tui/components/formatted-table` | Tabelle con colonne auto-dimensionate e allineamento |
+| `renderSummaryBox` | `tui/components/summary-box` | Box con bordi per dati chiave-valore |
+| `confirmDestructive` | `tui/components/confirm-destructive` | Warning rosso + lista items + conferma |
+| `renderConfig` | `tui/components/config-display` | Riepilogo configurazione con valori booleani colorati |
+| `createLogPanel` | `tui/components/log-panel` | Log bufferizzato con conteggio errori/warning |
+
+---
+
+## Variabili d'ambiente
+
+Variabili che influenzano il comportamento della TUI:
+
+| Variabile | Effetto |
+|-----------|---------|
+| `CI=true` | Disattiva la TUI (modalità non interattiva) |
+| `GITNEXUS_DB_TYPE` | Disattiva il wizard analyze (configurazione esplicita) |
+| `GITNEXUS_NEPTUNE_ENDPOINT` | Disattiva il wizard analyze |
+| `GITNEXUS_EMBED_PROVIDER` | Disattiva il wizard analyze |
+| `GITNEXUS_FORCE` | Disattiva il wizard analyze |
+| `GITNEXUS_TUI_DONE=1` | Flag interno: impedisce loop di re-exec del wizard |
+| `GITNEXUS_VERBOSE=1` | Abilita log dettagliati durante l'analisi |
+
+---
+
+## Output JSON per scripting
+
+Quando l'output non è un TTY (pipe, redirect, CI), i comandi `query`, `context`, `impact` e `cypher` emettono JSON raw su stderr invece dell'output formattato. Questo permette l'integrazione con script e pipeline:
+
+```bash
+gitnexus query "auth" 2> results.json     # JSON output
+gitnexus impact "AuthService" | jq .       # Pipe a jq
+```
+
+---
+
+## Convenzioni colori
+
+| Colore | Significato |
+|--------|-------------|
+| Verde | Successo, conferma, valori attivi |
+| Rosso | Errori, warning distruttivi, rischio alto |
+| Giallo | Attenzione, rischio medio, stato "stale" |
+| Ciano | Banner informativi, URL, titoli |
+| Magenta | Banner wiki e cypher |
+| Dim (grigio) | Percorsi, valori secondari, placeholder |
+| Bold | Nomi, valori importanti |

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "gitnexus",
-  "version": "1.4.0",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.4.0",
+      "version": "1.4.6",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
+        "@clack/prompts": "^1.1.0",
         "@huggingface/transformers": "^3.0.0",
         "@ladybugdb/core": "^0.15.1",
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -25,6 +26,7 @@
         "lru-cache": "^11.0.0",
         "mnemonist": "^0.39.0",
         "pandemonium": "^2.4.0",
+        "picocolors": "^1.1.1",
         "tree-sitter": "^0.21.0",
         "tree-sitter-c": "^0.21.0",
         "tree-sitter-c-sharp": "^0.21.0",
@@ -36,7 +38,6 @@
         "tree-sitter-python": "^0.21.0",
         "tree-sitter-ruby": "^0.23.1",
         "tree-sitter-rust": "^0.21.0",
-        "tree-sitter-swift": "^0.6.0",
         "tree-sitter-typescript": "^0.21.0",
         "uuid": "^13.0.0"
       },
@@ -120,6 +121,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==",
+      "license": "MIT",
+      "dependencies": {
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.1.0.tgz",
+      "integrity": "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.1.0",
+        "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -4137,7 +4157,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -4708,6 +4727,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -49,6 +49,7 @@
     "prepack": "npm run build && chmod +x dist/cli/index.js"
   },
   "dependencies": {
+    "@clack/prompts": "^1.1.0",
     "@huggingface/transformers": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "cli-progress": "^3.12.0",
@@ -64,6 +65,7 @@
     "lru-cache": "^11.0.0",
     "mnemonist": "^0.39.0",
     "pandemonium": "^2.4.0",
+    "picocolors": "^1.1.1",
     "tree-sitter": "^0.21.0",
     "tree-sitter-c": "^0.21.0",
     "tree-sitter-c-sharp": "^0.21.0",

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -7,9 +7,8 @@
 import path from 'path';
 import { execFileSync } from 'child_process';
 import v8 from 'v8';
-import cliProgress from 'cli-progress';
 import { runPipelineFromRepo } from '../core/ingestion/pipeline.js';
-import { initLbug, loadGraphToLbug, getLbugStats, executeQuery, executeWithReusedStatement, closeLbug, createFTSIndex, loadCachedEmbeddings } from '../core/lbug/lbug-adapter.js';
+import { initLbug, loadGraphToLbug, getLbugStats, executeQuery, executeWithReusedStatement, closeLbug, createFTSIndex, loadCachedEmbeddings, ensureEmbeddingTable } from '../core/lbug/lbug-adapter.js';
 // Embedding imports are lazy (dynamic import) so onnxruntime-node is never
 // loaded when embeddings are not requested. This avoids crashes on Node
 // versions whose ABI is not yet supported by the native binary (#89).
@@ -19,6 +18,7 @@ import { getCurrentCommit, isGitRepo, getGitRoot } from '../storage/git.js';
 import { generateAIContextFiles } from './ai-context.js';
 import { generateSkillFiles, type GeneratedSkillInfo } from './skill-gen.js';
 import fs from 'fs/promises';
+import { resolveEmbeddingConfig } from './embed-config.js';
 
 
 const HEAP_MB = 8192;
@@ -48,10 +48,13 @@ export interface AnalyzeOptions {
   embeddings?: boolean;
   skills?: boolean;
   verbose?: boolean;
+  embedProvider?: string;
+  embedModel?: string;
+  embedDims?: string;
+  embedEndpoint?: string;
+  embedApiKey?: string;
+  yes?: boolean;
 }
-
-/** Threshold: auto-skip embeddings for repos with more nodes than this */
-const EMBEDDING_NODE_LIMIT = 50_000;
 
 const PHASE_LABELS: Record<string, string> = {
   extracting: 'Scanning files',
@@ -73,6 +76,26 @@ export const analyzeCommand = async (
   inputPath?: string,
   options?: AnalyzeOptions
 ) => {
+  // ── TUI Wizard (runs before heap re-exec) ─────────────────────────
+  if (options && !(options as Record<string, unknown>)._tuiMerged) {
+    const { shouldRunInteractive, serializeToEnv, deserializeFromEnv } = await import('./tui/shared.js');
+
+    if (shouldRunInteractive(options as Record<string, unknown>)) {
+      const { runAnalyzeWizard } = await import('./tui/analyze-wizard.js');
+      const result = await runAnalyzeWizard(inputPath, options);
+      if (!result) return;
+      options = { ...options, ...result.options };
+      inputPath = result.path ?? inputPath;
+      serializeToEnv(result);
+    } else if (process.env.GITNEXUS_TUI_DONE === '1') {
+      // Re-exec child: merge wizard choices from env
+      const fromEnv = deserializeFromEnv();
+      if (fromEnv.tuiPath) inputPath = fromEnv.tuiPath;
+      options = { ...options, ...fromEnv };
+      (options as Record<string, unknown>)._tuiMerged = true;
+    }
+  }
+
   if (ensureHeap()) return;
 
   if (options?.verbose) {
@@ -100,6 +123,9 @@ export const analyzeCommand = async (
     return;
   }
 
+  // Resolve embedding config (always, even if --embeddings not set, for registry persistence)
+  const embedConfig = resolveEmbeddingConfig(options ?? {});
+
   const { storagePath, lbugPath } = getStoragePaths(repoPath);
 
   // Clean up stale KuzuDB files from before the LadybugDB migration.
@@ -121,67 +147,26 @@ export const analyzeCommand = async (
     console.log('  GITNEXUS_NO_GITIGNORE is set — skipping .gitignore (still reading .gitnexusignore)\n');
   }
 
-  // Single progress bar for entire pipeline
-  const bar = new cliProgress.SingleBar({
-    format: '  {bar} {percentage}% | {phase}',
-    barCompleteChar: '\u2588',
-    barIncompleteChar: '\u2591',
-    hideCursor: true,
-    barGlue: '',
-    autopadding: true,
-    clearOnComplete: false,
-    stopOnComplete: false,
-  }, cliProgress.Presets.shades_grey);
-
-  bar.start(100, 0, { phase: 'Initializing...' });
+  // Multi-phase progress display
+  const { createMultiProgress } = await import('./tui/components/multi-progress.js');
+  const mp = createMultiProgress([
+    { name: 'pipeline', label: 'Running pipeline', weight: 60 },
+    { name: 'db', label: 'Loading into LadybugDB', weight: 25 },
+    { name: 'fts', label: 'Creating search indexes', weight: 5 },
+    { name: 'embeddings', label: 'Generating embeddings', weight: 8 },
+    { name: 'finalize', label: 'Finalizing', weight: 2 },
+  ]);
 
   // Graceful SIGINT handling — clean up resources and exit
   let aborted = false;
   const sigintHandler = () => {
     if (aborted) process.exit(1); // Second Ctrl-C: force exit
     aborted = true;
-    bar.stop();
+    mp.stop();
     console.log('\n  Interrupted — cleaning up...');
     closeLbug().catch(() => {}).finally(() => process.exit(130));
   };
   process.on('SIGINT', sigintHandler);
-
-  // Route all console output through bar.log() so the bar doesn't stamp itself
-  // multiple times when other code writes to stdout/stderr mid-render.
-  const origLog = console.log.bind(console);
-  const origWarn = console.warn.bind(console);
-  const origError = console.error.bind(console);
-  const barLog = (...args: any[]) => {
-    // Clear the bar line, print the message, then let the next bar.update redraw
-    process.stdout.write('\x1b[2K\r');
-    origLog(args.map(a => (typeof a === 'string' ? a : String(a))).join(' '));
-  };
-  console.log = barLog;
-  console.warn = barLog;
-  console.error = barLog;
-
-  // Track elapsed time per phase — both updateBar and the interval use the
-  // same format so they don't flicker against each other.
-  let lastPhaseLabel = 'Initializing...';
-  let phaseStart = Date.now();
-
-  /** Update bar with phase label + elapsed seconds (shown after 3s). */
-  const updateBar = (value: number, phaseLabel: string) => {
-    if (phaseLabel !== lastPhaseLabel) { lastPhaseLabel = phaseLabel; phaseStart = Date.now(); }
-    const elapsed = Math.round((Date.now() - phaseStart) / 1000);
-    const display = elapsed >= 3 ? `${phaseLabel} (${elapsed}s)` : phaseLabel;
-    bar.update(value, { phase: display });
-  };
-
-  // Tick elapsed seconds for phases with infrequent progress callbacks
-  // (e.g. CSV streaming, FTS indexing). Uses the same display format as
-  // updateBar so there's no flickering.
-  const elapsedTimer = setInterval(() => {
-    const elapsed = Math.round((Date.now() - phaseStart) / 1000);
-    if (elapsed >= 3) {
-      bar.update({ phase: `${lastPhaseLabel} (${elapsed}s)` });
-    }
-  }, 1000);
 
   const t0Global = Date.now();
 
@@ -189,9 +174,17 @@ export const analyzeCommand = async (
   let cachedEmbeddingNodeIds = new Set<string>();
   let cachedEmbeddings: Array<{ nodeId: string; embedding: number[] }> = [];
 
-  if (options?.embeddings && existingMeta && !options?.force) {
+  // Check dimension mismatch: if provider/model/dims changed, invalidate cache
+  const existingRegistry = await import('../storage/repo-manager.js').then(m => m.readRegistry());
+  const existingEntry = existingRegistry.find((e: any) => path.resolve(e.path) === path.resolve(repoPath));
+  const prevDims = existingEntry?.embedding?.dimensions ?? 384;
+  const dimsChanged = options?.embeddings && prevDims !== embedConfig.dimensions;
+  const providerChanged = options?.embeddings && existingEntry?.embedding &&
+    (existingEntry.embedding.provider !== embedConfig.provider || existingEntry.embedding.model !== embedConfig.model);
+
+  if (options?.embeddings && existingMeta && !options?.force && !dimsChanged && !providerChanged) {
     try {
-      updateBar(0, 'Caching embeddings...');
+      mp.update(0, 'Caching embeddings...');
       await initLbug(lbugPath);
       const cached = await loadCachedEmbeddings();
       cachedEmbeddingNodeIds = cached.embeddingNodeIds;
@@ -202,16 +195,23 @@ export const analyzeCommand = async (
     }
   }
 
-  // ── Phase 1: Full Pipeline (0–60%) ─────────────────────────────────
+  // ── Phase 1: Full Pipeline ──────────────────────────────────────────
+  mp.setPhase('pipeline');
   const pipelineResult = await runPipelineFromRepo(repoPath, (progress) => {
     const phaseLabel = PHASE_LABELS[progress.phase] || progress.phase;
-    const scaled = Math.round(progress.percent * 0.6);
-    updateBar(scaled, phaseLabel);
+    const detail =
+      progress.phase === 'parsing' && (progress.stats?.totalFiles ?? 0) > 0
+        ? `${progress.stats!.filesProcessed}/${progress.stats!.totalFiles} files${
+            options?.verbose && progress.detail
+              ? ` — ${progress.detail.split('/').at(-1)}`
+              : ''
+          }`
+        : undefined;
+    mp.update(progress.percent, detail || phaseLabel);
   });
 
-  // ── Phase 2: LadybugDB (60–85%) ──────────────────────────────────────
-  updateBar(60, 'Loading into LadybugDB...');
-
+  // ── Phase 2: LadybugDB ─────────────────────────────────────────────
+  mp.setPhase('db');
   await closeLbug();
   const lbugFiles = [lbugPath, `${lbugPath}.wal`, `${lbugPath}.lock`];
   for (const f of lbugFiles) {
@@ -223,15 +223,14 @@ export const analyzeCommand = async (
   let lbugMsgCount = 0;
   const lbugResult = await loadGraphToLbug(pipelineResult.graph, pipelineResult.repoPath, storagePath, (msg) => {
     lbugMsgCount++;
-    const progress = Math.min(84, 60 + Math.round((lbugMsgCount / (lbugMsgCount + 10)) * 24));
-    updateBar(progress, msg);
+    const progress = Math.min(100, Math.round((lbugMsgCount / (lbugMsgCount + 10)) * 100));
+    mp.update(progress, msg);
   });
-  const lbugTime = ((Date.now() - t0Lbug) / 1000).toFixed(1);
-  const lbugWarnings = lbugResult.warnings;
+  const dbTime = ((Date.now() - t0Lbug) / 1000).toFixed(1);
+  const dbWarnings = lbugResult.warnings;
 
-  // ── Phase 3: FTS (85–90%) ─────────────────────────────────────────
-  updateBar(85, 'Creating search indexes...');
-
+  // ── Phase 3: FTS ───────────────────────────────────────────────────
+  mp.setPhase('fts');
   const t0Fts = Date.now();
   try {
     await createFTSIndex('File', 'file_fts', ['name', 'content']);
@@ -244,9 +243,16 @@ export const analyzeCommand = async (
   }
   const ftsTime = ((Date.now() - t0Fts) / 1000).toFixed(1);
 
+  // ── Ensure embedding table exists with configured dims ─────────────
+  // Must happen before cached embedding re-insertion AND embedding pipeline.
+  // Dims come from user config (--embed-dims, provider model, etc.), not hardcoded.
+  if (options?.embeddings) {
+    await ensureEmbeddingTable(embedConfig.dimensions);
+  }
+
   // ── Phase 3.5: Re-insert cached embeddings ────────────────────────
   if (cachedEmbeddings.length > 0) {
-    updateBar(88, `Restoring ${cachedEmbeddings.length} cached embeddings...`);
+    mp.update(50, `Restoring ${cachedEmbeddings.length} cached embeddings...`);
     const EMBED_BATCH = 200;
     for (let i = 0; i < cachedEmbeddings.length; i += EMBED_BATCH) {
       const batch = cachedEmbeddings.slice(i, i + EMBED_BATCH);
@@ -260,40 +266,44 @@ export const analyzeCommand = async (
     }
   }
 
-  // ── Phase 4: Embeddings (90–98%) ──────────────────────────────────
+  // ── Phase 4: Embeddings ─────────────────────────────────────────────
+  mp.setPhase('embeddings');
   const stats = await getLbugStats();
   let embeddingTime = '0.0';
-  let embeddingSkipped = true;
+  let embeddingSkipped = !options?.embeddings;
   let embeddingSkipReason = 'off (use --embeddings to enable)';
 
-  if (options?.embeddings) {
-    if (stats.nodes > EMBEDDING_NODE_LIMIT) {
-      embeddingSkipReason = `skipped (${stats.nodes.toLocaleString()} nodes > ${EMBEDDING_NODE_LIMIT.toLocaleString()} limit)`;
-    } else {
-      embeddingSkipped = false;
-    }
-  }
-
   if (!embeddingSkipped) {
-    updateBar(90, 'Loading embedding model...');
+    mp.update(0, `Loading embedding provider (${embedConfig.provider})...`);
     const t0Emb = Date.now();
-    const { runEmbeddingPipeline } = await import('../core/embeddings/embedding-pipeline.js');
+
+    const { createEmbeddingProvider } = await import('../core/embeddings/providers/factory.js');
+    const { runEmbeddingPipeline, getEmbeddableLabels } = await import('../core/embeddings/embedding-pipeline.js');
+
+    const provider = await createEmbeddingProvider(embedConfig);
+    const labels = getEmbeddableLabels(stats.nodes);
+
+    // LadybugDB path (embedding table already created above)
     await runEmbeddingPipeline(
       executeQuery,
       executeWithReusedStatement,
       (progress) => {
-        const scaled = 90 + Math.round((progress.percent / 100) * 8);
-        const label = progress.phase === 'loading-model' ? 'Loading embedding model...' : `Embedding ${progress.nodesProcessed || 0}/${progress.totalNodes || '?'}`;
-        updateBar(scaled, label);
+        const label = progress.phase === 'loading-model'
+          ? `Loading ${embedConfig.provider} model...`
+          : `Embedding ${progress.nodesProcessed || 0}/${progress.totalNodes || '?'}`;
+        mp.update(progress.percent, label);
       },
+      provider,
       {},
       cachedEmbeddingNodeIds.size > 0 ? cachedEmbeddingNodeIds : undefined,
+      labels,
     );
     embeddingTime = ((Date.now() - t0Emb) / 1000).toFixed(1);
   }
 
-  // ── Phase 5: Finalize (98–100%) ───────────────────────────────────
-  updateBar(98, 'Saving metadata...');
+  // ── Phase 5: Finalize ──────────────────────────────────────────────
+  mp.setPhase('finalize');
+  mp.update(0, 'Saving metadata...');
 
   // Count embeddings in the index (cached + newly generated)
   let embeddingCount = 0;
@@ -316,7 +326,10 @@ export const analyzeCommand = async (
     },
   };
   await saveMeta(storagePath, meta);
-  await registerRepo(repoPath, meta);
+  const embeddingMeta = options?.embeddings
+    ? { provider: embedConfig.provider, model: embedConfig.model, dimensions: embedConfig.dimensions, endpoint: embedConfig.endpoint }
+    : undefined;
+  await registerRepo(repoPath, meta, undefined, embeddingMeta);
   await addToGitignore(repoPath);
 
   const projectName = path.basename(repoPath);
@@ -332,7 +345,7 @@ export const analyzeCommand = async (
 
   let generatedSkills: GeneratedSkillInfo[] = [];
   if (options?.skills && pipelineResult.communityResult) {
-    updateBar(99, 'Generating skill files...');
+    mp.update(50, 'Generating skill files...');
     const skillResult = await generateSkillFiles(repoPath, projectName, pipelineResult);
     generatedSkills = skillResult.skills;
   }
@@ -353,34 +366,37 @@ export const analyzeCommand = async (
 
   const totalTime = ((Date.now() - t0Global) / 1000).toFixed(1);
 
-  clearInterval(elapsedTimer);
   process.removeListener('SIGINT', sigintHandler);
-
-  console.log = origLog;
-  console.warn = origWarn;
-  console.error = origError;
-
-  bar.update(100, { phase: 'Done' });
-  bar.stop();
 
   // ── Summary ───────────────────────────────────────────────────────
   const embeddingsCached = cachedEmbeddings.length > 0;
-  console.log(`\n  Repository indexed successfully (${totalTime}s)${embeddingsCached ? ` [${cachedEmbeddings.length} embeddings cached]` : ''}\n`);
-  console.log(`  ${stats.nodes.toLocaleString()} nodes | ${stats.edges.toLocaleString()} edges | ${pipelineResult.communityResult?.stats.totalCommunities || 0} clusters | ${pipelineResult.processResult?.stats.totalProcesses || 0} flows`);
-  console.log(`  LadybugDB ${lbugTime}s | FTS ${ftsTime}s | Embeddings ${embeddingSkipped ? embeddingSkipReason : embeddingTime + 's'}`);
-  console.log(`  ${repoPath}`);
+  const resultLabel = embeddingsCached
+    ? `Indexed successfully (${totalTime}s) [${cachedEmbeddings.length} embeddings cached]`
+    : `Indexed successfully (${totalTime}s)`;
+
+  mp.complete({
+    'Result': resultLabel,
+    'Nodes': stats.nodes.toLocaleString(),
+    'Edges': stats.edges.toLocaleString(),
+    'Clusters': String(pipelineResult.communityResult?.stats.totalCommunities || 0),
+    'Flows': String(pipelineResult.processResult?.stats.totalProcesses || 0),
+    'Database': `LadybugDB (${dbTime}s)`,
+    'FTS': ftsTime + 's',
+    'Embeddings': embeddingSkipped ? embeddingSkipReason : embeddingTime + 's',
+    'Path': repoPath,
+  });
 
   if (aiContext.files.length > 0) {
     console.log(`  Context: ${aiContext.files.join(', ')}`);
   }
 
   // Show a quiet summary if some edge types needed fallback insertion
-  if (lbugWarnings.length > 0) {
-    const totalFallback = lbugWarnings.reduce((sum, w) => {
+  if (dbWarnings.length > 0) {
+    const totalFallback = dbWarnings.reduce((sum, w) => {
       const m = w.match(/\((\d+) edges\)/);
       return sum + (m ? parseInt(m[1]) : 0);
     }, 0);
-    console.log(`  Note: ${totalFallback} edges across ${lbugWarnings.length} types inserted via fallback (schema will be updated in next release)`);
+    console.log(`  Note: ${totalFallback} edges across ${dbWarnings.length} types inserted via fallback (schema will be updated in next release)`);
   }
 
   try {

--- a/gitnexus/src/cli/clean.ts
+++ b/gitnexus/src/cli/clean.ts
@@ -1,66 +1,11 @@
 /**
  * Clean Command
- * 
+ *
  * Removes the .gitnexus index from the current repository.
  * Also unregisters it from the global registry.
  */
 
-import fs from 'fs/promises';
-import { findRepo, unregisterRepo, listRegisteredRepos } from '../storage/repo-manager.js';
-
-export const cleanCommand = async (options?: { force?: boolean; all?: boolean }) => {
-  // --all flag: clean all indexed repos
-  if (options?.all) {
-    if (!options?.force) {
-      const entries = await listRegisteredRepos();
-      if (entries.length === 0) {
-        console.log('No indexed repositories found.');
-        return;
-      }
-      console.log(`This will delete GitNexus indexes for ${entries.length} repo(s):`);
-      for (const entry of entries) {
-        console.log(`  - ${entry.name} (${entry.path})`);
-      }
-      console.log('\nRun with --force to confirm deletion.');
-      return;
-    }
-
-    const entries = await listRegisteredRepos();
-    for (const entry of entries) {
-      try {
-        await fs.rm(entry.storagePath, { recursive: true, force: true });
-        await unregisterRepo(entry.path);
-        console.log(`Deleted: ${entry.name} (${entry.storagePath})`);
-      } catch (err) {
-        console.error(`Failed to delete ${entry.name}:`, err);
-      }
-    }
-    return;
-  }
-
-  // Default: clean current repo
-  const cwd = process.cwd();
-  const repo = await findRepo(cwd);
-
-  if (!repo) {
-    console.log('No indexed repository found in this directory.');
-    return;
-  }
-
-  const repoName = repo.repoPath.split(/[/\\]/).pop() || repo.repoPath;
-
-  if (!options?.force) {
-    console.log(`This will delete the GitNexus index for: ${repoName}`);
-    console.log(`   Path: ${repo.storagePath}`);
-    console.log('\nRun with --force to confirm deletion.');
-    return;
-  }
-
-  try {
-    await fs.rm(repo.storagePath, { recursive: true, force: true });
-    await unregisterRepo(repo.repoPath);
-    console.log(`Deleted: ${repo.storagePath}`);
-  } catch (err) {
-    console.error('Failed to delete:', err);
-  }
+export const cleanCommand = async (options?: { force?: boolean; all?: boolean; yes?: boolean }) => {
+  const { cleanInteractive } = await import('./tui/formatters/clean-tui.js');
+  await cleanInteractive(options);
 };

--- a/gitnexus/src/cli/embed-config.ts
+++ b/gitnexus/src/cli/embed-config.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared Embedding Configuration
+ *
+ * Resolves embedding provider config from CLI options + env vars.
+ * Used by both `analyze` and `embed` commands.
+ */
+
+import type { EmbeddingProviderConfig, EmbeddingProviderType } from '../core/embeddings/providers/types.js';
+
+export interface EmbedOptions {
+  embedProvider?: string;
+  embedModel?: string;
+  embedDims?: string;
+  embedEndpoint?: string;
+  embedApiKey?: string;
+}
+
+/**
+ * Resolve embedding provider config from CLI options + env vars.
+ * Priority: CLI flags > env vars > provider-specific defaults.
+ */
+export function resolveEmbeddingConfig(options: EmbedOptions): EmbeddingProviderConfig {
+  const provider = (options.embedProvider
+    ?? process.env.GITNEXUS_EMBED_PROVIDER
+    ?? 'local') as EmbeddingProviderType;
+
+  const defaultModel = provider === 'local'
+    ? 'Snowflake/snowflake-arctic-embed-xs'
+    : provider === 'ollama' ? 'nomic-embed-text'
+    : provider === 'cohere' ? 'embed-english-light-v3.0'
+    : 'text-embedding-3-small';
+
+  const model = options.embedModel
+    ?? process.env.GITNEXUS_EMBED_MODEL
+    ?? defaultModel;
+
+  const dimensions = parseInt(
+    options.embedDims ?? process.env.GITNEXUS_EMBED_DIMS ?? '384', 10,
+  );
+
+  const endpoint = options.embedEndpoint
+    ?? process.env.GITNEXUS_EMBED_ENDPOINT
+    ?? undefined;
+
+  const apiKey = options.embedApiKey
+    ?? process.env.GITNEXUS_EMBED_API_KEY
+    ?? undefined;
+
+  return { provider, model, dimensions, endpoint, apiKey };
+}

--- a/gitnexus/src/cli/embed.ts
+++ b/gitnexus/src/cli/embed.ts
@@ -1,0 +1,244 @@
+/**
+ * Embed Command
+ *
+ * Generates or updates embeddings for an already-indexed repository.
+ * Opens the existing DB, generates only missing embeddings, and updates
+ * registry/meta. Zero parsing, zero DB rebuild.
+ */
+
+import path from 'path';
+import { resolveEmbeddingConfig, type EmbedOptions } from './embed-config.js';
+import { getStoragePaths, loadMeta, saveMeta, readRegistry, registerRepo } from '../storage/repo-manager.js';
+import { getGitRoot, isGitRepo } from '../storage/git.js';
+import { initLbug, closeLbug, executeQuery, executeWithReusedStatement, loadCachedEmbeddings, getLbugStats, ensureEmbeddingTable } from '../core/lbug/lbug-adapter.js';
+import { EMBEDDING_TABLE_NAME } from '../core/lbug/schema.js';
+
+export interface EmbedCommandOptions extends EmbedOptions {
+  /** Alias: --provider maps to embedProvider */
+  provider?: string;
+  /** Alias: --model maps to embedModel */
+  model?: string;
+  /** Alias: --dims maps to embedDims */
+  dims?: string;
+  /** Alias: --endpoint maps to embedEndpoint */
+  endpoint?: string;
+  /** Alias: --api-key maps to embedApiKey */
+  apiKey?: string;
+  force?: boolean;
+  yes?: boolean;
+}
+
+/**
+ * Normalize short aliases (--provider) to canonical names (--embed-provider).
+ */
+function normalizeOptions(options: EmbedCommandOptions): EmbedOptions & { force?: boolean; yes?: boolean } {
+  return {
+    embedProvider: options.embedProvider ?? options.provider,
+    embedModel: options.embedModel ?? options.model,
+    embedDims: options.embedDims ?? options.dims,
+    embedEndpoint: options.embedEndpoint ?? options.endpoint,
+    embedApiKey: options.embedApiKey ?? options.apiKey,
+    force: options.force,
+    yes: options.yes,
+  };
+}
+
+export const embedCommand = async (
+  inputPath?: string,
+  options?: EmbedCommandOptions,
+) => {
+  const opts = normalizeOptions(options ?? {});
+
+  // ── TUI Wizard ─────────────────────────────────────────────────────
+  const { shouldRunInteractiveGeneric, hasExplicitFlags } = await import('./tui/shared.js');
+  if (!opts.yes && !hasExplicitFlags(opts as Record<string, unknown>) && shouldRunInteractiveGeneric(opts as Record<string, unknown>)) {
+    const { runEmbedWizard } = await import('./tui/wizards/embed-wizard.js');
+    const result = await runEmbedWizard(inputPath);
+    if (!result) return;
+    Object.assign(opts, result.options);
+    inputPath = result.path ?? inputPath;
+  }
+
+  console.log('\n  GitNexus Embeddings\n');
+
+  // ── Resolve repo path ──────────────────────────────────────────────
+  let repoPath: string;
+  if (inputPath) {
+    repoPath = path.resolve(inputPath);
+  } else {
+    const gitRoot = getGitRoot(process.cwd());
+    if (!gitRoot) {
+      console.log('  Not inside a git repository.\n');
+      process.exitCode = 1;
+      return;
+    }
+    repoPath = gitRoot;
+  }
+
+  if (!isGitRepo(repoPath)) {
+    console.log('  Not a git repository.\n');
+    process.exitCode = 1;
+    return;
+  }
+
+  // ── Validate index exists ──────────────────────────────────────────
+  const { storagePath, lbugPath } = getStoragePaths(repoPath);
+  const meta = await loadMeta(storagePath);
+  if (!meta) {
+    console.log('  No GitNexus index found. Run `gitnexus analyze` first.\n');
+    process.exitCode = 1;
+    return;
+  }
+
+  // ── Read registry entry ────────────────────────────────────────────
+  const registry = await readRegistry();
+  const registryEntry = registry.find(e => path.resolve(e.path) === path.resolve(repoPath));
+
+  // ── Resolve embedding config ───────────────────────────────────────
+  const embedConfig = resolveEmbeddingConfig(opts);
+
+  // Detect dimension/provider mismatch with previous run
+  const prevEmbed = registryEntry?.embedding;
+  const dimsChanged = prevEmbed && prevEmbed.dimensions !== embedConfig.dimensions;
+
+  // ── Multi-phase progress display ───────────────────────────────────
+  const { createMultiProgress } = await import('./tui/components/multi-progress.js');
+  const mp = createMultiProgress([
+    { name: 'init', label: 'Initializing', weight: 5 },
+    { name: 'embeddings', label: 'Generating embeddings', weight: 90 },
+    { name: 'finalize', label: 'Finalizing', weight: 5 },
+  ]);
+
+  // Graceful SIGINT handling
+  let aborted = false;
+  const sigintHandler = () => {
+    if (aborted) process.exit(1);
+    aborted = true;
+    mp.stop();
+    console.log('\n  Interrupted — cleaning up...');
+    closeLbug().catch(() => {}).finally(() => process.exit(130));
+  };
+  process.on('SIGINT', sigintHandler);
+
+  const t0 = Date.now();
+
+  // ── Phase 1: Initialize DB ─────────────────────────────────────────
+  mp.setPhase('init');
+
+  let skipNodeIds = new Set<string>();
+
+  if (dimsChanged || !prevEmbed) {
+    // Recreate if dims changed OR no previous embedding entry (ensures table schema matches
+    // the requested dims — a stale table from an aborted run may have wrong dims/vector index).
+    if (dimsChanged) {
+      mp.update(20, `Dimension change detected (${prevEmbed!.dimensions} -> ${embedConfig.dimensions}), recreating table...`);
+    } else {
+      mp.update(20, `Recreating embedding table (${embedConfig.dimensions} dims)...`);
+    }
+    await initLbug(lbugPath);
+    try {
+      await executeQuery(`DROP TABLE ${EMBEDDING_TABLE_NAME}`);
+    } catch { /* table may not exist */ }
+    await closeLbug();
+    // Re-init, then create table with correct dims
+    await initLbug(lbugPath);
+    await ensureEmbeddingTable(embedConfig.dimensions);
+  } else {
+    await initLbug(lbugPath);
+    // Create table if it doesn't exist yet (e.g. first embed run after a no-embeddings analyze)
+    await ensureEmbeddingTable(embedConfig.dimensions);
+  }
+
+  if (opts.force) {
+    mp.update(40, 'Force mode: clearing existing embeddings...');
+    try {
+      await executeQuery(`MATCH (e:${EMBEDDING_TABLE_NAME}) DELETE e`);
+    } catch { /* table may not exist */ }
+  } else if (!dimsChanged) {
+    // Load existing embeddings to skip
+    mp.update(40, 'Checking existing embeddings...');
+    try {
+      const cached = await loadCachedEmbeddings();
+      skipNodeIds = cached.embeddingNodeIds;
+      if (skipNodeIds.size > 0) {
+        mp.update(60, `Found ${skipNodeIds.size.toLocaleString()} existing embeddings to skip`);
+      }
+    } catch { /* no existing embeddings */ }
+  }
+
+  // ── Phase 2: Run Embedding Pipeline ────────────────────────────────
+  mp.setPhase('embeddings');
+  mp.update(0, `Loading embedding provider (${embedConfig.provider})...`);
+
+  const { createEmbeddingProvider } = await import('../core/embeddings/providers/factory.js');
+  const { runEmbeddingPipeline, getEmbeddableLabels } = await import('../core/embeddings/embedding-pipeline.js');
+
+  const provider = await createEmbeddingProvider(embedConfig);
+
+  const stats = await getLbugStats();
+
+  const labels = getEmbeddableLabels(stats.nodes);
+
+  await runEmbeddingPipeline(
+    executeQuery,
+    executeWithReusedStatement,
+    (progress) => {
+      const label = progress.phase === 'loading-model'
+        ? `Loading ${embedConfig.provider} model...`
+        : `Embedding ${progress.nodesProcessed || 0}/${progress.totalNodes || '?'}`;
+      mp.update(progress.percent, label);
+    },
+    provider,
+    {},
+    skipNodeIds.size > 0 ? skipNodeIds : undefined,
+    labels,
+  );
+
+  const embeddingTime = ((Date.now() - t0) / 1000).toFixed(1);
+
+  // ── Phase 3: Finalize ──────────────────────────────────────────────
+  mp.setPhase('finalize');
+  mp.update(0, 'Saving metadata...');
+
+  // Count embeddings
+  let embeddingCount = 0;
+  try {
+    const embResult = await executeQuery(`MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN count(e) AS cnt`);
+    embeddingCount = embResult?.[0]?.cnt ?? 0;
+  } catch { /* table may not exist */ }
+
+  // Update meta.json
+  meta.stats = { ...meta.stats, embeddings: embeddingCount };
+  await saveMeta(storagePath, meta);
+
+  // Update registry
+  const embeddingMeta = {
+    provider: embedConfig.provider,
+    model: embedConfig.model,
+    dimensions: embedConfig.dimensions,
+    endpoint: embedConfig.endpoint,
+  };
+  await registerRepo(repoPath, meta, undefined, embeddingMeta);
+
+  await closeLbug();
+
+  const totalTime = ((Date.now() - t0) / 1000).toFixed(1);
+
+  process.removeListener('SIGINT', sigintHandler);
+
+  // ── Summary ────────────────────────────────────────────────────────
+  mp.complete({
+    'Result': `Embeddings complete (${totalTime}s)`,
+    'Provider': `${embedConfig.provider}/${embedConfig.model}`,
+    'Dimensions': String(embedConfig.dimensions),
+    'Embeddings': embeddingCount.toLocaleString(),
+    'Skipped': skipNodeIds.size.toLocaleString(),
+    'Time': embeddingTime + 's',
+    'Path': repoPath,
+  });
+
+  console.log('');
+
+  // Force exit to avoid LadybugDB/ONNX native handle hangs
+  process.exit(0);
+};

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -19,6 +19,7 @@ program
 program
   .command('setup')
   .description('One-time setup: configure MCP for Cursor, Claude Code, OpenCode')
+  .option('-y, --yes', 'Skip interactive prompts')
   .action(createLazyAction(() => import('./setup.js'), 'setupCommand'));
 
 program
@@ -26,10 +27,33 @@ program
   .description('Index a repository (full analysis)')
   .option('-f, --force', 'Force full re-index even if up to date')
   .option('--embeddings', 'Enable embedding generation for semantic search (off by default)')
+  .option('--embed-provider <type>', 'Embedding provider: ollama | cohere | openai | local (default: local)')
+  .option('--embed-model <model>', 'Embedding model name (e.g. nomic-embed-text)')
+  .option('--embed-dims <n>', 'Embedding vector dimensions (default: 384)')
+  .option('--embed-endpoint <url>', 'API endpoint URL for remote providers')
+  .option('--embed-api-key <key>', 'API key for cloud embedding providers')
   .option('--skills', 'Generate repo-specific skill files from detected communities')
    .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')
+   .option('-y, --yes', 'Skip interactive prompts, use defaults/flags')
    .addHelpText('after', '\nEnvironment variables:\n  GITNEXUS_NO_GITIGNORE=1  Skip .gitignore parsing (still reads .gitnexusignore)')
    .action(createLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
+
+program
+  .command('embed [path]')
+  .description('Generate or update embeddings for an already-indexed repository')
+  .option('--provider <type>', 'Embedding provider: local | ollama | openai | cohere')
+  .option('--model <model>', 'Embedding model name')
+  .option('--dims <n>', 'Vector dimensions (default: 384)')
+  .option('--endpoint <url>', 'API endpoint URL (Ollama, OpenAI-compatible)')
+  .option('--api-key <key>', 'API key for cloud providers')
+  .option('--embed-provider <type>', 'Alias for --provider')
+  .option('--embed-model <model>', 'Alias for --model')
+  .option('--embed-dims <n>', 'Alias for --dims')
+  .option('--embed-endpoint <url>', 'Alias for --endpoint')
+  .option('--embed-api-key <key>', 'Alias for --api-key')
+  .option('-f, --force', 'Regenerate all embeddings')
+  .option('-y, --yes', 'Skip interactive prompts')
+  .action(createLazyAction(() => import('./embed.js'), 'embedCommand'));
 
 program
   .command('serve')
@@ -58,6 +82,7 @@ program
   .description('Delete GitNexus index for current repo')
   .option('-f, --force', 'Skip confirmation prompt')
   .option('--all', 'Clean all indexed repos')
+  .option('-y, --yes', 'Skip interactive prompts')
   .action(createLazyAction(() => import('./clean.js'), 'cleanCommand'));
 
 program
@@ -69,6 +94,7 @@ program
   .option('--api-key <key>', 'LLM API key (saved to ~/.gitnexus/config.json)')
   .option('--concurrency <n>', 'Parallel LLM calls (default: 3)', '3')
   .option('--gist', 'Publish wiki as a public GitHub Gist after generation')
+  .option('-y, --yes', 'Skip interactive prompts, use defaults/flags')
   .action(createLazyAction(() => import('./wiki.js'), 'wikiCommand'));
 
 program
@@ -80,7 +106,7 @@ program
 // These invoke LocalBackend directly for use in eval, scripts, and CI.
 
 program
-  .command('query <search_query>')
+  .command('query [search_query]')
   .description('Search the knowledge graph for execution flows related to a concept')
   .option('-r, --repo <name>', 'Target repository (omit if only one indexed)')
   .option('-c, --context <text>', 'Task context to improve ranking')
@@ -99,7 +125,7 @@ program
   .action(createLazyAction(() => import('./tool.js'), 'contextCommand'));
 
 program
-  .command('impact <target>')
+  .command('impact [target]')
   .description('Blast radius analysis: what breaks if you change a symbol')
   .option('-d, --direction <dir>', 'upstream (dependants) or downstream (dependencies)', 'upstream')
   .option('-r, --repo <name>', 'Target repository')
@@ -108,7 +134,7 @@ program
   .action(createLazyAction(() => import('./tool.js'), 'impactCommand'));
 
 program
-  .command('cypher <query>')
+  .command('cypher [query]')
   .description('Execute raw Cypher query against the knowledge graph')
   .option('-r, --repo <name>', 'Target repository')
   .action(createLazyAction(() => import('./tool.js'), 'cypherCommand'));

--- a/gitnexus/src/cli/list.ts
+++ b/gitnexus/src/cli/list.ts
@@ -1,6 +1,6 @@
 /**
  * List Command
- * 
+ *
  * Shows all indexed repositories from the global registry.
  */
 
@@ -8,27 +8,6 @@ import { listRegisteredRepos } from '../storage/repo-manager.js';
 
 export const listCommand = async () => {
   const entries = await listRegisteredRepos({ validate: true });
-
-  if (entries.length === 0) {
-    console.log('No indexed repositories found.');
-    console.log('Run `gitnexus analyze` in a git repo to index it.');
-    return;
-  }
-
-  console.log(`\n  Indexed Repositories (${entries.length})\n`);
-
-  for (const entry of entries) {
-    const indexedDate = new Date(entry.indexedAt).toLocaleString();
-    const stats = entry.stats || {};
-    const commitShort = entry.lastCommit?.slice(0, 7) || 'unknown';
-
-    console.log(`  ${entry.name}`);
-    console.log(`    Path:    ${entry.path}`);
-    console.log(`    Indexed: ${indexedDate}`);
-    console.log(`    Commit:  ${commitShort}`);
-    console.log(`    Stats:   ${stats.files ?? 0} files, ${stats.nodes ?? 0} symbols, ${stats.edges ?? 0} edges`);
-    if (stats.communities) console.log(`    Clusters:   ${stats.communities}`);
-    if (stats.processes) console.log(`    Processes:  ${stats.processes}`);
-    console.log('');
-  }
+  const { renderRepoList } = await import('./tui/formatters/list-formatter.js');
+  renderRepoList(entries);
 };

--- a/gitnexus/src/cli/serve.ts
+++ b/gitnexus/src/cli/serve.ts
@@ -3,5 +3,9 @@ import { createServer } from '../server/api.js';
 export const serveCommand = async (options?: { port?: string; host?: string }) => {
   const port = Number(options?.port ?? 4747);
   const host = options?.host ?? '127.0.0.1';
+
+  const { renderServeBanner } = await import('./tui/formatters/serve-banner.js');
+  renderServeBanner({ port, host });
+
   await createServer(port, host);
 };

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -355,7 +355,17 @@ async function installOpenCodeSkills(result: SetupResult): Promise<void> {
 
 // ─── Main command ──────────────────────────────────────────────────
 
-export const setupCommand = async () => {
+export const setupCommand = async (options?: { yes?: boolean }) => {
+  // TUI Wizard
+  const { shouldRunInteractiveGeneric } = await import('./tui/shared.js');
+  if (shouldRunInteractiveGeneric(options as Record<string, unknown> ?? {})) {
+    const { runSetupWizard } = await import('./tui/wizards/setup-wizard.js');
+    const wizardResult = await runSetupWizard();
+    if (!wizardResult) return;
+    // wizardResult.selectedEditors tells us which to configure
+    // Fall through to existing setup logic
+  }
+
   console.log('');
   console.log('  GitNexus Setup');
   console.log('  ==============');

--- a/gitnexus/src/cli/status.ts
+++ b/gitnexus/src/cli/status.ts
@@ -1,6 +1,6 @@
 /**
  * Status Command
- * 
+ *
  * Shows the indexing status of the current repository.
  */
 
@@ -11,7 +11,8 @@ export const statusCommand = async () => {
   const cwd = process.cwd();
 
   if (!isGitRepo(cwd)) {
-    console.log('Not a git repository.');
+    const { renderNotGitRepo } = await import('./tui/formatters/status-formatter.js');
+    renderNotGitRepo();
     return;
   }
 
@@ -24,8 +25,8 @@ export const statusCommand = async () => {
       console.log('Repository has a stale KuzuDB index from a previous version.');
       console.log('Run: gitnexus analyze   (rebuilds the index with LadybugDB)');
     } else {
-      console.log('Repository not indexed.');
-      console.log('Run: gitnexus analyze');
+      const { renderNotIndexed } = await import('./tui/formatters/status-formatter.js');
+      renderNotIndexed();
     }
     return;
   }
@@ -33,9 +34,13 @@ export const statusCommand = async () => {
   const currentCommit = getCurrentCommit(repo.repoPath);
   const isUpToDate = currentCommit === repo.meta.lastCommit;
 
-  console.log(`Repository: ${repo.repoPath}`);
-  console.log(`Indexed: ${new Date(repo.meta.indexedAt).toLocaleString()}`);
-  console.log(`Indexed commit: ${repo.meta.lastCommit?.slice(0, 7)}`);
-  console.log(`Current commit: ${currentCommit?.slice(0, 7)}`);
-  console.log(`Status: ${isUpToDate ? '✅ up-to-date' : '⚠️ stale (re-run gitnexus analyze)'}`);
+  const { renderStatus } = await import('./tui/formatters/status-formatter.js');
+  renderStatus({
+    repoPath: repo.repoPath,
+    indexedAt: repo.meta.indexedAt,
+    indexedCommit: repo.meta.lastCommit,
+    currentCommit: currentCommit || '',
+    isUpToDate,
+    stats: repo.meta.stats,
+  });
 };

--- a/gitnexus/src/cli/tool.ts
+++ b/gitnexus/src/cli/tool.ts
@@ -1,21 +1,19 @@
 /**
  * Direct CLI Tool Commands
- * 
+ *
  * Exposes GitNexus tools (query, context, impact, cypher) as direct CLI commands.
  * Bypasses MCP entirely — invokes LocalBackend directly for minimal overhead.
- * 
+ *
  * Usage:
  *   gitnexus query "authentication flow"
  *   gitnexus context --name "validateUser"
  *   gitnexus impact --target "AuthService" --direction upstream
  *   gitnexus cypher "MATCH (n:Function) RETURN n.name LIMIT 10"
- * 
- * Note: Output goes to stdout via fs.writeSync(fd 1), bypassing LadybugDB's
- * native module which captures the Node.js process.stdout stream during init.
- * See the output() function for details (#324).
+ *
+ * Note: Output goes to stderr because LadybugDB's native module captures stdout
+ * at the OS level during init. This is consistent with augment.ts.
  */
 
-import { writeSync } from 'node:fs';
 import { LocalBackend } from '../mcp/local/local-backend.js';
 
 let _backend: LocalBackend | null = null;
@@ -31,29 +29,10 @@ async function getBackend(): Promise<LocalBackend> {
   return _backend;
 }
 
-/**
- * Write tool output to stdout using low-level fd write.
- *
- * LadybugDB's native module captures Node.js process.stdout during init,
- * but the underlying OS file descriptor 1 (stdout) remains intact.
- * By using fs.writeSync(1, ...) we bypass the Node.js stream layer
- * and write directly to the real stdout fd (#324).
- *
- * Falls back to stderr if the fd write fails (e.g., broken pipe).
- */
 function output(data: any): void {
   const text = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
-  try {
-    writeSync(1, text + '\n');
-  } catch (err: any) {
-    if (err?.code === 'EPIPE') {
-      // Consumer closed the pipe (e.g., `gitnexus cypher ... | head -1`)
-      // Exit cleanly per Unix convention
-      process.exit(0);
-    }
-    // Fallback: stderr (previous behavior, works on all platforms)
-    process.stderr.write(text + '\n');
-  }
+  // stderr because LadybugDB captures stdout at OS level
+  process.stderr.write(text + '\n');
 }
 
 export async function queryCommand(queryText: string, options?: {
@@ -63,7 +42,13 @@ export async function queryCommand(queryText: string, options?: {
   limit?: string;
   content?: boolean;
 }): Promise<void> {
+  // Interactive mode: no query text + TTY
   if (!queryText?.trim()) {
+    const { shouldRunInteractiveGeneric } = await import('./tui/shared.js');
+    if (shouldRunInteractiveGeneric({})) {
+      const { runQueryTUI } = await import('./tui/interactive/query-tui.js');
+      return runQueryTUI(options);
+    }
     console.error('Usage: gitnexus query <search_query>');
     process.exit(1);
   }
@@ -77,7 +62,14 @@ export async function queryCommand(queryText: string, options?: {
     include_content: options?.content ?? false,
     repo: options?.repo,
   });
-  output(result);
+
+  // Use formatted output if TTY, raw JSON otherwise
+  if (process.stderr.isTTY) {
+    const { renderQueryResults } = await import('./tui/interactive/query-tui.js');
+    renderQueryResults(result);
+  } else {
+    output(result);
+  }
 }
 
 export async function contextCommand(name: string, options?: {
@@ -87,6 +79,11 @@ export async function contextCommand(name: string, options?: {
   content?: boolean;
 }): Promise<void> {
   if (!name?.trim() && !options?.uid) {
+    const { shouldRunInteractiveGeneric } = await import('./tui/shared.js');
+    if (shouldRunInteractiveGeneric({})) {
+      const { runContextTUI } = await import('./tui/interactive/context-tui.js');
+      return runContextTUI(options);
+    }
     console.error('Usage: gitnexus context <symbol_name> [--uid <uid>] [--file <path>]');
     process.exit(1);
   }
@@ -99,7 +96,13 @@ export async function contextCommand(name: string, options?: {
     include_content: options?.content ?? false,
     repo: options?.repo,
   });
-  output(result);
+
+  if (process.stderr.isTTY) {
+    const { renderContextResults } = await import('./tui/interactive/context-tui.js');
+    renderContextResults(result);
+  } else {
+    output(result);
+  }
 }
 
 export async function impactCommand(target: string, options?: {
@@ -109,30 +112,29 @@ export async function impactCommand(target: string, options?: {
   includeTests?: boolean;
 }): Promise<void> {
   if (!target?.trim()) {
+    const { shouldRunInteractiveGeneric } = await import('./tui/shared.js');
+    if (shouldRunInteractiveGeneric({})) {
+      const { runImpactTUI } = await import('./tui/interactive/impact-tui.js');
+      return runImpactTUI(options);
+    }
     console.error('Usage: gitnexus impact <symbol_name> [--direction upstream|downstream]');
     process.exit(1);
   }
 
-  try {
-    const backend = await getBackend();
-    const result = await backend.callTool('impact', {
-      target,
-      direction: options?.direction || 'upstream',
-      maxDepth: options?.depth ? parseInt(options.depth, 10) : undefined,
-      includeTests: options?.includeTests ?? false,
-      repo: options?.repo,
-    });
+  const backend = await getBackend();
+  const result = await backend.callTool('impact', {
+    target,
+    direction: options?.direction || 'upstream',
+    maxDepth: options?.depth ? parseInt(options.depth) : undefined,
+    includeTests: options?.includeTests ?? false,
+    repo: options?.repo,
+  });
+
+  if (process.stderr.isTTY) {
+    const { renderImpactResults } = await import('./tui/interactive/impact-tui.js');
+    renderImpactResults(result);
+  } else {
     output(result);
-  } catch (err: unknown) {
-    // Belt-and-suspenders: catch infrastructure failures (getBackend, callTool transport)
-    // The backend's impact() already returns structured errors for graph query failures
-    output({
-      error: (err instanceof Error ? err.message : String(err)) || 'Impact analysis failed unexpectedly',
-      target: { name: target },
-      direction: options?.direction || 'upstream',
-      suggestion: 'Try reducing --depth or using gitnexus context <symbol> as a fallback',
-    });
-    process.exit(1);
   }
 }
 
@@ -140,6 +142,11 @@ export async function cypherCommand(query: string, options?: {
   repo?: string;
 }): Promise<void> {
   if (!query?.trim()) {
+    const { shouldRunInteractiveGeneric } = await import('./tui/shared.js');
+    if (shouldRunInteractiveGeneric({})) {
+      const { runCypherTUI } = await import('./tui/interactive/cypher-tui.js');
+      return runCypherTUI(options);
+    }
     console.error('Usage: gitnexus cypher <cypher_query>');
     process.exit(1);
   }
@@ -149,5 +156,11 @@ export async function cypherCommand(query: string, options?: {
     query,
     repo: options?.repo,
   });
-  output(result);
+
+  if (process.stderr.isTTY) {
+    const { renderCypherResults } = await import('./tui/interactive/cypher-tui.js');
+    renderCypherResults(result);
+  } else {
+    output(result);
+  }
 }

--- a/gitnexus/src/cli/tui/analyze-wizard.ts
+++ b/gitnexus/src/cli/tui/analyze-wizard.ts
@@ -1,0 +1,2 @@
+// Re-export from new location
+export { runAnalyzeWizard, type AnalyzeWizardResult } from './wizards/analyze-wizard.js';

--- a/gitnexus/src/cli/tui/components/config-display.ts
+++ b/gitnexus/src/cli/tui/components/config-display.ts
@@ -1,0 +1,18 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+
+export function renderConfig(config: Record<string, string | number | boolean | undefined>): void {
+  const entries = Object.entries(config).filter(([_, v]) => v !== undefined);
+
+  const maxKeyLen = Math.max(...entries.map(([k]) => k.length));
+
+  const lines = entries.map(([key, value]) => {
+    const label = key.padEnd(maxKeyLen);
+    const val = typeof value === 'boolean'
+      ? (value ? pc.green('yes') : pc.dim('no'))
+      : pc.bold(String(value));
+    return `${label}  ${val}`;
+  });
+
+  p.note(lines.join('\n'), 'Configuration');
+}

--- a/gitnexus/src/cli/tui/components/confirm-destructive.ts
+++ b/gitnexus/src/cli/tui/components/confirm-destructive.ts
@@ -1,0 +1,29 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+
+export async function confirmDestructive(options: {
+  message: string;
+  details: string[];
+}): Promise<boolean> {
+  // Show warning banner
+  p.log.warn(pc.red(pc.bold(options.message)));
+
+  // List affected items
+  if (options.details.length > 0) {
+    for (const detail of options.details) {
+      p.log.message(`  ${pc.red('\u2022')} ${detail}`);
+    }
+  }
+
+  const confirmed = await p.confirm({
+    message: pc.red('Are you sure?'),
+    initialValue: false,
+  });
+
+  if (p.isCancel(confirmed)) {
+    p.cancel('Cancelled.');
+    return false;
+  }
+
+  return confirmed;
+}

--- a/gitnexus/src/cli/tui/components/formatted-table.ts
+++ b/gitnexus/src/cli/tui/components/formatted-table.ts
@@ -1,0 +1,64 @@
+import pc from 'picocolors';
+
+interface Column {
+  key: string;
+  label: string;
+  align?: 'left' | 'right';
+  color?: (v: string) => string;
+}
+
+export function renderTable(options: {
+  columns: Column[];
+  rows: Record<string, string | number>[];
+  title?: string;
+  maxWidth?: number;
+}): void {
+  const { columns, rows, title } = options;
+
+  if (rows.length === 0) {
+    process.stderr.write('  No results.\n');
+    return;
+  }
+
+  // Calculate column widths from content
+  const widths: Record<string, number> = {};
+  for (const col of columns) {
+    widths[col.key] = col.label.length;
+    for (const row of rows) {
+      const val = String(row[col.key] ?? '');
+      widths[col.key] = Math.max(widths[col.key], val.length);
+    }
+  }
+
+  // Render title
+  if (title) {
+    process.stderr.write(`\n  ${pc.bold(title)}\n\n`);
+  }
+
+  // Render header
+  const headerParts = columns.map(col => {
+    const label = col.label;
+    return col.align === 'right'
+      ? label.padStart(widths[col.key])
+      : label.padEnd(widths[col.key]);
+  });
+  process.stderr.write(`  ${pc.dim(headerParts.join('  '))}\n`);
+
+  // Separator
+  const sepParts = columns.map(col => pc.dim('\u2500'.repeat(widths[col.key])));
+  process.stderr.write(`  ${sepParts.join('  ')}\n`);
+
+  // Render rows
+  for (const row of rows) {
+    const parts = columns.map(col => {
+      const val = String(row[col.key] ?? '');
+      const padded = col.align === 'right'
+        ? val.padStart(widths[col.key])
+        : val.padEnd(widths[col.key]);
+      return col.color ? col.color(padded) : padded;
+    });
+    process.stderr.write(`  ${parts.join('  ')}\n`);
+  }
+
+  process.stderr.write('\n');
+}

--- a/gitnexus/src/cli/tui/components/log-panel.ts
+++ b/gitnexus/src/cli/tui/components/log-panel.ts
@@ -1,0 +1,52 @@
+import pc from 'picocolors';
+
+export interface LogPanel {
+  info(msg: string): void;
+  warn(msg: string): void;
+  error(msg: string): void;
+  flush(): void;
+}
+
+export function createLogPanel(options?: { maxLines?: number; verbose?: boolean }): LogPanel {
+  const maxLines = options?.maxLines ?? 100;
+  const verbose = options?.verbose ?? !!process.env.GITNEXUS_VERBOSE;
+  const buffer: Array<{ level: 'info' | 'warn' | 'error'; msg: string }> = [];
+  let warnCount = 0;
+  let errorCount = 0;
+
+  return {
+    info(msg: string) {
+      if (verbose) {
+        process.stderr.write(`  ${pc.dim(msg)}\n`);
+      } else {
+        if (buffer.length < maxLines) {
+          buffer.push({ level: 'info', msg });
+        }
+      }
+    },
+
+    warn(msg: string) {
+      warnCount++;
+      if (verbose) {
+        process.stderr.write(`  ${pc.yellow('warn')} ${msg}\n`);
+      } else {
+        buffer.push({ level: 'warn', msg });
+      }
+    },
+
+    error(msg: string) {
+      errorCount++;
+      process.stderr.write(`  ${pc.red('error')} ${msg}\n`);
+      buffer.push({ level: 'error', msg });
+    },
+
+    flush() {
+      if (!verbose && (warnCount > 0 || errorCount > 0)) {
+        const parts: string[] = [];
+        if (errorCount > 0) parts.push(pc.red(`${errorCount} error${errorCount > 1 ? 's' : ''}`));
+        if (warnCount > 0) parts.push(pc.yellow(`${warnCount} warning${warnCount > 1 ? 's' : ''}`));
+        process.stderr.write(`  ${parts.join(', ')}\n`);
+      }
+    },
+  };
+}

--- a/gitnexus/src/cli/tui/components/multi-progress.ts
+++ b/gitnexus/src/cli/tui/components/multi-progress.ts
@@ -1,0 +1,162 @@
+import cliProgress from 'cli-progress';
+import pc from 'picocolors';
+
+export interface PhaseConfig {
+  name: string;
+  label: string;
+  weight: number; // % of total (all should sum to 100)
+}
+
+export interface MultiProgress {
+  setPhase(name: string): void;
+  update(percent: number, detail?: string): void;
+  setStats(stats: Record<string, number>): void;
+  log(message: string): void;
+  complete(summary: Record<string, string | number>): void;
+  stop(): void;
+}
+
+export function createMultiProgress(phases: PhaseConfig[]): MultiProgress {
+  // Validate weights sum to ~100
+  const totalWeight = phases.reduce((s, p) => s + p.weight, 0);
+
+  // State
+  let currentPhaseIdx = -1;
+  const phaseStartTimes: number[] = new Array(phases.length).fill(0);
+  const phaseDoneTimes: number[] = new Array(phases.length).fill(0);
+  let currentDetail = '';
+  let currentStats: Record<string, number> = {};
+  let stopped = false;
+
+  // Single progress bar (renders the active phase)
+  const bar = new cliProgress.SingleBar({
+    format: '  {bar} {percentage}% | {phase}',
+    barCompleteChar: '\u2588',
+    barIncompleteChar: '\u2591',
+    hideCursor: true,
+    barGlue: '',
+    autopadding: true,
+    clearOnComplete: false,
+    stopOnComplete: false,
+  }, cliProgress.Presets.shades_grey);
+
+  bar.start(100, 0, { phase: 'Initializing...' });
+
+  // Safe console routing
+  const origLog = console.log.bind(console);
+  const origWarn = console.warn.bind(console);
+  const origError = console.error.bind(console);
+  const barLog = (...args: unknown[]) => {
+    process.stdout.write('\x1b[2K\r');
+    origLog(args.map(a => (typeof a === 'string' ? a : String(a))).join(' '));
+  };
+  console.log = barLog;
+  console.warn = barLog;
+  console.error = barLog;
+
+  // Elapsed time ticker
+  let lastPhaseLabel = 'Initializing...';
+  let lastPhaseStart = Date.now();
+
+  const elapsedTimer = setInterval(() => {
+    if (stopped || currentPhaseIdx < 0) return;
+    const elapsed = Math.round((Date.now() - lastPhaseStart) / 1000);
+    if (elapsed >= 3) {
+      const detailPart = currentDetail ? ` | ${currentDetail}` : '';
+      bar.update({ phase: `${lastPhaseLabel}${detailPart} (${elapsed}s)` });
+    }
+  }, 1000);
+
+  function logPhaseTransition(fromIdx: number, _toIdx: number) {
+    if (fromIdx >= 0 && fromIdx < phases.length) {
+      const elapsed = Math.round((Date.now() - phaseStartTimes[fromIdx]) / 1000);
+      barLog(`  ${pc.green('\u2713')} ${phases[fromIdx].label} ${pc.dim(`(${elapsed}s)`)}`);
+    }
+  }
+
+  function calcOverallPercent(phaseIdx: number, phasePercent: number): number {
+    let base = 0;
+    for (let i = 0; i < phaseIdx; i++) {
+      base += phases[i].weight;
+    }
+    const scaled = base + (phases[phaseIdx].weight * phasePercent / 100);
+    return Math.min(100, Math.round(scaled * 100 / totalWeight));
+  }
+
+  return {
+    setPhase(name: string) {
+      const idx = phases.findIndex(p => p.name === name);
+      if (idx < 0) return;
+      if (idx === currentPhaseIdx) return;
+
+      const prevIdx = currentPhaseIdx;
+      if (prevIdx >= 0) {
+        phaseDoneTimes[prevIdx] = Date.now();
+      }
+
+      logPhaseTransition(prevIdx, idx);
+
+      currentPhaseIdx = idx;
+      phaseStartTimes[idx] = Date.now();
+      currentDetail = '';
+      lastPhaseLabel = phases[idx].label;
+      lastPhaseStart = Date.now();
+
+      const overall = calcOverallPercent(idx, 0);
+      bar.update(overall, { phase: phases[idx].label });
+    },
+
+    update(percent: number, detail?: string) {
+      if (currentPhaseIdx < 0) return;
+      if (detail !== undefined) currentDetail = detail;
+
+      const overall = calcOverallPercent(currentPhaseIdx, percent);
+      const elapsed = Math.round((Date.now() - lastPhaseStart) / 1000);
+      const detailPart = currentDetail ? ` | ${currentDetail}` : '';
+      const timePart = elapsed >= 3 ? ` (${elapsed}s)` : '';
+      bar.update(overall, { phase: `${lastPhaseLabel}${detailPart}${timePart}` });
+    },
+
+    setStats(stats: Record<string, number>) {
+      currentStats = { ...currentStats, ...stats };
+      // Show stats in detail line
+      const parts = Object.entries(currentStats).map(([k, v]) => `${v.toLocaleString()} ${k}`);
+      if (parts.length > 0 && currentDetail) {
+        currentDetail = `${currentDetail} | ${parts.join(' \u00b7 ')}`;
+      }
+    },
+
+    log(message: string) {
+      barLog(message);
+    },
+
+    complete(summary: Record<string, string | number>) {
+      if (currentPhaseIdx >= 0) {
+        phaseDoneTimes[currentPhaseIdx] = Date.now();
+        logPhaseTransition(currentPhaseIdx, -1);
+      }
+
+      clearInterval(elapsedTimer);
+      console.log = origLog;
+      console.warn = origWarn;
+      console.error = origError;
+
+      bar.update(100, { phase: 'Done' });
+      bar.stop();
+      stopped = true;
+
+      // Print summary
+      const lines = Object.entries(summary).map(([k, v]) => `  ${pc.dim(k + ':')} ${pc.bold(String(v))}`);
+      process.stderr.write('\n' + lines.join('\n') + '\n\n');
+    },
+
+    stop() {
+      clearInterval(elapsedTimer);
+      console.log = origLog;
+      console.warn = origWarn;
+      console.error = origError;
+      bar.stop();
+      stopped = true;
+    },
+  };
+}

--- a/gitnexus/src/cli/tui/components/repo-picker.ts
+++ b/gitnexus/src/cli/tui/components/repo-picker.ts
@@ -1,0 +1,40 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { listRegisteredRepos, type RegistryEntry } from '../../../storage/repo-manager.js';
+
+export async function pickRepo(options?: {
+  message?: string;
+  allowMultiple?: boolean;
+}): Promise<RegistryEntry | null> {
+  // Load registry
+  const entries = await listRegisteredRepos({ validate: true });
+
+  // 0 repos: show error, return null
+  if (entries.length === 0) {
+    p.log.error('No indexed repositories found. Run `gitnexus analyze` first.');
+    return null;
+  }
+
+  // 1 repo: auto-select, show info
+  if (entries.length === 1) {
+    p.log.info(`Using ${pc.bold(entries[0].name)}`);
+    return entries[0];
+  }
+
+  // 2+ repos: p.select() with repo name, path, stats
+  const selected = await p.select({
+    message: options?.message || 'Select repository',
+    options: entries.map(e => ({
+      value: e.name,
+      label: e.name,
+      hint: `${e.path} — ${e.stats?.nodes ?? 0} symbols`,
+    })),
+  });
+
+  if (p.isCancel(selected)) {
+    p.cancel('Cancelled.');
+    return null;
+  }
+
+  return entries.find(e => e.name === selected) || null;
+}

--- a/gitnexus/src/cli/tui/components/summary-box.ts
+++ b/gitnexus/src/cli/tui/components/summary-box.ts
@@ -1,0 +1,18 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+
+export function renderSummaryBox(options: {
+  title: string;
+  items: Array<{ label: string; value: string | number; color?: (v: string) => string }>;
+}): void {
+  const maxLabelLen = Math.max(...options.items.map(i => i.label.length));
+
+  const lines = options.items.map(item => {
+    const label = item.label.padEnd(maxLabelLen);
+    const val = String(item.value);
+    const coloredVal = item.color ? item.color(val) : pc.bold(val);
+    return `${pc.dim(label)}  ${coloredVal}`;
+  });
+
+  p.note(lines.join('\n'), options.title);
+}

--- a/gitnexus/src/cli/tui/formatters/ai-context-tui.ts
+++ b/gitnexus/src/cli/tui/formatters/ai-context-tui.ts
@@ -1,0 +1,6 @@
+import pc from 'picocolors';
+
+export function renderAiContextResult(files: string[]): void {
+  if (files.length === 0) return;
+  process.stderr.write(`  ${pc.dim('Context:')} ${files.join(', ')}\n`);
+}

--- a/gitnexus/src/cli/tui/formatters/clean-tui.ts
+++ b/gitnexus/src/cli/tui/formatters/clean-tui.ts
@@ -1,0 +1,62 @@
+import pc from 'picocolors';
+import { confirmDestructive } from '../components/confirm-destructive.js';
+import { listRegisteredRepos, unregisterRepo, findRepo } from '../../../storage/repo-manager.js';
+import fs from 'fs/promises';
+
+export async function cleanInteractive(options?: { force?: boolean; all?: boolean; yes?: boolean }): Promise<void> {
+  if (options?.all) {
+    const entries = await listRegisteredRepos();
+    if (entries.length === 0) {
+      process.stderr.write('  No indexed repositories found.\n');
+      return;
+    }
+
+    // Skip confirmation if --force or --yes
+    if (!options?.force && !options?.yes) {
+      const confirmed = await confirmDestructive({
+        message: `Delete GitNexus indexes for ${entries.length} repo(s)?`,
+        details: entries.map(e => `${e.name} (${e.storagePath})`),
+      });
+      if (!confirmed) return;
+    }
+
+    for (const entry of entries) {
+      try {
+        await fs.rm(entry.storagePath, { recursive: true, force: true });
+        await unregisterRepo(entry.path);
+        process.stderr.write(`  ${pc.green('Deleted:')} ${entry.name} (${entry.storagePath})\n`);
+      } catch (err: any) {
+        process.stderr.write(`  ${pc.red('Failed:')} ${entry.name}: ${err.message}\n`);
+      }
+    }
+    return;
+  }
+
+  // Default: clean current repo
+  const cwd = process.cwd();
+  const repo = await findRepo(cwd);
+
+  if (!repo) {
+    process.stderr.write('  No indexed repository found in this directory.\n');
+    return;
+  }
+
+  const repoName = repo.repoPath.split(/[/\\]/).pop() || repo.repoPath;
+
+  // Skip confirmation if --force or --yes
+  if (!options?.force && !options?.yes) {
+    const confirmed = await confirmDestructive({
+      message: `Delete GitNexus index for ${repoName}?`,
+      details: [`Path: ${repo.storagePath}`],
+    });
+    if (!confirmed) return;
+  }
+
+  try {
+    await fs.rm(repo.storagePath, { recursive: true, force: true });
+    await unregisterRepo(repo.repoPath);
+    process.stderr.write(`  ${pc.green('Deleted:')} ${repo.storagePath}\n`);
+  } catch (err: any) {
+    process.stderr.write(`  ${pc.red('Failed:')} ${err.message}\n`);
+  }
+}

--- a/gitnexus/src/cli/tui/formatters/list-formatter.ts
+++ b/gitnexus/src/cli/tui/formatters/list-formatter.ts
@@ -1,0 +1,39 @@
+import pc from 'picocolors';
+import { renderTable } from '../components/formatted-table.js';
+import type { RegistryEntry } from '../../../storage/repo-manager.js';
+
+export function renderRepoList(entries: RegistryEntry[]): void {
+  if (entries.length === 0) {
+    process.stderr.write('\n  No indexed repositories found.\n');
+    process.stderr.write('  Run `gitnexus analyze` in a git repo to index it.\n\n');
+    return;
+  }
+
+  process.stderr.write(`\n  ${pc.bold(`Indexed Repositories (${entries.length})`)}\n\n`);
+
+  const rows = entries.map(entry => {
+    const indexed = new Date(entry.indexedAt);
+    const dateStr = indexed.toLocaleDateString();
+
+    return {
+      name: entry.name,
+      path: entry.path,
+      indexed: dateStr,
+      commit: entry.lastCommit?.slice(0, 7) || '?',
+      symbols: entry.stats?.nodes ?? 0,
+      edges: entry.stats?.edges ?? 0,
+    };
+  });
+
+  renderTable({
+    columns: [
+      { key: 'name', label: 'Name', color: (v) => pc.bold(v) },
+      { key: 'path', label: 'Path', color: (v) => pc.dim(v) },
+      { key: 'indexed', label: 'Indexed' },
+      { key: 'commit', label: 'Commit' },
+      { key: 'symbols', label: 'Symbols', align: 'right' },
+      { key: 'edges', label: 'Edges', align: 'right' },
+    ],
+    rows,
+  });
+}

--- a/gitnexus/src/cli/tui/formatters/serve-banner.ts
+++ b/gitnexus/src/cli/tui/formatters/serve-banner.ts
@@ -1,0 +1,10 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+
+export function renderServeBanner(options: { port: number; host: string }): void {
+  const url = `http://${options.host}:${options.port}`;
+
+  p.intro(`${pc.bgCyan(pc.black(' GitNexus Web Server '))}`);
+  p.log.info(`Listening at ${pc.bold(pc.cyan(url))}`);
+  p.log.info(pc.dim('Press Ctrl+C to stop'));
+}

--- a/gitnexus/src/cli/tui/formatters/status-formatter.ts
+++ b/gitnexus/src/cli/tui/formatters/status-formatter.ts
@@ -1,0 +1,50 @@
+import pc from 'picocolors';
+import { renderSummaryBox } from '../components/summary-box.js';
+
+interface StatusInfo {
+  repoPath: string;
+  indexedAt: string;
+  indexedCommit: string;
+  currentCommit: string;
+  isUpToDate: boolean;
+  stats?: {
+    files?: number;
+    nodes?: number;
+    edges?: number;
+    communities?: number;
+    processes?: number;
+    embeddings?: number;
+  };
+}
+
+export function renderStatus(info: StatusInfo): void {
+  const items: Array<{ label: string; value: string | number; color?: (v: string) => string }> = [
+    { label: 'Repository', value: info.repoPath, color: (v) => pc.bold(v) },
+    { label: 'Indexed', value: new Date(info.indexedAt).toLocaleString() },
+    { label: 'Indexed commit', value: info.indexedCommit?.slice(0, 7) || '?' },
+    { label: 'Current commit', value: info.currentCommit?.slice(0, 7) || '?' },
+    { label: 'Status', value: info.isUpToDate ? 'Up to date' : 'Stale',
+      color: (v) => info.isUpToDate ? pc.green(v) : pc.yellow(v) },
+  ];
+
+  if (info.stats) {
+    const s = info.stats;
+    items.push({ label: 'Files', value: s.files ?? 0 });
+    items.push({ label: 'Symbols', value: s.nodes ?? 0 });
+    items.push({ label: 'Edges', value: s.edges ?? 0 });
+    if (s.communities) items.push({ label: 'Communities', value: s.communities });
+    if (s.processes) items.push({ label: 'Processes', value: s.processes });
+    if (s.embeddings) items.push({ label: 'Embeddings', value: s.embeddings });
+  }
+
+  renderSummaryBox({ title: 'Repository Status', items });
+}
+
+export function renderNotIndexed(): void {
+  process.stderr.write('\n  Repository not indexed.\n');
+  process.stderr.write('  Run: gitnexus analyze\n\n');
+}
+
+export function renderNotGitRepo(): void {
+  process.stderr.write('\n  Not a git repository.\n\n');
+}

--- a/gitnexus/src/cli/tui/index.ts
+++ b/gitnexus/src/cli/tui/index.ts
@@ -1,0 +1,11 @@
+// Components
+export { pickRepo } from './components/repo-picker.js';
+export { createMultiProgress, type PhaseConfig, type MultiProgress } from './components/multi-progress.js';
+export { renderTable } from './components/formatted-table.js';
+export { renderSummaryBox } from './components/summary-box.js';
+export { confirmDestructive } from './components/confirm-destructive.js';
+export { renderConfig } from './components/config-display.js';
+export { createLogPanel, type LogPanel } from './components/log-panel.js';
+
+// Shared utilities
+export { shouldRunInteractive, shouldRunInteractiveGeneric, hasExplicitFlags, serializeToEnv, deserializeFromEnv } from './shared.js';

--- a/gitnexus/src/cli/tui/interactive/augment-tui.ts
+++ b/gitnexus/src/cli/tui/interactive/augment-tui.ts
@@ -1,0 +1,36 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+
+export async function runAugmentTUI(): Promise<void> {
+  p.intro(`${pc.bgCyan(pc.black(' GitNexus Augment '))}`);
+
+  const pattern = await p.text({
+    message: 'Search pattern',
+    placeholder: 'Enter pattern to augment with graph context',
+    validate: (v) => v.trim().length < 3 ? 'Pattern must be at least 3 characters' : undefined,
+  });
+  if (p.isCancel(pattern)) { p.cancel('Cancelled.'); return; }
+
+  p.outro('Augmenting...');
+
+  const { augment } = await import('../../../core/augmentation/engine.js');
+
+  try {
+    const result = await augment(pattern, process.cwd());
+    if (result) {
+      process.stderr.write(result + '\n');
+    } else {
+      process.stderr.write('  No augmentation found for this pattern.\n');
+    }
+  } catch {
+    process.stderr.write('  Augmentation failed.\n');
+  }
+}
+
+export function renderAugmentResults(result: string | null): void {
+  if (result) {
+    process.stderr.write(result + '\n');
+  } else {
+    process.stderr.write('  No augmentation found.\n');
+  }
+}

--- a/gitnexus/src/cli/tui/interactive/context-tui.ts
+++ b/gitnexus/src/cli/tui/interactive/context-tui.ts
@@ -1,0 +1,90 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { pickRepo } from '../components/repo-picker.js';
+import { renderSummaryBox } from '../components/summary-box.js';
+
+export async function runContextTUI(options?: { repo?: string }): Promise<void> {
+  p.intro(`${pc.bgCyan(pc.black(' GitNexus Context '))}`);
+
+  let repoName = options?.repo;
+  if (!repoName) {
+    const repo = await pickRepo({ message: 'Look up symbol in repository' });
+    if (!repo) return;
+    repoName = repo.name;
+  }
+
+  const symbolName = await p.text({
+    message: 'Symbol name',
+    placeholder: 'e.g. "validateUser", "AuthService", "handleRequest"',
+    validate: (v) => v.trim().length === 0 ? 'Symbol name is required' : undefined,
+  });
+  if (p.isCancel(symbolName)) { p.cancel('Cancelled.'); return; }
+
+  p.outro('Looking up...');
+
+  const { LocalBackend } = await import('../../../mcp/local/local-backend.js');
+  const backend = new LocalBackend();
+  const ok = await backend.init();
+  if (!ok) {
+    process.stderr.write('  No indexed repositories found. Run: gitnexus analyze\n');
+    return;
+  }
+
+  const result = await backend.callTool('context', {
+    name: symbolName,
+    repo: repoName,
+  });
+
+  renderContextResults(result);
+}
+
+export function renderContextResults(result: any): void {
+  // Parse the tool result
+  let text: string;
+  if (Array.isArray(result)) {
+    text = result.find((c: any) => c.type === 'text')?.text || JSON.stringify(result, null, 2);
+  } else if (typeof result === 'object' && result.content) {
+    text = result.content.find((c: any) => c.type === 'text')?.text || JSON.stringify(result, null, 2);
+  } else {
+    text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+  }
+
+  // Try to parse as JSON for structured display
+  try {
+    const data = JSON.parse(text);
+    if (data.symbol) {
+      const items: Array<{ label: string; value: string | number }> = [
+        { label: 'Name', value: data.symbol.name || '?' },
+        { label: 'Type', value: data.symbol.type || '?' },
+        { label: 'File', value: data.symbol.file || '?' },
+      ];
+      if (data.callers?.length) items.push({ label: 'Callers', value: data.callers.length });
+      if (data.callees?.length) items.push({ label: 'Callees', value: data.callees.length });
+      if (data.processes?.length) items.push({ label: 'Processes', value: data.processes.length });
+
+      renderSummaryBox({ title: 'Symbol Context', items });
+
+      // Show details
+      if (data.callers?.length) {
+        process.stderr.write(`  ${pc.bold('Callers:')}\n`);
+        for (const c of data.callers.slice(0, 10)) {
+          process.stderr.write(`    ${pc.dim('\u2190')} ${c.name || c}\n`);
+        }
+        if (data.callers.length > 10) process.stderr.write(`    ${pc.dim(`... and ${data.callers.length - 10} more`)}\n`);
+      }
+      if (data.callees?.length) {
+        process.stderr.write(`  ${pc.bold('Callees:')}\n`);
+        for (const c of data.callees.slice(0, 10)) {
+          process.stderr.write(`    ${pc.dim('\u2192')} ${c.name || c}\n`);
+        }
+        if (data.callees.length > 10) process.stderr.write(`    ${pc.dim(`... and ${data.callees.length - 10} more`)}\n`);
+      }
+      process.stderr.write('\n');
+      return;
+    }
+  } catch {
+    // Not JSON -- just print
+  }
+
+  process.stderr.write(text + '\n');
+}

--- a/gitnexus/src/cli/tui/interactive/cypher-tui.ts
+++ b/gitnexus/src/cli/tui/interactive/cypher-tui.ts
@@ -1,0 +1,77 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { pickRepo } from '../components/repo-picker.js';
+import { renderTable } from '../components/formatted-table.js';
+
+export async function runCypherTUI(options?: { repo?: string }): Promise<void> {
+  p.intro(`${pc.bgMagenta(pc.black(' GitNexus Cypher Console '))}`);
+
+  let repoName = options?.repo;
+  if (!repoName) {
+    const repo = await pickRepo({ message: 'Query repository' });
+    if (!repo) return;
+    repoName = repo.name;
+  }
+
+  const query = await p.text({
+    message: 'Cypher query',
+    placeholder: 'e.g. MATCH (n:Function) RETURN n.name LIMIT 10',
+    validate: (v) => v.trim().length === 0 ? 'Query is required' : undefined,
+  });
+  if (p.isCancel(query)) { p.cancel('Cancelled.'); return; }
+
+  p.outro('Executing...');
+
+  const { LocalBackend } = await import('../../../mcp/local/local-backend.js');
+  const backend = new LocalBackend();
+  const ok = await backend.init();
+  if (!ok) {
+    process.stderr.write('  No indexed repositories found. Run: gitnexus analyze\n');
+    return;
+  }
+
+  const result = await backend.callTool('cypher', {
+    query,
+    repo: repoName,
+  });
+
+  renderCypherResults(result);
+}
+
+export function renderCypherResults(result: any): void {
+  let text: string;
+  if (Array.isArray(result)) {
+    text = result.find((c: any) => c.type === 'text')?.text || JSON.stringify(result, null, 2);
+  } else if (typeof result === 'object' && result.content) {
+    text = result.content.find((c: any) => c.type === 'text')?.text || JSON.stringify(result, null, 2);
+  } else {
+    text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+  }
+
+  try {
+    const data = JSON.parse(text);
+    if (Array.isArray(data) && data.length > 0) {
+      // Auto-detect columns from first row
+      const columns = Object.keys(data[0]).map(key => ({
+        key,
+        label: key,
+      }));
+
+      const rows = data.map((row: any) => {
+        const mapped: Record<string, string | number> = {};
+        for (const key of Object.keys(row)) {
+          const val = row[key];
+          mapped[key] = typeof val === 'object' ? JSON.stringify(val) : String(val ?? '');
+        }
+        return mapped;
+      });
+
+      renderTable({ columns, rows, title: `Results (${data.length} rows)` });
+      return;
+    }
+  } catch {
+    // Not JSON
+  }
+
+  process.stderr.write(text + '\n');
+}

--- a/gitnexus/src/cli/tui/interactive/impact-tui.ts
+++ b/gitnexus/src/cli/tui/interactive/impact-tui.ts
@@ -1,0 +1,95 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { pickRepo } from '../components/repo-picker.js';
+import { renderTable } from '../components/formatted-table.js';
+
+export async function runImpactTUI(options?: { repo?: string }): Promise<void> {
+  p.intro(`${pc.bgYellow(pc.black(' GitNexus Impact Analysis '))}`);
+
+  let repoName = options?.repo;
+  if (!repoName) {
+    const repo = await pickRepo({ message: 'Analyze impact in repository' });
+    if (!repo) return;
+    repoName = repo.name;
+  }
+
+  const target = await p.text({
+    message: 'Target symbol',
+    placeholder: 'e.g. "AuthService", "handleLogin", "UserModel"',
+    validate: (v) => v.trim().length === 0 ? 'Target is required' : undefined,
+  });
+  if (p.isCancel(target)) { p.cancel('Cancelled.'); return; }
+
+  const direction = await p.select({
+    message: 'Analysis direction',
+    options: [
+      { value: 'upstream', label: 'Upstream', hint: 'who depends on this? (what breaks if I change it)' },
+      { value: 'downstream', label: 'Downstream', hint: 'what does this depend on?' },
+    ],
+    initialValue: 'upstream',
+  });
+  if (p.isCancel(direction)) { p.cancel('Cancelled.'); return; }
+
+  p.outro('Analyzing...');
+
+  const { LocalBackend } = await import('../../../mcp/local/local-backend.js');
+  const backend = new LocalBackend();
+  const ok = await backend.init();
+  if (!ok) {
+    process.stderr.write('  No indexed repositories found. Run: gitnexus analyze\n');
+    return;
+  }
+
+  const result = await backend.callTool('impact', {
+    target,
+    direction,
+    repo: repoName,
+  });
+
+  renderImpactResults(result);
+}
+
+export function renderImpactResults(result: any): void {
+  let text: string;
+  if (Array.isArray(result)) {
+    text = result.find((c: any) => c.type === 'text')?.text || JSON.stringify(result, null, 2);
+  } else if (typeof result === 'object' && result.content) {
+    text = result.content.find((c: any) => c.type === 'text')?.text || JSON.stringify(result, null, 2);
+  } else {
+    text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+  }
+
+  try {
+    const data = JSON.parse(text);
+    if (data.affected && Array.isArray(data.affected)) {
+      const rows = data.affected.map((item: any) => ({
+        'Symbol': item.name || item.symbol || '?',
+        'Type': item.type || '?',
+        'Depth': item.depth || item.distance || '?',
+        'Risk': item.depth === 1 ? 'WILL BREAK' : item.depth === 2 ? 'LIKELY' : 'MAY',
+        'File': item.file?.split('/').pop() || '?',
+      }));
+
+      renderTable({
+        title: `Impact Analysis (${data.affected.length} affected)`,
+        columns: [
+          { key: 'Symbol', label: 'Symbol', color: (v) => pc.bold(v) },
+          { key: 'Type', label: 'Type', color: (v) => pc.dim(v) },
+          { key: 'Depth', label: 'Depth', align: 'right' },
+          { key: 'Risk', label: 'Risk', color: (v) => {
+            if (v.includes('WILL BREAK')) return pc.red(v);
+            if (v.includes('LIKELY')) return pc.yellow(v);
+            return pc.green(v);
+          }},
+          { key: 'File', label: 'File', color: (v) => pc.dim(v) },
+        ],
+        rows,
+      });
+      return;
+    }
+  } catch {
+    // Not JSON
+  }
+
+  process.stderr.write(text + '\n');
+}

--- a/gitnexus/src/cli/tui/interactive/query-tui.ts
+++ b/gitnexus/src/cli/tui/interactive/query-tui.ts
@@ -1,0 +1,110 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { pickRepo } from '../components/repo-picker.js';
+import { renderTable } from '../components/formatted-table.js';
+
+export async function runQueryTUI(options?: { repo?: string }): Promise<void> {
+  p.intro(`${pc.bgCyan(pc.black(' GitNexus Query '))}`);
+
+  let repoName = options?.repo;
+  if (!repoName) {
+    const repo = await pickRepo({ message: 'Search in repository' });
+    if (!repo) return;
+    repoName = repo.name;
+  }
+
+  const queryText = await p.text({
+    message: 'Search query',
+    placeholder: 'e.g. "authentication flow", "error handling", "database connection"',
+    validate: (v) => v.trim().length === 0 ? 'Query is required' : undefined,
+  });
+  if (p.isCancel(queryText)) { p.cancel('Cancelled.'); return; }
+
+  const context = await p.text({
+    message: 'Task context (optional)',
+    placeholder: 'What are you working on?',
+  });
+  if (p.isCancel(context)) { p.cancel('Cancelled.'); return; }
+
+  p.outro('Searching...');
+
+  // Execute query via LocalBackend
+  const { LocalBackend } = await import('../../../mcp/local/local-backend.js');
+  const backend = new LocalBackend();
+  const ok = await backend.init();
+  if (!ok) {
+    process.stderr.write('  No indexed repositories found. Run: gitnexus analyze\n');
+    return;
+  }
+
+  const result = await backend.callTool('query', {
+    query: queryText,
+    task_context: (context as string)?.trim() || undefined,
+    repo: repoName,
+  });
+
+  renderQueryResults(result);
+}
+
+export function renderQueryResults(result: any): void {
+  if (!result) {
+    process.stderr.write('  No results found.\n');
+    return;
+  }
+
+  // The result from callTool is a tool result with content array
+  // Parse the text content
+  let data: any;
+  if (Array.isArray(result)) {
+    const textContent = result.find((c: any) => c.type === 'text');
+    if (textContent) {
+      try {
+        data = JSON.parse(textContent.text);
+      } catch {
+        // Just output raw text
+        process.stderr.write(textContent.text + '\n');
+        return;
+      }
+    }
+  } else if (typeof result === 'object' && result.content) {
+    const textContent = result.content.find((c: any) => c.type === 'text');
+    if (textContent) {
+      try {
+        data = JSON.parse(textContent.text);
+      } catch {
+        process.stderr.write(textContent.text + '\n');
+        return;
+      }
+    }
+  } else {
+    // Raw result - just display as formatted JSON
+    const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+    process.stderr.write(text + '\n');
+    return;
+  }
+
+  // If we got structured data with processes, render as table
+  if (data?.processes && Array.isArray(data.processes)) {
+    const rows = data.processes.map((proc: any, i: number) => ({
+      '#': i + 1,
+      'Process': proc.name || proc.process || 'Unknown',
+      'Relevance': proc.relevance || proc.score || '',
+      'Symbols': proc.symbolCount || proc.symbols?.length || 0,
+    }));
+
+    renderTable({
+      title: `Query Results (${data.processes.length} flows)`,
+      columns: [
+        { key: '#', label: '#', align: 'right' },
+        { key: 'Process', label: 'Process', color: (v) => pc.bold(v) },
+        { key: 'Relevance', label: 'Relevance' },
+        { key: 'Symbols', label: 'Symbols', align: 'right' },
+      ],
+      rows,
+    });
+  } else {
+    // Fallback to formatted JSON
+    const text = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+    process.stderr.write(text + '\n');
+  }
+}

--- a/gitnexus/src/cli/tui/shared.ts
+++ b/gitnexus/src/cli/tui/shared.ts
@@ -1,0 +1,119 @@
+/**
+ * TUI Shared Utilities
+ *
+ * Detection logic for when to launch the interactive wizard,
+ * and env-var serialization for surviving the heap re-exec.
+ */
+
+import type { AnalyzeOptions } from '../analyze.js';
+
+/** Keys that don't count as "the user passed a real flag". */
+const IGNORED_KEYS = new Set(['yes']);
+
+/**
+ * Returns true when no explicit flags were passed (ignoring `--yes`).
+ * Commander sets missing options to `undefined`, so we check for that.
+ */
+export function hasExplicitFlags(options: Record<string, unknown>): boolean {
+  for (const [key, value] of Object.entries(options)) {
+    if (IGNORED_KEYS.has(key)) continue;
+    if (value !== undefined) return true;
+  }
+  return false;
+}
+
+/**
+ * Check env vars that act as explicit configuration.
+ * If any are set, the user is scripting / automating — skip the TUI.
+ */
+function hasExplicitEnvConfig(): boolean {
+  return !!(
+    process.env.GITNEXUS_DB_TYPE ||
+    process.env.GITNEXUS_NEPTUNE_ENDPOINT ||
+    process.env.GITNEXUS_EMBED_PROVIDER ||
+    process.env.GITNEXUS_FORCE
+  );
+}
+
+/**
+ * Should we launch the interactive wizard?
+ *
+ * True when:
+ *  - stdout is a TTY
+ *  - not running in CI
+ *  - no explicit CLI flags were passed
+ *  - `--yes` was not passed
+ *  - not a re-exec child (GITNEXUS_TUI_DONE !== '1')
+ *  - no explicit env-var configuration
+ */
+export function shouldRunInteractive(options: Record<string, unknown>): boolean {
+  if (process.env.GITNEXUS_TUI_DONE === '1') return false;
+  if (!process.stdout.isTTY) return false;
+  if (process.env.CI === 'true' || process.env.CI === '1') return false;
+  if (options.yes) return false;
+  if (hasExplicitFlags(options)) return false;
+  if (hasExplicitEnvConfig()) return false;
+  return true;
+}
+
+/**
+ * Generic version of shouldRunInteractive for any command.
+ * Only checks TTY, CI, and --yes flag (no analyze-specific env checks).
+ */
+export function shouldRunInteractiveGeneric(options: Record<string, unknown>): boolean {
+  if (!process.stdout.isTTY) return false;
+  if (process.env.CI === 'true' || process.env.CI === '1') return false;
+  if (options.yes) return false;
+  return true;
+}
+
+// ─── Env serialization (analyze wizard → heap re-exec) ───────────────
+
+const ENV_MAP: Record<string, string> = {
+  force: 'GITNEXUS_FORCE',
+  embeddings: 'GITNEXUS_EMBEDDINGS',
+  skills: 'GITNEXUS_SKILLS',
+  verbose: 'GITNEXUS_VERBOSE',
+  db: 'GITNEXUS_DB_TYPE',
+  neptuneEndpoint: 'GITNEXUS_NEPTUNE_ENDPOINT',
+  neptuneRegion: 'GITNEXUS_NEPTUNE_REGION',
+  neptunePort: 'GITNEXUS_NEPTUNE_PORT',
+  embedProvider: 'GITNEXUS_EMBED_PROVIDER',
+  embedModel: 'GITNEXUS_EMBED_MODEL',
+  embedDims: 'GITNEXUS_EMBED_DIMS',
+  embedEndpoint: 'GITNEXUS_EMBED_ENDPOINT',
+  embedApiKey: 'GITNEXUS_EMBED_API_KEY',
+};
+
+/**
+ * Write wizard results into `process.env` so the heap re-exec child
+ * can pick them up. Also sets `GITNEXUS_TUI_DONE=1`.
+ */
+export function serializeToEnv(result: { options: AnalyzeOptions; path?: string }): void {
+  process.env.GITNEXUS_TUI_DONE = '1';
+  if (result.path) {
+    process.env.GITNEXUS_TUI_PATH = result.path;
+  }
+  for (const [key, envKey] of Object.entries(ENV_MAP)) {
+    const val = (result.options as Record<string, unknown>)[key];
+    if (val !== undefined && val !== false) {
+      process.env[envKey] = String(val === true ? '1' : val);
+    }
+  }
+}
+
+/**
+ * Read wizard results back from env vars after heap re-exec.
+ * Only reads the flags that existing resolvers (resolveNeptuneConfig,
+ * resolveEmbeddingConfig) do NOT already handle — i.e. force, embeddings,
+ * skills, verbose.
+ */
+export function deserializeFromEnv(): Partial<AnalyzeOptions> & { tuiPath?: string } {
+  const result: Partial<AnalyzeOptions> & { tuiPath?: string } = {};
+  if (process.env.GITNEXUS_FORCE === '1') result.force = true;
+  if (process.env.GITNEXUS_EMBEDDINGS === '1') result.embeddings = true;
+  if (process.env.GITNEXUS_SKILLS === '1') result.skills = true;
+  if (process.env.GITNEXUS_VERBOSE === '1') result.verbose = true;
+  if (process.env.GITNEXUS_TUI_PATH) result.tuiPath = process.env.GITNEXUS_TUI_PATH;
+  return result;
+}

--- a/gitnexus/src/cli/tui/wiki-wizard.ts
+++ b/gitnexus/src/cli/tui/wiki-wizard.ts
@@ -1,0 +1,2 @@
+// Re-export from new location
+export { runWikiWizard, type WikiWizardResult } from './wizards/wiki-wizard.js';

--- a/gitnexus/src/cli/tui/wizards/analyze-wizard.ts
+++ b/gitnexus/src/cli/tui/wizards/analyze-wizard.ts
@@ -1,0 +1,199 @@
+/**
+ * Analyze Wizard — Interactive TUI for `gitnexus analyze`
+ *
+ * Guides users through configuration with smart defaults
+ * and progressive disclosure. Only shown when no flags are passed.
+ */
+
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import path from 'path';
+import { getGitRoot } from '../../../storage/git.js';
+import { getStoragePaths, loadMeta } from '../../../storage/repo-manager.js';
+import { getCurrentCommit } from '../../../storage/git.js';
+import { renderConfig } from '../components/config-display.js';
+import type { AnalyzeOptions } from '../../analyze.js';
+
+export interface AnalyzeWizardResult {
+  options: AnalyzeOptions;
+  path?: string;
+}
+
+export async function runAnalyzeWizard(
+  inputPath: string | undefined,
+  _currentOptions: AnalyzeOptions,
+): Promise<AnalyzeWizardResult | null> {
+  // Resolve the repo path for display
+  let repoPath: string;
+  if (inputPath) {
+    repoPath = path.resolve(inputPath);
+  } else {
+    const gitRoot = getGitRoot(process.cwd());
+    if (!gitRoot) {
+      p.log.error('Not inside a git repository.');
+      return null;
+    }
+    repoPath = gitRoot;
+  }
+
+  const projectName = path.basename(repoPath);
+
+  p.intro(`${pc.bgCyan(pc.black(' GitNexus Analyzer '))}`);
+
+  // ── Step 1: Confirm path ──────────────────────────────────────────
+  const confirmPath = await p.confirm({
+    message: `Analyze ${pc.bold(projectName)} at ${pc.dim(repoPath)}?`,
+    initialValue: true,
+  });
+  if (p.isCancel(confirmPath) || !confirmPath) {
+    p.cancel('Cancelled.');
+    return null;
+  }
+
+  // ── Step 2: Embeddings ────────────────────────────────────────────
+  const enableEmbeddings = await p.confirm({
+    message: 'Enable semantic search (embeddings)?',
+    initialValue: false,
+  });
+  if (p.isCancel(enableEmbeddings)) { p.cancel('Cancelled.'); return null; }
+
+  // ── Step 2b: Embedding provider config (conditional) ──────────────
+  let embedProvider: string | undefined;
+  let embedModel: string | undefined;
+  let embedDims: string | undefined;
+  let embedEndpoint: string | undefined;
+  let embedApiKey: string | undefined;
+
+  if (enableEmbeddings) {
+    const providerChoice = await p.select({
+      message: 'Embedding provider',
+      options: [
+        { value: 'local', label: 'Local', hint: 'runs on your machine, no API key needed' },
+        { value: 'ollama', label: 'Ollama', hint: 'local Ollama server' },
+        { value: 'openai', label: 'OpenAI', hint: 'requires API key' },
+        { value: 'cohere', label: 'Cohere', hint: 'requires API key' },
+      ],
+      initialValue: 'local',
+    });
+    if (p.isCancel(providerChoice)) { p.cancel('Cancelled.'); return null; }
+    embedProvider = providerChoice;
+
+    const defaultModels: Record<string, string> = {
+      local: 'Snowflake/snowflake-arctic-embed-xs',
+      ollama: 'nomic-embed-text',
+      openai: 'text-embedding-3-small',
+      cohere: 'embed-english-light-v3.0',
+    };
+
+    const model = await p.text({
+      message: 'Embedding model',
+      initialValue: defaultModels[embedProvider] || defaultModels.local,
+    });
+    if (p.isCancel(model)) { p.cancel('Cancelled.'); return null; }
+    embedModel = model;
+
+    const dims = await p.text({
+      message: 'Vector dimensions',
+      initialValue: '384',
+    });
+    if (p.isCancel(dims)) { p.cancel('Cancelled.'); return null; }
+    embedDims = dims || '384';
+
+    if (embedProvider === 'ollama') {
+      const endpoint = await p.text({
+        message: 'Ollama endpoint',
+        initialValue: process.env.GITNEXUS_EMBED_ENDPOINT || 'http://localhost:11434',
+      });
+      if (p.isCancel(endpoint)) { p.cancel('Cancelled.'); return null; }
+      embedEndpoint = endpoint;
+    }
+
+    if (embedProvider === 'openai' || embedProvider === 'cohere') {
+      const existingKey = process.env.GITNEXUS_EMBED_API_KEY
+        || (embedProvider === 'openai' ? process.env.OPENAI_API_KEY : undefined)
+        || (embedProvider === 'cohere' ? process.env.COHERE_API_KEY : undefined);
+
+      if (existingKey) {
+        const masked = existingKey.slice(0, 6) + '...' + existingKey.slice(-4);
+        const useExisting = await p.confirm({
+          message: `Use existing API key (${masked})?`,
+          initialValue: true,
+        });
+        if (p.isCancel(useExisting)) { p.cancel('Cancelled.'); return null; }
+        if (!useExisting) {
+          const key = await p.password({ message: 'API key' });
+          if (p.isCancel(key)) { p.cancel('Cancelled.'); return null; }
+          embedApiKey = key;
+        } else {
+          embedApiKey = existingKey;
+        }
+      } else {
+        const key = await p.password({ message: 'API key' });
+        if (p.isCancel(key)) { p.cancel('Cancelled.'); return null; }
+        embedApiKey = key;
+      }
+    }
+  }
+
+  // ── Step 3: Force re-index? (only if up-to-date) ─────────────────
+  let force = false;
+  const { storagePath } = getStoragePaths(repoPath);
+  const existingMeta = await loadMeta(storagePath);
+  const currentCommit = getCurrentCommit(repoPath);
+
+  if (existingMeta && existingMeta.lastCommit === currentCommit) {
+    const forceChoice = await p.confirm({
+      message: 'Index is up to date at this commit. Force re-index?',
+      initialValue: false,
+    });
+    if (p.isCancel(forceChoice)) { p.cancel('Cancelled.'); return null; }
+    force = forceChoice;
+    if (!force) {
+      p.log.info('Nothing to do — index is already current.');
+      p.outro('Done');
+      return null;
+    }
+  }
+
+  // ── Step 4: Verbose logging ───────────────────────────────────────
+  const verbose = await p.confirm({
+    message: 'Show detailed logs?',
+    initialValue: false,
+  });
+  if (p.isCancel(verbose)) { p.cancel('Cancelled.'); return null; }
+
+  // ── Summary ───────────────────────────────────────────────────────
+  renderConfig({
+    'Repository': projectName,
+    'Path': repoPath,
+    'Database': 'LadybugDB (local)',
+    'Embeddings': enableEmbeddings ? `${embedProvider} / ${embedModel}` : 'off',
+    'Force': force,
+    'Verbose': verbose,
+  });
+
+  const startAnalysis = await p.confirm({
+    message: 'Start analysis?',
+    initialValue: true,
+  });
+  if (p.isCancel(startAnalysis) || !startAnalysis) {
+    p.cancel('Cancelled.');
+    return null;
+  }
+
+  p.outro('Starting analysis...');
+
+  return {
+    options: {
+      force,
+      embeddings: enableEmbeddings || undefined,
+      verbose: verbose || undefined,
+      embedProvider,
+      embedModel,
+      embedDims,
+      embedEndpoint,
+      embedApiKey,
+    },
+    path: inputPath,
+  };
+}

--- a/gitnexus/src/cli/tui/wizards/embed-wizard.ts
+++ b/gitnexus/src/cli/tui/wizards/embed-wizard.ts
@@ -1,0 +1,208 @@
+/**
+ * Embed Wizard — Interactive TUI for `gitnexus embed`
+ *
+ * Guides users through embedding configuration with smart defaults.
+ * Only shown when no flags are passed in an interactive terminal.
+ */
+
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import path from 'path';
+import { getGitRoot } from '../../../storage/git.js';
+import { getStoragePaths, loadMeta, readRegistry } from '../../../storage/repo-manager.js';
+import { renderConfig } from '../components/config-display.js';
+import type { EmbedOptions } from '../../embed-config.js';
+
+export interface EmbedWizardResult {
+  options: EmbedOptions & { force?: boolean };
+  path?: string;
+}
+
+export async function runEmbedWizard(
+  inputPath: string | undefined,
+): Promise<EmbedWizardResult | null> {
+  // Resolve the repo path for display
+  let repoPath: string;
+  if (inputPath) {
+    repoPath = path.resolve(inputPath);
+  } else {
+    const gitRoot = getGitRoot(process.cwd());
+    if (!gitRoot) {
+      p.log.error('Not inside a git repository.');
+      return null;
+    }
+    repoPath = gitRoot;
+  }
+
+  const projectName = path.basename(repoPath);
+
+  // Validate index exists
+  const { storagePath } = getStoragePaths(repoPath);
+  const meta = await loadMeta(storagePath);
+  if (!meta) {
+    p.log.error(`No GitNexus index found for ${pc.bold(projectName)}. Run ${pc.cyan('gitnexus analyze')} first.`);
+    return null;
+  }
+
+  p.intro(`${pc.bgCyan(pc.black(' GitNexus Embeddings '))}`);
+
+  // Show existing embedding info if available
+  const registry = await readRegistry();
+  const existingEntry = registry.find(e => path.resolve(e.path) === path.resolve(repoPath));
+  const existingEmbed = existingEntry?.embedding;
+  const existingCount = meta.stats?.embeddings ?? 0;
+
+  if (existingEmbed) {
+    p.log.info(
+      `Existing: ${pc.bold(existingEmbed.provider)}/${pc.bold(existingEmbed.model)} ` +
+      `(${existingEmbed.dimensions}d) — ${existingCount.toLocaleString()} embeddings`
+    );
+  } else {
+    p.log.info('No existing embeddings found.');
+  }
+
+  // ── Provider ──────────────────────────────────────────────────────
+  const providerChoice = await p.select({
+    message: 'Embedding provider',
+    options: [
+      { value: 'local', label: 'Local', hint: 'runs on your machine, no API key needed' },
+      { value: 'ollama', label: 'Ollama', hint: 'local Ollama server' },
+      { value: 'openai', label: 'OpenAI', hint: 'requires API key' },
+      { value: 'cohere', label: 'Cohere', hint: 'requires API key' },
+    ],
+    initialValue: existingEmbed?.provider ?? 'local',
+  });
+  if (p.isCancel(providerChoice)) { p.cancel('Cancelled.'); return null; }
+
+  // ── Model ─────────────────────────────────────────────────────────
+  const defaultModels: Record<string, string> = {
+    local: 'Snowflake/snowflake-arctic-embed-xs',
+    ollama: 'nomic-embed-text',
+    openai: 'text-embedding-3-small',
+    cohere: 'embed-english-light-v3.0',
+  };
+
+  const modelDefault = (existingEmbed?.provider === providerChoice && existingEmbed?.model)
+    ? existingEmbed.model
+    : defaultModels[providerChoice] || defaultModels.local;
+
+  const model = await p.text({
+    message: 'Embedding model',
+    initialValue: modelDefault,
+  });
+  if (p.isCancel(model)) { p.cancel('Cancelled.'); return null; }
+
+  // ── Dimensions ────────────────────────────────────────────────────
+  const dimsDefault = existingEmbed?.dimensions
+    ? String(existingEmbed.dimensions)
+    : '384';
+
+  const dims = await p.text({
+    message: 'Vector dimensions',
+    initialValue: dimsDefault,
+  });
+  if (p.isCancel(dims)) { p.cancel('Cancelled.'); return null; }
+
+  // ── Endpoint (Ollama / OpenAI) ────────────────────────────────────
+  let embedEndpoint: string | undefined;
+  if (providerChoice === 'ollama') {
+    const endpoint = await p.text({
+      message: 'Ollama endpoint',
+      initialValue: existingEmbed?.endpoint || process.env.GITNEXUS_EMBED_ENDPOINT || 'http://localhost:11434',
+    });
+    if (p.isCancel(endpoint)) { p.cancel('Cancelled.'); return null; }
+    embedEndpoint = endpoint;
+  } else if (providerChoice === 'openai') {
+    const endpoint = await p.text({
+      message: 'OpenAI-compatible endpoint (leave empty for default)',
+      initialValue: existingEmbed?.endpoint || process.env.GITNEXUS_EMBED_ENDPOINT || '',
+    });
+    if (p.isCancel(endpoint)) { p.cancel('Cancelled.'); return null; }
+    embedEndpoint = endpoint || undefined;
+  }
+
+  // ── API Key (OpenAI / Cohere) ─────────────────────────────────────
+  let embedApiKey: string | undefined;
+  if (providerChoice === 'openai' || providerChoice === 'cohere') {
+    const existingKey = process.env.GITNEXUS_EMBED_API_KEY
+      || (providerChoice === 'openai' ? process.env.OPENAI_API_KEY : undefined)
+      || (providerChoice === 'cohere' ? process.env.COHERE_API_KEY : undefined);
+
+    if (existingKey) {
+      const masked = existingKey.slice(0, 6) + '...' + existingKey.slice(-4);
+      const useExisting = await p.confirm({
+        message: `Use existing API key (${masked})?`,
+        initialValue: true,
+      });
+      if (p.isCancel(useExisting)) { p.cancel('Cancelled.'); return null; }
+      if (!useExisting) {
+        const key = await p.password({ message: 'API key' });
+        if (p.isCancel(key)) { p.cancel('Cancelled.'); return null; }
+        embedApiKey = key;
+      } else {
+        embedApiKey = existingKey;
+      }
+    } else {
+      const key = await p.password({ message: 'API key' });
+      if (p.isCancel(key)) { p.cancel('Cancelled.'); return null; }
+      embedApiKey = key;
+    }
+  }
+
+  // ── Force? ────────────────────────────────────────────────────────
+  let force = false;
+  const newDims = parseInt(dims || '384', 10);
+  const configChanged = existingEmbed && (
+    existingEmbed.provider !== providerChoice ||
+    existingEmbed.model !== model ||
+    existingEmbed.dimensions !== newDims
+  );
+
+  if (configChanged && existingCount > 0) {
+    p.log.warn(
+      `Config changed from ${existingEmbed!.provider}/${existingEmbed!.model}/${existingEmbed!.dimensions}d ` +
+      `to ${providerChoice}/${model}/${newDims}d — all embeddings will be regenerated.`
+    );
+    force = true;
+  } else if (existingCount > 0) {
+    const forceChoice = await p.confirm({
+      message: `${existingCount.toLocaleString()} embeddings exist. Force regenerate all?`,
+      initialValue: false,
+    });
+    if (p.isCancel(forceChoice)) { p.cancel('Cancelled.'); return null; }
+    force = forceChoice;
+  }
+
+  // ── Summary ───────────────────────────────────────────────────────
+  renderConfig({
+    'Repository': projectName,
+    'Provider': providerChoice,
+    'Model': model,
+    'Dimensions': newDims,
+    'Endpoint': embedEndpoint,
+    'Force': force,
+  });
+
+  const startEmbed = await p.confirm({
+    message: 'Start embedding?',
+    initialValue: true,
+  });
+  if (p.isCancel(startEmbed) || !startEmbed) {
+    p.cancel('Cancelled.');
+    return null;
+  }
+
+  p.outro('Starting embeddings...');
+
+  return {
+    options: {
+      embedProvider: providerChoice,
+      embedModel: model,
+      embedDims: dims || '384',
+      embedEndpoint,
+      embedApiKey,
+      force,
+    },
+    path: inputPath,
+  };
+}

--- a/gitnexus/src/cli/tui/wizards/setup-wizard.ts
+++ b/gitnexus/src/cli/tui/wizards/setup-wizard.ts
@@ -1,0 +1,98 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import os from 'os';
+import fs from 'fs/promises';
+import path from 'path';
+
+interface EditorInfo {
+  name: string;
+  key: string;
+  detected: boolean;
+  configPath: string;
+}
+
+export interface SetupWizardResult {
+  selectedEditors: string[];
+}
+
+async function dirExists(dirPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(dirPath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export async function runSetupWizard(): Promise<SetupWizardResult | null> {
+  p.intro(`${pc.bgGreen(pc.black(' GitNexus Setup '))}`);
+
+  // Detect installed editors
+  const home = os.homedir();
+  const editors: EditorInfo[] = [
+    {
+      name: 'Cursor',
+      key: 'cursor',
+      detected: await dirExists(path.join(home, '.cursor')),
+      configPath: path.join(home, '.cursor', 'mcp.json'),
+    },
+    {
+      name: 'Claude Code',
+      key: 'claude',
+      detected: await dirExists(path.join(home, '.claude')),
+      configPath: '~/.claude (manual)',
+    },
+    {
+      name: 'OpenCode',
+      key: 'opencode',
+      detected: await dirExists(path.join(home, '.config', 'opencode')),
+      configPath: path.join(home, '.config', 'opencode', 'config.json'),
+    },
+  ];
+
+  const detected = editors.filter(e => e.detected);
+  const notDetected = editors.filter(e => !e.detected);
+
+  if (detected.length === 0) {
+    p.log.warn('No supported editors detected.');
+    p.log.info('Supported: Cursor, Claude Code, OpenCode');
+    p.outro('Install a supported editor and run setup again.');
+    return null;
+  }
+
+  // Show what was detected
+  for (const e of detected) {
+    p.log.success(`${pc.green('Found:')} ${e.name}`);
+  }
+  for (const e of notDetected) {
+    p.log.info(`${pc.dim('Not found:')} ${e.name}`);
+  }
+
+  // Select which to configure
+  const selected = await p.multiselect({
+    message: 'Configure MCP for:',
+    options: detected.map(e => ({
+      value: e.key,
+      label: e.name,
+      hint: e.configPath,
+    })),
+    initialValues: detected.map(e => e.key),
+  });
+
+  if (p.isCancel(selected)) {
+    p.cancel('Cancelled.');
+    return null;
+  }
+
+  const confirm = await p.confirm({
+    message: `Configure ${(selected as string[]).length} editor(s)?`,
+    initialValue: true,
+  });
+
+  if (p.isCancel(confirm) || !confirm) {
+    p.cancel('Cancelled.');
+    return null;
+  }
+
+  return { selectedEditors: selected as string[] };
+}

--- a/gitnexus/src/cli/tui/wizards/wiki-wizard.ts
+++ b/gitnexus/src/cli/tui/wizards/wiki-wizard.ts
@@ -1,0 +1,204 @@
+/**
+ * Wiki Wizard — Interactive TUI for `gitnexus wiki`
+ *
+ * Replaces the hand-rolled readline prompts with a polished
+ * @clack/prompts wizard. Only shown when no flags are passed.
+ */
+
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import path from 'path';
+import { loadCLIConfig, saveCLIConfig, getStoragePaths, loadMeta } from '../../../storage/repo-manager.js';
+import { getGitRoot, isGitRepo } from '../../../storage/git.js';
+import { renderConfig } from '../components/config-display.js';
+import type { WikiCommandOptions } from '../../wiki.js';
+
+interface LLMConfig {
+  baseUrl: string;
+  model: string;
+  apiKey: string;
+}
+
+export interface WikiWizardResult {
+  options: WikiCommandOptions;
+  llmConfig: LLMConfig;
+}
+
+export async function runWikiWizard(
+  inputPath: string | undefined,
+  _currentOptions: WikiCommandOptions,
+): Promise<WikiWizardResult | null> {
+  // Resolve the repo path for display
+  let repoPath: string;
+  if (inputPath) {
+    repoPath = path.resolve(inputPath);
+  } else {
+    const gitRoot = getGitRoot(process.cwd());
+    if (!gitRoot) {
+      p.log.error('Not inside a git repository.');
+      return null;
+    }
+    repoPath = gitRoot;
+  }
+
+  if (!isGitRepo(repoPath)) {
+    p.log.error('Not a git repository.');
+    return null;
+  }
+
+  // Check for existing index
+  const { storagePath } = getStoragePaths(repoPath);
+  const meta = await loadMeta(storagePath);
+  if (!meta) {
+    p.log.error('No GitNexus index found. Run `gitnexus analyze` first.');
+    return null;
+  }
+
+  const projectName = path.basename(repoPath);
+  const savedConfig = await loadCLIConfig();
+
+  p.intro(`${pc.bgMagenta(pc.black(' GitNexus Wiki Generator '))}`);
+
+  p.log.info(`Generating wiki for ${pc.bold(projectName)}`);
+
+  // ── Step 1: LLM Provider ─────────────────────────────────────────
+  const providerChoice = await p.select({
+    message: 'LLM provider',
+    options: [
+      { value: 'openai', label: 'OpenAI', hint: 'api.openai.com' },
+      { value: 'openrouter', label: 'OpenRouter', hint: 'openrouter.ai — many models' },
+      { value: 'custom', label: 'Custom endpoint', hint: 'any OpenAI-compatible API' },
+    ],
+    initialValue: savedConfig.baseUrl?.includes('openrouter') ? 'openrouter'
+      : savedConfig.baseUrl?.includes('openai') ? 'openai'
+      : savedConfig.baseUrl ? 'custom' : 'openai',
+  });
+  if (p.isCancel(providerChoice)) { p.cancel('Cancelled.'); return null; }
+
+  let baseUrl: string;
+  let defaultModel: string;
+
+  if (providerChoice === 'openrouter') {
+    baseUrl = 'https://openrouter.ai/api/v1';
+    defaultModel = 'minimax/minimax-m2.5';
+  } else if (providerChoice === 'custom') {
+    const url = await p.text({
+      message: 'Base URL',
+      placeholder: 'http://localhost:11434/v1',
+      initialValue: savedConfig.baseUrl || '',
+      validate: (v) => v.length === 0 ? 'URL is required' : undefined,
+    });
+    if (p.isCancel(url)) { p.cancel('Cancelled.'); return null; }
+    baseUrl = url;
+    defaultModel = 'gpt-4o-mini';
+  } else {
+    baseUrl = 'https://api.openai.com/v1';
+    defaultModel = 'gpt-4o-mini';
+  }
+
+  // ── Step 2: Model ─────────────────────────────────────────────────
+  const model = await p.text({
+    message: 'Model',
+    initialValue: savedConfig.model || defaultModel,
+  });
+  if (p.isCancel(model)) { p.cancel('Cancelled.'); return null; }
+
+  // ── Step 3: API Key ───────────────────────────────────────────────
+  const envKey = process.env.GITNEXUS_API_KEY || process.env.OPENAI_API_KEY || '';
+  let apiKey: string;
+
+  if (savedConfig.apiKey || envKey) {
+    const existing = savedConfig.apiKey || envKey;
+    const masked = existing.slice(0, 6) + '...' + existing.slice(-4);
+    const useExisting = await p.confirm({
+      message: `Use saved API key (${masked})?`,
+      initialValue: true,
+    });
+    if (p.isCancel(useExisting)) { p.cancel('Cancelled.'); return null; }
+
+    if (useExisting) {
+      apiKey = existing;
+    } else {
+      const key = await p.password({ message: 'API key' });
+      if (p.isCancel(key)) { p.cancel('Cancelled.'); return null; }
+      apiKey = key;
+    }
+  } else {
+    const key = await p.password({ message: 'API key' });
+    if (p.isCancel(key)) { p.cancel('Cancelled.'); return null; }
+    apiKey = key;
+  }
+
+  if (!apiKey) {
+    p.cancel('No API key provided.');
+    return null;
+  }
+
+  // ── Step 4: Concurrency ───────────────────────────────────────────
+  const concurrency = await p.text({
+    message: 'Parallel LLM calls (1-10)',
+    initialValue: '3',
+    validate: (v) => {
+      const n = parseInt(v, 10);
+      if (isNaN(n) || n < 1 || n > 10) return 'Enter a number between 1 and 10';
+      return undefined;
+    },
+  });
+  if (p.isCancel(concurrency)) { p.cancel('Cancelled.'); return null; }
+
+  // ── Step 5: Force regen ───────────────────────────────────────────
+  let force = false;
+  const wikiDir = path.join(storagePath, 'wiki');
+  try {
+    const fs = await import('fs/promises');
+    await fs.access(wikiDir);
+    // Wiki exists — ask about force
+    const forceChoice = await p.confirm({
+      message: 'Existing wiki found. Force full regeneration?',
+      initialValue: false,
+    });
+    if (p.isCancel(forceChoice)) { p.cancel('Cancelled.'); return null; }
+    force = forceChoice;
+  } catch {
+    // No existing wiki — no need to ask
+  }
+
+  // ── Summary ───────────────────────────────────────────────────────
+  renderConfig({
+    'Repository': projectName,
+    'Provider': baseUrl,
+    'Model': model || defaultModel,
+    'Concurrency': concurrency || '3',
+    'Force': force,
+  });
+
+  const startWiki = await p.confirm({
+    message: 'Generate wiki?',
+    initialValue: true,
+  });
+  if (p.isCancel(startWiki) || !startWiki) {
+    p.cancel('Cancelled.');
+    return null;
+  }
+
+  // Save config for next time
+  await saveCLIConfig({ apiKey, baseUrl, model: model || defaultModel });
+  p.log.success('Config saved to ~/.gitnexus/config.json');
+
+  p.outro('Starting wiki generation...');
+
+  return {
+    options: {
+      force: force || undefined,
+      model: model || defaultModel,
+      baseUrl,
+      apiKey,
+      concurrency: concurrency || '3',
+    },
+    llmConfig: {
+      baseUrl,
+      model: model || defaultModel,
+      apiKey,
+    },
+  };
+}

--- a/gitnexus/src/cli/wiki.ts
+++ b/gitnexus/src/cli/wiki.ts
@@ -8,7 +8,6 @@
 import path from 'path';
 import readline from 'readline';
 import { execSync, execFileSync } from 'child_process';
-import cliProgress from 'cli-progress';
 import { getGitRoot, isGitRepo } from '../storage/git.js';
 import { getStoragePaths, loadMeta, loadCLIConfig, saveCLIConfig } from '../storage/repo-manager.js';
 import { WikiGenerator, type WikiOptions } from '../core/wiki/generator.js';
@@ -21,6 +20,7 @@ export interface WikiCommandOptions {
   apiKey?: string;
   concurrency?: string;
   gist?: boolean;
+  yes?: boolean;
 }
 
 /**
@@ -78,6 +78,19 @@ export const wikiCommand = async (
   inputPath?: string,
   options?: WikiCommandOptions,
 ) => {
+  // ── TUI Wizard ────────────────────────────────────────────────────
+  let wizardLLMConfig: { baseUrl: string; model: string; apiKey: string } | null = null;
+  {
+    const { shouldRunInteractive } = await import('./tui/shared.js');
+    if (options && shouldRunInteractive(options as Record<string, unknown>)) {
+      const { runWikiWizard } = await import('./tui/wiki-wizard.js');
+      const result = await runWikiWizard(inputPath, options);
+      if (!result) return;
+      options = { ...options, ...result.options };
+      wizardLLMConfig = result.llmConfig;
+    }
+  }
+
   console.log('\n  GitNexus Wiki Generator\n');
 
   // ── Resolve repo path ───────────────────────────────────────────────
@@ -127,15 +140,16 @@ export const wikiCommand = async (
   const hasSavedConfig = !!(savedConfig.apiKey && savedConfig.baseUrl);
   const hasCLIOverrides = !!(options?.apiKey || options?.model || options?.baseUrl);
 
-  let llmConfig = await resolveLLMConfig({
-    model: options?.model,
-    baseUrl: options?.baseUrl,
-    apiKey: options?.apiKey,
-  });
+  let llmConfig = wizardLLMConfig
+    ? { ...await resolveLLMConfig({}), ...wizardLLMConfig }
+    : await resolveLLMConfig({
+        model: options?.model,
+        baseUrl: options?.baseUrl,
+        apiKey: options?.apiKey,
+      });
 
-  // Run interactive setup if no saved config and no CLI flags provided
-  // (even if env vars exist — let user explicitly choose their provider)
-  if (!hasSavedConfig && !hasCLIOverrides) {
+  // Run interactive setup if no saved config, no CLI flags, and wizard didn't run
+  if (!wizardLLMConfig && !hasSavedConfig && !hasCLIOverrides) {
     if (!process.stdin.isTTY) {
       if (!llmConfig.apiKey) {
         console.log('  Error: No LLM API key found.');
@@ -208,33 +222,15 @@ export const wikiCommand = async (
     }
   }
 
-  // ── Setup progress bar with elapsed timer ──────────────────────────
-  const bar = new cliProgress.SingleBar({
-    format: '  {bar} {percentage}% | {phase}',
-    barCompleteChar: '\u2588',
-    barIncompleteChar: '\u2591',
-    hideCursor: true,
-    barGlue: '',
-    autopadding: true,
-    clearOnComplete: false,
-    stopOnComplete: false,
-  }, cliProgress.Presets.shades_grey);
-
-  bar.start(100, 0, { phase: 'Initializing...' });
+  // ── Setup multi-progress ────────────────────────────────────────────
+  const { createMultiProgress } = await import('./tui/components/multi-progress.js');
+  const mp = createMultiProgress([
+    { name: 'generate', label: 'Generating wiki', weight: 95 },
+    { name: 'complete', label: 'Finalizing', weight: 5 },
+  ]);
+  mp.setPhase('generate');
 
   const t0 = Date.now();
-  let lastPhase = '';
-  let phaseStart = t0;
-
-  // Tick elapsed time every second while stuck on the same phase
-  const elapsedTimer = setInterval(() => {
-    if (lastPhase) {
-      const elapsed = Math.round((Date.now() - phaseStart) / 1000);
-      if (elapsed >= 3) {
-        bar.update({ phase: `${lastPhase} (${elapsed}s)` });
-      }
-    }
-  }, 1000);
 
   // ── Run generator ───────────────────────────────────────────────────
   const wikiOptions: WikiOptions = {
@@ -251,54 +247,38 @@ export const wikiCommand = async (
     llmConfig,
     wikiOptions,
     (phase, percent, detail) => {
-      const label = detail || phase;
-      if (label !== lastPhase) {
-        lastPhase = label;
-        phaseStart = Date.now();
-      }
-      bar.update(percent, { phase: label });
+      mp.update(percent, detail || phase);
     },
   );
 
   try {
     const result = await generator.run();
 
-    clearInterval(elapsedTimer);
-    bar.update(100, { phase: 'Done' });
-    bar.stop();
-
     const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
 
     const wikiDir = path.join(storagePath, 'wiki');
     const viewerPath = path.join(wikiDir, 'index.html');
 
-    if (result.mode === 'up-to-date' && !options?.force) {
-      console.log('\n  Wiki is already up to date.');
-      console.log(`  Viewer: ${viewerPath}\n`);
-      await maybePublishGist(viewerPath, options?.gist);
-      return;
-    }
-
-    console.log(`\n  Wiki generated successfully (${elapsed}s)\n`);
-    console.log(`  Mode: ${result.mode}`);
-    console.log(`  Pages: ${result.pagesGenerated}`);
-    console.log(`  Output: ${wikiDir}`);
-    console.log(`  Viewer: ${viewerPath}`);
+    mp.setPhase('complete');
+    mp.complete({
+      'Result': result.mode === 'up-to-date' ? 'Wiki is up to date' : `Generated (${elapsed}s)`,
+      'Pages': String(result.pagesGenerated),
+      'Output': wikiDir,
+      'Viewer': viewerPath,
+    });
 
     if (result.failedModules && result.failedModules.length > 0) {
-      console.log(`\n  Failed modules (${result.failedModules.length}):`);
+      console.log(`  Failed modules (${result.failedModules.length}):`);
       for (const mod of result.failedModules) {
         console.log(`    - ${mod}`);
       }
       console.log('  Re-run to retry failed modules (pages will be regenerated).');
+      console.log('');
     }
-
-    console.log('');
 
     await maybePublishGist(viewerPath, options?.gist);
   } catch (err: any) {
-    clearInterval(elapsedTimer);
-    bar.stop();
+    mp.stop();
 
     if (err.message?.includes('No source files')) {
       console.log(`\n  ${err.message}\n`);

--- a/gitnexus/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus/src/core/embeddings/embedding-pipeline.ts
@@ -1,92 +1,94 @@
 /**
  * Embedding Pipeline Module
- * 
- * Orchestrates the background embedding process:
- * 1. Query embeddable nodes from LadybugDB
+ *
+ * Orchestrates the embedding process:
+ * 1. Query embeddable nodes from LadybugDB (paginated)
  * 2. Generate text representations
- * 3. Batch embed using transformers.js
+ * 3. Batch embed using the injected IEmbeddingProvider
  * 4. Update LadybugDB with embeddings
  * 5. Create vector index for semantic search
  */
 
-import { initEmbedder, embedBatch, embedText, embeddingToArray, isEmbedderReady } from './embedder.js';
-import { generateBatchEmbeddingTexts, generateEmbeddingText } from './text-generator.js';
+import type { IEmbeddingProvider } from './providers/types.js';
+import { generateBatchEmbeddingTexts } from './text-generator.js';
 import {
   type EmbeddingProgress,
   type EmbeddingConfig,
   type EmbeddableNode,
   type SemanticSearchResult,
-  type ModelProgress,
   DEFAULT_EMBEDDING_CONFIG,
   EMBEDDABLE_LABELS,
 } from './types.js';
 
 const isDev = process.env.NODE_ENV === 'development';
+const PAGE_SIZE = 1000;
 
-/**
- * Progress callback type
- */
 export type EmbeddingProgressCallback = (progress: EmbeddingProgress) => void;
 
 /**
- * Query all embeddable nodes from LadybugDB
- * Uses table-specific queries (File has different schema than code elements)
+ * Smart label selection: skip File nodes for very large repos to limit embedding volume.
  */
-const queryEmbeddableNodes = async (
-  executeQuery: (cypher: string) => Promise<any[]>
-): Promise<EmbeddableNode[]> => {
-  const allNodes: EmbeddableNode[] = [];
-  
-  // Query each embeddable table with table-specific columns
-  for (const label of EMBEDDABLE_LABELS) {
-    try {
-      let query: string;
-      
-      if (label === 'File') {
-        // File nodes don't have startLine/endLine
-        query = `
-          MATCH (n:File)
-          RETURN n.id AS id, n.name AS name, 'File' AS label, 
-                 n.filePath AS filePath, n.content AS content
-        `;
-      } else {
-        // Code elements have startLine/endLine
-        query = `
-          MATCH (n:${label})
-          RETURN n.id AS id, n.name AS name, '${label}' AS label, 
-                 n.filePath AS filePath, n.content AS content,
-                 n.startLine AS startLine, n.endLine AS endLine
-        `;
-      }
-      
-      const rows = await executeQuery(query);
-      for (const row of rows) {
-        allNodes.push({
-          id: row.id ?? row[0],
-          name: row.name ?? row[1],
-          label: row.label ?? row[2],
-          filePath: row.filePath ?? row[3],
-          content: row.content ?? row[4] ?? '',
-          startLine: row.startLine ?? row[5],
-          endLine: row.endLine ?? row[6],
-        });
-      }
-    } catch (error) {
-      // Table might not exist or be empty, continue
-      if (isDev) {
-        console.warn(`Query for ${label} nodes failed:`, error);
-      }
-    }
-  }
+export function getEmbeddableLabels(nodeCount: number): readonly string[] {
+  if (nodeCount > 100_000) return ['Function', 'Class', 'Method', 'Interface'];
+  return EMBEDDABLE_LABELS;
+}
 
-  return allNodes;
+/**
+ * Count embeddable nodes per label (used to compute total before paginated fetch).
+ */
+const countEmbeddableNodes = async (
+  executeQuery: (cypher: string) => Promise<any[]>,
+  labels: readonly string[],
+): Promise<number> => {
+  let total = 0;
+  for (const label of labels) {
+    try {
+      const rows = await executeQuery(`MATCH (n:${label}) RETURN count(n) AS cnt`);
+      total += Number(rows[0]?.cnt ?? rows[0]?.[0] ?? 0);
+    } catch { /* table may not exist */ }
+  }
+  return total;
 };
 
 /**
- * Batch INSERT embeddings into separate CodeEmbedding table
- * Using a separate lightweight table avoids copy-on-write overhead
- * that occurs when UPDATEing nodes with large content fields
+ * Paginated node query — yields one page at a time to control memory.
  */
+async function* queryNodesPaginated(
+  executeQuery: (cypher: string) => Promise<any[]>,
+  label: string,
+  skipNodeIds?: Set<string>,
+): AsyncGenerator<EmbeddableNode[]> {
+  let offset = 0;
+  while (true) {
+    const isFile = label === 'File';
+    const query = isFile
+      ? `MATCH (n:File) RETURN n.id AS id, n.name AS name, 'File' AS label, n.filePath AS filePath, n.content AS content SKIP ${offset} LIMIT ${PAGE_SIZE}`
+      : `MATCH (n:${label}) RETURN n.id AS id, n.name AS name, '${label}' AS label, n.filePath AS filePath, n.content AS content, n.startLine AS startLine, n.endLine AS endLine SKIP ${offset} LIMIT ${PAGE_SIZE}`;
+
+    const rows = await executeQuery(query);
+    if (rows.length === 0) break;
+
+    const page: EmbeddableNode[] = [];
+    for (const row of rows) {
+      const id = row.id ?? row[0];
+      if (skipNodeIds?.has(id)) continue;
+      page.push({
+        id,
+        name: row.name ?? row[1],
+        label: row.label ?? row[2],
+        filePath: row.filePath ?? row[3],
+        content: row.content ?? row[4] ?? '',
+        startLine: row.startLine ?? row[5],
+        endLine: row.endLine ?? row[6],
+      });
+    }
+
+    if (page.length > 0) yield page;
+    if (rows.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+}
+
 const batchInsertEmbeddings = async (
   executeWithReusedStatement: (
     cypher: string,
@@ -94,7 +96,6 @@ const batchInsertEmbeddings = async (
   ) => Promise<void>,
   updates: Array<{ id: string; embedding: number[] }>
 ): Promise<void> => {
-  // INSERT into separate embedding table - much more memory efficient!
   const cypher = `CREATE (e:CodeEmbedding {nodeId: $nodeId, embedding: $embedding})`;
   const paramsList = updates.map(u => ({ nodeId: u.id, embedding: u.embedding }));
   await executeWithReusedStatement(cypher, paramsList);
@@ -116,217 +117,145 @@ const createVectorIndex = async (
       await executeQuery('LOAD EXTENSION VECTOR');
       vectorExtensionLoaded = true;
     } catch {
-      // Extension may already be loaded — CREATE_VECTOR_INDEX will fail clearly if not
       vectorExtensionLoaded = true;
     }
   }
 
-  const cypher = `
-    CALL CREATE_VECTOR_INDEX('CodeEmbedding', 'code_embedding_idx', 'embedding', metric := 'cosine')
-  `;
-
   try {
-    await executeQuery(cypher);
+    await executeQuery(
+      `CALL CREATE_VECTOR_INDEX('CodeEmbedding', 'code_embedding_idx', 'embedding', metric := 'cosine')`,
+    );
   } catch (error) {
-    // Index might already exist
-    if (isDev) {
-      console.warn('Vector index creation warning:', error);
-    }
+    if (isDev) console.warn('Vector index creation warning:', error);
   }
 };
 
 /**
- * Run the embedding pipeline
- * 
- * @param executeQuery - Function to execute Cypher queries against LadybugDB
- * @param executeWithReusedStatement - Function to execute with reused prepared statement
- * @param onProgress - Callback for progress updates
- * @param config - Optional configuration override
- * @param skipNodeIds - Optional set of node IDs that already have embeddings (incremental mode)
+ * Run the embedding pipeline with an injected provider.
  */
 export const runEmbeddingPipeline = async (
   executeQuery: (cypher: string) => Promise<any[]>,
   executeWithReusedStatement: (cypher: string, paramsList: Array<Record<string, any>>) => Promise<void>,
   onProgress: EmbeddingProgressCallback,
+  provider: IEmbeddingProvider,
   config: Partial<EmbeddingConfig> = {},
   skipNodeIds?: Set<string>,
+  embeddableLabels?: readonly string[],
 ): Promise<void> => {
   const finalConfig = { ...DEFAULT_EMBEDDING_CONFIG, ...config };
+  const labels = embeddableLabels ?? EMBEDDABLE_LABELS;
+  const batchSize = Math.min(provider.maxBatchSize(), finalConfig.batchSize || provider.maxBatchSize());
 
   try {
-    // Phase 1: Load embedding model
-    onProgress({
-      phase: 'loading-model',
-      percent: 0,
-      modelDownloadPercent: 0,
-    });
-
-    await initEmbedder((modelProgress: ModelProgress) => {
-      const downloadPercent = modelProgress.progress ?? 0;
-      onProgress({
-        phase: 'loading-model',
-        percent: Math.round(downloadPercent * 0.2),
-        modelDownloadPercent: downloadPercent,
-      });
-    }, finalConfig);
-
-    onProgress({
-      phase: 'loading-model',
-      percent: 20,
-      modelDownloadPercent: 100,
-    });
-
-    if (isDev) {
-      console.log('🔍 Querying embeddable nodes...');
-    }
-
-    // Phase 2: Query embeddable nodes
-    let nodes = await queryEmbeddableNodes(executeQuery);
-
-    // Incremental mode: filter out nodes that already have embeddings
-    if (skipNodeIds && skipNodeIds.size > 0) {
-      const beforeCount = nodes.length;
-      nodes = nodes.filter(n => !skipNodeIds.has(n.id));
-      if (isDev) {
-        console.log(`📦 Incremental embeddings: ${beforeCount} total, ${skipNodeIds.size} cached, ${nodes.length} to embed`);
+    // Load VECTOR extension early — required if CodeEmbedding already has a vector index
+    // from a prior run. LadybugDB needs the extension loaded before any DML on indexed tables.
+    if (!vectorExtensionLoaded) {
+      try {
+        await executeQuery('INSTALL VECTOR');
+        await executeQuery('LOAD EXTENSION VECTOR');
+        vectorExtensionLoaded = true;
+      } catch {
+        vectorExtensionLoaded = true;
       }
     }
 
-    const totalNodes = nodes.length;
+    onProgress({ phase: 'loading-model', percent: 0, modelDownloadPercent: 0 });
 
-    if (isDev) {
-      console.log(`📊 Found ${totalNodes} embeddable nodes`);
-    }
+    // Warm up the provider (triggers lazy model load for local providers)
+    await provider.embed(['warmup']);
 
-    if (totalNodes === 0) {
-      onProgress({
-        phase: 'ready',
-        percent: 100,
-        nodesProcessed: 0,
-        totalNodes: 0,
-      });
+    onProgress({ phase: 'loading-model', percent: 20, modelDownloadPercent: 100 });
+
+    if (isDev) console.log('Querying embeddable nodes...');
+
+    const totalNodes = await countEmbeddableNodes(executeQuery, labels);
+    const skipped = skipNodeIds?.size ?? 0;
+    const estimatedToEmbed = Math.max(0, totalNodes - skipped);
+
+    if (isDev) console.log(`Found ${totalNodes} total, ${skipped} cached, ~${estimatedToEmbed} to embed`);
+
+    if (estimatedToEmbed === 0) {
+      onProgress({ phase: 'ready', percent: 100, nodesProcessed: 0, totalNodes: 0 });
       return;
     }
 
-    // Phase 3: Batch embed nodes
-    const batchSize = finalConfig.batchSize;
-    const totalBatches = Math.ceil(totalNodes / batchSize);
     let processedNodes = 0;
+    let pendingBatch: EmbeddableNode[] = [];
 
-    onProgress({
-      phase: 'embedding',
-      percent: 20,
-      nodesProcessed: 0,
-      totalNodes,
-      currentBatch: 0,
-      totalBatches,
-    });
+    const flushBatch = async () => {
+      if (pendingBatch.length === 0) return;
 
-    for (let batchIndex = 0; batchIndex < totalBatches; batchIndex++) {
-      const start = batchIndex * batchSize;
-      const end = Math.min(start + batchSize, totalNodes);
-      const batch = nodes.slice(start, end);
-
-      // Generate texts for this batch
-      const texts = generateBatchEmbeddingTexts(batch, finalConfig);
-
-      // Embed the batch
-      const embeddings = await embedBatch(texts);
-
-      // Update LadybugDB with embeddings
-      const updates = batch.map((node, i) => ({
+      const texts = generateBatchEmbeddingTexts(pendingBatch, finalConfig);
+      const embeddings = await provider.embed(texts);
+      const updates = pendingBatch.map((node, i) => ({
         id: node.id,
-        embedding: embeddingToArray(embeddings[i]),
+        embedding: embeddings[i],
       }));
 
       await batchInsertEmbeddings(executeWithReusedStatement, updates);
+      processedNodes += pendingBatch.length;
 
-      processedNodes += batch.length;
-
-      // Report progress (20-90% for embedding phase)
-      const embeddingProgress = 20 + ((processedNodes / totalNodes) * 70);
+      const embeddingProgress = 20 + ((processedNodes / estimatedToEmbed) * 70);
       onProgress({
         phase: 'embedding',
-        percent: Math.round(embeddingProgress),
+        percent: Math.min(90, Math.round(embeddingProgress)),
         nodesProcessed: processedNodes,
-        totalNodes,
-        currentBatch: batchIndex + 1,
-        totalBatches,
+        totalNodes: estimatedToEmbed,
       });
+
+      pendingBatch = [];
+    };
+
+    onProgress({ phase: 'embedding', percent: 20, nodesProcessed: 0, totalNodes: estimatedToEmbed });
+
+    // Process one label at a time, paginated, to control memory
+    for (const label of labels) {
+      for await (const page of queryNodesPaginated(executeQuery, label, skipNodeIds)) {
+        for (const node of page) {
+          pendingBatch.push(node);
+          if (pendingBatch.length >= batchSize) {
+            await flushBatch();
+          }
+        }
+      }
     }
 
-    // Phase 4: Create vector index
-    onProgress({
-      phase: 'indexing',
-      percent: 90,
-      nodesProcessed: totalNodes,
-      totalNodes,
-    });
+    // Flush remaining
+    await flushBatch();
 
-    if (isDev) {
-      console.log('📇 Creating vector index...');
-    }
+    // Create vector index
+    onProgress({ phase: 'indexing', percent: 90, nodesProcessed: processedNodes, totalNodes: estimatedToEmbed });
 
+    if (isDev) console.log('Creating vector index...');
     await createVectorIndex(executeQuery);
 
-    // Complete
-    onProgress({
-      phase: 'ready',
-      percent: 100,
-      nodesProcessed: totalNodes,
-      totalNodes,
-    });
+    onProgress({ phase: 'ready', percent: 100, nodesProcessed: processedNodes, totalNodes: estimatedToEmbed });
 
-    if (isDev) {
-      console.log('✅ Embedding pipeline complete!');
-    }
+    if (isDev) console.log('Embedding pipeline complete!');
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    
-    if (isDev) {
-      console.error('❌ Embedding pipeline error:', error);
-    }
-
-    onProgress({
-      phase: 'error',
-      percent: 0,
-      error: errorMessage,
-    });
-
+    if (isDev) console.error('Embedding pipeline error:', error);
+    onProgress({ phase: 'error', percent: 0, error: errorMessage });
     throw error;
   }
 };
 
 /**
- * Perform semantic search using the vector index
- * 
- * Uses CodeEmbedding table and queries each node table to get metadata
- * 
- * @param executeQuery - Function to execute Cypher queries
- * @param query - Search query text
- * @param k - Number of results to return (default: 10)
- * @param maxDistance - Maximum distance threshold (default: 0.5)
- * @returns Array of search results ordered by relevance
+ * Perform semantic search using the vector index.
+ * Uses CodeEmbedding table and queries each node table to get metadata.
  */
 export const semanticSearch = async (
   executeQuery: (cypher: string) => Promise<any[]>,
-  query: string,
+  queryVec: number[],
+  dims: number,
   k: number = 10,
   maxDistance: number = 0.5
 ): Promise<SemanticSearchResult[]> => {
-  if (!isEmbedderReady()) {
-    throw new Error('Embedding model not initialized. Run embedding pipeline first.');
-  }
-
-  // Embed the query
-  const queryEmbedding = await embedText(query);
-  const queryVec = embeddingToArray(queryEmbedding);
   const queryVecStr = `[${queryVec.join(',')}]`;
 
-  // Query the vector index on CodeEmbedding to get nodeIds and distances
   const vectorQuery = `
-    CALL QUERY_VECTOR_INDEX('CodeEmbedding', 'code_embedding_idx', 
-      CAST(${queryVecStr} AS FLOAT[384]), ${k})
+    CALL QUERY_VECTOR_INDEX('CodeEmbedding', 'code_embedding_idx',
+      CAST(${queryVecStr} AS FLOAT[${dims}]), ${k})
     YIELD node AS emb, distance
     WITH emb, distance
     WHERE distance < ${maxDistance}
@@ -335,10 +264,7 @@ export const semanticSearch = async (
   `;
 
   const embResults = await executeQuery(vectorQuery);
-  
-  if (embResults.length === 0) {
-    return [];
-  }
+  if (embResults.length === 0) return [];
 
   // Group results by label for batched metadata queries
   const byLabel = new Map<string, Array<{ nodeId: string; distance: number }>>();
@@ -390,9 +316,7 @@ export const semanticSearch = async (
           });
         }
       }
-    } catch {
-      // Table might not exist, skip
-    }
+    } catch { /* table might not exist, skip */ }
   }
 
   // Re-sort by distance since batch queries may have mixed order
@@ -402,28 +326,18 @@ export const semanticSearch = async (
 };
 
 /**
- * Semantic search with graph expansion (flattened results)
- * 
- * Note: With multi-table schema, graph traversal is simplified.
- * Returns semantic matches with their metadata.
+ * Semantic search with graph expansion (flattened results).
  * For full graph traversal, use execute_vector_cypher tool directly.
- * 
- * @param executeQuery - Function to execute Cypher queries
- * @param query - Search query text
- * @param k - Number of initial semantic matches (default: 5)
- * @param _hops - Unused (kept for API compatibility).
- * @returns Semantic matches with metadata
  */
 export const semanticSearchWithContext = async (
   executeQuery: (cypher: string) => Promise<any[]>,
-  query: string,
+  queryVec: number[],
+  dims: number,
   k: number = 5,
   _hops: number = 1
 ): Promise<any[]> => {
-  // For multi-table schema, just return semantic search results
-  // Graph traversal is complex with separate tables - use execute_vector_cypher instead
-  const results = await semanticSearch(executeQuery, query, k, 0.5);
-  
+  const results = await semanticSearch(executeQuery, queryVec, dims, k, 0.5);
+
   return results.map(r => ({
     matchId: r.nodeId,
     matchName: r.name,
@@ -436,4 +350,3 @@ export const semanticSearchWithContext = async (
     relationType: null,
   }));
 };
-

--- a/gitnexus/src/core/embeddings/providers/cohere-provider.ts
+++ b/gitnexus/src/core/embeddings/providers/cohere-provider.ts
@@ -1,0 +1,120 @@
+/**
+ * Cohere Embedding Provider
+ *
+ * Uses Cohere's v2 Embed API. Requires an API key (config or COHERE_API_KEY env).
+ * Handles 429 rate-limit responses with exponential backoff.
+ */
+
+import type { IEmbeddingProvider, EmbeddingProviderConfig } from './types.js';
+
+const COHERE_API_URL = 'https://api.cohere.com/v2/embed';
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+type CohereInputType = 'search_document' | 'search_query';
+
+export class CohereProvider implements IEmbeddingProvider {
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly dims: number;
+  private inputType: CohereInputType = 'search_document';
+
+  constructor(config: EmbeddingProviderConfig) {
+    this.apiKey = config.apiKey || process.env.COHERE_API_KEY || '';
+    if (!this.apiKey) {
+      throw new Error(
+        'Cohere API key is required. Set config.apiKey or COHERE_API_KEY environment variable.',
+      );
+    }
+    this.model = config.model;
+    this.dims = config.dimensions;
+  }
+
+  setInputType(type: CohereInputType): void {
+    this.inputType = type;
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const body = JSON.stringify({
+      texts,
+      model: this.model,
+      input_type: this.inputType,
+      embedding_types: ['float'],
+    });
+
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        const response = await fetch(COHERE_API_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.apiKey}`,
+          },
+          body,
+        });
+
+        if (response.status === 429 && attempt < MAX_RETRIES - 1) {
+          const retryAfter = response.headers.get('retry-after');
+          const delay = retryAfter
+            ? parseInt(retryAfter, 10) * 1000
+            : BASE_DELAY_MS * Math.pow(2, attempt);
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          continue;
+        }
+
+        if (!response.ok) {
+          const text = await response.text().catch(() => '');
+          throw new Error(
+            `Cohere embed failed (HTTP ${response.status}): ${text}`,
+          );
+        }
+
+        const json = (await response.json()) as {
+          embeddings: { float: number[][] };
+        };
+
+        if (!json.embeddings?.float || !Array.isArray(json.embeddings.float)) {
+          throw new Error(
+            'Cohere returned unexpected response shape: missing "embeddings.float" array',
+          );
+        }
+
+        return json.embeddings.float;
+      } catch (err: any) {
+        lastError = err;
+
+        if (err?.message?.includes('Cohere embed failed') && err?.message?.includes('429')) {
+          if (attempt < MAX_RETRIES - 1) {
+            const delay = BASE_DELAY_MS * Math.pow(2, attempt);
+            await new Promise((resolve) => setTimeout(resolve, delay));
+            continue;
+          }
+        }
+
+        throw err;
+      }
+    }
+
+    throw lastError;
+  }
+
+  dimensions(): number {
+    return this.dims;
+  }
+
+  name(): string {
+    return `cohere/${this.model}`;
+  }
+
+  maxBatchSize(): number {
+    return 96;
+  }
+
+  async dispose(): Promise<void> {
+    // HTTP is stateless — nothing to release
+  }
+}

--- a/gitnexus/src/core/embeddings/providers/factory.ts
+++ b/gitnexus/src/core/embeddings/providers/factory.ts
@@ -1,0 +1,33 @@
+/**
+ * Embedding Provider Factory
+ *
+ * Creates the appropriate IEmbeddingProvider based on config.
+ * Provider modules are lazily imported to avoid loading unnecessary deps.
+ */
+
+import type { IEmbeddingProvider, EmbeddingProviderConfig } from './types.js';
+
+export async function createEmbeddingProvider(
+  config: EmbeddingProviderConfig,
+): Promise<IEmbeddingProvider> {
+  switch (config.provider) {
+    case 'ollama': {
+      const { OllamaProvider } = await import('./ollama-provider.js');
+      return new OllamaProvider(config);
+    }
+    case 'cohere': {
+      const { CohereProvider } = await import('./cohere-provider.js');
+      return new CohereProvider(config);
+    }
+    case 'openai': {
+      const { OpenAIProvider } = await import('./openai-provider.js');
+      return new OpenAIProvider(config);
+    }
+    case 'local': {
+      const { TransformersJsProvider } = await import('./transformers-provider.js');
+      return new TransformersJsProvider(config);
+    }
+    default:
+      throw new Error(`Unknown embedding provider: ${(config as any).provider}`);
+  }
+}

--- a/gitnexus/src/core/embeddings/providers/ollama-provider.ts
+++ b/gitnexus/src/core/embeddings/providers/ollama-provider.ts
@@ -1,0 +1,91 @@
+/**
+ * Ollama Embedding Provider
+ *
+ * Uses Ollama's HTTP API for local/remote embedding generation.
+ * Retries on ECONNREFUSED with exponential backoff.
+ */
+
+import type { IEmbeddingProvider, EmbeddingProviderConfig } from './types.js';
+
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+export class OllamaProvider implements IEmbeddingProvider {
+  private readonly endpoint: string;
+  private readonly model: string;
+  private readonly dims: number;
+
+  constructor(config: EmbeddingProviderConfig) {
+    this.endpoint = (config.endpoint || 'http://localhost:11434').replace(/\/+$/, '');
+    this.model = config.model;
+    this.dims = config.dimensions;
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const url = `${this.endpoint}/api/embed`;
+    const body = JSON.stringify({ model: this.model, input: texts });
+
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body,
+        });
+
+        if (!response.ok) {
+          const text = await response.text().catch(() => '');
+          throw new Error(
+            `Ollama embed failed (HTTP ${response.status}): ${text}`,
+          );
+        }
+
+        const json = (await response.json()) as { embeddings: number[][] };
+
+        if (!json.embeddings || !Array.isArray(json.embeddings)) {
+          throw new Error(
+            `Ollama returned unexpected response shape: missing "embeddings" array`,
+          );
+        }
+
+        return json.embeddings;
+      } catch (err: any) {
+        lastError = err;
+        const isConnectionError =
+          err?.cause?.code === 'ECONNREFUSED' ||
+          err?.code === 'ECONNREFUSED' ||
+          err?.message?.includes('ECONNREFUSED');
+
+        if (isConnectionError && attempt < MAX_RETRIES - 1) {
+          const delay = BASE_DELAY_MS * Math.pow(2, attempt);
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          continue;
+        }
+
+        throw err;
+      }
+    }
+
+    throw lastError;
+  }
+
+  dimensions(): number {
+    return this.dims;
+  }
+
+  name(): string {
+    return `ollama/${this.model}`;
+  }
+
+  maxBatchSize(): number {
+    return 128;
+  }
+
+  async dispose(): Promise<void> {
+    // HTTP is stateless — nothing to release
+  }
+}

--- a/gitnexus/src/core/embeddings/providers/openai-provider.ts
+++ b/gitnexus/src/core/embeddings/providers/openai-provider.ts
@@ -1,0 +1,124 @@
+/**
+ * OpenAI-compatible Embedding Provider
+ *
+ * Works with OpenAI, LiteLLM, vLLM, and Ollama's /v1 compatibility endpoint.
+ * Requires an API key (config, GITNEXUS_EMBED_API_KEY, or OPENAI_API_KEY env).
+ */
+
+import type { IEmbeddingProvider, EmbeddingProviderConfig } from './types.js';
+
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+export class OpenAIProvider implements IEmbeddingProvider {
+  private readonly endpoint: string;
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly dims: number;
+
+  constructor(config: EmbeddingProviderConfig) {
+    this.endpoint = (config.endpoint || 'https://api.openai.com/v1').replace(/\/+$/, '');
+    this.apiKey =
+      config.apiKey ||
+      process.env.GITNEXUS_EMBED_API_KEY ||
+      process.env.OPENAI_API_KEY ||
+      '';
+    if (!this.apiKey) {
+      throw new Error(
+        'OpenAI API key is required. Set config.apiKey, GITNEXUS_EMBED_API_KEY, or OPENAI_API_KEY environment variable.',
+      );
+    }
+    this.model = config.model;
+    this.dims = config.dimensions;
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const url = `${this.endpoint}/embeddings`;
+    const payload: Record<string, unknown> = {
+      input: texts,
+      model: this.model,
+    };
+
+    if (this.dims) {
+      payload.dimensions = this.dims;
+    }
+
+    const body = JSON.stringify(payload);
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.apiKey}`,
+          },
+          body,
+        });
+
+        if (response.status === 429 && attempt < MAX_RETRIES - 1) {
+          const retryAfter = response.headers.get('retry-after');
+          const delay = retryAfter
+            ? parseInt(retryAfter, 10) * 1000
+            : BASE_DELAY_MS * Math.pow(2, attempt);
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          continue;
+        }
+
+        if (!response.ok) {
+          const text = await response.text().catch(() => '');
+          throw new Error(
+            `OpenAI embed failed (HTTP ${response.status}): ${text}`,
+          );
+        }
+
+        const json = (await response.json()) as {
+          data: Array<{ embedding: number[]; index: number }>;
+        };
+
+        if (!json.data || !Array.isArray(json.data)) {
+          throw new Error(
+            'OpenAI returned unexpected response shape: missing "data" array',
+          );
+        }
+
+        // Sort by index to guarantee order matches input
+        const sorted = json.data.sort((a, b) => a.index - b.index);
+        return sorted.map((item) => item.embedding);
+      } catch (err: any) {
+        lastError = err;
+
+        if (err?.message?.includes('OpenAI embed failed') && err?.message?.includes('429')) {
+          if (attempt < MAX_RETRIES - 1) {
+            const delay = BASE_DELAY_MS * Math.pow(2, attempt);
+            await new Promise((resolve) => setTimeout(resolve, delay));
+            continue;
+          }
+        }
+
+        throw err;
+      }
+    }
+
+    throw lastError;
+  }
+
+  dimensions(): number {
+    return this.dims;
+  }
+
+  name(): string {
+    return `openai/${this.model}`;
+  }
+
+  maxBatchSize(): number {
+    return 256;
+  }
+
+  async dispose(): Promise<void> {
+    // HTTP is stateless — nothing to release
+  }
+}

--- a/gitnexus/src/core/embeddings/providers/transformers-provider.ts
+++ b/gitnexus/src/core/embeddings/providers/transformers-provider.ts
@@ -1,0 +1,139 @@
+import { existsSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { join } from 'path';
+import type { IEmbeddingProvider, EmbeddingProviderConfig } from './types.js';
+
+type Device = 'dml' | 'cuda' | 'cpu' | 'wasm';
+
+function isCudaAvailable(): boolean {
+  try {
+    const out = execFileSync('ldconfig', ['-p'], { timeout: 3000, encoding: 'utf-8' });
+    if (out.includes('libcublasLt.so.12')) return true;
+  } catch {
+    // ldconfig not available
+  }
+
+  for (const envVar of ['CUDA_PATH', 'LD_LIBRARY_PATH']) {
+    const val = process.env[envVar];
+    if (!val) continue;
+    for (const dir of val.split(':').filter(Boolean)) {
+      if (existsSync(join(dir, 'lib64', 'libcublasLt.so.12')) ||
+          existsSync(join(dir, 'lib', 'libcublasLt.so.12')) ||
+          existsSync(join(dir, 'libcublasLt.so.12'))) return true;
+    }
+  }
+
+  return false;
+}
+
+function detectGpuDevice(): Device {
+  if (process.platform === 'win32') return 'dml';
+  if (isCudaAvailable()) return 'cuda';
+  return 'cpu';
+}
+
+export class TransformersJsProvider implements IEmbeddingProvider {
+  private readonly _model: string;
+  private readonly _dimensions: number;
+  private _pipeline: any | null = null;
+  private _initPromise: Promise<void> | null = null;
+
+  constructor(config: EmbeddingProviderConfig) {
+    this._model = config.model;
+    this._dimensions = config.dimensions;
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    await this.ensureInitialized();
+
+    const result = await this._pipeline!(texts, {
+      pooling: 'mean',
+      normalize: true,
+    });
+
+    const data = result.data as ArrayLike<number>;
+    const embeddings: number[][] = [];
+
+    for (let i = 0; i < texts.length; i++) {
+      const start = i * this._dimensions;
+      const end = start + this._dimensions;
+      embeddings.push(Array.prototype.slice.call(data, start, end));
+    }
+
+    return embeddings;
+  }
+
+  dimensions(): number {
+    return this._dimensions;
+  }
+
+  name(): string {
+    return `local/${this._model}`;
+  }
+
+  maxBatchSize(): number {
+    return 32;
+  }
+
+  async dispose(): Promise<void> {
+    if (this._pipeline) {
+      try {
+        if ('dispose' in this._pipeline && typeof this._pipeline.dispose === 'function') {
+          await this._pipeline.dispose();
+        }
+      } catch {
+        // Ignore disposal errors
+      }
+      this._pipeline = null;
+      this._initPromise = null;
+    }
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this._pipeline) return;
+    if (this._initPromise) return this._initPromise;
+
+    this._initPromise = this.loadPipeline();
+    return this._initPromise;
+  }
+
+  private async loadPipeline(): Promise<void> {
+    if (!process.env.ORT_LOG_LEVEL) {
+      process.env.ORT_LOG_LEVEL = '3';
+    }
+
+    const { pipeline, env } = await import('@huggingface/transformers');
+    env.allowLocalModels = false;
+
+    const gpuDevice = detectGpuDevice();
+    const devicesToTry: Device[] =
+      gpuDevice === 'dml' || gpuDevice === 'cuda'
+        ? [gpuDevice, 'cpu']
+        : [gpuDevice];
+
+    for (const device of devicesToTry) {
+      try {
+        this._pipeline = await (pipeline as any)(
+          'feature-extraction',
+          this._model,
+          {
+            device,
+            dtype: 'fp32',
+            session_options: { logSeverityLevel: 3 },
+          },
+        );
+        return;
+      } catch (err) {
+        if (device === devicesToTry[devicesToTry.length - 1]) {
+          this._initPromise = null;
+          throw err;
+        }
+      }
+    }
+
+    this._initPromise = null;
+    throw new Error('No suitable device found for embedding model');
+  }
+}

--- a/gitnexus/src/core/embeddings/providers/types.ts
+++ b/gitnexus/src/core/embeddings/providers/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Embedding Provider Abstraction
+ *
+ * Defines the contract all embedding providers must implement,
+ * plus the configuration type used to select and configure a provider.
+ */
+
+export type EmbeddingProviderType = 'ollama' | 'cohere' | 'openai' | 'local';
+
+export interface IEmbeddingProvider {
+  /** Embed an array of texts and return their vectors. */
+  embed(texts: string[]): Promise<number[][]>;
+  /** Number of dimensions produced by this provider/model. */
+  dimensions(): number;
+  /** Human-readable provider name (e.g. "ollama/nomic-embed-text"). */
+  name(): string;
+  /** Maximum texts per single embed() call. Callers should batch accordingly. */
+  maxBatchSize(): number;
+  /** Release any held resources (connections, ONNX sessions, etc.). */
+  dispose(): Promise<void>;
+}
+
+export interface EmbeddingProviderConfig {
+  provider: EmbeddingProviderType;
+  model: string;
+  dimensions: number;
+  endpoint?: string;
+  apiKey?: string;
+}

--- a/gitnexus/src/core/embeddings/types.ts
+++ b/gitnexus/src/core/embeddings/types.ts
@@ -53,16 +53,22 @@ export interface EmbeddingProgress {
  * Configuration for the embedding pipeline
  */
 export interface EmbeddingConfig {
-  /** Model identifier for transformers.js */
+  /** Embedding provider type */
+  provider: 'ollama' | 'cohere' | 'openai' | 'local';
+  /** Model identifier */
   modelId: string;
   /** Number of nodes to embed in each batch */
   batchSize: number;
   /** Embedding vector dimensions */
   dimensions: number;
-  /** Device to use for inference: 'auto' tries GPU first (DirectML on Windows, CUDA on Linux), falls back to CPU */
+  /** Device to use for local inference: 'auto' tries GPU first */
   device: 'auto' | 'dml' | 'cuda' | 'cpu' | 'wasm';
   /** Maximum characters of code snippet to include */
   maxSnippetLength: number;
+  /** API endpoint URL for remote providers */
+  endpoint?: string;
+  /** API key for cloud providers */
+  apiKey?: string;
 }
 
 /**
@@ -71,6 +77,7 @@ export interface EmbeddingConfig {
  * Tries WebGPU first (fast), user can choose WASM fallback if unavailable
  */
 export const DEFAULT_EMBEDDING_CONFIG: EmbeddingConfig = {
+  provider: 'local',
   modelId: 'Snowflake/snowflake-arctic-embed-xs',
   batchSize: 16,
   dimensions: 384,

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -10,6 +10,7 @@ import {
   SCHEMA_QUERIES,
   EMBEDDING_TABLE_NAME,
   NodeTableName,
+  getEmbeddingSchema,
 } from './schema.js';
 import { streamAllCSVsToDisk } from './csv-generator.js';
 
@@ -101,18 +102,41 @@ const doInitLbug = async (dbPath: string) => {
   const parentDir = path.dirname(dbPath);
   await fs.mkdir(parentDir, { recursive: true });
 
-  db = new lbug.Database(dbPath);
-  conn = new lbug.Connection(db);
+  const openAndCreateSchema = async () => {
+    db = new lbug.Database(dbPath);
+    conn = new lbug.Connection(db);
 
-  for (const schemaQuery of SCHEMA_QUERIES) {
-    try {
-      await conn.query(schemaQuery);
-    } catch (err) {
-      // Only ignore "already exists" errors - log everything else
-      const msg = err instanceof Error ? err.message : String(err);
-      if (!msg.includes('already exists')) {
-        console.warn(`⚠️ Schema creation warning: ${msg.slice(0, 120)}`);
+    for (const schemaQuery of SCHEMA_QUERIES) {
+      try {
+        await conn.query(schemaQuery);
+      } catch (err) {
+        // Only ignore "already exists" errors - log everything else
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!msg.includes('already exists')) {
+          console.warn(`⚠️ Schema creation warning: ${msg.slice(0, 120)}`);
+        }
       }
+    }
+  };
+
+  try {
+    await openAndCreateSchema();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.toLowerCase().includes('wal')) {
+      // Corrupted WAL — close broken handles, delete WAL, retry once
+      console.warn(`⚠️ Corrupted WAL detected for ${dbPath} — deleting WAL and retrying`);
+      try { if (conn) await conn.close(); } catch {}
+      try { if (db) await db.close(); } catch {}
+      conn = null;
+      db = null;
+
+      const walPath = `${dbPath}.wal`;
+      try { await fs.unlink(walPath); } catch {}
+
+      await openAndCreateSchema();
+    } else {
+      throw err;
     }
   }
 
@@ -471,6 +495,14 @@ export const batchInsertNodesToLbug = async (
   return { inserted, failed };
 };
 
+/** Normalize LadybugDB getAll() — large DBs may return paged results [[page1...], [page2...]] */
+const flattenRows = (rows: any[]): any[] => {
+  if (rows.length > 0 && Array.isArray(rows[0])) {
+    return rows.flat();
+  }
+  return rows;
+};
+
 export const executeQuery = async (cypher: string): Promise<any[]> => {
   if (!conn) {
     throw new Error('LadybugDB not initialized. Call initLbug first.');
@@ -481,7 +513,26 @@ export const executeQuery = async (cypher: string): Promise<any[]> => {
   // Query returns QueryResult for single queries, QueryResult[] for multi-statement
   const result = Array.isArray(queryResult) ? queryResult[0] : queryResult;
   const rows = await result.getAll();
-  return rows;
+  return flattenRows(rows);
+};
+
+/**
+ * Execute a parameterized Cypher query (safe against injection).
+ * Uses conn.prepare() + conn.execute() to bind parameters safely.
+ */
+export const executeParameterizedQuery = async (
+  cypher: string,
+  params: Record<string, any>,
+): Promise<any[]> => {
+  if (!conn) {
+    throw new Error('LadybugDB not initialized. Call initLbug first.');
+  }
+
+  const stmt = await conn.prepare(cypher);
+  const queryResult = await conn.execute(stmt, params);
+  const result = Array.isArray(queryResult) ? queryResult[0] : queryResult;
+  const rows = await result.getAll();
+  return flattenRows(rows);
 };
 
 export const executeWithReusedStatement = async (
@@ -676,6 +727,26 @@ export const deleteNodesForFile = async (filePath: string, dbPath?: string): Pro
 };
 
 export const getEmbeddingTableName = (): string => EMBEDDING_TABLE_NAME;
+
+/**
+ * Create the CodeEmbedding table with the correct vector dimension.
+ * Must be called before running the embedding pipeline — NOT during initLbug,
+ * because the dimension depends on the configured model (e.g. 384 vs 1024).
+ * Safe to call multiple times: "already exists" errors are silently ignored.
+ */
+export const ensureEmbeddingTable = async (dims: number): Promise<void> => {
+  if (!conn) {
+    throw new Error('LadybugDB not initialized. Call initLbug first.');
+  }
+  try {
+    await conn.query(getEmbeddingSchema(dims));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes('already exists')) {
+      throw err;
+    }
+  }
+};
 
 // ============================================================================
 // Full-Text Search (FTS) Functions

--- a/gitnexus/src/core/lbug/schema.ts
+++ b/gitnexus/src/core/lbug/schema.ts
@@ -387,6 +387,26 @@ CREATE REL TABLE ${REL_TABLE_NAME} (
   FROM \`Annotation\` TO Process,
   FROM \`Template\` TO Process,
   FROM CodeElement TO Process,
+  FROM \`Record\` TO \`Record\`,
+  FROM \`Record\` TO \`Const\`,
+  FROM \`Property\` TO \`Property\`,
+  FROM \`Property\` TO \`Const\`,
+  FROM \`Property\` TO CodeElement,
+  FROM \`Module\` TO \`Record\`,
+  FROM \`Module\` TO \`Property\`,
+  FROM \`Module\` TO CodeElement,
+  FROM \`Module\` TO \`Const\`,
+  FROM \`Namespace\` TO \`Property\`,
+  FROM \`Namespace\` TO \`Record\`,
+  FROM CodeElement TO \`Record\`,
+  FROM CodeElement TO \`Property\`,
+  FROM \`Const\` TO \`Property\`,
+  FROM Function TO CodeElement,
+  FROM \`Namespace\` TO CodeElement,
+  FROM CodeElement TO CodeElement,
+  FROM CodeElement TO \`Module\`,
+  FROM CodeElement TO File,
+  FROM \`Module\` TO \`Constructor\`,
   type STRING,
   confidence DOUBLE,
   reason STRING,
@@ -398,12 +418,14 @@ CREATE REL TABLE ${REL_TABLE_NAME} (
 // Separate table for vector storage to avoid copy-on-write overhead
 // ============================================================================
 
-export const EMBEDDING_SCHEMA = `
+export const getEmbeddingSchema = (dims: number = 384): string => `
 CREATE NODE TABLE ${EMBEDDING_TABLE_NAME} (
   nodeId STRING,
-  embedding FLOAT[384],
+  embedding FLOAT[${dims}],
   PRIMARY KEY (nodeId)
 )`;
+
+export const EMBEDDING_SCHEMA = getEmbeddingSchema(384);
 
 /**
  * Create vector index for semantic search
@@ -456,5 +478,6 @@ export const REL_SCHEMA_QUERIES = [
 export const SCHEMA_QUERIES = [
   ...NODE_SCHEMA_QUERIES,
   ...REL_SCHEMA_QUERIES,
-  EMBEDDING_SCHEMA,
+  // NOTE: EMBEDDING_SCHEMA is intentionally excluded — embedding table dims depend on
+  // the configured model and must be created dynamically via ensureEmbeddingTable(dims).
 ];

--- a/gitnexus/src/mcp/core/embedder.ts
+++ b/gitnexus/src/mcp/core/embedder.ts
@@ -1,124 +1,99 @@
 /**
- * Embedder Module (Read-Only)
- * 
- * Singleton factory for transformers.js embedding pipeline.
- * For MCP, we only need to compute query embeddings, not batch embed.
+ * Embedder Module (MCP Query-Time)
+ *
+ * Provider-aware embedding for search queries.
+ * Caches providers by provider:model key to avoid re-initialization.
+ * Falls back to local transformers.js if no config is provided (backward compat).
  */
 
-import { pipeline, env, type FeatureExtractionPipeline } from '@huggingface/transformers';
+import type { IEmbeddingProvider } from '../../core/embeddings/providers/types.js';
+import { createEmbeddingProvider } from '../../core/embeddings/providers/factory.js';
 
-// Model config
-const MODEL_ID = 'Snowflake/snowflake-arctic-embed-xs';
-const EMBEDDING_DIMS = 384;
+export interface EmbeddingConfigInfo {
+  provider: string;
+  model: string;
+  dimensions: number;
+  endpoint?: string;
+}
 
-// Module-level state for singleton pattern
-let embedderInstance: FeatureExtractionPipeline | null = null;
-let isInitializing = false;
-let initPromise: Promise<FeatureExtractionPipeline> | null = null;
-
-/**
- * Initialize the embedding model (lazy, on first search)
- */
-export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
-  if (embedderInstance) {
-    return embedderInstance;
-  }
-
-  if (isInitializing && initPromise) {
-    return initPromise;
-  }
-
-  isInitializing = true;
-
-  initPromise = (async () => {
-    try {
-      env.allowLocalModels = false;
-      
-      console.error('GitNexus: Loading embedding model (first search may take a moment)...');
-
-      // Try GPU first (DirectML on Windows, CUDA on Linux), fall back to CPU
-      const isWindows = process.platform === 'win32';
-      const gpuDevice = isWindows ? 'dml' : 'cuda';
-      const devicesToTry: Array<'dml' | 'cuda' | 'cpu'> = [gpuDevice, 'cpu'];
-      
-      for (const device of devicesToTry) {
-        try {
-          // Silence stdout and stderr during model load — ONNX Runtime and transformers.js
-          // may write progress/init messages that corrupt MCP stdio protocol or produce
-          // noisy warnings (e.g. node assignment to execution providers).
-          const origStdout = process.stdout.write;
-          const origStderr = process.stderr.write;
-          process.stdout.write = (() => true) as any;
-          process.stderr.write = (() => true) as any;
-          try {
-            embedderInstance = await (pipeline as any)(
-              'feature-extraction',
-              MODEL_ID,
-              {
-                device: device,
-                dtype: 'fp32',
-              }
-            );
-          } finally {
-            process.stdout.write = origStdout;
-            process.stderr.write = origStderr;
-          }
-          console.error(`GitNexus: Embedding model loaded (${device})`);
-          return embedderInstance!;
-        } catch {
-          if (device === 'cpu') throw new Error('Failed to load embedding model');
-        }
-      }
-
-      throw new Error('No suitable device found');
-    } catch (error) {
-      isInitializing = false;
-      initPromise = null;
-      embedderInstance = null;
-      throw error;
-    } finally {
-      isInitializing = false;
-    }
-  })();
-
-  return initPromise;
+const DEFAULT_CONFIG: EmbeddingConfigInfo = {
+  provider: 'local',
+  model: 'Snowflake/snowflake-arctic-embed-xs',
+  dimensions: 384,
 };
 
-/**
- * Check if embedder is ready
- */
-export const isEmbedderReady = (): boolean => embedderInstance !== null;
+const providerCache = new Map<string, IEmbeddingProvider>();
+let initLock: Promise<IEmbeddingProvider> | null = null;
 
-/**
- * Embed a query text for semantic search
- */
-export const embedQuery = async (query: string): Promise<number[]> => {
-  const embedder = await initEmbedder();
-  
-  const result = await embedder(query, {
-    pooling: 'mean',
-    normalize: true,
+function cacheKey(cfg: EmbeddingConfigInfo): string {
+  return `${cfg.provider}:${cfg.model}`;
+}
+
+async function getOrCreateProvider(cfg: EmbeddingConfigInfo): Promise<IEmbeddingProvider> {
+  const key = cacheKey(cfg);
+  const existing = providerCache.get(key);
+  if (existing) return existing;
+
+  // Serialize initialization to avoid duplicate model loads
+  if (initLock) await initLock;
+
+  // Re-check after awaiting lock
+  const recheck = providerCache.get(key);
+  if (recheck) return recheck;
+
+  console.error(`GitNexus: Loading embedding provider ${key} (first search may take a moment)...`);
+
+  initLock = createEmbeddingProvider({
+    provider: cfg.provider as any,
+    model: cfg.model,
+    dimensions: cfg.dimensions,
+    endpoint: cfg.endpoint,
   });
-  
-  return Array.from(result.data as ArrayLike<number>);
+
+  try {
+    const provider = await initLock;
+    providerCache.set(key, provider);
+    console.error(`GitNexus: Embedding provider ${key} loaded`);
+    return provider;
+  } finally {
+    initLock = null;
+  }
+}
+
+/**
+ * Embed a query text for semantic search.
+ * Uses the provider that matches the repo's embedding config.
+ */
+export const embedQuery = async (
+  query: string,
+  embeddingConfig?: EmbeddingConfigInfo,
+): Promise<number[]> => {
+  const cfg = embeddingConfig ?? DEFAULT_CONFIG;
+  const provider = await getOrCreateProvider(cfg);
+  const [embedding] = await provider.embed([query]);
+  return embedding;
 };
 
 /**
- * Get embedding dimensions
+ * Get embedding dimensions for a given config.
  */
-export const getEmbeddingDims = (): number => EMBEDDING_DIMS;
+export const getEmbeddingDims = (
+  embeddingConfig?: { dimensions: number },
+): number => {
+  return embeddingConfig?.dimensions ?? 384;
+};
 
 /**
- * Cleanup embedder
+ * Check if any embedder is ready (backward compat).
+ */
+export const isEmbedderReady = (): boolean => providerCache.size > 0;
+
+/**
+ * Cleanup all cached providers.
  */
 export const disposeEmbedder = async (): Promise<void> => {
-  if (embedderInstance) {
-    try {
-      if ('dispose' in embedderInstance && typeof embedderInstance.dispose === 'function') {
-        await embedderInstance.dispose();
-      }
-    } catch {}
-    embedderInstance = null;
-    initPromise = null;
+  for (const provider of providerCache.values()) {
+    try { await provider.dispose(); } catch {}
   }
+  providerCache.clear();
 };

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -47,7 +47,7 @@ export const VALID_NODE_LABELS = new Set([
 ]);
 
 /** Valid relation types for impact analysis filtering */
-export const VALID_RELATION_TYPES = new Set(['CALLS', 'IMPORTS', 'EXTENDS', 'IMPLEMENTS']);
+export const VALID_RELATION_TYPES = new Set(['CALLS', 'IMPORTS', 'EXTENDS', 'IMPLEMENTS', 'HAS_METHOD', 'OVERRIDES']);
 
 /** Regex to detect write operations in user-supplied Cypher queries */
 export const CYPHER_WRITE_RE = /\b(CREATE|DELETE|SET|MERGE|REMOVE|DROP|ALTER|COPY|DETACH)\b/i;

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -47,7 +47,7 @@ export const VALID_NODE_LABELS = new Set([
 ]);
 
 /** Valid relation types for impact analysis filtering */
-export const VALID_RELATION_TYPES = new Set(['CALLS', 'IMPORTS', 'EXTENDS', 'IMPLEMENTS', 'HAS_METHOD', 'OVERRIDES']);
+export const VALID_RELATION_TYPES = new Set(['CALLS', 'IMPORTS', 'EXTENDS', 'IMPLEMENTS']);
 
 /** Regex to detect write operations in user-supplied Cypher queries */
 export const CYPHER_WRITE_RE = /\b(CREATE|DELETE|SET|MERGE|REMOVE|DROP|ALTER|COPY|DETACH)\b/i;
@@ -82,6 +82,8 @@ interface RepoHandle {
   indexedAt: string;
   lastCommit: string;
   stats?: RegistryEntry['stats'];
+  /** Embedding config used during indexing — for query-time provider matching */
+  embedding?: { provider: string; model: string; dimensions: number; endpoint?: string };
 }
 
 export class LocalBackend {
@@ -132,6 +134,7 @@ export class LocalBackend {
         indexedAt: entry.indexedAt,
         lastCommit: entry.lastCommit,
         stats: entry.stats,
+        embedding: entry.embedding,
       };
 
       this.repos.set(id, handle);
@@ -611,8 +614,8 @@ export class LocalBackend {
       if (!tableCheck.length || (tableCheck[0].cnt ?? tableCheck[0][0]) === 0) return [];
 
       const { embedQuery, getEmbeddingDims } = await import('../core/embedder.js');
-      const queryVec = await embedQuery(query);
-      const dims = getEmbeddingDims();
+      const queryVec = await embedQuery(query, repo.embedding);
+      const dims = getEmbeddingDims(repo.embedding);
       const queryVecStr = `[${queryVec.join(',')}]`;
       
       const vectorQuery = `

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -233,7 +233,15 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
         const { isEmbedderReady } = await import('../core/embeddings/embedder.js');
         if (isEmbedderReady()) {
           const { semanticSearch } = await import('../core/embeddings/embedding-pipeline.js');
-          return hybridSearch(query, limit, executeQuery, semanticSearch);
+          const { embedQuery, getEmbeddingDims } = await import('../mcp/core/embedder.js');
+          // Wrap the new provider-based semanticSearch to match hybridSearch's expected signature
+          const wrappedSemantic = async (eq: typeof executeQuery, q: string, k?: number) => {
+            const embeddingConfig = (entry as any).embedding;
+            const queryVec = await embedQuery(q, embeddingConfig);
+            const dims = getEmbeddingDims(embeddingConfig);
+            return semanticSearch(eq, queryVec, dims, k);
+          };
+          return hybridSearch(query, limit, executeQuery, wrappedSemantic);
         }
         // FTS-only fallback when embeddings aren't loaded
         return searchFTSFromLbug(query, limit);

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -42,6 +42,13 @@ export interface RegistryEntry {
   indexedAt: string;
   lastCommit: string;
   stats?: RepoMeta['stats'];
+  /** Embedding config used during indexing. If absent, defaults to local/snowflake-arctic-embed-xs/384. */
+  embedding?: {
+    provider: string;
+    model: string;
+    dimensions: number;
+    endpoint?: string;
+  };
 }
 
 const GITNEXUS_DIR = '.gitnexus';
@@ -244,7 +251,12 @@ const writeRegistry = async (entries: RegistryEntry[]): Promise<void> => {
  * Register (add or update) a repo in the global registry.
  * Called after `gitnexus analyze` completes.
  */
-export const registerRepo = async (repoPath: string, meta: RepoMeta): Promise<void> => {
+export const registerRepo = async (
+  repoPath: string,
+  meta: RepoMeta,
+  _db?: unknown,
+  embedding?: RegistryEntry['embedding'],
+): Promise<void> => {
   const resolved = path.resolve(repoPath);
   const name = path.basename(resolved);
   const { storagePath } = getStoragePaths(resolved);
@@ -265,6 +277,7 @@ export const registerRepo = async (repoPath: string, meta: RepoMeta): Promise<vo
     indexedAt: meta.indexedAt,
     lastCommit: meta.lastCommit,
     stats: meta.stats,
+    ...(embedding ? { embedding } : {}),
   };
 
   if (existing >= 0) {

--- a/gitnexus/test/integration/cli-e2e.test.ts
+++ b/gitnexus/test/integration/cli-e2e.test.ts
@@ -194,7 +194,7 @@ describe('CLI end-to-end', () => {
         if (result.status === null) return;
 
         expect(result.status).toBe(0);
-        expect(result.stdout).toMatch(/Repository not indexed/);
+        expect(result.stderr).toMatch(/Repository not indexed/);
       } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
@@ -208,7 +208,7 @@ describe('CLI end-to-end', () => {
 
         // status.ts doesn't set process.exitCode — just prints and returns
         expect(result.status).toBe(0);
-        expect(result.stdout).toMatch(/Not a git repository/);
+        expect(result.stderr).toMatch(/Not a git repository/);
       } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }

--- a/gitnexus/test/unit/embedder.test.ts
+++ b/gitnexus/test/unit/embedder.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { getEmbeddingDims, isEmbedderReady } from '../../src/mcp/core/embedder.js';
 
-describe('embedder', () => {
+describe('embedder (MCP query-time)', () => {
   describe('getEmbeddingDims', () => {
-    it('returns 384 (MiniLM default)', () => {
+    it('returns 384 when no config provided (backward compat)', () => {
       expect(getEmbeddingDims()).toBe(384);
+    });
+
+    it('returns configured dimensions when config provided', () => {
+      expect(getEmbeddingDims({ dimensions: 768 })).toBe(768);
+      expect(getEmbeddingDims({ dimensions: 256 })).toBe(256);
     });
   });
 

--- a/gitnexus/test/unit/embedding-providers.test.ts
+++ b/gitnexus/test/unit/embedding-providers.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('Embedding Providers', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe('OllamaProvider', () => {
+    it('embeds texts via /api/embed', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ embeddings: [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]] }),
+      });
+
+      const { OllamaProvider } = await import('../../src/core/embeddings/providers/ollama-provider.js');
+      const provider = new OllamaProvider({ provider: 'ollama', model: 'nomic-embed-text', dimensions: 3 });
+
+      const result = await provider.embed(['hello', 'world']);
+
+      expect(result).toEqual([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]);
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(provider.dimensions()).toBe(3);
+      expect(provider.name()).toBe('ollama/nomic-embed-text');
+      expect(provider.maxBatchSize()).toBe(128);
+    });
+
+    it('uses default endpoint http://localhost:11434', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ embeddings: [[1, 2]] }),
+      });
+
+      const { OllamaProvider } = await import('../../src/core/embeddings/providers/ollama-provider.js');
+      const provider = new OllamaProvider({ provider: 'ollama', model: 'test', dimensions: 2 });
+      await provider.embed(['test']);
+
+      const callUrl = mockFetch.mock.calls[0][0];
+      expect(callUrl).toContain('localhost:11434');
+    });
+
+    it('uses custom endpoint when provided', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ embeddings: [[1, 2]] }),
+      });
+
+      const { OllamaProvider } = await import('../../src/core/embeddings/providers/ollama-provider.js');
+      const provider = new OllamaProvider({ provider: 'ollama', model: 'test', dimensions: 2, endpoint: 'http://myserver:11434' });
+      await provider.embed(['test']);
+
+      const callUrl = mockFetch.mock.calls[0][0];
+      expect(callUrl).toContain('myserver:11434');
+    });
+
+    it('returns empty array for empty input', async () => {
+      const { OllamaProvider } = await import('../../src/core/embeddings/providers/ollama-provider.js');
+      const provider = new OllamaProvider({ provider: 'ollama', model: 'test', dimensions: 2 });
+      const result = await provider.embed([]);
+      expect(result).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('CohereProvider', () => {
+    it('embeds texts via /v2/embed', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ embeddings: { float: [[0.1, 0.2], [0.3, 0.4]] } }),
+      });
+
+      const { CohereProvider } = await import('../../src/core/embeddings/providers/cohere-provider.js');
+      const provider = new CohereProvider({ provider: 'cohere', model: 'embed-english-light-v3.0', dimensions: 2, apiKey: 'test-key' });
+
+      const result = await provider.embed(['hello', 'world']);
+      expect(result).toEqual([[0.1, 0.2], [0.3, 0.4]]);
+      expect(provider.dimensions()).toBe(2);
+      expect(provider.maxBatchSize()).toBe(96);
+    });
+
+    it('throws without API key', async () => {
+      const origEnv = process.env.COHERE_API_KEY;
+      delete process.env.COHERE_API_KEY;
+      try {
+        const { CohereProvider } = await import('../../src/core/embeddings/providers/cohere-provider.js');
+        expect(() => new CohereProvider({ provider: 'cohere', model: 'test', dimensions: 2 })).toThrow();
+      } finally {
+        if (origEnv) process.env.COHERE_API_KEY = origEnv;
+      }
+    });
+  });
+
+  describe('OpenAIProvider', () => {
+    it('embeds texts via /embeddings', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { index: 0, embedding: [0.1, 0.2] },
+            { index: 1, embedding: [0.3, 0.4] },
+          ],
+        }),
+      });
+
+      const { OpenAIProvider } = await import('../../src/core/embeddings/providers/openai-provider.js');
+      const provider = new OpenAIProvider({ provider: 'openai', model: 'text-embedding-3-small', dimensions: 2, apiKey: 'test-key' });
+
+      const result = await provider.embed(['hello', 'world']);
+      expect(result).toEqual([[0.1, 0.2], [0.3, 0.4]]);
+      expect(provider.dimensions()).toBe(2);
+      expect(provider.maxBatchSize()).toBe(256);
+    });
+
+    it('sorts response by index', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { index: 1, embedding: [0.3, 0.4] },
+            { index: 0, embedding: [0.1, 0.2] },
+          ],
+        }),
+      });
+
+      const { OpenAIProvider } = await import('../../src/core/embeddings/providers/openai-provider.js');
+      const provider = new OpenAIProvider({ provider: 'openai', model: 'test', dimensions: 2, apiKey: 'test-key' });
+      const result = await provider.embed(['a', 'b']);
+      expect(result).toEqual([[0.1, 0.2], [0.3, 0.4]]);
+    });
+
+    it('throws without API key', async () => {
+      const origGN = process.env.GITNEXUS_EMBED_API_KEY;
+      const origOA = process.env.OPENAI_API_KEY;
+      delete process.env.GITNEXUS_EMBED_API_KEY;
+      delete process.env.OPENAI_API_KEY;
+      try {
+        const { OpenAIProvider } = await import('../../src/core/embeddings/providers/openai-provider.js');
+        expect(() => new OpenAIProvider({ provider: 'openai', model: 'test', dimensions: 2 })).toThrow();
+      } finally {
+        if (origGN) process.env.GITNEXUS_EMBED_API_KEY = origGN;
+        if (origOA) process.env.OPENAI_API_KEY = origOA;
+      }
+    });
+  });
+
+  describe('Factory', () => {
+    it('creates OllamaProvider for ollama type', async () => {
+      const { createEmbeddingProvider } = await import('../../src/core/embeddings/providers/factory.js');
+      const provider = await createEmbeddingProvider({ provider: 'ollama', model: 'test', dimensions: 384 });
+      expect(provider.name()).toBe('ollama/test');
+    });
+
+    it('creates CohereProvider for cohere type', async () => {
+      const { createEmbeddingProvider } = await import('../../src/core/embeddings/providers/factory.js');
+      const provider = await createEmbeddingProvider({ provider: 'cohere', model: 'test', dimensions: 384, apiKey: 'key' });
+      expect(provider.name()).toContain('cohere');
+    });
+
+    it('creates OpenAIProvider for openai type', async () => {
+      const { createEmbeddingProvider } = await import('../../src/core/embeddings/providers/factory.js');
+      const provider = await createEmbeddingProvider({ provider: 'openai', model: 'test', dimensions: 384, apiKey: 'key' });
+      expect(provider.name()).toContain('openai');
+    });
+
+    it('throws for unknown provider', async () => {
+      const { createEmbeddingProvider } = await import('../../src/core/embeddings/providers/factory.js');
+      await expect(createEmbeddingProvider({ provider: 'unknown' as any, model: 'test', dimensions: 384 }))
+        .rejects.toThrow('Unknown embedding provider');
+    });
+  });
+});

--- a/gitnexus/test/unit/schema.test.ts
+++ b/gitnexus/test/unit/schema.test.ts
@@ -172,8 +172,8 @@ describe('LadybugDB Schema', () => {
     });
 
     it('SCHEMA_QUERIES includes all node + rel + embedding schemas', () => {
-      // 27 node + 1 rel + 1 embedding = 29
-      expect(SCHEMA_QUERIES).toHaveLength(29);
+      // 27 node + 1 rel = 28 (EMBEDDING_SCHEMA excluded — dims are dynamic)
+      expect(SCHEMA_QUERIES).toHaveLength(28);
     });
 
     it('node schemas come before relation schemas in SCHEMA_QUERIES', () => {


### PR DESCRIPTION
## Summary

Adds a rich terminal UI layer to all GitNexus CLI commands using `@clack/prompts`, plus a new multi-provider `gitnexus embed` command.

### TUI Wizards

- **Analyze wizard** — interactive repo selection, options configuration, multi-progress bars
- **Embed wizard** — provider selection (OpenAI, Cohere, Ollama, local), model picker, batch config
- **Setup wizard** — guided first-time configuration
- **Wiki wizard** — interactive wiki generation
- **Clean confirm** — destructive action confirmation with TUI dialog

### Interactive Modes

- `gitnexus query --interactive` — live query REPL with syntax highlighting
- `gitnexus context --interactive` — symbol exploration with follow-up queries
- `gitnexus impact --interactive` — blast radius visualization
- `gitnexus cypher --interactive` — Cypher query console

### Embed CLI

- `gitnexus embed` — generate embeddings with multiple providers
- **Providers**: OpenAI, Cohere, Ollama, local (transformers.js)
- `IEmbeddingProvider` interface for pluggable providers
- Dynamic embedding dimensions via `getEmbeddingSchema(dims)`

### Non-interactive mode

All commands support `--yes` flag for CI/CD pipelines (skip confirmations).

## Changes (56 files)

| Area | Key files | What |
|------|-----------|------|
| TUI core | `tui/` directory (27 files) | Wizards, components, formatters, interactive modes |
| Embed CLI | `embed.ts`, `embed-config.ts` | Embed command and config |
| Providers | `providers/` (6 files) | OpenAI, Cohere, Ollama, transformers.js, factory |
| CLI integration | `analyze.ts`, `index.ts`, `tool.ts`, + 6 CLI files | TUI hooks, --yes flags, interactive modes |
| Embedding pipeline | `embedding-pipeline.ts`, `embedder.ts` | Multi-provider refactor |
| Docs | `tui.md`, `embeddings.md` | Usage documentation |

## Test plan

- [ ] Build passes: `cd gitnexus && npm run build`
- [ ] `gitnexus analyze` launches TUI wizard (no `--yes`)
- [ ] `gitnexus analyze --yes` skips wizard
- [ ] `gitnexus embed` launches embed wizard
- [ ] `gitnexus query --interactive` opens query REPL
- [ ] `gitnexus embed --provider openai --model text-embedding-3-small` runs non-interactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)