### PR TITLE
fix: markdown heading regex fails on Windows (CRLF line endings)

### DIFF
--- a/gitnexus/src/core/ingestion/markdown-processor.ts
+++ b/gitnexus/src/core/ingestion/markdown-processor.ts
@@ -10,7 +10,7 @@ import path from 'node:path';
 import { generateId } from '../../lib/utils.js';
 import { KnowledgeGraph, GraphNode, GraphRelationship } from '../graph/types.js';
 
-const HEADING_RE = /^(#{1,6})\s+(.+)$/;
+const HEADING_RE = /^(#{1,6})\s+(.+?)[\r\t ]*$/;
 const LINK_RE = /\[([^\]]*)\]\(([^)]+)\)/g;
 const MD_EXTENSIONS = new Set(['.md', '.mdx']);
 


### PR DESCRIPTION
## Summary

The markdown processor's `HEADING_RE` regex silently fails to match any headings in files with Windows-style CRLF (`\r\n`) line endings. This means **zero Section nodes** are created for markdown files on Windows, while the same files index correctly on macOS/Linux.

### Root Cause

`String.split('\n')` leaves a trailing `\r` on each line when the file uses CRLF endings. The original regex:

```js
const HEADING_RE = /^(#{1,6})\s+(.+)$/;
```

The `$` anchor does not match before `\r` in JavaScript's non-multiline regex mode, so `'# My Heading\r'.match(HEADING_RE)` returns `null`.

### Fix

```js
const HEADING_RE = /^(#{1,6})\s+(.+?)[\r\t ]*$/;
```

- Changed `.+` to `.+?` (non-greedy) so the capture group doesn't swallow trailing whitespace
- Added `[\r\t ]*` before `$` to consume optional carriage returns and trailing whitespace

### Impact

Tested on a 424-file markdown-heavy repository on Windows 10:

| Metric | Before | After |
|--------|--------|-------|
| Section nodes created | 22 (only LF-encoded files) | 8,072 (all files) |
| Files affected | 2 / 424 | 424 / 424 |

No impact on LF-only files (macOS/Linux) — the `[\r\t ]*` simply matches zero characters.

## Test plan

- [x] Verified `'# Heading\r'.match(HEADING_RE)` returns a match
- [x] Verified `'# Heading'.match(HEADING_RE)` still works (LF case)
- [x] Full re-index on Windows: 22 → 8,072 sections from 424 markdown files
- [ ] Existing test suite passes