### PR TITLE
fix: probe CUDA availability in MCP embedder before requesting it

### DIFF
--- a/gitnexus/src/mcp/core/embedder.ts
+++ b/gitnexus/src/mcp/core/embedder.ts
@@ -6,10 +6,59 @@
  */
 
 import { pipeline, env, type FeatureExtractionPipeline } from '@huggingface/transformers';
+import { existsSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { join, dirname } from 'path';
+import { createRequire } from 'module';
 import { isHttpMode, getHttpDimensions, httpEmbedQuery } from '../../core/embeddings/http-client.js';
 
 // Model config
 const MODEL_ID = 'Snowflake/snowflake-arctic-embed-xs';
+
+/**
+ * Check whether onnxruntime-node ships the CUDA execution provider.
+ * Resolves from transformers' module scope to find the same binary it will dlopen.
+ */
+function hasOrtCudaProvider(): boolean {
+  try {
+    const require = createRequire(import.meta.url);
+    const transformersDir = dirname(require.resolve('@huggingface/transformers/package.json'));
+    const ortRequire = createRequire(join(transformersDir, 'package.json'));
+    const ortPath = dirname(ortRequire.resolve('onnxruntime-node/package.json'));
+    const arch = process.arch;
+    return existsSync(join(ortPath, 'bin', 'napi-v6', 'linux', arch, 'libonnxruntime_providers_cuda.so'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check whether CUDA libraries are available on the system.
+ * A failed CUDA attempt poisons ONNX Runtime process state, making the
+ * CPU fallback fail too.  We must probe before ever requesting CUDA.
+ */
+function isCudaAvailable(): boolean {
+  if (!hasOrtCudaProvider()) return false;
+
+  try {
+    const out = execFileSync('ldconfig', ['-p'], { timeout: 3000, encoding: 'utf-8' });
+    if (out.includes('libcublasLt.so.12')) return true;
+  } catch {
+    // ldconfig not available
+  }
+
+  for (const envVar of ['CUDA_PATH', 'LD_LIBRARY_PATH']) {
+    const val = process.env[envVar];
+    if (!val) continue;
+    for (const dir of val.split(':').filter(Boolean)) {
+      if (existsSync(join(dir, 'lib64', 'libcublasLt.so.12')) ||
+          existsSync(join(dir, 'lib', 'libcublasLt.so.12')) ||
+          existsSync(join(dir, 'libcublasLt.so.12'))) return true;
+    }
+  }
+
+  return false;
+}
 
 // Module-level state for singleton pattern
 let embedderInstance: FeatureExtractionPipeline | null = null;
@@ -40,10 +89,15 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
       
       console.error('GitNexus: Loading embedding model (first search may take a moment)...');
 
-      // Try GPU first (DirectML on Windows, CUDA on Linux), fall back to CPU
+      // Try GPU first (DirectML on Windows, CUDA on Linux), fall back to CPU.
+      // CRITICAL: probe for CUDA before requesting it — a failed CUDA attempt
+      // poisons ONNX Runtime's native state so even CPU fallback fails.
       const isWindows = process.platform === 'win32';
-      const gpuDevice = isWindows ? 'dml' : 'cuda';
-      const devicesToTry: Array<'dml' | 'cuda' | 'cpu'> = [gpuDevice, 'cpu'];
+      const gpuDevice = isWindows ? 'dml' : (isCudaAvailable() ? 'cuda' : 'cpu');
+      const devicesToTry: Array<'dml' | 'cuda' | 'cpu'> =
+        (gpuDevice === 'dml' || gpuDevice === 'cuda')
+          ? [gpuDevice, 'cpu']
+          : ['cpu'];
       
       for (const device of devicesToTry) {
         try {

--- a/gitnexus/src/mcp/core/embedder.ts
+++ b/gitnexus/src/mcp/core/embedder.ts
@@ -90,8 +90,6 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
       console.error('GitNexus: Loading embedding model (first search may take a moment)...');
 
       // Try GPU first (DirectML on Windows, CUDA on Linux), fall back to CPU.
-      // CRITICAL: probe for CUDA before requesting it — a failed CUDA attempt
-      // poisons ONNX Runtime's native state so even CPU fallback fails.
       const isWindows = process.platform === 'win32';
       const gpuDevice = isWindows ? 'dml' : (isCudaAvailable() ? 'cuda' : 'cpu');
       const devicesToTry: Array<'dml' | 'cuda' | 'cpu'> =


### PR DESCRIPTION
## Summary

Add CUDA availability probe to the MCP embedder so semantic search works on systems without CUDA.

## Motivation / context

The MCP embedder blindly attempted CUDA initialization on Linux. When CUDA libraries were absent, the failed attempt poisoned ONNX Runtime's native state, causing the CPU fallback to fail with the same CUDA error. This silently disabled all semantic vector search — the `catch` in `semanticSearch()` swallowed the error and returned `[]`, so queries fell back to BM25-only with no visible indication.

The core embedder (`src/core/embeddings/embedder.ts`) already had `isCudaAvailable()` / `hasOrtCudaProvider()` guards that probe for CUDA libraries before requesting them. The MCP embedder was missing these guards.

## Areas touched

- [X] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- Port `hasOrtCudaProvider()` and `isCudaAvailable()` from the core embedder to the MCP embedder
- Skip CUDA attempt entirely when system lacks required libraries
- Affects both MCP server and CLI `query` command (both use the same MCP embedder)

**Explicitly out of scope / not done here**

- Refactoring to share the CUDA probe between core and MCP embedders

## Implementation notes

- `hasOrtCudaProvider()` resolves `onnxruntime-node` from transformers.js's module scope and checks for `libonnxruntime_providers_cuda.so`
- `isCudaAvailable()` additionally probes `ldconfig -p` and `CUDA_PATH`/`LD_LIBRARY_PATH` for `libcublasLt.so.12`
- Device list construction now skips CUDA when probe returns false, going straight to CPU

## Testing & verification

- [X] `cd gitnexus && npx tsc --noEmit`
- [X] `cd gitnexus && npm test` — 128 files, 4457 tests passed
- [X] Manual: `npx gitnexus query "retry with exponential backoff" -r GitNexus` now prints "Embedding model loaded (cpu)" and returns semantic results (previously returned BM25-only)

## Risk & rollout

- No behavioral change on systems with CUDA — the probe returns true and CUDA is attempted as before
- On systems without CUDA, semantic search now works instead of silently failing
- No migration or config changes needed

## Checklist

- [X] PR body meets repo minimum length
- [ ] If `AGENTS.md` / overlays changed: N/A
- [X] No secrets, tokens, or machine-specific paths committed
