### PR TITLE
feat: detect SwiftUI navigation patterns (NAVIGATES_TO edges)

### DIFF
--- a/gitnexus-shared/src/graph/types.ts
+++ b/gitnexus-shared/src/graph/types.ts
@@ -115,7 +115,8 @@ export type RelationshipType =
   | 'HANDLES_TOOL'
   | 'ENTRY_POINT_OF'
   | 'WRAPS'
-  | 'QUERIES';
+  | 'QUERIES'
+  | 'NAVIGATES_TO'; // SwiftUI View → View navigation
 
 export interface GraphNode {
   id: string;

--- a/gitnexus-shared/src/lbug/schema-constants.ts
+++ b/gitnexus-shared/src/lbug/schema-constants.ts
@@ -67,6 +67,7 @@ export const REL_TYPES = [
   'ENTRY_POINT_OF',
   'WRAPS',
   'QUERIES',
+  'NAVIGATES_TO', // SwiftUI View → View navigation
 ] as const;
 
 export type RelType = (typeof REL_TYPES)[number];

--- a/gitnexus/src/core/ingestion/call-processor.ts
+++ b/gitnexus/src/core/ingestion/call-processor.ts
@@ -40,6 +40,7 @@ import type { TieredCandidates } from './model/resolution-context.js';
 import { isLanguageAvailable, loadParser, loadLanguage } from '../tree-sitter/parser-loader.js';
 import { getProvider } from './languages/index.js';
 import { generateId } from '../../lib/utils.js';
+import type { ExtractedNavigation } from './swiftui-navigation.js';
 import { getLanguageFromFilename, SupportedLanguages } from 'gitnexus-shared';
 import { isVerboseIngestionEnabled } from './utils/verbose.js';
 import { yieldToEventLoop } from './utils/event-loop.js';
@@ -3299,4 +3300,44 @@ export const extractFetchCallsFromFiles = async (
   }
 
   return result;
+};
+
+// ============================================================================
+// SwiftUI Navigation Processing
+// ============================================================================
+
+export const processSwiftUINavigation = (graph: KnowledgeGraph, navigations: ExtractedNavigation[]): number => {
+  const structsByName = new Map<string, { id: string; filePath: string }[]>();
+  graph.forEachNode((node) => {
+    if (node.label === 'Struct' && node.properties.name) {
+      const name = node.properties.name as string;
+      let entries = structsByName.get(name);
+      if (!entries) { entries = []; structsByName.set(name, entries); }
+      entries.push({ id: node.id, filePath: node.properties.filePath as string });
+    }
+  });
+  const seenEdges = new Set<string>();
+  let edgesCreated = 0;
+  for (const nav of navigations) {
+    let sourceId: string;
+    if (nav.sourceView) {
+      const structId = findStructInIndex(structsByName, nav.sourceView, nav.filePath);
+      sourceId = structId || generateId('File', nav.filePath);
+    } else { sourceId = generateId('File', nav.filePath); }
+    const targetId = findStructInIndex(structsByName, nav.targetView);
+    if (!targetId) continue;
+    const relId = generateId('NAVIGATES_TO', `${sourceId}->${targetId}:${nav.navigationType}`);
+    if (seenEdges.has(relId)) continue;
+    seenEdges.add(relId);
+    graph.addRelationship({ id: relId, sourceId, targetId, type: 'NAVIGATES_TO', confidence: 0.9, reason: nav.navigationType });
+    edgesCreated++;
+  }
+  return edgesCreated;
+};
+
+const findStructInIndex = (index: Map<string, { id: string; filePath: string }[]>, name: string, preferFilePath?: string): string | undefined => {
+  const entries = index.get(name);
+  if (!entries || entries.length === 0) return undefined;
+  if (preferFilePath) { const sameFile = entries.find(e => e.filePath === preferFilePath); if (sameFile) return sameFile.id; }
+  return entries[0].id;
 };

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -47,6 +47,7 @@ import type {
   ExtractedORMQuery,
 } from './workers/parse-worker.js';
 import { getTreeSitterBufferSize, TREE_SITTER_MAX_BUFFER } from './constants.js';
+import type { ExtractedNavigation } from './swiftui-navigation.js';
 
 export type FileProgressCallback = (current: number, total: number, filePath: string) => void;
 
@@ -60,6 +61,7 @@ export interface WorkerExtractedData {
   decoratorRoutes: ExtractedDecoratorRoute[];
   toolDefs: ExtractedToolDef[];
   ormQueries: ExtractedORMQuery[];
+  navigations: ExtractedNavigation[];
   constructorBindings: FileConstructorBindings[];
   fileScopeBindings: FileScopeBindings[];
 }
@@ -94,6 +96,7 @@ const processParsingWithWorkers = async (
       decoratorRoutes: [],
       toolDefs: [],
       ormQueries: [],
+      navigations: [],
       constructorBindings: [],
       fileScopeBindings: [],
     };
@@ -118,6 +121,7 @@ const processParsingWithWorkers = async (
   const allDecoratorRoutes: ExtractedDecoratorRoute[] = [];
   const allToolDefs: ExtractedToolDef[] = [];
   const allORMQueries: ExtractedORMQuery[] = [];
+  const allNavigations: ExtractedNavigation[] = [];
   const allConstructorBindings: FileConstructorBindings[] = [];
   const fileScopeBindingsByFile: FileScopeBindings[] = [];
   for (const result of chunkResults) {
@@ -185,6 +189,7 @@ const processParsingWithWorkers = async (
     decoratorRoutes: allDecoratorRoutes,
     toolDefs: allToolDefs,
     ormQueries: allORMQueries,
+    navigations: allNavigations,
     constructorBindings: allConstructorBindings,
     fileScopeBindings: fileScopeBindingsByFile,
   };

--- a/gitnexus/src/core/ingestion/pipeline-phases/index.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/index.ts
@@ -15,6 +15,7 @@ export { parsePhase, type ParseOutput } from './parse.js';
 export { routesPhase, type RoutesOutput, type RouteEntry } from './routes.js';
 export { toolsPhase, type ToolsOutput, type ToolDef } from './tools.js';
 export { ormPhase, type ORMOutput } from './orm.js';
+export { swiftuiNavigationPhase, type SwiftUINavigationOutput } from './swiftui-navigation.js';
 export { crossFilePhase, type CrossFileOutput } from './cross-file.js';
 export { mroPhase, type MROOutput } from './mro.js';
 export { communitiesPhase, type CommunitiesOutput } from './communities.js';

--- a/gitnexus/src/core/ingestion/pipeline-phases/parse-impl.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/parse-impl.ts
@@ -68,6 +68,8 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { isDev } from '../utils/env.js';
 import { synthesizeWildcardImportBindings, needsSynthesis } from './wildcard-synthesis.js';
 import { extractORMQueriesInline } from './orm-extraction.js';
+import { extractSwiftUINavigations } from '../swiftui-navigation.js';
+import type { ExtractedNavigation } from '../swiftui-navigation.js';
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
@@ -106,6 +108,7 @@ export async function runChunkedParseAndResolve(
   allDecoratorRoutes: ExtractedDecoratorRoute[];
   allToolDefs: ExtractedToolDef[];
   allORMQueries: ExtractedORMQuery[];
+  allNavigations: ExtractedNavigation[];
   bindingAccumulator: BindingAccumulator;
   resolutionContext: ReturnType<typeof createResolutionContext>;
   usedWorkerPool: boolean;
@@ -248,6 +251,7 @@ export async function runChunkedParseAndResolve(
   const allDecoratorRoutes: ExtractedDecoratorRoute[] = [];
   const allToolDefs: ExtractedToolDef[] = [];
   const allORMQueries: ExtractedORMQuery[] = [];
+  const allNavigations: ExtractedNavigation[] = [];
   const deferredWorkerCalls: ExtractedCall[] = [];
   const deferredWorkerHeritage: ExtractedHeritage[] = [];
   const deferredConstructorBindings: FileConstructorBindings[] = [];
@@ -393,6 +397,9 @@ export async function runChunkedParseAndResolve(
         if (chunkWorkerData.ormQueries?.length) {
           for (const item of chunkWorkerData.ormQueries) allORMQueries.push(item);
         }
+        if (chunkWorkerData.navigations?.length) {
+          for (const item of chunkWorkerData.navigations) allNavigations.push(item);
+        }
       } else {
         await processImports(graph, chunkFiles, astCache, ctx, undefined, repoPath, allPaths);
         sequentialChunkPaths.push(chunkPaths);
@@ -509,6 +516,7 @@ export async function runChunkedParseAndResolve(
       }
       for (const f of chunkFiles) {
         extractORMQueriesInline(f.path, f.content, allORMQueries);
+        extractSwiftUINavigations(f.path, f.content, allNavigations);
       }
       astCache.clear();
       cachedSequentialChunkFiles[chunkIdx] = [];
@@ -589,6 +597,7 @@ export async function runChunkedParseAndResolve(
     allDecoratorRoutes,
     allToolDefs,
     allORMQueries,
+    allNavigations,
     bindingAccumulator,
     resolutionContext: ctx,
     // Whether a worker pool was actually live for this run. False means the

--- a/gitnexus/src/core/ingestion/pipeline-phases/parse.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/parse.ts
@@ -27,6 +27,7 @@ import type {
   ExtractedToolDef,
   ExtractedORMQuery,
 } from '../workers/parse-worker.js';
+import type { ExtractedNavigation } from '../swiftui-navigation.js';
 import type { createResolutionContext } from '../model/resolution-context.js';
 import { runChunkedParseAndResolve } from './parse-impl.js';
 
@@ -47,6 +48,7 @@ export interface ParseOutput {
   readonly allDecoratorRoutes: readonly ExtractedDecoratorRoute[];
   readonly allToolDefs: readonly ExtractedToolDef[];
   readonly allORMQueries: readonly ExtractedORMQuery[];
+  readonly allNavigations: readonly ExtractedNavigation[];
   bindingAccumulator: BindingAccumulator;
   /** Resolution context from the parse phase — carries importMap, namedImportMap, etc. */
   resolutionContext: ReturnType<typeof createResolutionContext>;

--- a/gitnexus/src/core/ingestion/pipeline-phases/swiftui-navigation.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/swiftui-navigation.ts
@@ -1,0 +1,45 @@
+/**
+ * Phase: swiftui-navigation
+ *
+ * Processes extracted SwiftUI navigation patterns and creates NAVIGATES_TO edges.
+ *
+ * @deps    parse
+ * @reads   allNavigations (from parse)
+ * @writes  graph (NAVIGATES_TO edges)
+ */
+
+import type { PipelinePhase, PipelineContext, PhaseResult } from './types.js';
+import { getPhaseOutput } from './types.js';
+import type { ParseOutput } from './parse.js';
+import { processSwiftUINavigation } from '../call-processor.js';
+import { isDev } from '../utils/env.js';
+
+export interface SwiftUINavigationOutput {
+  edgesCreated: number;
+}
+
+export const swiftuiNavigationPhase: PipelinePhase<SwiftUINavigationOutput> = {
+  name: 'swiftui-navigation',
+  deps: ['parse'],
+
+  async execute(
+    ctx: PipelineContext,
+    deps: ReadonlyMap<string, PhaseResult<unknown>>,
+  ): Promise<SwiftUINavigationOutput> {
+    const { allNavigations } = getPhaseOutput<ParseOutput>(deps, 'parse');
+
+    if (!allNavigations || allNavigations.length === 0) {
+      return { edgesCreated: 0 };
+    }
+
+    const edgesCreated = processSwiftUINavigation(ctx.graph, allNavigations as any[]);
+
+    if (isDev) {
+      console.log(
+        `SwiftUI navigation: ${edgesCreated} NAVIGATES_TO edges from ${allNavigations.length} patterns`,
+      );
+    }
+
+    return { edgesCreated };
+  },
+};

--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -37,6 +37,12 @@ import {
   type CommunitiesOutput,
   type ProcessesOutput,
 } from './pipeline-phases/index.js';
+import {
+  processImports,
+  processImportsFromExtracted,
+  buildImportResolutionContext
+} from './import-processor.js';
+import { extractSwiftUINavigations } from './swiftui-navigation.js';
 
 export interface PipelineOptions {
   /** Skip MRO, community detection, and process extraction for faster test runs. */

--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -29,6 +29,7 @@ import {
   routesPhase,
   toolsPhase,
   ormPhase,
+  swiftuiNavigationPhase,
   crossFilePhase,
   mroPhase,
   communitiesPhase,
@@ -42,7 +43,6 @@ import {
   processImportsFromExtracted,
   buildImportResolutionContext
 } from './import-processor.js';
-import { extractSwiftUINavigations } from './swiftui-navigation.js';
 
 export interface PipelineOptions {
   /** Skip MRO, community detection, and process extraction for faster test runs. */
@@ -85,6 +85,7 @@ function buildPhaseList(options?: PipelineOptions): PipelinePhase[] {
     routesPhase,
     toolsPhase,
     ormPhase,
+    swiftuiNavigationPhase,
     crossFilePhase,
   ];
 

--- a/gitnexus/src/core/ingestion/swiftui-navigation.ts
+++ b/gitnexus/src/core/ingestion/swiftui-navigation.ts
@@ -1,0 +1,66 @@
+/**
+ * SwiftUI Navigation Pattern Detection
+ *
+ * Regex-based extraction of NavigationLink, .sheet, .fullScreenCover,
+ * .navigationDestination, and TabView patterns from Swift source files.
+ */
+
+export type SwiftUINavigationType = 'navigation-link' | 'sheet' | 'full-screen-cover' | 'navigation-destination' | 'tab-view';
+
+export interface ExtractedNavigation {
+  filePath: string;
+  sourceView?: string;
+  targetView: string;
+  navigationType: SwiftUINavigationType;
+  lineNumber: number;
+}
+
+const NAVIGATION_LINK_RE = /NavigationLink\s*\(\s*(?:destination\s*:\s*)?([A-Z]\w*View\w*)\s*\(/g;
+const SHEET_RE = /\.(sheet|fullScreenCover)\s*\([^)]*\)\s*\{[\s\S]*?([A-Z]\w*View\w*)\s*\(/g;
+const NAV_DESTINATION_RE = /\.navigationDestination\s*\([^)]*\)\s*\{[\s\S]*?([A-Z]\w*View\w*)\s*\(/g;
+const TABVIEW_RE = /TabView\s*(?:\([^)]*\))?\s*\{([\s\S]*?)\n\}/g;
+const TABVIEW_CHILD_RE = /([A-Z]\w*View\w*)\s*\(\s*\)/g;
+
+const findEnclosingSwiftView = (content: string, offset: number): string | undefined => {
+  const before = content.slice(0, offset);
+  const structRe = /struct\s+(\w+)\s*(?::\s*[\w,\s]+)?\{/g;
+  let lastMatch: string | undefined;
+  let m;
+  while ((m = structRe.exec(before)) !== null) { lastMatch = m[1]; }
+  return lastMatch;
+};
+
+export const extractSwiftUINavigations = (filePath: string, content: string, navigations: ExtractedNavigation[]): void => {
+  if (!filePath.endsWith('.swift')) return;
+  let match;
+
+  NAVIGATION_LINK_RE.lastIndex = 0;
+  while ((match = NAVIGATION_LINK_RE.exec(content)) !== null) {
+    const lineNumber = content.slice(0, match.index).split('\n').length - 1;
+    navigations.push({ filePath, sourceView: findEnclosingSwiftView(content, match.index), targetView: match[1], navigationType: 'navigation-link', lineNumber });
+  }
+
+  SHEET_RE.lastIndex = 0;
+  while ((match = SHEET_RE.exec(content)) !== null) {
+    const lineNumber = content.slice(0, match.index).split('\n').length - 1;
+    const navType = match[1] === 'fullScreenCover' ? 'full-screen-cover' as const : 'sheet' as const;
+    navigations.push({ filePath, sourceView: findEnclosingSwiftView(content, match.index), targetView: match[2], navigationType: navType, lineNumber });
+  }
+
+  NAV_DESTINATION_RE.lastIndex = 0;
+  while ((match = NAV_DESTINATION_RE.exec(content)) !== null) {
+    const lineNumber = content.slice(0, match.index).split('\n').length - 1;
+    navigations.push({ filePath, sourceView: findEnclosingSwiftView(content, match.index), targetView: match[1], navigationType: 'navigation-destination', lineNumber });
+  }
+
+  TABVIEW_RE.lastIndex = 0;
+  while ((match = TABVIEW_RE.exec(content)) !== null) {
+    const tabLineNumber = content.slice(0, match.index).split('\n').length - 1;
+    const sourceView = findEnclosingSwiftView(content, match.index);
+    let childMatch;
+    TABVIEW_CHILD_RE.lastIndex = 0;
+    while ((childMatch = TABVIEW_CHILD_RE.exec(match[1])) !== null) {
+      navigations.push({ filePath, sourceView, targetView: childMatch[1], navigationType: 'tab-view', lineNumber: tabLineNumber });
+    }
+  }
+};

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -14,6 +14,7 @@ import Ruby from 'tree-sitter-ruby';
 import { createRequire } from 'node:module';
 import { SupportedLanguages } from 'gitnexus-shared';
 import { getProvider } from '../languages/index.js';
+import { extractSwiftUINavigations, type ExtractedNavigation, type SwiftUINavigationType } from '../swiftui-navigation.js';
 import { getTreeSitterBufferSize, TREE_SITTER_MAX_BUFFER } from '../constants.js';
 import type { SymbolTableReader } from '../model/symbol-table.js';
 import type { ExtractedHeritage } from '../model/heritage-map.js';
@@ -266,6 +267,7 @@ export interface ParseWorkerResult {
   decoratorRoutes: ExtractedDecoratorRoute[];
   toolDefs: ExtractedToolDef[];
   ormQueries: ExtractedORMQuery[];
+  navigations: ExtractedNavigation[];
   constructorBindings: FileConstructorBindings[];
   /** All-scope type bindings from TypeEnv for BindingAccumulator (includes function-local). */
   fileScopeBindings: FileScopeBindings[];
@@ -709,6 +711,7 @@ const processBatch = (
     decoratorRoutes: [],
     toolDefs: [],
     ormQueries: [],
+    navigations: [],
     constructorBindings: [],
     fileScopeBindings: [],
     skippedLanguages: {},
@@ -2246,6 +2249,8 @@ const processFileGroup = (
 
     // Extract ORM queries (Prisma, Supabase)
     extractORMQueries(file.path, parseContent, result.ormQueries);
+    // ── SwiftUI Navigation Detection ──
+    extractSwiftUINavigations(file.path, file.content, result.navigations);
 
     // Vue: emit CALLS edges for components used in <template>
     if (language === SupportedLanguages.Vue) {
@@ -2280,6 +2285,7 @@ let accumulated: ParseWorkerResult = {
   decoratorRoutes: [],
   toolDefs: [],
   ormQueries: [],
+  navigations: [],
   constructorBindings: [],
   fileScopeBindings: [],
   skippedLanguages: {},
@@ -2307,6 +2313,7 @@ const mergeResult = (target: ParseWorkerResult, src: ParseWorkerResult) => {
   appendAll(target.decoratorRoutes, src.decoratorRoutes);
   appendAll(target.toolDefs, src.toolDefs);
   appendAll(target.ormQueries, src.ormQueries);
+  appendAll(target.navigations, src.navigations);
   appendAll(target.constructorBindings, src.constructorBindings);
   appendAll(target.fileScopeBindings, src.fileScopeBindings);
   for (const [lang, count] of Object.entries(src.skippedLanguages)) {
@@ -2358,6 +2365,7 @@ parentPort!.on('message', (msg: WorkerIncomingMessage) => {
         decoratorRoutes: [],
         toolDefs: [],
         ormQueries: [],
+        navigations: [],
         constructorBindings: [],
         fileScopeBindings: [],
         skippedLanguages: {},

--- a/gitnexus/src/core/lbug/schema.ts
+++ b/gitnexus/src/core/lbug/schema.ts
@@ -338,6 +338,7 @@ CREATE REL TABLE ${REL_TABLE_NAME} (
   FROM \`Struct\` TO Interface,
   FROM \`Struct\` TO \`Constructor\`,
   FROM \`Struct\` TO \`Property\`,
+  FROM \`Struct\` TO File,
   FROM \`Enum\` TO \`Enum\`,
   FROM \`Enum\` TO Community,
   FROM \`Enum\` TO Class,

--- a/gitnexus/test/fixtures/swiftui-nav-repo/CameraView.swift
+++ b/gitnexus/test/fixtures/swiftui-nav-repo/CameraView.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct CameraView: View {
+    var body: some View {
+        Text("CameraView")
+    }
+}

--- a/gitnexus/test/fixtures/swiftui-nav-repo/ContentView.swift
+++ b/gitnexus/test/fixtures/swiftui-nav-repo/ContentView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var showSettings = false
+    @State private var showCamera = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                NavigationLink(destination: ProductDetailView(product: Product())) {
+                    Text("Product")
+                }
+                NavigationLink(destination: ProfileView()) {
+                    Text("Profile")
+                }
+            }
+            .sheet(isPresented: $showSettings) {
+                SettingsView()
+            }
+            .fullScreenCover(isPresented: $showCamera) {
+                CameraView()
+            }
+            .navigationDestination(for: Product.self) { product in
+                ProductDetailView(product: product)
+            }
+        }
+    }
+}

--- a/gitnexus/test/fixtures/swiftui-nav-repo/HomeView.swift
+++ b/gitnexus/test/fixtures/swiftui-nav-repo/HomeView.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        Text("HomeView")
+    }
+}

--- a/gitnexus/test/fixtures/swiftui-nav-repo/MainTabView.swift
+++ b/gitnexus/test/fixtures/swiftui-nav-repo/MainTabView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            HomeView()
+                .tabItem { Label("Home", systemImage: "house") }
+            SearchView()
+                .tabItem { Label("Search", systemImage: "magnifyingglass") }
+            ProfileView()
+                .tabItem { Label("Profile", systemImage: "person") }
+        }
+    }
+}

--- a/gitnexus/test/fixtures/swiftui-nav-repo/ProductDetailView.swift
+++ b/gitnexus/test/fixtures/swiftui-nav-repo/ProductDetailView.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct ProductDetailView: View {
+    var body: some View {
+        Text("ProductDetailView")
+    }
+}

--- a/gitnexus/test/fixtures/swiftui-nav-repo/ProfileView.swift
+++ b/gitnexus/test/fixtures/swiftui-nav-repo/ProfileView.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct ProfileView: View {
+    var body: some View {
+        Text("ProfileView")
+    }
+}

--- a/gitnexus/test/fixtures/swiftui-nav-repo/SearchView.swift
+++ b/gitnexus/test/fixtures/swiftui-nav-repo/SearchView.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct SearchView: View {
+    var body: some View {
+        Text("SearchView")
+    }
+}

--- a/gitnexus/test/fixtures/swiftui-nav-repo/SettingsView.swift
+++ b/gitnexus/test/fixtures/swiftui-nav-repo/SettingsView.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        Text("SettingsView")
+    }
+}

--- a/gitnexus/test/integration/swiftui-navigation.test.ts
+++ b/gitnexus/test/integration/swiftui-navigation.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'path';
+import { runPipelineFromRepo } from '../../src/core/ingestion/pipeline.js';
+import type { PipelineResult } from '../../src/types/pipeline.js';
+
+const FIXTURE = path.resolve(__dirname, '..', 'fixtures', 'swiftui-nav-repo');
+
+describe('SwiftUI navigation graph', () => {
+  let result: PipelineResult;
+  beforeAll(async () => { result = await runPipelineFromRepo(FIXTURE, () => {}); }, 60000);
+
+  it('creates Struct nodes for SwiftUI Views', () => {
+    const structs: string[] = [];
+    result.graph.forEachNode(n => { if (n.label === 'Struct') structs.push(n.properties.name as string); });
+    expect(structs).toContain('ContentView');
+    expect(structs).toContain('ProductDetailView');
+    expect(structs).toContain('MainTabView');
+  });
+
+  it('creates NAVIGATES_TO edges', () => {
+    const navEdges: { target: string; reason: string }[] = [];
+    result.graph.forEachRelationship(r => {
+      if (r.type === 'NAVIGATES_TO') {
+        const tgt = result.graph.getNode(r.targetId);
+        navEdges.push({ target: (tgt?.properties.name ?? tgt?.id) as string, reason: r.reason ?? '' });
+      }
+    });
+    expect(navEdges.length).toBeGreaterThan(0);
+    expect(navEdges.some(e => e.reason === 'navigation-link' && e.target === 'ProductDetailView')).toBe(true);
+    expect(navEdges.some(e => e.reason === 'sheet' && e.target === 'SettingsView')).toBe(true);
+    expect(navEdges.some(e => e.reason === 'full-screen-cover' && e.target === 'CameraView')).toBe(true);
+    expect(navEdges.some(e => e.reason === 'tab-view' && e.target === 'HomeView')).toBe(true);
+  });
+
+  it('source Views are detected', () => {
+    const sources: string[] = [];
+    result.graph.forEachRelationship(r => {
+      if (r.type === 'NAVIGATES_TO') {
+        const src = result.graph.getNode(r.sourceId);
+        if (src?.label === 'Struct') sources.push(src.properties.name as string);
+      }
+    });
+    expect(sources).toContain('ContentView');
+    expect(sources).toContain('MainTabView');
+  });
+});


### PR DESCRIPTION
## Summary

- Add regex-based detection for SwiftUI navigation patterns: `NavigationLink`, `.sheet`, `.fullScreenCover`, `.navigationDestination`, and `TabView`
- Create `NAVIGATES_TO` edges between SwiftUI View structs in the knowledge graph
- New shared module `swiftui-navigation.ts` for extraction logic (safe for both worker and main-thread import)

## Changes

| File | Change |
|------|--------|
| `schema.ts` | Add `NAVIGATES_TO` to `REL_TYPES` + `Struct→File` relation pair |
| `graph/types.ts` | Add `NAVIGATES_TO` to `RelationshipType` union |
| `swiftui-navigation.ts` | **New** — shared extraction module with regex detectors |
| `parse-worker.ts` | Add `navigations` field to `ParseWorkerResult`, call extraction in worker path |
| `parsing-processor.ts` | Propagate `navigations` through `WorkerExtractedData` |
| `call-processor.ts` | Add `processSwiftUINavigation()` — builds Struct→Struct graph edges |
| `pipeline.ts` | Integrate Phase 3.7 + sequential path extraction |

## Detection patterns

- **NavigationLink**: `NavigationLink(destination: SomeView(...))`
- **Sheet**: `.sheet(isPresented: $flag) { SomeView() }`
- **FullScreenCover**: `.fullScreenCover(isPresented: $flag) { SomeView() }`
- **NavigationDestination**: `.navigationDestination(for: Type.self) { SomeView(...) }`
- **TabView**: `TabView { ChildView().tabItem { ... } }`

## Test plan

- [x] Integration test with 8-file SwiftUI fixture (3 tests, all passing)
- [x] TypeScript build passes
- [x] Verified on real Swift projects via `gitnexus analyze --force`
- [x] No regression on existing test suite (CI: ubuntu, macos, windows all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)