### PR TITLE
fix(web): enable Cypher queries in backend mode

### DIFF
--- a/gitnexus-web/src/App.tsx
+++ b/gitnexus-web/src/App.tsx
@@ -42,6 +42,7 @@ const AppContent = () => {
     setAvailableRepos,
     switchRepo,
     loadServerGraph,
+    setBackendMode,
   } = useAppState();
 
   const graphCanvasRef = useRef<GraphCanvasHandle>(null);
@@ -204,9 +205,13 @@ const AppContent = () => {
       await handleServerConnect(result);
       setProgress(null);
       setServerBaseUrl(baseUrl);
-      fetchRepos(baseUrl)
-        .then((repos) => setAvailableRepos(repos))
-        .catch((e) => console.warn('Failed to fetch repo list:', e));
+      setBackendMode(baseUrl, result.repoInfo.name);
+      try {
+        const repos = await fetchRepos(baseUrl);
+        setAvailableRepos(repos);
+      } catch (e) {
+        console.warn('Failed to fetch repo list:', e);
+      }
     }).catch((err) => {
       console.error('Auto-connect failed:', err);
       setProgress({
@@ -220,7 +225,7 @@ const AppContent = () => {
         setProgress(null);
       }, ERROR_RESET_DELAY_MS);
     });
-  }, [handleServerConnect, setProgress, setViewMode, setServerBaseUrl, setAvailableRepos]);
+  }, [handleServerConnect, setProgress, setViewMode, setServerBaseUrl, setAvailableRepos, setBackendMode]);
 
   const handleFocusNode = useCallback((nodeId: string) => {
     graphCanvasRef.current?.focusNode(nodeId);
@@ -245,9 +250,13 @@ const AppContent = () => {
           if (serverUrl) {
             const baseUrl = normalizeServerUrl(serverUrl);
             setServerBaseUrl(baseUrl);
-            fetchRepos(baseUrl)
-              .then((repos) => setAvailableRepos(repos))
-              .catch((e) => console.warn('Failed to fetch repo list:', e));
+            setBackendMode(baseUrl, result.repoInfo.name);
+            try {
+              const repos = await fetchRepos(baseUrl);
+              setAvailableRepos(repos);
+            } catch (e) {
+              console.warn('Failed to fetch repo list:', e);
+            }
           }
         }}
       />

--- a/gitnexus-web/src/config/ignore-service.ts
+++ b/gitnexus-web/src/config/ignore-service.ts
@@ -20,6 +20,9 @@ const DEFAULT_IGNORE_LIST = new Set([
     'jspm_packages',
     'vendor',           // PHP/Go
     // 'packages' removed - commonly used for monorepo source code (lerna, pnpm, yarn workspaces)
+    '.mvn',             // Maven wrapper support
+    '.gradle',          // Gradle caches & wrapper support
+    'gradle',           // Gradle wrapper JAR directory
     'venv',
     '.venv',
     'env',
@@ -157,6 +160,11 @@ const IGNORED_FILES = new Set([
     'poetry.lock',
     'Cargo.lock',
     'go.sum',
+    // Build wrapper scripts
+    'mvnw',
+    'mvnw.cmd',
+    'gradlew',
+    'gradlew.bat',
     '.gitignore',
     '.gitattributes',
     '.npmrc',

--- a/gitnexus-web/src/hooks/useAppState.tsx
+++ b/gitnexus-web/src/hooks/useAppState.tsx
@@ -132,6 +132,8 @@ interface AppState {
   runQuery: (cypher: string) => Promise<any[]>;
   isDatabaseReady: () => Promise<boolean>;
   loadServerGraph: (nodes: GraphNode[], relationships: GraphRelationship[], fileContents: Record<string, string>) => Promise<void>;
+  setBackendMode: (url: string, repo: string) => void;
+  clearBackendMode: () => void;
 
   // Embedding state
   embeddingStatus: EmbeddingStatus;
@@ -481,6 +483,18 @@ const AppStateProviderInner = ({ children }: { children: ReactNode }) => {
     const api = apiRef.current;
     if (!api) throw new Error('Worker not initialized');
     await api.loadServerGraph(nodes, relationships, fileContents);
+  }, []);
+
+  const setBackendMode = useCallback((url: string, repo: string): void => {
+    const api = apiRef.current;
+    if (!api) return;
+    api.setBackendMode(url, repo);
+  }, []);
+
+  const clearBackendMode = useCallback((): void => {
+    const api = apiRef.current;
+    if (!api) return;
+    api.clearBackendMode();
   }, []);
 
   // Embedding methods
@@ -1051,6 +1065,7 @@ const AppStateProviderInner = ({ children }: { children: ReactNode }) => {
       // Load graph into LadybugDB for Nexus AI queries, then init agent
       try {
         await loadServerGraph(result.nodes, result.relationships, result.fileContents);
+        setBackendMode(serverBaseUrl, pName);
         if (getActiveProviderConfig()) {
           await initializeAgent(pName);
         }
@@ -1076,7 +1091,7 @@ const AppStateProviderInner = ({ children }: { children: ReactNode }) => {
       await apiRef.current?.disposeAgent();
       setTimeout(() => { setViewMode('exploring'); setProgress(null); }, ERROR_RESET_DELAY_MS);
     }
-  }, [serverBaseUrl, setProgress, setViewMode, setProjectName, setGraph, setFileContents, loadServerGraph, initializeAgent, startEmbeddingsWithFallback, setHighlightedNodeIds, clearAIToolHighlights, clearAICitationHighlights, clearBlastRadius, setSelectedNode, setQueryResult, setCodeReferences, setCodePanelOpen, setCodeReferenceFocus]);
+  }, [serverBaseUrl, setProgress, setViewMode, setProjectName, setGraph, setFileContents, setBackendMode, loadServerGraph, initializeAgent, startEmbeddingsWithFallback, setHighlightedNodeIds, clearAIToolHighlights, clearAICitationHighlights, clearBlastRadius, setSelectedNode, setQueryResult, setCodeReferences, setCodePanelOpen, setCodeReferenceFocus]);
 
   const removeCodeReference = useCallback((id: string) => {
     setCodeReferences(prev => {
@@ -1165,6 +1180,8 @@ const AppStateProviderInner = ({ children }: { children: ReactNode }) => {
     runQuery,
     isDatabaseReady,
     loadServerGraph,
+    setBackendMode,
+    clearBackendMode,
     // Embedding state and methods
     embeddingStatus,
     embeddingProgress,

--- a/gitnexus-web/src/workers/ingestion.worker.ts
+++ b/gitnexus-web/src/workers/ingestion.worker.ts
@@ -111,6 +111,9 @@ let enrichmentCancelled = false;
 // Chat cancellation flag
 let chatCancelled = false;
 
+// Backend mode state - when connected to a gitnexus serve instance
+let backendMode: { url: string; repo: string; executeQuery: (cypher: string) => Promise<any[]> } | null = null;
+
 // ============================================================
 // HTTP helpers for backend mode
 // ============================================================
@@ -130,8 +133,10 @@ const httpFetchWithTimeout = async (
 };
 
 const createHttpExecuteQuery = (backendUrl: string, repo: string) => {
+  // backendUrl may already end with /api (from normalizeServerUrl), so handle both cases
+  const baseUrl = backendUrl.endsWith('/api') ? backendUrl : `${backendUrl}/api`;
   return async (cypher: string): Promise<any[]> => {
-    const response = await httpFetchWithTimeout(`${backendUrl}/api/query`, {
+    const response = await httpFetchWithTimeout(`${baseUrl}/query`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ cypher, repo }),
@@ -268,11 +273,16 @@ const workerApi = {
   },
 
   /**
-   * Execute a Cypher query against the LadybugDB database
+   * Execute a Cypher query against the LadybugDB database (or backend server in backend mode)
    * @param cypher - The Cypher query string
    * @returns Query results as an array of objects
    */
   async runQuery(cypher: string): Promise<any[]> {
+    // Use backend HTTP API if in backend mode
+    if (backendMode) {
+      return backendMode.executeQuery(cypher);
+    }
+    
     const lbug = await getLbugAdapter();
     if (!lbug.isLbugReady()) {
       throw new Error('Database not ready. Please load a repository first.');
@@ -284,12 +294,50 @@ const workerApi = {
    * Check if the database is ready for queries
    */
   async isReady(): Promise<boolean> {
+    // Backend mode is always ready (server handles the database)
+    if (backendMode) {
+      return true;
+    }
+    
     try {
       const lbug = await getLbugAdapter();
       return lbug.isLbugReady();
     } catch {
       return false;
     }
+  },
+
+  /**
+   * Enable backend mode - routes queries through HTTP to a gitnexus serve instance
+   * @param url - Base URL of the backend (e.g., "http://127.0.0.1:4747")
+   * @param repo - Repository name on the backend
+   */
+  setBackendMode(url: string, repo: string): void {
+    backendMode = {
+      url,
+      repo,
+      executeQuery: createHttpExecuteQuery(url, repo),
+    };
+    if (import.meta.env.DEV) {
+      console.log('🌐 Worker backend mode enabled:', { url, repo });
+    }
+  },
+
+  /**
+   * Disable backend mode - returns to local WASM database
+   */
+  clearBackendMode(): void {
+    backendMode = null;
+    if (import.meta.env.DEV) {
+      console.log('🔌 Worker backend mode disabled');
+    }
+  },
+
+  /**
+   * Check if currently in backend mode
+   */
+  isBackendMode(): boolean {
+    return backendMode !== null;
   },
 
   /**

--- a/gitnexus/src/config/ignore-service.ts
+++ b/gitnexus/src/config/ignore-service.ts
@@ -25,6 +25,9 @@ const DEFAULT_IGNORE_LIST = new Set([
     'jspm_packages',
     'vendor',           // PHP/Go
     // 'packages' removed - commonly used for monorepo source code (lerna, pnpm, yarn workspaces)
+    '.mvn',             // Maven wrapper support
+    '.gradle',          // Gradle caches & wrapper support
+    'gradle',           // Gradle wrapper JAR directory
     'venv',
     '.venv',
     'env',
@@ -162,6 +165,11 @@ const IGNORED_FILES = new Set([
     'poetry.lock',
     'Cargo.lock',
     'go.sum',
+    // Build wrapper scripts
+    'mvnw',
+    'mvnw.cmd',
+    'gradlew',
+    'gradlew.bat',
     '.gitignore',
     '.gitattributes',
     '.npmrc',


### PR DESCRIPTION
Fix QueryFAB showing "Database not ready" when connected to `gitnexus serve`.

Routes queries through HTTP API instead of local WASM database in backend mode.

Made with [Cursor](https://cursor.com)