### PR TITLE
feat: add --ignore-embeddings-node-limit flag to bypass 50K node cap

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -46,6 +46,7 @@ function ensureHeap(): boolean {
 export interface AnalyzeOptions {
   force?: boolean;
   embeddings?: boolean;
+  ignoreEmbeddingsNodeLimit?: boolean;
   skills?: boolean;
   verbose?: boolean;
 }
@@ -267,8 +268,8 @@ export const analyzeCommand = async (
   let embeddingSkipReason = 'off (use --embeddings to enable)';
 
   if (options?.embeddings) {
-    if (stats.nodes > EMBEDDING_NODE_LIMIT) {
-      embeddingSkipReason = `skipped (${stats.nodes.toLocaleString()} nodes > ${EMBEDDING_NODE_LIMIT.toLocaleString()} limit)`;
+    if (stats.nodes > EMBEDDING_NODE_LIMIT && !options.ignoreEmbeddingsNodeLimit) {
+      embeddingSkipReason = `skipped (${stats.nodes.toLocaleString()} nodes > ${EMBEDDING_NODE_LIMIT.toLocaleString()} limit; use --ignore-embeddings-node-limit to override)`;
     } else {
       embeddingSkipped = false;
     }

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -26,6 +26,7 @@ program
   .description('Index a repository (full analysis)')
   .option('-f, --force', 'Force full re-index even if up to date')
   .option('--embeddings', 'Enable embedding generation for semantic search (off by default)')
+  .option('--ignore-embeddings-node-limit', 'Bypass the 50,000-node safety cap for embedding generation (use with --embeddings on large repos)')
   .option('--skills', 'Generate repo-specific skill files from detected communities')
    .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')
    .addHelpText('after', '\nEnvironment variables:\n  GITNEXUS_NO_GITIGNORE=1  Skip .gitignore parsing (still reads .gitnexusignore)')


### PR DESCRIPTION
## Summary

This PR adds a new CLI flag, `--ignore-embeddings-node-limit`, to the `analyze` command.

When used together with `--embeddings`, this flag bypasses the existing 50,000-node safety cap for embedding generation.

It also updates the skip message to clearly inform users that they can override the limit with `--ignore-embeddings-node-limit`.

Closes #382

## Changes

- Added `--ignore-embeddings-node-limit` to the `analyze` command
- Allowed embedding generation to continue beyond the 50,000-node limit when the flag is provided
- Updated the skip message to mention the override flag

## Test Plan

- [ ] Run `npx gitnexus analyze --embeddings` on a repository with more than 50,000 nodes and verify that embeddings are skipped with the updated message mentioning `--ignore-embeddings-node-limit`
- [ ] Run `npx gitnexus analyze --embeddings --ignore-embeddings-node-limit` on the same repository and verify that embeddings are generated
- [ ] Run `npx gitnexus analyze --help` and verify that the new flag appears in the CLI help output
- [ ] Run the existing test suite (`npm test`) and verify that there are no regressions