### PR TITLE
fix: auto-detect default branch for generated context files (#243)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ To configure MCP for your editor, run `npx gitnexus setup` once — or set it up
 | **Codex**       | Yes | Yes    | —                   | MCP + Skills   |
 | **Windsurf**    | Yes | —     | —                   | MCP            |
 | **OpenCode**    | Yes | Yes    | —                   | MCP + Skills   |
-| **Codex**       | Yes | —     | —                   | MCP            |
 
 > **Claude Code** gets the deepest integration: MCP tools + agent skills + PreToolUse hooks that enrich searches with graph context + PostToolUse hooks that auto-reindex after commits.
 
@@ -144,6 +143,12 @@ claude mcp add gitnexus -- npx -y gitnexus@latest mcp
 
 # Windows
 claude mcp add gitnexus -- cmd /c npx -y gitnexus@latest mcp
+```
+
+**Codex** (full support — MCP + skills):
+
+```bash
+codex mcp add gitnexus -- npx -y gitnexus@latest mcp
 ```
 
 **Codex** (full support — MCP + skills):

--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -66,6 +66,12 @@ claude mcp add gitnexus -- cmd /c npx -y gitnexus@latest mcp
 codex mcp add gitnexus -- npx -y gitnexus@latest mcp
 ```
 
+### Codex (full support — MCP + skills)
+
+```bash
+codex mcp add gitnexus -- npx -y gitnexus@latest mcp
+```
+
 ### Cursor / Windsurf
 
 Add to `~/.cursor/mcp.json` (global — works for all projects):


### PR DESCRIPTION
## Summary

- Fixes hardcoded `base_ref: "main"` in the regression debugging tip inside generated `AGENTS.md` / `CLAUDE.md`
- Adds `getDefaultBranch(repoPath)` to `src/storage/git.ts` with a three-step detection strategy:
  1. `git symbolic-ref refs/remotes/origin/HEAD` — most reliable when a remote is configured
  2. Probe for a local `main` or `master` branch via `git show-ref`
  3. Fall back to `"main"` if nothing is found
- Threads the detected branch through `generateAIContextFiles` → `generateGitNexusContent`

Closes #243

## Test plan

- [ ] Repo with `main` as default branch → generated context contains `base_ref: "main"`
- [ ] Repo with `master` as default branch → generated context contains `base_ref: "master"`
- [ ] Repo with `develop` as default branch (origin/HEAD set) → generated context contains `base_ref: "develop"`
- [ ] Repo with no remote configured → falls back gracefully to `"main"`
- [ ] Existing callers of `generateAIContextFiles` without `defaultBranch` arg still work (parameter defaults to `'main'`)