### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -56,7 +56,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 | Flag                | Effect                                    |
 | ------------------- | ----------------------------------------- |
 | `--force`           | Force full regeneration                   |
-| `--model <model>`   | LLM model (default: minimax/minimax-m2.5) |
+| `--model <model>`   | LLM model (default: minimax/minimax-m2.7) |
 | `--base-url <url>`  | LLM API base URL                          |
 | `--api-key <key>`   | LLM API key                               |
 | `--concurrency <n>` | Parallel LLM calls (default: 3)           |

--- a/eval/README.md
+++ b/eval/README.md
@@ -19,7 +19,7 @@ Evaluate whether GitNexus code intelligence improves AI agent performance on rea
 **Models supported:**
 
 - Claude 3.5 Haiku, Claude Sonnet 4, Claude Opus 4
-- MiniMax M1 2.5
+- MiniMax M2.7, M2.7 Highspeed, M1 2.5
 - GLM 4.7, GLM 5
 - Any model supported by litellm (add a YAML config)
 

--- a/eval/configs/models/minimax-m2.7-highspeed.yaml
+++ b/eval/configs/models/minimax-m2.7-highspeed.yaml
@@ -1,10 +1,10 @@
-# MiniMax M2.5 — via OpenRouter (set OPENROUTER_API_KEY in .env)
+# MiniMax M2.7 Highspeed — via OpenRouter (set OPENROUTER_API_KEY in .env)
+# High-speed version of M2.7 for low-latency scenarios.
 # Uses text-based model class because MiniMax doesn't support tool_calls natively.
 # The action_regex tells mini-swe-agent to parse ```bash blocks from responses.
-# Note: For the latest MiniMax model, see minimax-m2.7.yaml
 model:
   model_class: litellm_textbased
-  model_name: "openrouter/minimax/minimax-m2.5"
+  model_name: "openrouter/minimax/minimax-m2.7-highspeed"
   action_regex: "```(?:bash|mswea_bash_command)\\s*\\n(.*?)\\n```"
   cost_tracking: "ignore_errors"
   model_kwargs:

--- a/eval/configs/models/minimax-m2.7.yaml
+++ b/eval/configs/models/minimax-m2.7.yaml
@@ -1,10 +1,10 @@
-# MiniMax M2.5 — via OpenRouter (set OPENROUTER_API_KEY in .env)
+# MiniMax M2.7 — via OpenRouter (set OPENROUTER_API_KEY in .env)
+# Latest flagship model with enhanced reasoning and coding capabilities.
 # Uses text-based model class because MiniMax doesn't support tool_calls natively.
 # The action_regex tells mini-swe-agent to parse ```bash blocks from responses.
-# Note: For the latest MiniMax model, see minimax-m2.7.yaml
 model:
   model_class: litellm_textbased
-  model_name: "openrouter/minimax/minimax-m2.5"
+  model_name: "openrouter/minimax/minimax-m2.7"
   action_regex: "```(?:bash|mswea_bash_command)\\s*\\n(.*?)\\n```"
   cost_tracking: "ignore_errors"
   model_kwargs:

--- a/gitnexus-claude-plugin/skills/gitnexus-cli/SKILL.md
+++ b/gitnexus-claude-plugin/skills/gitnexus-cli/SKILL.md
@@ -56,7 +56,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 | Flag | Effect |
 |------|--------|
 | `--force` | Force full regeneration |
-| `--model <model>` | LLM model (default: minimax/minimax-m2.5) |
+| `--model <model>` | LLM model (default: minimax/minimax-m2.7) |
 | `--base-url <url>` | LLM API base URL |
 | `--api-key <key>` | LLM API key |
 | `--concurrency <n>` | Parallel LLM calls (default: 3) |

--- a/gitnexus/skills/gitnexus-cli.md
+++ b/gitnexus/skills/gitnexus-cli.md
@@ -56,7 +56,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 | Flag                | Effect                                    |
 | ------------------- | ----------------------------------------- |
 | `--force`           | Force full regeneration                   |
-| `--model <model>`   | LLM model (default: minimax/minimax-m2.5) |
+| `--model <model>`   | LLM model (default: minimax/minimax-m2.7) |
 | `--base-url <url>`  | LLM API base URL                          |
 | `--api-key <key>`   | LLM API key                               |
 | `--concurrency <n>` | Parallel LLM calls (default: 3)           |

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -64,7 +64,7 @@ program
   .command('wiki [path]')
   .description('Generate repository wiki from knowledge graph')
   .option('-f, --force', 'Force full regeneration even if up to date')
-  .option('--model <model>', 'LLM model name (default: minimax/minimax-m2.5)')
+  .option('--model <model>', 'LLM model name (default: minimax/minimax-m2.7)')
   .option('--base-url <url>', 'LLM API base URL (default: OpenAI)')
   .option('--api-key <key>', 'LLM API key (saved to ~/.gitnexus/config.json)')
   .option('--concurrency <n>', 'Parallel LLM calls (default: 3)', '3')

--- a/gitnexus/src/cli/wiki.ts
+++ b/gitnexus/src/cli/wiki.ts
@@ -161,7 +161,7 @@ export const wikiCommand = async (
 
       if (choice === '2') {
         baseUrl = 'https://openrouter.ai/api/v1';
-        defaultModel = 'minimax/minimax-m2.5';
+        defaultModel = 'minimax/minimax-m2.7';
       } else if (choice === '3') {
         baseUrl = await prompt('  Base URL (e.g. http://localhost:11434/v1): ');
         if (!baseUrl) {

--- a/gitnexus/src/core/wiki/llm-client.ts
+++ b/gitnexus/src/core/wiki/llm-client.ts
@@ -46,7 +46,7 @@ export async function resolveLLMConfig(overrides?: Partial<LLMConfig>): Promise<
     model: overrides?.model
       || process.env.GITNEXUS_MODEL
       || savedConfig.model
-      || 'minimax/minimax-m2.5',
+      || 'minimax/minimax-m2.7',
     maxTokens: overrides?.maxTokens ?? 16_384,
     temperature: overrides?.temperature ?? 0,
   };

--- a/gitnexus/test/unit/llm-client-defaults.test.ts
+++ b/gitnexus/test/unit/llm-client-defaults.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the repo-manager to avoid file system access
+vi.mock('../../src/storage/repo-manager.js', () => ({
+  loadCLIConfig: vi.fn().mockResolvedValue({}),
+}));
+
+describe('LLM client defaults', () => {
+  beforeEach(() => {
+    // Clear relevant env vars so defaults are used
+    delete process.env.GITNEXUS_MODEL;
+    delete process.env.GITNEXUS_API_KEY;
+    delete process.env.GITNEXUS_LLM_BASE_URL;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it('uses MiniMax-M2.7 as default model', async () => {
+    const { resolveLLMConfig } = await import('../../src/core/wiki/llm-client.js');
+    const config = await resolveLLMConfig();
+    expect(config.model).toBe('minimax/minimax-m2.7');
+  });
+
+  it('uses OpenRouter as default base URL', async () => {
+    const { resolveLLMConfig } = await import('../../src/core/wiki/llm-client.js');
+    const config = await resolveLLMConfig();
+    expect(config.baseUrl).toBe('https://openrouter.ai/api/v1');
+  });
+
+  it('allows model override via parameter', async () => {
+    const { resolveLLMConfig } = await import('../../src/core/wiki/llm-client.js');
+    const config = await resolveLLMConfig({ model: 'minimax/minimax-m2.7-highspeed' });
+    expect(config.model).toBe('minimax/minimax-m2.7-highspeed');
+  });
+
+  it('allows model override via env var', async () => {
+    process.env.GITNEXUS_MODEL = 'minimax/minimax-m2.5';
+    const { resolveLLMConfig } = await import('../../src/core/wiki/llm-client.js');
+    const config = await resolveLLMConfig();
+    expect(config.model).toBe('minimax/minimax-m2.5');
+    delete process.env.GITNEXUS_MODEL;
+  });
+});


### PR DESCRIPTION
## Summary
- Add MiniMax-M2.7 and MiniMax-M2.7-highspeed to eval model configs
- Set MiniMax-M2.7 as new default model (previously M2.5)
- Update CLI help text, skill documentation, and eval README
- Keep all previous models (M2.5, M1 2.5) as available alternatives
- Add unit test for LLM client default model verification

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities. This upgrade ensures GitNexus users benefit from the newest model by default while maintaining backward compatibility with older models.

## Changes
| File | Change |
|------|--------|
| `gitnexus/src/core/wiki/llm-client.ts` | Default model → M2.7 |
| `gitnexus/src/cli/wiki.ts` | OpenRouter default → M2.7 |
| `gitnexus/src/cli/index.ts` | CLI help text → M2.7 |
| `gitnexus/skills/gitnexus-cli.md` | Skill doc → M2.7 |
| `gitnexus-claude-plugin/skills/gitnexus-cli/SKILL.md` | Plugin doc → M2.7 |
| `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` | Claude skill doc → M2.7 |
| `eval/configs/models/minimax-m2.7.yaml` | New M2.7 eval config |
| `eval/configs/models/minimax-m2.7-highspeed.yaml` | New M2.7 Highspeed eval config |
| `eval/README.md` | Updated supported models list |
| `eval/configs/models/minimax-m2.1.yaml` | Added note pointing to M2.7 |
| `gitnexus/test/unit/llm-client-defaults.test.ts` | Unit test for default model |

## Testing
- Unit test verifies MiniMax-M2.7 is the default model
- Unit test verifies model override via parameter and env var
- All previous models remain functional as alternatives
