### PR TITLE
feat: enforce unified security mode across Web, CLI, and Wiki with test hardening

### DIFF
--- a/gitnexus-web/api/proxy.ts
+++ b/gitnexus-web/api/proxy.ts
@@ -1,0 +1,166 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+/**
+ * CORS Proxy for isomorphic-git
+ * 
+ * isomorphic-git calls: /api/proxy?url=https://github.com/...
+ */
+const ALLOWED_TARGET_HOSTS = [
+  'github.com',
+  'api.github.com',
+  'raw.githubusercontent.com',
+  'codeload.github.com',
+];
+
+const isLocalOnlyMode = process.env.GITNEXUS_LOCAL_ONLY === undefined
+  || process.env.GITNEXUS_LOCAL_ONLY === ''
+  || (process.env.GITNEXUS_LOCAL_ONLY !== '0' && process.env.GITNEXUS_LOCAL_ONLY !== 'false');
+
+const ALLOWED_CORS_ORIGINS = new Set(
+  isLocalOnlyMode
+    ? [
+      'http://localhost:5173',
+      'http://127.0.0.1:5173',
+      'http://localhost:4173',
+      'http://127.0.0.1:4173',
+    ]
+    : [
+      'https://gitnexus.vercel.app',
+      'http://localhost:5173',
+      'http://127.0.0.1:5173',
+      'http://localhost:4173',
+      'http://127.0.0.1:4173',
+    ]
+);
+
+const isAllowedTargetHost = (hostname: string): boolean => (
+  ALLOWED_TARGET_HOSTS.some((host) => hostname === host || hostname.endsWith(`.${host}`))
+);
+
+const isAllowedCorsOrigin = (origin: string | undefined): boolean => (
+  !!origin && ALLOWED_CORS_ORIGINS.has(origin)
+);
+
+const setCorsHeaders = (req: VercelRequest, res: VercelResponse): boolean => {
+  const origin = typeof req.headers.origin === 'string' ? req.headers.origin : undefined;
+  if (!isAllowedCorsOrigin(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, Git-Protocol, Accept');
+  res.setHeader('Access-Control-Expose-Headers', 'Content-Type, Content-Length, ETag, Last-Modified');
+  return true;
+};
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    if (!setCorsHeaders(req, res)) {
+      res.status(403).json({ error: 'Origin not allowed' });
+      return;
+    }
+    res.status(200).end();
+    return;
+  }
+
+  if (!setCorsHeaders(req, res)) {
+    res.status(403).json({ error: 'Origin not allowed' });
+    return;
+  }
+
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  // Get URL from query parameter
+  const { url } = req.query;
+  
+  if (!url || typeof url !== 'string') {
+    res.status(400).json({ error: 'Missing url query parameter' });
+    return;
+  }
+
+  // Only allow trusted GitHub hosts for security
+  let parsedUrl: URL;
+  
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    res.status(400).json({ error: 'Invalid URL' });
+    return;
+  }
+  
+  if (parsedUrl.protocol !== 'https:') {
+    res.status(403).json({ error: 'Only HTTPS URLs are allowed' });
+    return;
+  }
+
+  if (!isAllowedTargetHost(parsedUrl.hostname)) {
+    res.status(403).json({ error: 'Only GitHub URLs are allowed' });
+    return;
+  }
+
+  try {
+    const headers: Record<string, string> = {
+      'User-Agent': 'git/isomorphic-git',
+    };
+    
+    // Forward relevant headers
+    // Never forward browser auth headers to non-core GitHub hosts.
+    if (
+      req.headers.authorization
+      && (parsedUrl.hostname === 'github.com' || parsedUrl.hostname === 'api.github.com' || parsedUrl.hostname === 'codeload.github.com')
+    ) {
+      headers['Authorization'] = req.headers.authorization as string;
+    }
+    if (req.headers['content-type']) {
+      headers['Content-Type'] = req.headers['content-type'] as string;
+    }
+    if (req.headers['git-protocol']) {
+      headers['Git-Protocol'] = req.headers['git-protocol'] as string;
+    }
+    if (req.headers.accept) {
+      headers['Accept'] = req.headers.accept as string;
+    }
+
+    // Get request body for POST requests
+    let body: Buffer | undefined;
+    if (req.method === 'POST') {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+      }
+      body = Buffer.concat(chunks);
+    }
+
+    const response = await fetch(url, {
+      method: req.method || 'GET',
+      headers,
+      body: body ? new Uint8Array(body) : undefined,
+    });
+
+    // Forward response headers (except ones that cause issues)
+    const skipHeaders = [
+      'content-encoding', 
+      'transfer-encoding', 
+      'connection',
+      'www-authenticate', // IMPORTANT: Strip this to prevent browser's native auth popup!
+    ];
+    
+    response.headers.forEach((value, key) => {
+      if (!skipHeaders.includes(key.toLowerCase())) {
+        res.setHeader(key, value);
+      }
+    });
+
+    res.status(response.status);
+    const buffer = await response.arrayBuffer();
+    res.send(Buffer.from(buffer));
+    
+  } catch (error) {
+    console.error('Proxy error:', error);
+    res.status(500).json({ error: 'Proxy request failed' });
+  }
+}
+

--- a/gitnexus-web/src/components/SettingsPanel.tsx
+++ b/gitnexus-web/src/components/SettingsPanel.tsx
@@ -1,18 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import {
-  X,
-  Key,
-  Server,
-  Brain,
-  Check,
-  AlertCircle,
-  Eye,
-  EyeOff,
-  RefreshCw,
-  ChevronDown,
-  Loader2,
-  Search,
-} from '@/lib/lucide-icons';
+import { X, Key, Server, Brain, Check, AlertCircle, Eye, EyeOff, RefreshCw, ChevronDown, Loader2, Search } from '@/lib/lucide-icons';
 import {
   loadSettings,
   saveSettings,
@@ -22,6 +9,7 @@ import {
 } from '../core/llm/settings-service';
 import type { LLMSettings, LLMProvider } from '../core/llm/types';
 import { DEFAULT_OLLAMA_BASE_URL } from '../config/ui-constants';
+import { isLocalOnlyMode } from '../config/security-mode';
 import { ProviderConfigCard } from './settings/ProviderConfigCard';
 
 interface SettingsPanelProps {
@@ -44,13 +32,7 @@ interface OpenRouterModelComboboxProps {
   onLoadModels: () => void;
 }
 
-const OpenRouterModelCombobox = ({
-  value,
-  onChange,
-  models,
-  isLoading,
-  onLoadModels,
-}: OpenRouterModelComboboxProps) => {
+const OpenRouterModelCombobox = ({ value, onChange, models, isLoading, onLoadModels }: OpenRouterModelComboboxProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
@@ -60,15 +42,16 @@ const OpenRouterModelCombobox = ({
   const filteredModels = useMemo(() => {
     if (!searchTerm.trim()) return models;
     const lower = searchTerm.toLowerCase();
-    return models.filter(
-      (m) => m.id.toLowerCase().includes(lower) || m.name.toLowerCase().includes(lower),
+    return models.filter(m =>
+      m.id.toLowerCase().includes(lower) ||
+      m.name.toLowerCase().includes(lower)
     );
   }, [models, searchTerm]);
 
   // Find display name for current value
   const displayValue = useMemo(() => {
     if (!value) return '';
-    const found = models.find((m) => m.id === value);
+    const found = models.find(m => m.id === value);
     return found ? found.name : value;
   }, [value, models]);
 
@@ -111,7 +94,7 @@ const OpenRouterModelCombobox = ({
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && searchTerm) {
       // If exact match in filtered, select it; otherwise use raw input
-      const exact = filteredModels.find((m) => m.id.toLowerCase() === searchTerm.toLowerCase());
+      const exact = filteredModels.find(m => m.id.toLowerCase() === searchTerm.toLowerCase());
       if (exact) {
         handleSelect(exact.id);
       } else if (filteredModels.length === 1) {
@@ -133,7 +116,8 @@ const OpenRouterModelCombobox = ({
       {/* Main input/button */}
       <div
         onClick={handleOpen}
-        className={`flex w-full cursor-pointer items-center gap-2 rounded-xl border bg-elevated px-4 py-3 transition-all ${isOpen ? 'border-accent ring-2 ring-accent/20' : 'border-border-subtle hover:border-accent/50'}`}
+        className={`w-full px-4 py-3 bg-elevated border rounded-xl cursor-pointer transition-all flex items-center gap-2
+          ${isOpen ? 'border-accent ring-2 ring-accent/20' : 'border-border-subtle hover:border-accent/50'}`}
       >
         {isOpen ? (
           <input
@@ -143,61 +127,58 @@ const OpenRouterModelCombobox = ({
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             placeholder="Search or type model ID..."
-            className="flex-1 bg-transparent font-mono text-sm text-text-primary outline-none placeholder:text-text-muted"
-            onClick={(e) => e.stopPropagation()}
+            className="flex-1 bg-transparent text-text-primary placeholder:text-text-muted outline-none font-mono text-sm"
+            onClick={e => e.stopPropagation()}
           />
         ) : (
-          <span
-            className={`flex-1 truncate font-mono text-sm ${value ? 'text-text-primary' : 'text-text-muted'}`}
-          >
+          <span className={`flex-1 font-mono text-sm truncate ${value ? 'text-text-primary' : 'text-text-muted'}`}>
             {displayValue || 'Select or type a model...'}
           </span>
         )}
         <div className="flex items-center gap-1">
-          {isLoading && <Loader2 className="h-4 w-4 animate-spin text-text-muted" />}
-          <ChevronDown
-            className={`h-4 w-4 text-text-muted transition-transform ${isOpen ? 'rotate-180' : ''}`}
-          />
+          {isLoading && <Loader2 className="w-4 h-4 animate-spin text-text-muted" />}
+          <ChevronDown className={`w-4 h-4 text-text-muted transition-transform ${isOpen ? 'rotate-180' : ''}`} />
         </div>
       </div>
 
       {/* Dropdown */}
       {isOpen && (
-        <div className="absolute z-50 mt-1 w-full overflow-hidden rounded-xl border border-border-subtle bg-elevated shadow-xl">
+        <div className="absolute z-50 w-full mt-1 bg-elevated border border-border-subtle rounded-xl shadow-xl overflow-hidden">
           {isLoading ? (
-            <div className="flex items-center justify-center gap-2 px-4 py-6 text-center text-sm text-text-muted">
-              <Loader2 className="h-4 w-4 animate-spin" />
+            <div className="px-4 py-6 text-center text-text-muted text-sm flex items-center justify-center gap-2">
+              <Loader2 className="w-4 h-4 animate-spin" />
               Loading models...
             </div>
           ) : filteredModels.length === 0 ? (
             <div className="px-4 py-4 text-center">
               {models.length === 0 ? (
-                <div className="text-sm text-text-muted">
-                  <Search className="mx-auto mb-2 h-5 w-5 opacity-50" />
+                <div className="text-text-muted text-sm">
+                  <Search className="w-5 h-5 mx-auto mb-2 opacity-50" />
                   <p>Type a model ID or press Enter</p>
-                  <p className="mt-1 text-xs">e.g. openai/gpt-4o</p>
+                  <p className="text-xs mt-1">e.g. openai/gpt-4o</p>
                 </div>
               ) : (
-                <div className="text-sm text-text-muted">
+                <div className="text-text-muted text-sm">
                   <p>No models match "{searchTerm}"</p>
-                  <p className="mt-1 text-xs">Press Enter to use as custom ID</p>
+                  <p className="text-xs mt-1">Press Enter to use as custom ID</p>
                 </div>
               )}
             </div>
           ) : (
             <div className="max-h-64 overflow-y-auto">
-              {filteredModels.slice(0, 50).map((model) => (
+              {filteredModels.slice(0, 50).map(model => (
                 <button
                   key={model.id}
                   onClick={() => handleSelect(model.id)}
-                  className={`flex w-full flex-col px-4 py-2.5 text-left transition-colors hover:bg-hover ${model.id === value ? 'bg-accent/10' : ''}`}
+                  className={`w-full px-4 py-2.5 text-left hover:bg-hover transition-colors flex flex-col
+                    ${model.id === value ? 'bg-accent/10' : ''}`}
                 >
-                  <span className="truncate text-sm text-text-primary">{model.name}</span>
-                  <span className="truncate font-mono text-xs text-text-muted">{model.id}</span>
+                  <span className="text-text-primary text-sm truncate">{model.name}</span>
+                  <span className="text-text-muted text-xs font-mono truncate">{model.id}</span>
                 </button>
               ))}
               {filteredModels.length > 50 && (
-                <div className="border-t border-border-subtle px-4 py-2 text-center text-xs text-text-muted">
+                <div className="px-4 py-2 text-xs text-text-muted text-center border-t border-border-subtle">
                   +{filteredModels.length - 50} more • Refine your search
                 </div>
               )}
@@ -212,9 +193,7 @@ const OpenRouterModelCombobox = ({
 /**
  * Check connection to local Ollama instance
  */
-const checkOllamaStatus = async (
-  baseUrl: string,
-): Promise<{ ok: boolean; error: string | null }> => {
+const checkOllamaStatus = async (baseUrl: string): Promise<{ ok: boolean; error: string | null }> => {
   try {
     const response = await fetch(`${baseUrl}/api/tags`, {
       method: 'GET',
@@ -223,10 +202,7 @@ const checkOllamaStatus = async (
 
     if (!response.ok) {
       if (response.status === 0 || response.status === 404) {
-        return {
-          ok: false,
-          error: "Cannot connect to Ollama. Make sure it's running with `ollama serve`",
-        };
+        return { ok: false, error: 'Cannot connect to Ollama. Make sure it\'s running with `ollama serve`' };
       }
       return { ok: false, error: `Ollama API error: ${response.status}` };
     }
@@ -235,19 +211,13 @@ const checkOllamaStatus = async (
   } catch (error) {
     return {
       ok: false,
-      error: "Cannot connect to Ollama. Make sure it's running with `ollama serve`",
+      error: 'Cannot connect to Ollama. Make sure it\'s running with `ollama serve`'
     };
   }
 };
 
-export const SettingsPanel = ({
-  isOpen,
-  onClose,
-  onSettingsSaved,
-  backendUrl,
-  isBackendConnected,
-  onBackendUrlChange,
-}: SettingsPanelProps) => {
+export const SettingsPanel = ({ isOpen, onClose, onSettingsSaved, backendUrl, isBackendConnected, onBackendUrlChange }: SettingsPanelProps) => {
+  const localOnlyMode = isLocalOnlyMode();
   const [settings, setSettings] = useState<LLMSettings>(loadSettings);
   const [showApiKey, setShowApiKey] = useState<Record<string, boolean>>({});
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'error'>('idle');
@@ -306,7 +276,7 @@ export const SettingsPanel = ({
   }, [settings.ollama?.baseUrl, settings.activeProvider, checkOllamaConnection]);
 
   const handleProviderChange = (provider: LLMProvider) => {
-    setSettings((prev) => ({ ...prev, activeProvider: provider }));
+    setSettings(prev => ({ ...prev, activeProvider: provider }));
   };
 
   const handleSave = () => {
@@ -324,34 +294,31 @@ export const SettingsPanel = ({
   };
 
   const toggleApiKeyVisibility = (key: string) => {
-    setShowApiKey((prev) => ({ ...prev, [key]: !prev[key] }));
+    setShowApiKey(prev => ({ ...prev, [key]: !prev[key] }));
   };
 
   if (!isOpen) return null;
 
-  const providers: LLMProvider[] = [
-    'openai',
-    'gemini',
-    'anthropic',
-    'azure-openai',
-    'ollama',
-    'openrouter',
-    'minimax',
-    'glm',
-  ];
+  const providers: LLMProvider[] = localOnlyMode
+    ? ['ollama', 'openai', 'glm']
+    : ['openai', 'gemini', 'anthropic', 'azure-openai', 'ollama', 'openrouter', 'minimax', 'glm'];
+
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+      />
 
       {/* Panel */}
-      <div className="relative mx-4 flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-2xl border border-border-subtle bg-surface shadow-2xl">
+      <div className="relative bg-surface border border-border-subtle rounded-2xl shadow-2xl max-w-lg w-full mx-4 overflow-hidden max-h-[90vh] flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-border-subtle bg-elevated/50 px-6 py-4">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border-subtle bg-elevated/50">
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/20">
-              <Brain className="h-5 w-5 text-accent" />
+            <div className="w-10 h-10 flex items-center justify-center bg-accent/20 rounded-xl">
+              <Brain className="w-5 h-5 text-accent" />
             </div>
             <div>
               <h2 className="text-lg font-semibold text-text-primary">AI Settings</h2>
@@ -360,25 +327,25 @@ export const SettingsPanel = ({
           </div>
           <button
             onClick={onClose}
-            className="rounded-lg p-2 text-text-muted transition-colors hover:bg-hover hover:text-text-primary"
+            className="p-2 text-text-muted hover:text-text-primary hover:bg-hover rounded-lg transition-colors"
           >
-            <X className="h-5 w-5" />
+            <X className="w-5 h-5" />
           </button>
         </div>
 
         {/* Content */}
-        <div className="flex-1 space-y-6 overflow-y-auto p-6">
+        <div className="flex-1 overflow-y-auto p-6 space-y-6">
           {/* Local Server */}
           {backendUrl !== undefined && onBackendUrlChange && (
             <div className="space-y-3">
-              <label className="block text-sm font-medium text-text-secondary">Local Server</label>
+              <label className="block text-sm font-medium text-text-secondary">
+                Local Server
+              </label>
               <div className="space-y-2">
-                <div className="mb-2 flex items-center gap-2">
-                  <Server className="h-4 w-4 text-text-muted" />
+                <div className="flex items-center gap-2 mb-2">
+                  <Server className="w-4 h-4 text-text-muted" />
                   <span className="text-sm text-text-secondary">Backend URL</span>
-                  <span
-                    className={`h-2 w-2 rounded-full ${isBackendConnected ? 'bg-green-400' : 'bg-red-400'}`}
-                  />
+                  <span className={`w-2 h-2 rounded-full ${isBackendConnected ? 'bg-green-400' : 'bg-red-400'}`} />
                   <span className="text-xs text-text-muted">
                     {isBackendConnected ? 'Connected' : 'Not connected'}
                   </span>
@@ -388,11 +355,10 @@ export const SettingsPanel = ({
                   value={backendUrl}
                   onChange={(e) => onBackendUrlChange(e.target.value)}
                   placeholder="http://localhost:4747"
-                  className="w-full rounded-xl border border-border-subtle bg-elevated px-4 py-3 font-mono text-sm text-text-primary transition-all outline-none placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20"
+                  className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all font-mono text-sm"
                 />
                 <p className="text-xs text-text-muted">
-                  Run <code className="rounded bg-elevated px-1 py-0.5">gitnexus serve</code> to
-                  start the local server
+                  Run <code className="px-1 py-0.5 bg-elevated rounded">gitnexus serve</code> to start the local server
                 </p>
               </div>
             </div>
@@ -400,36 +366,27 @@ export const SettingsPanel = ({
 
           {/* Provider Selection */}
           <div className="space-y-3">
-            <label className="block text-sm font-medium text-text-secondary">Provider</label>
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-              {providers.map((provider) => (
+            <label className="block text-sm font-medium text-text-secondary">
+              Provider
+            </label>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              {providers.map(provider => (
                 <button
                   key={provider}
                   onClick={() => handleProviderChange(provider)}
-                  className={`flex items-center gap-3 rounded-xl border-2 p-4 transition-all ${
-                    settings.activeProvider === provider
+                  className={`
+                    flex items-center gap-3 p-4 rounded-xl border-2 transition-all
+                    ${settings.activeProvider === provider
                       ? 'border-accent bg-accent/10 text-text-primary'
-                      : 'border-border-subtle bg-elevated text-text-secondary hover:border-accent/50'
-                  } `}
+                      : 'border-border-subtle bg-elevated hover:border-accent/50 text-text-secondary'
+                    }
+                  `}
                 >
-                  <div
-                    className={`flex h-8 w-8 items-center justify-center rounded-lg text-lg ${settings.activeProvider === provider ? 'bg-accent/20' : 'bg-surface'} `}
-                  >
-                    {provider === 'openai'
-                      ? '🤖'
-                      : provider === 'gemini'
-                        ? '💎'
-                        : provider === 'anthropic'
-                          ? '🧠'
-                          : provider === 'ollama'
-                            ? '🦙'
-                            : provider === 'openrouter'
-                              ? '🌐'
-                              : provider === 'minimax'
-                                ? '⚡'
-                                : provider === 'glm'
-                                  ? '🔮'
-                                  : '☁️'}
+                  <div className={`
+                    w-8 h-8 rounded-lg flex items-center justify-center text-lg
+                    ${settings.activeProvider === provider ? 'bg-accent/20' : 'bg-surface'}
+                  `}>
+                    {provider === 'openai' ? '🤖' : provider === 'gemini' ? '💎' : provider === 'anthropic' ? '🧠' : provider === 'ollama' ? '🦙' : provider === 'openrouter' ? '🌐' : provider === 'minimax' ? '⚡' : provider === 'glm' ? '🔮' : '☁️'}
                   </div>
                   <span className="font-medium">{getProviderDisplayName(provider)}</span>
                 </button>
@@ -437,7 +394,7 @@ export const SettingsPanel = ({
             </div>
           </div>
 
-          <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-200">
+          <div className="p-3 bg-amber-500/10 border border-amber-500/30 rounded-xl text-xs text-amber-200">
             API keys are stored in session storage and will be cleared when you close this tab.
           </div>
 
@@ -452,43 +409,38 @@ export const SettingsPanel = ({
                 helperLink: 'https://platform.openai.com/api-keys',
                 helperLinkLabel: 'OpenAI Platform',
                 isVisible: !!showApiKey['openai'],
-                onChange: (value) =>
-                  setSettings((prev) => ({
-                    ...prev,
-                    openai: { ...prev.openai!, apiKey: value },
-                  })),
+                onChange: (value) => setSettings(prev => ({
+                  ...prev,
+                  openai: { ...prev.openai!, apiKey: value }
+                })),
                 onToggleVisibility: () => toggleApiKeyVisibility('openai'),
               }}
               model={{
                 value: settings.openai?.model ?? 'gpt-5.2-chat',
                 placeholder: 'e.g., gpt-4o, gpt-4-turbo, gpt-3.5-turbo',
-                onChange: (value) =>
-                  setSettings((prev) => ({
-                    ...prev,
-                    openai: { ...prev.openai!, model: value },
-                  })),
+                onChange: (value) => setSettings(prev => ({
+                  ...prev,
+                  openai: { ...prev.openai!, model: value }
+                })),
               }}
             >
               <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm font-medium text-text-secondary">
-                  <Server className="h-4 w-4" />
-                  Base URL <span className="font-normal text-text-muted">(optional)</span>
+                  <Server className="w-4 h-4" />
+                  Base URL <span className="text-text-muted font-normal">(optional)</span>
                 </label>
                 <input
                   type="url"
                   value={settings.openai?.baseUrl ?? ''}
-                  onChange={(e) =>
-                    setSettings((prev) => ({
-                      ...prev,
-                      openai: { ...prev.openai!, baseUrl: e.target.value },
-                    }))
-                  }
+                  onChange={e => setSettings(prev => ({
+                    ...prev,
+                    openai: { ...prev.openai!, baseUrl: e.target.value }
+                  }))}
                   placeholder="https://api.openai.com/v1 (default)"
-                  className="w-full rounded-xl border border-border-subtle bg-elevated px-4 py-3 text-text-primary transition-all outline-none placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20"
+                  className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all"
                 />
                 <p className="text-xs text-text-muted">
-                  Leave empty to use the default OpenAI API. Set a custom URL for proxies or
-                  compatible APIs.
+                  Leave empty to use the default OpenAI API. Set a custom URL for proxies or compatible APIs.
                 </p>
               </div>
             </ProviderConfigCard>
@@ -505,21 +457,19 @@ export const SettingsPanel = ({
                 helperLink: 'https://aistudio.google.com/app/apikey',
                 helperLinkLabel: 'Google AI Studio',
                 isVisible: !!showApiKey['gemini'],
-                onChange: (value) =>
-                  setSettings((prev) => ({
-                    ...prev,
-                    gemini: { ...prev.gemini!, apiKey: value },
-                  })),
+                onChange: (value) => setSettings(prev => ({
+                  ...prev,
+                  gemini: { ...prev.gemini!, apiKey: value }
+                })),
                 onToggleVisibility: () => toggleApiKeyVisibility('gemini'),
               }}
               model={{
                 value: settings.gemini?.model ?? 'gemini-2.0-flash',
                 placeholder: 'e.g., gemini-2.0-flash, gemini-1.5-pro',
-                onChange: (value) =>
-                  setSettings((prev) => ({
-                    ...prev,
-                    gemini: { ...prev.gemini!, model: value },
-                  })),
+                onChange: (value) => setSettings(prev => ({
+                  ...prev,
+                  gemini: { ...prev.gemini!, model: value }
+                })),
               }}
             />
           )}
@@ -535,76 +485,66 @@ export const SettingsPanel = ({
                 helperLink: 'https://console.anthropic.com/settings/keys',
                 helperLinkLabel: 'Anthropic Console',
                 isVisible: !!showApiKey['anthropic'],
-                onChange: (value) =>
-                  setSettings((prev) => ({
-                    ...prev,
-                    anthropic: { ...prev.anthropic!, apiKey: value },
-                  })),
+                onChange: (value) => setSettings(prev => ({
+                  ...prev,
+                  anthropic: { ...prev.anthropic!, apiKey: value }
+                })),
                 onToggleVisibility: () => toggleApiKeyVisibility('anthropic'),
               }}
               model={{
                 value: settings.anthropic?.model ?? 'claude-sonnet-4-20250514',
                 placeholder: 'e.g., claude-sonnet-4-20250514, claude-3-opus',
-                onChange: (value) =>
-                  setSettings((prev) => ({
-                    ...prev,
-                    anthropic: { ...prev.anthropic!, model: value },
-                  })),
+                onChange: (value) => setSettings(prev => ({
+                  ...prev,
+                  anthropic: { ...prev.anthropic!, model: value }
+                })),
               }}
             />
           )}
 
           {/* Azure OpenAI Settings */}
           {settings.activeProvider === 'azure-openai' && (
-            <div className="animate-fade-in space-y-4">
+            <div className="space-y-4 animate-fade-in">
               <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm font-medium text-text-secondary">
-                  <Key className="h-4 w-4" />
+                  <Key className="w-4 h-4" />
                   API Key
                 </label>
                 <div className="relative">
                   <input
                     type={showApiKey['azure'] ? 'text' : 'password'}
                     value={settings.azureOpenAI?.apiKey ?? ''}
-                    onChange={(e) =>
-                      setSettings((prev) => ({
-                        ...prev,
-                        azureOpenAI: { ...prev.azureOpenAI!, apiKey: e.target.value },
-                      }))
-                    }
+                    onChange={e => setSettings(prev => ({
+                      ...prev,
+                      azureOpenAI: { ...prev.azureOpenAI!, apiKey: e.target.value }
+                    }))}
                     placeholder="Enter your Azure OpenAI API key"
-                    className="w-full rounded-xl border border-border-subtle bg-elevated px-4 py-3 pr-12 text-text-primary transition-all outline-none placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20"
+                    className="w-full px-4 py-3 pr-12 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all"
                   />
                   <button
                     type="button"
                     onClick={() => toggleApiKeyVisibility('azure')}
-                    className="absolute top-1/2 right-3 -translate-y-1/2 p-1 text-text-muted transition-colors hover:text-text-primary"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-text-muted hover:text-text-primary transition-colors"
                   >
-                    {showApiKey['azure'] ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
+                    {showApiKey['azure'] ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                   </button>
                 </div>
               </div>
 
               <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm font-medium text-text-secondary">
-                  <Server className="h-4 w-4" />
+                  <Server className="w-4 h-4" />
                   Endpoint
                 </label>
                 <input
                   type="url"
                   value={settings.azureOpenAI?.endpoint ?? ''}
-                  onChange={(e) =>
-                    setSettings((prev) => ({
-                      ...prev,
-                      azureOpenAI: { ...prev.azureOpenAI!, endpoint: e.target.value },
-                    }))
-                  }
+                  onChange={e => setSettings(prev => ({
+                    ...prev,
+                    azureOpenAI: { ...prev.azureOpenAI!, endpoint: e.target.value }
+                  }))}
                   placeholder="https://your-resource.openai.azure.com"
-                  className="w-full rounded-xl border border-border-subtle bg-elevated px-4 py-3 text-text-primary transition-all outline-none placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20"
+                  className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all"
                 />
               </div>
 
@@ -613,14 +553,12 @@ export const SettingsPanel = ({
                 <input
                   type="text"
                   value={settings.azureOpenAI?.deploymentName ?? ''}
-                  onChange={(e) =>
-                    setSettings((prev) => ({
-                      ...prev,
-                      azureOpenAI: { ...prev.azureOpenAI!, deploymentName: e.target.value },
-                    }))
-                  }
+                  onChange={e => setSettings(prev => ({
+                    ...prev,
+                    azureOpenAI: { ...prev.azureOpenAI!, deploymentName: e.target.value }
+                  }))}
                   placeholder="e.g., gpt-4o-deployment"
-                  className="w-full rounded-xl border border-border-subtle bg-elevated px-4 py-3 text-text-primary transition-all outline-none placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20"
+                  className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all"
                 />
               </div>
 
@@ -630,14 +568,12 @@ export const SettingsPanel = ({
                   <input
                     type="text"
                     value={settings.azureOpenAI?.model ?? 'gpt-4o'}
-                    onChange={(e) =>
-                      setSettings((prev) => ({
-                        ...prev,
-                        azureOpenAI: { ...prev.azureOpenAI!, model: e.target.value },
-                      }))
-                    }
+                    onChange={e => setSettings(prev => ({
+                      ...prev,
+                      azureOpenAI: { ...prev.azureOpenAI!, model: e.target.value }
+                    }))}
                     placeholder="gpt-4o"
-                    className="w-full rounded-xl border border-border-subtle bg-elevated px-4 py-3 text-text-primary transition-all outline-none placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20"
+                    className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all"
                   />
                 </div>
 
@@ -646,14 +582,12 @@ export const SettingsPanel = ({
                   <input
                     type="text"
                     value={settings.azureOpenAI?.apiVersion ?? '2024-08-01-preview'}
-                    onChange={(e) =>
-                      setSettings((prev) => ({
-                        ...prev,
-                        azureOpenAI: { ...prev.azureOpenAI!, apiVersion: e.target.value },
-                      }))
-                    }
+                    onChange={e => setSettings(prev => ({
+                      ...prev,
+                      azureOpenAI: { ...prev.azureOpenAI!, apiVersion: e.target.value }
+                    }))}
                     placeholder="2024-08-01-preview"
-                    className="w-full rounded-xl border border-border-subtle bg-elevated px-4 py-3 text-text-primary transition-all outline-none placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20"
+                    className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all"
                   />
                 </div>
               </div>
@@ -674,10 +608,10 @@ export const SettingsPanel = ({
 
           {/* Ollama Settings */}
           {settings.activeProvider === 'ollama' && (
-            <div className="animate-fade-in space-y-4">
+            <div className="space-y-4 animate-fade-in">
               {/* How to run Ollama */}
-              <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3">
-                <p className="text-xs leading-relaxed text-amber-300">
+              <div className="p-3 bg-amber-500/10 border border-amber-500/30 rounded-xl">
+                <p className="text-xs text-amber-300 leading-relaxed">
                   <span className="font-medium">📋 Quick Start:</span> Install Ollama from{' '}
                   <a
                     href="https://ollama.ai"
@@ -686,46 +620,41 @@ export const SettingsPanel = ({
                     className="text-accent hover:underline"
                   >
                     ollama.ai
-                  </a>
-                  , then run:
+                  </a>, then run:
                 </p>
-                <code className="mt-2 block rounded-lg bg-black/30 px-3 py-2 font-mono text-sm text-amber-200">
+                <code className="block mt-2 px-3 py-2 bg-black/30 rounded-lg text-amber-200 font-mono text-sm">
                   ollama serve
                 </code>
               </div>
 
               <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm font-medium text-text-secondary">
-                  <Server className="h-4 w-4" />
+                  <Server className="w-4 h-4" />
                   Base URL
                 </label>
                 <div className="flex gap-2">
                   <input
                     type="url"
                     value={settings.ollama?.baseUrl ?? DEFAULT_OLLAMA_BASE_URL}
-                    onChange={(e) =>
-                      setSettings((prev) => ({
-                        ...prev,
-                        ollama: { ...prev.ollama!, baseUrl: e.target.value },
-                      }))
-                    }
+                    onChange={e => setSettings(prev => ({
+                      ...prev,
+                      ollama: { ...prev.ollama!, baseUrl: e.target.value }
+                    }))}
                     placeholder={DEFAULT_OLLAMA_BASE_URL}
-                    className="flex-1 rounded-xl border border-border-subtle bg-elevated px-4 py-3 font-mono text-sm text-text-primary transition-all outline-none placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20"
+                    className="flex-1 px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all font-mono text-sm"
                   />
                   <button
                     type="button"
-                    onClick={() =>
-                      checkOllamaConnection(settings.ollama?.baseUrl ?? DEFAULT_OLLAMA_BASE_URL)
-                    }
+                    onClick={() => checkOllamaConnection(settings.ollama?.baseUrl ?? DEFAULT_OLLAMA_BASE_URL)}
                     disabled={isCheckingOllama}
-                    className="rounded-xl border border-border-subtle bg-elevated px-3 py-3 text-text-secondary transition-colors hover:border-accent/50 hover:text-text-primary disabled:opacity-50"
+                    className="px-3 py-3 bg-elevated border border-border-subtle rounded-xl text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors disabled:opacity-50"
                     title="Check connection"
                   >
-                    <RefreshCw className={`h-4 w-4 ${isCheckingOllama ? 'animate-spin' : ''}`} />
+                    <RefreshCw className={`w-4 h-4 ${isCheckingOllama ? 'animate-spin' : ''}`} />
                   </button>
                 </div>
                 <p className="text-xs text-text-muted">
-                  Default port is <code className="rounded bg-elevated px-1 py-0.5">11434</code>.
+                  Default port is <code className="px-1 py-0.5 bg-elevated rounded">11434</code>.
                 </p>
               </div>
 
@@ -733,9 +662,9 @@ export const SettingsPanel = ({
                 <label className="text-sm font-medium text-text-secondary">Model</label>
 
                 {ollamaError && !isCheckingOllama && (
-                  <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-2">
-                    <p className="flex items-center gap-1 text-xs text-red-400">
-                      <AlertCircle className="h-3 w-3" />
+                  <div className="p-2 bg-red-500/10 border border-red-500/30 rounded-lg">
+                    <p className="text-xs text-red-400 flex items-center gap-1">
+                      <AlertCircle className="w-3 h-3" />
                       {ollamaError}
                     </p>
                   </div>
@@ -744,18 +673,15 @@ export const SettingsPanel = ({
                 <input
                   type="text"
                   value={settings.ollama?.model ?? ''}
-                  onChange={(e) =>
-                    setSettings((prev) => ({
-                      ...prev,
-                      ollama: { ...prev.ollama!, model: e.target.value },
-                    }))
-                  }
+                  onChange={e => setSettings(prev => ({
+                    ...prev,
+                    ollama: { ...prev.ollama!, model: e.target.value }
+                  }))}
                   placeholder="e.g., llama3.2, mistral, codellama"
-                  className="w-full rounded-xl border border-border-subtle bg-elevated px-4 py-3 font-mono text-sm text-text-primary transition-all outline-none placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20"
+                  className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all font-mono text-sm"
                 />
                 <p className="text-xs text-text-muted">
-                  Pull a model with{' '}
-                  <code className="rounded bg-elevated px-1 py-0.5">ollama pull llama3.2</code>
+                  Pull a model with <code className="px-1 py-0.5 bg-elevated rounded">ollama pull llama3.2</code>
                 </p>
               </div>
             </div>
@@ -772,11 +698,10 @@ export const SettingsPanel = ({
                 helperLink: 'https://openrouter.ai/keys',
                 helperLinkLabel: 'OpenRouter Keys',
                 isVisible: !!showApiKey['openrouter'],
-                onChange: (value) =>
-                  setSettings((prev) => ({
-                    ...prev,
-                    openrouter: { ...prev.openrouter!, apiKey: value },
-                  })),
+                onChange: (value) => setSettings(prev => ({
+                  ...prev,
+                  openrouter: { ...prev.openrouter!, apiKey: value }
+                })),
                 onToggleVisibility: () => toggleApiKeyVisibility('openrouter'),
               }}
             >
@@ -784,12 +709,10 @@ export const SettingsPanel = ({
                 <label className="text-sm font-medium text-text-secondary">Model</label>
                 <OpenRouterModelCombobox
                   value={settings.openrouter?.model ?? ''}
-                  onChange={(model) =>
-                    setSettings((prev) => ({
-                      ...prev,
-                      openrouter: { ...prev.openrouter!, model },
-                    }))
-                  }
+                  onChange={(model) => setSettings(prev => ({
+                    ...prev,
+                    openrouter: { ...prev.openrouter!, model }
+                  }))}
                   models={openRouterModels}
                   isLoading={isLoadingModels}
                   onLoadModels={loadOpenRouterModels}
@@ -820,21 +743,19 @@ export const SettingsPanel = ({
                 helperLink: 'https://platform.minimax.io',
                 helperLinkLabel: 'MiniMax Platform',
                 isVisible: !!showApiKey['minimax'],
-                onChange: (value) =>
-                  setSettings((prev) => ({
-                    ...prev,
-                    minimax: { ...prev.minimax!, apiKey: value },
-                  })),
+                onChange: (value) => setSettings(prev => ({
+                  ...prev,
+                  minimax: { ...prev.minimax!, apiKey: value }
+                })),
                 onToggleVisibility: () => toggleApiKeyVisibility('minimax'),
               }}
               model={{
                 value: settings.minimax?.model ?? 'MiniMax-M2.5',
                 placeholder: 'e.g., MiniMax-M2.5, MiniMax-M2.5-highspeed',
-                onChange: (value) =>
-                  setSettings((prev) => ({
-                    ...prev,
-                    minimax: { ...prev.minimax!, model: value },
-                  })),
+                onChange: (value) => setSettings(prev => ({
+                  ...prev,
+                  minimax: { ...prev.minimax!, model: value }
+                })),
                 helperText: 'Available: MiniMax-M2.5 (default), MiniMax-M2.5-highspeed (faster)',
               }}
             />
@@ -842,35 +763,29 @@ export const SettingsPanel = ({
 
           {/* GLM Settings */}
           {settings.activeProvider === 'glm' && (
-            <div className="animate-fade-in space-y-4">
+            <div className="space-y-4 animate-fade-in">
               <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm font-medium text-text-secondary">
-                  <Key className="h-4 w-4" />
+                  <Key className="w-4 h-4" />
                   API Key
                 </label>
                 <div className="relative">
                   <input
                     type={showApiKey['glm'] ? 'text' : 'password'}
                     value={settings.glm?.apiKey ?? ''}
-                    onChange={(e) =>
-                      setSettings((prev) => ({
-                        ...prev,
-                        glm: { ...prev.glm!, apiKey: e.target.value },
-                      }))
-                    }
+                    onChange={e => setSettings(prev => ({
+                      ...prev,
+                      glm: { ...prev.glm!, apiKey: e.target.value }
+                    }))}
                     placeholder="Enter your Z.AI API key"
-                    className="w-full rounded-xl border border-border-subtle bg-elevated px-4 py-3 pr-12 text-text-primary transition-all outline-none placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20"
+                    className="w-full px-4 py-3 pr-12 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all"
                   />
                   <button
                     type="button"
                     onClick={() => toggleApiKeyVisibility('glm')}
-                    className="absolute top-1/2 right-3 -translate-y-1/2 p-1 text-text-muted transition-colors hover:text-text-primary"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-text-muted hover:text-text-primary transition-colors"
                   >
-                    {showApiKey['glm'] ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
+                    {showApiKey['glm'] ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                   </button>
                 </div>
                 <p className="text-xs text-text-muted">
@@ -890,18 +805,14 @@ export const SettingsPanel = ({
                 <label className="text-sm font-medium text-text-secondary">Model</label>
                 <select
                   value={settings.glm?.model ?? 'GLM-5'}
-                  onChange={(e) =>
-                    setSettings((prev) => ({
-                      ...prev,
-                      glm: { ...prev.glm!, model: e.target.value },
-                    }))
-                  }
-                  className="w-full rounded-xl border border-border-subtle bg-elevated px-4 py-3 font-mono text-sm text-text-primary transition-all outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+                  onChange={e => setSettings(prev => ({
+                    ...prev,
+                    glm: { ...prev.glm!, model: e.target.value }
+                  }))}
+                  className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all font-mono text-sm"
                 >
-                  {getAvailableModels('glm').map((model) => (
-                    <option key={model} value={model}>
-                      {model}
-                    </option>
+                  {getAvailableModels('glm').map(model => (
+                    <option key={model} value={model}>{model}</option>
                   ))}
                 </select>
               </div>
@@ -911,14 +822,12 @@ export const SettingsPanel = ({
                 <input
                   type="text"
                   value={settings.glm?.baseUrl ?? 'https://api.z.ai/api/coding/paas/v4'}
-                  onChange={(e) =>
-                    setSettings((prev) => ({
-                      ...prev,
-                      glm: { ...prev.glm!, baseUrl: e.target.value },
-                    }))
-                  }
+                  onChange={e => setSettings(prev => ({
+                    ...prev,
+                    glm: { ...prev.glm!, baseUrl: e.target.value }
+                  }))}
                   placeholder="https://api.z.ai/api/coding/paas/v4"
-                  className="w-full rounded-xl border border-border-subtle bg-elevated px-4 py-3 font-mono text-sm text-text-primary transition-all outline-none placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20"
+                  className="w-full px-4 py-3 bg-elevated border border-border-subtle rounded-xl text-text-primary placeholder:text-text-muted focus:border-accent focus:ring-2 focus:ring-accent/20 outline-none transition-all font-mono text-sm"
                 />
                 <p className="text-xs text-text-muted">
                   Coding API (default). Use https://api.z.ai/api/paas/v4 for the general API.
@@ -928,33 +837,33 @@ export const SettingsPanel = ({
           )}
 
           {/* Privacy Note */}
-          <div className="rounded-xl border border-border-subtle bg-elevated/50 p-4">
+          <div className="p-4 bg-elevated/50 border border-border-subtle rounded-xl">
             <div className="flex gap-3">
-              <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-green-500/20 text-green-400">
+              <div className="w-8 h-8 flex items-center justify-center bg-green-500/20 rounded-lg text-green-400 flex-shrink-0">
                 🔒
               </div>
-              <div className="text-xs leading-relaxed text-text-muted">
-                <span className="font-medium text-text-secondary">Privacy:</span> Your API keys are
-                stored only in your browser's session storage and are cleared when the tab closes.
-                They're sent directly to the LLM provider when you chat. Your code never leaves your
-                machine.
+              <div className="text-xs text-text-muted leading-relaxed">
+                <span className="text-text-secondary font-medium">Privacy:</span>{' '}
+                {localOnlyMode
+                  ? 'Local-only mode is ON. Only local provider endpoints should be used. API keys remain in browser session storage and are cleared when the tab closes.'
+                  : 'API keys are stored only in browser session storage and are cleared when the tab closes. If you use remote providers, prompts and selected code context may leave your machine.'}
               </div>
             </div>
           </div>
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between border-t border-border-subtle bg-elevated/30 px-6 py-4">
+        <div className="flex items-center justify-between px-6 py-4 border-t border-border-subtle bg-elevated/30">
           <div className="flex items-center gap-2 text-sm">
             {saveStatus === 'saved' && (
-              <span className="flex animate-fade-in items-center gap-1.5 text-green-400">
-                <Check className="h-4 w-4" />
+              <span className="flex items-center gap-1.5 text-green-400 animate-fade-in">
+                <Check className="w-4 h-4" />
                 Settings saved
               </span>
             )}
             {saveStatus === 'error' && (
-              <span className="flex animate-fade-in items-center gap-1.5 text-red-400">
-                <AlertCircle className="h-4 w-4" />
+              <span className="flex items-center gap-1.5 text-red-400 animate-fade-in">
+                <AlertCircle className="w-4 h-4" />
                 Failed to save
               </span>
             )}
@@ -962,13 +871,13 @@ export const SettingsPanel = ({
           <div className="flex items-center gap-3">
             <button
               onClick={onClose}
-              className="px-4 py-2 text-sm text-text-secondary transition-colors hover:text-text-primary"
+              className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary transition-colors"
             >
               Cancel
             </button>
             <button
               onClick={handleSave}
-              className="rounded-lg bg-accent px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-dim"
+              className="px-5 py-2 bg-accent text-white text-sm font-medium rounded-lg hover:bg-accent-dim transition-colors"
             >
               Save Settings
             </button>
@@ -978,3 +887,4 @@ export const SettingsPanel = ({
     </div>
   );
 };
+

--- a/gitnexus-web/src/config/security-mode.ts
+++ b/gitnexus-web/src/config/security-mode.ts
@@ -1,0 +1,17 @@
+const isLocalOnlyEnabled = (value: string | undefined): boolean => (
+  value === undefined || value === '' || (value !== '0' && value !== 'false')
+);
+
+export const isLocalOnlyMode = (): boolean => (
+  isLocalOnlyEnabled(import.meta.env.VITE_GITNEXUS_LOCAL_ONLY)
+);
+
+export const isLoopbackUrl = (rawUrl: string | undefined): boolean => {
+  if (!rawUrl) return false;
+  try {
+    const parsed = new URL(rawUrl);
+    return parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '::1';
+  } catch {
+    return false;
+  }
+};

--- a/gitnexus-web/src/config/security-mode.ts
+++ b/gitnexus-web/src/config/security-mode.ts
@@ -1,6 +1,9 @@
-const isLocalOnlyEnabled = (value: string | undefined): boolean => (
-  value === undefined || value === '' || (value !== '0' && value !== 'false')
-);
+const FALSEY_LOCAL_ONLY_VALUES = new Set(['', '0', 'false']);
+
+export const isLocalOnlyEnabled = (value: string | undefined): boolean => {
+  if (value === undefined) return false;
+  return !FALSEY_LOCAL_ONLY_VALUES.has(value.trim().toLowerCase());
+};
 
 export const isLocalOnlyMode = (): boolean => (
   isLocalOnlyEnabled(import.meta.env.VITE_GITNEXUS_LOCAL_ONLY)

--- a/gitnexus-web/src/core/llm/agent.ts
+++ b/gitnexus-web/src/core/llm/agent.ts
@@ -27,6 +27,7 @@ import type {
 } from './types';
 import { type CodebaseContext, buildDynamicSystemPrompt } from './context-builder';
 import { DEFAULT_OLLAMA_BASE_URL, DEFAULT_OPENROUTER_BASE_URL } from '../../config/ui-constants';
+import { isLocalOnlyMode, isLoopbackUrl } from '../../config/security-mode';
 
 /**
  * System prompt for the Graph RAG agent
@@ -125,6 +126,34 @@ BAD:  A[User's Data] --> B(Process & Save)
 GOOD: A["User Data"] --> B["Process and Save"]
 `;
 export const createChatModel = (config: ProviderConfig): BaseChatModel => {
+  if (isLocalOnlyMode()) {
+    switch (config.provider) {
+      case 'ollama': {
+        const baseUrl = (config as OllamaConfig).baseUrl ?? DEFAULT_OLLAMA_BASE_URL;
+        if (!isLoopbackUrl(baseUrl)) {
+          throw new Error(`Local-only mode requires Ollama base URL to be local (got: ${baseUrl})`);
+        }
+        break;
+      }
+      case 'openai': {
+        const baseUrl = (config as OpenAIConfig).baseUrl;
+        if (!isLoopbackUrl(baseUrl)) {
+          throw new Error('Local-only mode only allows OpenAI-compatible endpoints on localhost/127.0.0.1/::1');
+        }
+        break;
+      }
+      case 'glm': {
+        const baseUrl = (config as GLMConfig).baseUrl;
+        if (!isLoopbackUrl(baseUrl)) {
+          throw new Error('Local-only mode only allows GLM endpoints on localhost/127.0.0.1/::1');
+        }
+        break;
+      }
+      default:
+        throw new Error(`Local-only mode does not allow provider: ${config.provider}`);
+    }
+  }
+
   switch (config.provider) {
     case 'openai': {
       const openaiConfig = config as OpenAIConfig;

--- a/gitnexus-web/src/core/llm/settings-service.ts
+++ b/gitnexus-web/src/core/llm/settings-service.ts
@@ -20,6 +20,7 @@ import {
   ProviderConfig,
 } from './types';
 import { DEFAULT_OPENROUTER_BASE_URL, DEFAULT_OLLAMA_BASE_URL } from '../../config/ui-constants';
+import { isLocalOnlyMode, isLoopbackUrl } from '../../config/security-mode';
 
 const STORAGE_KEY = 'gitnexus-llm-settings';
 
@@ -319,6 +320,20 @@ const providerBuilders: Record<LLMProvider, ProviderBuilder> = {
 
 export const getActiveProviderConfig = (): ProviderConfig | null => {
   const settings = loadSettings();
+  if (isLocalOnlyMode()) {
+    if (settings.activeProvider === 'ollama') {
+      const baseUrl = settings.ollama?.baseUrl ?? DEFAULT_OLLAMA_BASE_URL;
+      if (!isLoopbackUrl(baseUrl)) return null;
+    } else if (settings.activeProvider === 'openai') {
+      const baseUrl = settings.openai?.baseUrl;
+      if (!isLoopbackUrl(baseUrl)) return null;
+    } else if (settings.activeProvider === 'glm') {
+      const baseUrl = settings.glm?.baseUrl;
+      if (!isLoopbackUrl(baseUrl)) return null;
+    } else {
+      return null;
+    }
+  }
   const builder = providerBuilders[settings.activeProvider];
   return builder ? builder(settings) : null;
 };

--- a/gitnexus-web/src/services/git-clone.ts
+++ b/gitnexus-web/src/services/git-clone.ts
@@ -1,0 +1,221 @@
+import git from 'isomorphic-git';
+import http from 'isomorphic-git/http/web';
+import LightningFS from '@isomorphic-git/lightning-fs';
+import { shouldIgnorePath } from '../config/ignore-service';
+import { isLocalOnlyMode } from '../config/security-mode';
+import { FileEntry } from './zip';
+
+// Initialize virtual filesystem (persists in IndexedDB)
+// Use a unique name each time to avoid stale data issues
+let fs: LightningFS;
+let pfs: any;
+
+const initFS = () => {
+  // Create a fresh filesystem instance
+  const fsName = `gitnexus-git-${Date.now()}`;
+  fs = new LightningFS(fsName);
+  pfs = fs.promises;
+  return fsName;
+};
+
+// Hosted proxy URL - use this for localhost to avoid local proxy issues
+const HOSTED_PROXY_URL = 'https://gitnexus.vercel.app/api/proxy';
+
+/**
+ * Custom HTTP client that uses a query-param based proxy
+ * - In development (localhost): uses the hosted Vercel proxy for reliability
+ * - In production: uses the local /api/proxy endpoint
+ */
+const createProxiedHttp = (): typeof http => {
+  const isDev = typeof window !== 'undefined' && window.location.hostname === 'localhost';
+  const localOnly = isLocalOnlyMode();
+  
+  return {
+    request: async (config) => {
+      // In local-only mode, never route through the hosted proxy.
+      const proxyBase = isDev && !localOnly ? HOSTED_PROXY_URL : '/api/proxy';
+      const proxyUrl = `${proxyBase}?url=${encodeURIComponent(config.url)}`;
+      
+      // Call the original http.request with the proxied URL
+      return http.request({
+        ...config,
+        url: proxyUrl,
+      });
+    },
+  };
+};
+
+/**
+ * Parse GitHub URL to extract owner and repo
+ * Supports: 
+ *   - https://github.com/owner/repo
+ *   - https://github.com/owner/repo.git
+ *   - github.com/owner/repo
+ */
+export const parseGitHubUrl = (url: string): { owner: string; repo: string } | null => {
+  const cleaned = url.trim().replace(/\.git$/, '');
+  const match = cleaned.match(/github\.com\/([^\/]+)\/([^\/]+)/);
+  
+  if (!match) return null;
+  
+  return {
+    owner: match[1],
+    repo: match[2],
+  };
+};
+
+/**
+ * Clone a GitHub repository using isomorphic-git
+ * Returns files in the same format as extractZip for compatibility
+ * 
+ * @param url - GitHub repository URL
+ * @param onProgress - Progress callback
+ * @param token - Optional GitHub PAT for private repos (sent only to trusted GitHub hosts via proxy)
+ */
+export const cloneRepository = async (
+  url: string,
+  onProgress?: (phase: string, progress: number) => void,
+  token?: string
+): Promise<FileEntry[]> => {
+  const parsed = parseGitHubUrl(url);
+  if (!parsed) {
+    throw new Error('Invalid GitHub URL. Use format: https://github.com/owner/repo');
+  }
+
+  // Initialize fresh filesystem to avoid stale IndexedDB data
+  const fsName = initFS();
+  
+  const dir = `/${parsed.repo}`;
+  const repoUrl = `https://github.com/${parsed.owner}/${parsed.repo}.git`;
+
+  try {
+    onProgress?.('cloning', 0);
+
+    const httpClient = createProxiedHttp();
+    
+    // Clone with shallow depth for speed
+    await git.clone({
+      fs,
+      http: httpClient,
+      dir,
+      url: repoUrl,
+      depth: 1,
+      // Auth callback for private repos (PAT forwarded only via configured proxy path)
+      onAuth: token ? () => ({ username: token, password: 'x-oauth-basic' }) : undefined,
+      onProgress: (event) => {
+        if (event.total) {
+          const percent = Math.round((event.loaded / event.total) * 100);
+          onProgress?.('cloning', percent);
+        }
+      },
+    });
+
+    onProgress?.('reading', 0);
+
+    // Read all files from the cloned repo
+    const files = await readAllFiles(dir, dir);
+
+    // Cleanup: remove the cloned repo from virtual FS to save space
+    await removeDirectory(dir);
+    
+    // Also try to clean up the IndexedDB database
+    try {
+      indexedDB.deleteDatabase(fsName);
+    } catch {}
+
+    onProgress?.('complete', 100);
+
+    return files;
+  } catch (error) {
+    // Cleanup on error
+    try {
+      await removeDirectory(dir);
+      indexedDB.deleteDatabase(fsName);
+    } catch {}
+    
+    throw error;
+  }
+};
+
+/**
+ * Recursively read all files from a directory in the virtual filesystem
+ */
+const readAllFiles = async (baseDir: string, currentDir: string): Promise<FileEntry[]> => {
+  const files: FileEntry[] = [];
+  
+  let entries: string[];
+  try {
+    entries = await pfs.readdir(currentDir);
+  } catch (err) {
+    // Directory might not exist or be inaccessible
+    console.warn(`Cannot read directory: ${currentDir}`);
+    return files;
+  }
+
+  for (const entry of entries) {
+    // Skip .git directory
+    if (entry === '.git') continue;
+
+    const fullPath = `${currentDir}/${entry}`;
+    const relativePath = fullPath.replace(`${baseDir}/`, '');
+
+    // Check ignore rules
+    if (shouldIgnorePath(relativePath)) continue;
+
+    // Try to stat the file - skip if it fails (broken symlinks, etc.)
+    let stat;
+    try {
+      stat = await pfs.stat(fullPath);
+    } catch {
+      // Skip files that can't be stat'd (broken symlinks, permission issues)
+      if (import.meta.env.DEV) {
+        console.warn(`Skipping unreadable entry: ${relativePath}`);
+      }
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      // Recurse into subdirectory
+      const subFiles = await readAllFiles(baseDir, fullPath);
+      files.push(...subFiles);
+    } else {
+      // Read file content
+      try {
+        const content = await pfs.readFile(fullPath, { encoding: 'utf8' }) as string;
+        files.push({
+          path: relativePath,
+          content,
+        });
+      } catch {
+        // Skip binary files or files that can't be read as text
+      }
+    }
+  }
+
+  return files;
+};
+
+/**
+ * Recursively remove a directory from the virtual filesystem
+ */
+const removeDirectory = async (dir: string): Promise<void> => {
+  try {
+    const entries = await pfs.readdir(dir);
+    
+    for (const entry of entries) {
+      const fullPath = `${dir}/${entry}`;
+      const stat = await pfs.stat(fullPath);
+      
+      if (stat.isDirectory()) {
+        await removeDirectory(fullPath);
+      } else {
+        await pfs.unlink(fullPath);
+      }
+    }
+    
+    await pfs.rmdir(dir);
+  } catch {
+    // Ignore errors during cleanup
+  }
+};
+

--- a/gitnexus-web/test/unit/security-mode.test.ts
+++ b/gitnexus-web/test/unit/security-mode.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { isLocalOnlyEnabled } from '../../src/config/security-mode';
+
+describe('web security-mode', () => {
+  it('treats unset value as disabled', () => {
+    expect(isLocalOnlyEnabled(undefined)).toBe(false);
+  });
+
+  it('treats explicit falsey values as disabled', () => {
+    expect(isLocalOnlyEnabled('')).toBe(false);
+    expect(isLocalOnlyEnabled('0')).toBe(false);
+    expect(isLocalOnlyEnabled('false')).toBe(false);
+    expect(isLocalOnlyEnabled('FALSE')).toBe(false);
+    expect(isLocalOnlyEnabled(' false ')).toBe(false);
+  });
+
+  it('treats explicit truthy values as enabled', () => {
+    expect(isLocalOnlyEnabled('1')).toBe(true);
+    expect(isLocalOnlyEnabled('true')).toBe(true);
+    expect(isLocalOnlyEnabled('yes')).toBe(true);
+  });
+});

--- a/gitnexus-web/test/unit/settings-service.test.ts
+++ b/gitnexus-web/test/unit/settings-service.test.ts
@@ -96,7 +96,11 @@ describe('getActiveProviderConfig', () => {
   it('returns config for openai when API key is set', () => {
     const settings = loadSettings();
     settings.activeProvider = 'openai';
-    settings.openai = { ...settings.openai, apiKey: 'sk-test-123' };
+    settings.openai = {
+      ...settings.openai,
+      apiKey: 'sk-test-123',
+      baseUrl: 'http://127.0.0.1:11434/v1',
+    };
     saveSettings(settings);
 
     const config = getActiveProviderConfig();

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -47,6 +47,7 @@ program
   .description('Start local HTTP server for web UI connection')
   .option('-p, --port <port>', 'Port number', '4747')
   .option('--host <host>', 'Bind address (default: 127.0.0.1, use 0.0.0.0 for remote access)')
+  .option('--local-only', 'Strict local mode: loopback-only host and localhost-only CORS')
   .action(createLazyAction(() => import('./serve.js'), 'serveCommand'));
 
 program
@@ -93,6 +94,7 @@ program
   .option('--no-reasoning-model', 'Disable reasoning model mode (overrides saved config)')
   .option('--concurrency <n>', 'Parallel LLM calls (default: 3)', '3')
   .option('--gist', 'Publish wiki as a public GitHub Gist after generation')
+  .option('--local-only', 'Strict local mode: local LLM endpoint only and gist publishing disabled')
   .option('-v, --verbose', 'Enable verbose output (show LLM commands and responses)')
   .option('--review', 'Stop after grouping to review module structure before generating pages')
   .action(createLazyAction(() => import('./wiki.js'), 'wikiCommand'));

--- a/gitnexus/src/cli/serve.ts
+++ b/gitnexus/src/cli/serve.ts
@@ -1,34 +1,12 @@
 import { createServer } from '../server/api.js';
 
-// Catch anything that would cause a silent exit
-process.on('uncaughtException', (err) => {
-  console.error('\n[gitnexus serve] Uncaught exception:', err.message);
-  if (process.env.DEBUG) console.error(err.stack);
-  process.exit(1);
-});
-process.on('unhandledRejection', (reason: any) => {
-  console.error('\n[gitnexus serve] Unhandled rejection:', reason?.message || reason);
-  if (process.env.DEBUG) console.error(reason?.stack);
-  process.exit(1);
-});
+const isLocalOnlyEnabled = (value: string | undefined): boolean => (
+  value === undefined || value === '' || (value !== '0' && value !== 'false')
+);
 
-export const serveCommand = async (options?: { port?: string; host?: string }) => {
+export const serveCommand = async (options?: { port?: string; host?: string; localOnly?: boolean }) => {
   const port = Number(options?.port ?? 4747);
   const host = options?.host ?? '127.0.0.1';
-
-  try {
-    await createServer(port, host);
-  } catch (err: any) {
-    console.error(`\nFailed to start GitNexus server:\n`);
-    console.error(`  ${err.message || err}\n`);
-    if (err.code === 'EADDRINUSE') {
-      console.error(`  Port ${port} is already in use. Either:`);
-      console.error(`    1. Stop the other process using port ${port}`);
-      console.error(`    2. Use a different port: gitnexus serve --port 4748\n`);
-    }
-    if (err.stack && process.env.DEBUG) {
-      console.error(err.stack);
-    }
-    process.exit(1);
-  }
+  const localOnly = !!options?.localOnly || isLocalOnlyEnabled(process.env.GITNEXUS_LOCAL_ONLY);
+  await createServer(port, host, { localOnly });
 };

--- a/gitnexus/src/cli/serve.ts
+++ b/gitnexus/src/cli/serve.ts
@@ -1,12 +1,9 @@
 import { createServer } from '../server/api.js';
-
-const isLocalOnlyEnabled = (value: string | undefined): boolean => (
-  value === undefined || value === '' || (value !== '0' && value !== 'false')
-);
+import { isLocalOnlyMode } from '../config/security-mode.js';
 
 export const serveCommand = async (options?: { port?: string; host?: string; localOnly?: boolean }) => {
   const port = Number(options?.port ?? 4747);
   const host = options?.host ?? '127.0.0.1';
-  const localOnly = !!options?.localOnly || isLocalOnlyEnabled(process.env.GITNEXUS_LOCAL_ONLY);
+  const localOnly = !!options?.localOnly || isLocalOnlyMode();
   await createServer(port, host, { localOnly });
 };

--- a/gitnexus/src/cli/wiki.ts
+++ b/gitnexus/src/cli/wiki.ts
@@ -1,23 +1,18 @@
 /**
  * Wiki Command
- *
+ * 
  * Generates repository documentation from the knowledge graph.
  * Usage: gitnexus wiki [path] [options]
  */
 
 import path from 'path';
 import readline from 'readline';
-import { execSync, execFileSync } from 'child_process';
+import { execSync, execFileSync, spawnSync } from 'child_process';
 import cliProgress from 'cli-progress';
 import { getGitRoot, isGitRepo } from '../storage/git.js';
-import {
-  getStoragePaths,
-  loadMeta,
-  loadCLIConfig,
-  saveCLIConfig,
-} from '../storage/repo-manager.js';
+import { getStoragePaths, loadMeta, loadCLIConfig, saveCLIConfig } from '../storage/repo-manager.js';
 import { WikiGenerator, type WikiOptions } from '../core/wiki/generator.js';
-import { resolveLLMConfig, type LLMProvider } from '../core/wiki/llm-client.js';
+import { resolveLLMConfig, type LLMProvider, isLocalOnlyMode, isLoopbackUrl } from '../core/wiki/llm-client.js';
 import { detectCursorCLI } from '../core/wiki/cursor-client.js';
 
 export interface WikiCommandOptions {
@@ -32,6 +27,50 @@ export interface WikiCommandOptions {
   provider?: LLMProvider;
   verbose?: boolean;
   review?: boolean;
+  localOnly?: boolean;
+}
+
+function parseCommandArgs(command: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  let escaping = false;
+
+  for (const ch of command) {
+    if (escaping) {
+      current += ch;
+      escaping = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaping = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += ch;
+  }
+
+  if (escaping) current += '\\';
+  if (current.length > 0) tokens.push(current);
+  return tokens;
 }
 
 /**
@@ -85,7 +124,12 @@ function prompt(question: string, hide = false): Promise<string> {
   });
 }
 
-export const wikiCommand = async (inputPath?: string, options?: WikiCommandOptions) => {
+export const wikiCommand = async (
+  inputPath?: string,
+  options?: WikiCommandOptions,
+) => {
+  const localOnly = !!options?.localOnly || isLocalOnlyMode();
+
   // Set verbose mode globally for cursor-client to pick up
   if (options?.verbose) {
     process.env.GITNEXUS_VERBOSE = '1';
@@ -175,6 +219,20 @@ export const wikiCommand = async (inputPath?: string, options?: WikiCommandOptio
     apiVersion: options?.apiVersion,
     isReasoningModel: options?.reasoningModel,
   });
+
+  if (localOnly) {
+    if (llmConfig.provider === 'cursor') {
+      console.log('  Error: --local-only does not allow Cursor provider (networked service).\n');
+      process.exitCode = 1;
+      return;
+    }
+    if (!isLoopbackUrl(llmConfig.baseUrl)) {
+      console.log(`  Error: --local-only requires a local LLM endpoint (got: ${llmConfig.baseUrl}).`);
+      console.log('  Example: --base-url http://localhost:11434/v1\n');
+      process.exitCode = 1;
+      return;
+    }
+  }
 
   // Run interactive setup if no saved config and no CLI flags provided
   // (even if env vars exist — let user explicitly choose their provider)
@@ -346,20 +404,31 @@ export const wikiCommand = async (inputPath?: string, options?: WikiCommandOptio
     }
   }
 
+  if (localOnly) {
+    if (llmConfig.provider === 'cursor') {
+      console.log('  Error: --local-only does not allow Cursor provider (networked service).\n');
+      process.exitCode = 1;
+      return;
+    }
+    if (!isLoopbackUrl(llmConfig.baseUrl)) {
+      console.log(`  Error: --local-only requires a local LLM endpoint (got: ${llmConfig.baseUrl}).`);
+      console.log('  Example: --base-url http://localhost:11434/v1\n');
+      process.exitCode = 1;
+      return;
+    }
+  }
+
   // ── Setup progress bar with elapsed timer ──────────────────────────
-  const bar = new cliProgress.SingleBar(
-    {
-      format: '  {bar} {percentage}% | {phase}',
-      barCompleteChar: '\u2588',
-      barIncompleteChar: '\u2591',
-      hideCursor: true,
-      barGlue: '',
-      autopadding: true,
-      clearOnComplete: false,
-      stopOnComplete: false,
-    },
-    cliProgress.Presets.shades_grey,
-  );
+  const bar = new cliProgress.SingleBar({
+    format: '  {bar} {percentage}% | {phase}',
+    barCompleteChar: '\u2588',
+    barIncompleteChar: '\u2591',
+    hideCursor: true,
+    barGlue: '',
+    autopadding: true,
+    clearOnComplete: false,
+    stopOnComplete: false,
+  }, cliProgress.Presets.shades_grey);
 
   bar.start(100, 0, { phase: 'Initializing...' });
 
@@ -416,18 +485,13 @@ export const wikiCommand = async (inputPath?: string, options?: WikiCommandOptio
     if (options?.review && result.moduleTree) {
       console.log(`\n  Module structure ready for review (${elapsed}s)\n`);
       console.log('  Modules to generate:\n');
-
+      
       const printTree = (nodes: typeof result.moduleTree, indent = 0) => {
         for (const node of nodes) {
           const prefix = '  '.repeat(indent + 2);
           const fileCount = node.files?.length || 0;
           const childCount = node.children?.length || 0;
-          const suffix =
-            fileCount > 0
-              ? ` (${fileCount} files)`
-              : childCount > 0
-                ? ` (${childCount} children)`
-                : '';
+          const suffix = fileCount > 0 ? ` (${fileCount} files)` : childCount > 0 ? ` (${childCount} children)` : '';
           console.log(`${prefix}- ${node.name}${suffix}`);
           if (node.children && node.children.length > 0) {
             printTree(node.children, indent + 1);
@@ -435,10 +499,10 @@ export const wikiCommand = async (inputPath?: string, options?: WikiCommandOptio
         }
       };
       printTree(result.moduleTree);
-
+      
       console.log(`\n  Tree saved to: ${treeFile}`);
       console.log('  You can edit this file to remove/rename modules.\n');
-
+      
       // Ask for confirmation (auto-continue in non-interactive environments)
       if (!process.stdin.isTTY) {
         console.log('  Non-interactive mode — auto-continuing with generation.\n');
@@ -447,37 +511,49 @@ export const wikiCommand = async (inputPath?: string, options?: WikiCommandOptio
         ? await prompt('  Continue with generation? (Y/n/edit): ')
         : 'y';
       const choice = answer.trim().toLowerCase();
-
+      
       if (choice === 'n' || choice === 'no') {
         console.log('\n  Generation cancelled. Run `gitnexus wiki` later to generate.\n');
         return;
       }
-
+      
       if (choice === 'edit' || choice === 'e') {
         // Open editor for the user
         const editor = process.env.EDITOR || process.env.VISUAL || 'vi';
+        const editorParts = parseCommandArgs(editor);
+        const editorCmd = editorParts[0];
+        const editorArgs = editorParts.slice(1);
         console.log(`\n  Opening ${treeFile} in ${editor}...`);
         console.log('  Save and close the editor when done.\n');
-
+        
         try {
-          execFileSync(editor, [treeFile], { stdio: 'inherit' });
+          if (!editorCmd) {
+            throw new Error('No editor command provided');
+          }
+          const result = spawnSync(editorCmd, [...editorArgs, treeFile], {
+            stdio: 'inherit',
+            shell: false,
+          });
+          if (result.error || result.status !== 0) {
+            throw result.error ?? new Error(`Editor exited with code ${result.status}`);
+          }
         } catch {
           console.log(`  Could not open editor. Please edit manually:\n  ${treeFile}\n`);
           console.log('  Then run `gitnexus wiki` to continue.\n');
           return;
         }
       }
-
+      
       // Continue with generation using the (possibly edited) tree
       console.log('\n  Continuing with wiki generation...\n');
       bar.start(100, 30, { phase: 'Generating pages...' });
-
+      
       // Re-run generator without reviewOnly flag
       const continueOptions: WikiOptions = {
         ...wikiOptions,
         reviewOnly: false,
       };
-
+      
       const continueGenerator = new WikiGenerator(
         repoPath,
         storagePath,
@@ -493,28 +569,28 @@ export const wikiCommand = async (inputPath?: string, options?: WikiCommandOptio
           bar.update(percent, { phase: label });
         },
       );
-
+      
       const continueResult = await continueGenerator.run();
-
+      
       bar.update(100, { phase: 'Done' });
       bar.stop();
-
+      
       const totalElapsed = ((Date.now() - t0) / 1000).toFixed(1);
       console.log(`\n  Wiki generated successfully (${totalElapsed}s)\n`);
       console.log(`  Mode: ${continueResult.mode}`);
       console.log(`  Pages: ${continueResult.pagesGenerated}`);
       console.log(`  Output: ${wikiDir}`);
       console.log(`  Viewer: ${viewerPath}`);
-
+      
       if (continueResult.failedModules && continueResult.failedModules.length > 0) {
         console.log(`\n  Failed modules (${continueResult.failedModules.length}):`);
         for (const mod of continueResult.failedModules) {
           console.log(`    - ${mod}`);
         }
       }
-
+      
       console.log('');
-      await maybePublishGist(viewerPath, options?.gist);
+      await maybePublishGist(viewerPath, localOnly ? false : options?.gist);
       return;
     }
 
@@ -523,7 +599,7 @@ export const wikiCommand = async (inputPath?: string, options?: WikiCommandOptio
     if (result.mode === 'up-to-date' && !options?.force) {
       console.log('\n  Wiki is already up to date.');
       console.log(`  Viewer: ${viewerPath}\n`);
-      await maybePublishGist(viewerPath, options?.gist);
+      await maybePublishGist(viewerPath, localOnly ? false : options?.gist);
       return;
     }
 
@@ -543,7 +619,7 @@ export const wikiCommand = async (inputPath?: string, options?: WikiCommandOptio
 
     console.log('');
 
-    await maybePublishGist(viewerPath, options?.gist);
+    await maybePublishGist(viewerPath, localOnly ? false : options?.gist);
   } catch (err: any) {
     clearInterval(elapsedTimer);
     bar.stop();
@@ -560,19 +636,13 @@ export const wikiCommand = async (inputPath?: string, options?: WikiCommandOptio
       console.log(`\n  LLM Error: ${err.message}\n`);
 
       // Offer to reconfigure on auth-related failures
-      const isAuthError =
-        err.message?.includes('401') ||
-        err.message?.includes('403') ||
-        err.message?.includes('502') ||
-        err.message?.includes('authenticate') ||
-        err.message?.includes('Unauthorized');
+      const isAuthError = err.message?.includes('401') || err.message?.includes('403')
+        || err.message?.includes('502') || err.message?.includes('authenticate')
+        || err.message?.includes('Unauthorized');
       if (isAuthError && process.stdin.isTTY) {
         const answer = await new Promise<string>((resolve) => {
           const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-          rl.question('  Reconfigure LLM settings? (Y/n): ', (ans) => {
-            rl.close();
-            resolve(ans.trim().toLowerCase());
-          });
+          rl.question('  Reconfigure LLM settings? (Y/n): ', (ans) => { rl.close(); resolve(ans.trim().toLowerCase()); });
         });
         if (!answer || answer === 'y' || answer === 'yes') {
           // Clear saved config so next run triggers interactive setup
@@ -603,15 +673,15 @@ function hasGhCLI(): boolean {
 
 function publishGist(htmlPath: string): { url: string; rawUrl: string } | null {
   try {
-    const output = execFileSync(
-      'gh',
-      ['gist', 'create', htmlPath, '--desc', 'Repository Wiki — generated by GitNexus', '--public'],
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
-    ).trim();
+    const output = execFileSync('gh', [
+      'gist', 'create', htmlPath,
+      '--desc', 'Repository Wiki — generated by GitNexus',
+      '--public',
+    ], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
 
     // gh gist create prints the gist URL as the last line
     const lines = output.split('\n');
-    const gistUrl = lines.find((l) => l.includes('gist.github.com')) || lines[lines.length - 1];
+    const gistUrl = lines.find(l => l.includes('gist.github.com')) || lines[lines.length - 1];
 
     if (!gistUrl || !gistUrl.includes('gist.github.com')) return null;
 

--- a/gitnexus/src/config/security-mode.ts
+++ b/gitnexus/src/config/security-mode.ts
@@ -1,0 +1,10 @@
+const FALSEY_LOCAL_ONLY_VALUES = new Set(['', '0', 'false']);
+
+export const isLocalOnlyEnabled = (value: string | undefined): boolean => {
+  if (value === undefined) return false;
+  return !FALSEY_LOCAL_ONLY_VALUES.has(value.trim().toLowerCase());
+};
+
+export const isLocalOnlyMode = (): boolean => (
+  isLocalOnlyEnabled(process.env.GITNEXUS_LOCAL_ONLY)
+);

--- a/gitnexus/src/core/wiki/html-viewer.ts
+++ b/gitnexus/src/core/wiki/html-viewer.ts
@@ -7,6 +7,7 @@
 
 import fs from 'fs/promises';
 import path from 'path';
+import { isLocalOnlyMode } from '../../config/security-mode.js';
 
 interface ModuleTreeNode {
   name: string;
@@ -60,10 +61,6 @@ function esc(text: string): string {
     .replace(/"/g, '&quot;');
 }
 
-const isLocalOnlyMode = process.env.GITNEXUS_LOCAL_ONLY === undefined
-  || process.env.GITNEXUS_LOCAL_ONLY === ''
-  || (process.env.GITNEXUS_LOCAL_ONLY !== '0' && process.env.GITNEXUS_LOCAL_ONLY !== 'false');
-
 function serializeForInlineScript(value: unknown): string {
   return JSON.stringify(value)
     .replace(/</g, '\\u003c')
@@ -83,6 +80,7 @@ function buildHTML(
   const pagesJSON = serializeForInlineScript(pages);
   const treeJSON = serializeForInlineScript(moduleTree);
   const metaJSON = serializeForInlineScript(meta);
+  const localOnlyMode = isLocalOnlyMode();
 
   const parts: string[] = [];
 
@@ -93,7 +91,7 @@ function buildHTML(
   parts.push('<meta charset="UTF-8">');
   parts.push('<meta name="viewport" content="width=device-width, initial-scale=1.0">');
   parts.push('<title>' + esc(projectName) + ' — Wiki</title>');
-  if (!isLocalOnlyMode) {
+  if (!localOnlyMode) {
     parts.push('<script src="https://cdn.jsdelivr.net/npm/marked@11.0.0/marked.min.js"><\/script>');
     parts.push('<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"><\/script>');
     parts.push('<script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"><\/script>');

--- a/gitnexus/src/core/wiki/html-viewer.ts
+++ b/gitnexus/src/core/wiki/html-viewer.ts
@@ -18,29 +18,28 @@ interface ModuleTreeNode {
 /**
  * Generate the wiki HTML viewer (index.html) from existing markdown pages.
  */
-export async function generateHTMLViewer(wikiDir: string, projectName: string): Promise<string> {
+export async function generateHTMLViewer(
+  wikiDir: string,
+  projectName: string,
+): Promise<string> {
   // Load module tree
   let moduleTree: ModuleTreeNode[] = [];
   try {
     const raw = await fs.readFile(path.join(wikiDir, 'module_tree.json'), 'utf-8');
     moduleTree = JSON.parse(raw);
-  } catch {
-    /* will show empty nav */
-  }
+  } catch { /* will show empty nav */ }
 
   // Load meta
   let meta: Record<string, unknown> | null = null;
   try {
     const raw = await fs.readFile(path.join(wikiDir, 'meta.json'), 'utf-8');
     meta = JSON.parse(raw);
-  } catch {
-    /* no meta */
-  }
+  } catch { /* no meta */ }
 
   // Read all markdown files into a { slug: content } map
   const pages: Record<string, string> = {};
   const dirEntries = await fs.readdir(wikiDir);
-  for (const f of dirEntries.filter((f) => f.endsWith('.md'))) {
+  for (const f of dirEntries.filter(f => f.endsWith('.md'))) {
     const content = await fs.readFile(path.join(wikiDir, f), 'utf-8');
     pages[f.replace(/\.md$/, '')] = content;
   }
@@ -61,18 +60,29 @@ function esc(text: string): string {
     .replace(/"/g, '&quot;');
 }
 
+const isLocalOnlyMode = process.env.GITNEXUS_LOCAL_ONLY === undefined
+  || process.env.GITNEXUS_LOCAL_ONLY === ''
+  || (process.env.GITNEXUS_LOCAL_ONLY !== '0' && process.env.GITNEXUS_LOCAL_ONLY !== 'false');
+
+function serializeForInlineScript(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
 function buildHTML(
   projectName: string,
   moduleTree: ModuleTreeNode[],
   pages: Record<string, string>,
   meta: Record<string, unknown> | null,
 ): string {
-  // Embed data as JSON inside the HTML.
-  // Escape </script> sequences so they don't prematurely close the <script> tag.
-  const escScript = (s: string) => s.replace(/<\//g, '<\\/');
-  const pagesJSON = escScript(JSON.stringify(pages));
-  const treeJSON = escScript(JSON.stringify(moduleTree));
-  const metaJSON = escScript(JSON.stringify(meta));
+  // Embed data as JSON inside the HTML
+  const pagesJSON = serializeForInlineScript(pages);
+  const treeJSON = serializeForInlineScript(moduleTree);
+  const metaJSON = serializeForInlineScript(meta);
 
   const parts: string[] = [];
 
@@ -83,10 +93,11 @@ function buildHTML(
   parts.push('<meta charset="UTF-8">');
   parts.push('<meta name="viewport" content="width=device-width, initial-scale=1.0">');
   parts.push('<title>' + esc(projectName) + ' — Wiki</title>');
-  parts.push('<script src="https://cdn.jsdelivr.net/npm/marked@11.0.0/marked.min.js"><\/script>');
-  parts.push(
-    '<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"><\/script>',
-  );
+  if (!isLocalOnlyMode) {
+    parts.push('<script src="https://cdn.jsdelivr.net/npm/marked@11.0.0/marked.min.js"><\/script>');
+    parts.push('<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"><\/script>');
+    parts.push('<script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"><\/script>');
+  }
   parts.push('<style>');
   parts.push(CSS);
   parts.push('</style>');
@@ -94,9 +105,7 @@ function buildHTML(
 
   // ── Body ──
   parts.push('<body>');
-  parts.push(
-    '<button class="menu-toggle" id="menu-toggle" aria-label="Toggle menu">&#9776;</button>',
-  );
+  parts.push('<button class="menu-toggle" id="menu-toggle" aria-label="Toggle menu">&#9776;</button>');
   parts.push('<div class="layout">');
 
   // Sidebar
@@ -215,9 +224,14 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
 const JS_APP = `
 (function() {
   var activePage = 'overview';
+  var HAS_MARKED = typeof marked !== 'undefined' && typeof marked.parse === 'function';
+  var HAS_DOMPURIFY = typeof DOMPurify !== 'undefined' && typeof DOMPurify.sanitize === 'function';
+  var HAS_MERMAID = typeof mermaid !== 'undefined';
 
   document.addEventListener('DOMContentLoaded', function() {
-    mermaid.initialize({ startOnLoad: false, theme: 'neutral', securityLevel: 'loose' });
+    if (HAS_MERMAID) {
+      mermaid.initialize({ startOnLoad: false, theme: 'neutral', securityLevel: 'strict' });
+    }
     renderMeta();
     renderNav();
     document.getElementById('menu-toggle').addEventListener('click', function() {
@@ -302,7 +316,8 @@ const JS_APP = `
       return;
     }
 
-    contentEl.innerHTML = marked.parse(md);
+    var rendered = HAS_MARKED ? marked.parse(md) : '<pre>' + escH(md) + '</pre>';
+    contentEl.innerHTML = HAS_DOMPURIFY ? DOMPurify.sanitize(rendered) : rendered;
 
     // Rewrite .md links to hash navigation
     var links = contentEl.querySelectorAll('a[href]');
@@ -329,7 +344,9 @@ const JS_APP = `
       div.textContent = mermaidBlocks[i].textContent;
       pre.parentNode.replaceChild(div, pre);
     }
-    try { mermaid.run({ querySelector: '.mermaid' }); } catch(e) {}
+    if (HAS_MERMAID) {
+      try { mermaid.run({ querySelector: '.mermaid' }); } catch(e) {}
+    }
 
     window.scrollTo(0, 0);
     document.getElementById('sidebar').classList.remove('open');

--- a/gitnexus/src/core/wiki/llm-client.ts
+++ b/gitnexus/src/core/wiki/llm-client.ts
@@ -29,6 +29,24 @@ export interface LLMResponse {
   completionTokens?: number;
 }
 
+const isLocalOnlyEnabled = (value: string | undefined): boolean => (
+  value === undefined || value === '' || (value !== '0' && value !== 'false')
+);
+
+export const isLocalOnlyMode = (): boolean => (
+  isLocalOnlyEnabled(process.env.GITNEXUS_LOCAL_ONLY)
+);
+
+export const isLoopbackUrl = (rawUrl: string | undefined): boolean => {
+  if (!rawUrl) return false;
+  try {
+    const parsed = new URL(rawUrl);
+    return parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '::1';
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Resolve LLM configuration from env vars, saved config, and optional overrides.
  * Priority: overrides (CLI flags) > env vars > ~/.gitnexus/config.json > error

--- a/gitnexus/src/core/wiki/llm-client.ts
+++ b/gitnexus/src/core/wiki/llm-client.ts
@@ -6,6 +6,7 @@
  *
  * Config priority: CLI flags > env vars > defaults
  */
+import { isLocalOnlyMode as getProcessLocalOnlyMode } from '../../config/security-mode.js';
 
 export type LLMProvider = 'openai' | 'openrouter' | 'azure' | 'custom' | 'cursor';
 
@@ -29,12 +30,8 @@ export interface LLMResponse {
   completionTokens?: number;
 }
 
-const isLocalOnlyEnabled = (value: string | undefined): boolean => (
-  value === undefined || value === '' || (value !== '0' && value !== 'false')
-);
-
 export const isLocalOnlyMode = (): boolean => (
-  isLocalOnlyEnabled(process.env.GITNEXUS_LOCAL_ONLY)
+  getProcessLocalOnlyMode()
 );
 
 export const isLoopbackUrl = (rawUrl: string | undefined): boolean => {

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -15,17 +15,14 @@ import fs from 'fs/promises';
 import { loadMeta, listRegisteredRepos } from '../storage/repo-manager.js';
 import { executeQuery, closeLbug, withLbugDb } from '../core/lbug/lbug-adapter.js';
 import { NODE_TABLES } from '../core/lbug/schema.js';
-import { GraphNode, GraphRelationship } from '../core/graph/types.js';
+import type { GraphNode, GraphRelationship } from 'gitnexus-shared';
 import { searchFTSFromLbug } from '../core/search/bm25-index.js';
 import { hybridSearch } from '../core/search/hybrid-search.js';
 // Embedding imports are lazy (dynamic import) to avoid loading onnxruntime-node
 // at server startup — crashes on unsupported Node ABI versions (#89)
 import { LocalBackend } from '../mcp/local/local-backend.js';
 import { mountMCPEndpoints } from './mcp-http.js';
-
-const isLocalOnlyEnabled = (value: string | undefined): boolean => (
-  value === undefined || value === '' || (value !== '0' && value !== 'false')
-);
+import { isLocalOnlyMode } from '../config/security-mode.js';
 
 const isLoopbackHost = (host: string): boolean => (
   host === '127.0.0.1' || host === 'localhost' || host === '::1'
@@ -196,7 +193,7 @@ export const createServer = async (
   host: string = '127.0.0.1',
   opts?: { localOnly?: boolean },
 ) => {
-  const localOnly = !!opts?.localOnly || isLocalOnlyEnabled(process.env.GITNEXUS_LOCAL_ONLY);
+  const localOnly = !!opts?.localOnly || isLocalOnlyMode();
   if (localOnly && !isLoopbackHost(host)) {
     throw new Error('Local-only mode requires --host to be loopback (127.0.0.1, localhost, or ::1).');
   }

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -12,30 +12,24 @@ import express from 'express';
 import cors from 'cors';
 import path from 'path';
 import fs from 'fs/promises';
-import { createRequire } from 'node:module';
-import { loadMeta, listRegisteredRepos, getStoragePath } from '../storage/repo-manager.js';
-import {
-  executeQuery,
-  executePrepared,
-  executeWithReusedStatement,
-  closeLbug,
-  withLbugDb,
-} from '../core/lbug/lbug-adapter.js';
-import { isWriteQuery } from '../mcp/core/lbug-adapter.js';
-import { NODE_TABLES, type GraphNode, type GraphRelationship } from 'gitnexus-shared';
+import { loadMeta, listRegisteredRepos } from '../storage/repo-manager.js';
+import { executeQuery, closeLbug, withLbugDb } from '../core/lbug/lbug-adapter.js';
+import { NODE_TABLES } from '../core/lbug/schema.js';
+import { GraphNode, GraphRelationship } from '../core/graph/types.js';
 import { searchFTSFromLbug } from '../core/search/bm25-index.js';
 import { hybridSearch } from '../core/search/hybrid-search.js';
 // Embedding imports are lazy (dynamic import) to avoid loading onnxruntime-node
 // at server startup — crashes on unsupported Node ABI versions (#89)
 import { LocalBackend } from '../mcp/local/local-backend.js';
 import { mountMCPEndpoints } from './mcp-http.js';
-import { fork } from 'child_process';
-import { fileURLToPath, pathToFileURL } from 'url';
-import { JobManager } from './analyze-job.js';
-import { extractRepoName, getCloneDir, cloneOrPull } from './git-clone.js';
 
-const _require = createRequire(import.meta.url);
-const pkg = _require('../../package.json');
+const isLocalOnlyEnabled = (value: string | undefined): boolean => (
+  value === undefined || value === '' || (value !== '0' && value !== 'false')
+);
+
+const isLoopbackHost = (host: string): boolean => (
+  host === '127.0.0.1' || host === 'localhost' || host === '::1'
+);
 
 /**
  * Determine whether an HTTP Origin header value is allowed by CORS policy.
@@ -54,20 +48,31 @@ const pkg = _require('../../package.json');
  *                 when the header is absent (non-browser request).
  * @returns `true` if the origin is allowed, `false` otherwise.
  */
-export const isAllowedOrigin = (origin: string | undefined): boolean => {
+export const isAllowedOrigin = (origin: string | undefined, localOnly = false): boolean => {
   if (origin === undefined) {
     // Non-browser requests (curl, server-to-server) have no Origin header
     return true;
   }
 
+  if (localOnly) {
+    return (
+      origin.startsWith('http://localhost:')
+      || origin === 'http://localhost'
+      || origin.startsWith('http://127.0.0.1:')
+      || origin === 'http://127.0.0.1'
+      || origin.startsWith('http://[::1]:')
+      || origin === 'http://[::1]'
+    );
+  }
+
   if (
-    origin.startsWith('http://localhost:') ||
-    origin === 'http://localhost' ||
-    origin.startsWith('http://127.0.0.1:') ||
-    origin === 'http://127.0.0.1' ||
-    origin.startsWith('http://[::1]:') ||
-    origin === 'http://[::1]' ||
-    origin === 'https://gitnexus.vercel.app'
+    origin.startsWith('http://localhost:')
+    || origin === 'http://localhost'
+    || origin.startsWith('http://127.0.0.1:')
+    || origin === 'http://127.0.0.1'
+    || origin.startsWith('http://[::1]:')
+    || origin === 'http://[::1]'
+    || origin === 'https://gitnexus.vercel.app'
   ) {
     return true;
   }
@@ -89,7 +94,7 @@ export const isAllowedOrigin = (origin: string | undefined): boolean => {
   if (protocol !== 'http:' && protocol !== 'https:') return false;
 
   const octets = hostname.split('.').map(Number);
-  if (octets.length !== 4 || octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)) {
+  if (octets.length !== 4 || octets.some(o => !Number.isInteger(o) || o < 0 || o > 255)) {
     return false;
   }
 
@@ -105,17 +110,13 @@ export const isAllowedOrigin = (origin: string | undefined): boolean => {
   return false;
 };
 
-const buildGraph = async (
-  includeContent = false,
-): Promise<{ nodes: GraphNode[]; relationships: GraphRelationship[] }> => {
+const buildGraph = async (): Promise<{ nodes: GraphNode[]; relationships: GraphRelationship[] }> => {
   const nodes: GraphNode[] = [];
   for (const table of NODE_TABLES) {
     try {
       let query = '';
       if (table === 'File') {
-        query = includeContent
-          ? `MATCH (n:File) RETURN n.id AS id, n.name AS name, n.filePath AS filePath, n.content AS content`
-          : `MATCH (n:File) RETURN n.id AS id, n.name AS name, n.filePath AS filePath`;
+        query = `MATCH (n:File) RETURN n.id AS id, n.name AS name, n.filePath AS filePath, n.content AS content`;
       } else if (table === 'Folder') {
         query = `MATCH (n:Folder) RETURN n.id AS id, n.name AS name, n.filePath AS filePath`;
       } else if (table === 'Community') {
@@ -123,9 +124,7 @@ const buildGraph = async (
       } else if (table === 'Process') {
         query = `MATCH (n:Process) RETURN n.id AS id, n.label AS label, n.heuristicLabel AS heuristicLabel, n.processType AS processType, n.stepCount AS stepCount, n.communities AS communities, n.entryPointId AS entryPointId, n.terminalId AS terminalId`;
       } else {
-        query = includeContent
-          ? `MATCH (n:${table}) RETURN n.id AS id, n.name AS name, n.filePath AS filePath, n.startLine AS startLine, n.endLine AS endLine, n.content AS content`
-          : `MATCH (n:${table}) RETURN n.id AS id, n.name AS name, n.filePath AS filePath, n.startLine AS startLine, n.endLine AS endLine`;
+        query = `MATCH (n:${table}) RETURN n.id AS id, n.name AS name, n.filePath AS filePath, n.startLine AS startLine, n.endLine AS endLine, n.content AS content`;
       }
 
       const rows = await executeQuery(query);
@@ -138,7 +137,7 @@ const buildGraph = async (
             filePath: row.filePath ?? row[2],
             startLine: row.startLine,
             endLine: row.endLine,
-            content: includeContent ? row.content : undefined,
+            content: row.content,
             heuristicLabel: row.heuristicLabel,
             cohesion: row.cohesion,
             symbolCount: row.symbolCount,
@@ -157,7 +156,7 @@ const buildGraph = async (
 
   const relationships: GraphRelationship[] = [];
   const relRows = await executeQuery(
-    `MATCH (a)-[r:CodeRelation]->(b) RETURN a.id AS sourceId, b.id AS targetId, r.type AS type, r.confidence AS confidence, r.reason AS reason, r.step AS step`,
+    `MATCH (a)-[r:CodeRelation]->(b) RETURN a.id AS sourceId, b.id AS targetId, r.type AS type, r.confidence AS confidence, r.reason AS reason, r.step AS step`
   );
   for (const row of relRows) {
     relationships.push({
@@ -172,84 +171,6 @@ const buildGraph = async (
   }
 
   return { nodes, relationships };
-};
-
-/**
- * Mount an SSE progress endpoint for a JobManager.
- * Handles: initial state, terminal events, heartbeat, event IDs, client disconnect.
- */
-const mountSSEProgress = (app: express.Express, routePath: string, jm: JobManager) => {
-  app.get(routePath, (req, res) => {
-    const job = jm.getJob(req.params.jobId);
-    if (!job) {
-      res.status(404).json({ error: 'Job not found' });
-      return;
-    }
-
-    let eventId = 0;
-    res.writeHead(200, {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
-      'X-Accel-Buffering': 'no',
-    });
-
-    // Send current state immediately
-    eventId++;
-    res.write(`id: ${eventId}\ndata: ${JSON.stringify(job.progress)}\n\n`);
-
-    // If already terminal, send event and close
-    if (job.status === 'complete' || job.status === 'failed') {
-      eventId++;
-      res.write(
-        `id: ${eventId}\nevent: ${job.status}\ndata: ${JSON.stringify({
-          repoName: job.repoName,
-          error: job.error,
-        })}\n\n`,
-      );
-      res.end();
-      return;
-    }
-
-    // Heartbeat to detect zombie connections
-    const heartbeat = setInterval(() => {
-      try {
-        res.write(':heartbeat\n\n');
-      } catch {
-        clearInterval(heartbeat);
-        unsubscribe();
-      }
-    }, 30_000);
-
-    // Subscribe to progress updates
-    const unsubscribe = jm.onProgress(job.id, (progress) => {
-      try {
-        eventId++;
-        if (progress.phase === 'complete' || progress.phase === 'failed') {
-          const eventJob = jm.getJob(req.params.jobId);
-          res.write(
-            `id: ${eventId}\nevent: ${progress.phase}\ndata: ${JSON.stringify({
-              repoName: eventJob?.repoName,
-              error: eventJob?.error,
-            })}\n\n`,
-          );
-          clearInterval(heartbeat);
-          res.end();
-          unsubscribe();
-        } else {
-          res.write(`id: ${eventId}\ndata: ${JSON.stringify(progress)}\n\n`);
-        }
-      } catch {
-        clearInterval(heartbeat);
-        unsubscribe();
-      }
-    });
-
-    req.on('close', () => {
-      clearInterval(heartbeat);
-      unsubscribe();
-    });
-  });
 };
 
 const statusFromError = (err: any): number => {
@@ -270,107 +191,52 @@ const requestedRepo = (req: express.Request): string | undefined => {
   return undefined;
 };
 
-export const createServer = async (port: number, host: string = '127.0.0.1') => {
+export const createServer = async (
+  port: number,
+  host: string = '127.0.0.1',
+  opts?: { localOnly?: boolean },
+) => {
+  const localOnly = !!opts?.localOnly || isLocalOnlyEnabled(process.env.GITNEXUS_LOCAL_ONLY);
+  if (localOnly && !isLoopbackHost(host)) {
+    throw new Error('Local-only mode requires --host to be loopback (127.0.0.1, localhost, or ::1).');
+  }
+
   const app = express();
-  app.disable('x-powered-by');
 
   // CORS: allow localhost, private/LAN networks, and the deployed site.
   // Non-browser requests (curl, server-to-server) have no origin and are allowed.
-  app.use(
-    cors({
-      origin: (origin, callback) => {
-        if (isAllowedOrigin(origin)) {
-          callback(null, true);
-        } else {
-          callback(new Error('Not allowed by CORS'));
-        }
-      },
-    }),
-  );
+  app.use(cors({
+    origin: (origin, callback) => {
+      if (isAllowedOrigin(origin, localOnly)) {
+        callback(null, true);
+      } else {
+        callback(new Error('Not allowed by CORS'));
+      }
+    }
+  }));
   app.use(express.json({ limit: '10mb' }));
 
   // Initialize MCP backend (multi-repo, shared across all MCP sessions)
   const backend = new LocalBackend();
   await backend.init();
   const cleanupMcp = mountMCPEndpoints(app, backend);
-  const jobManager = new JobManager();
-
-  // Shared repo lock — prevents concurrent analyze + embed on the same repo path,
-  // which would corrupt LadybugDB (analyze calls closeLbug + initLbug while embed has queries in flight).
-  const activeRepoPaths = new Set<string>();
-
-  const acquireRepoLock = (repoPath: string): string | null => {
-    if (activeRepoPaths.has(repoPath)) {
-      return `Another job is already active for this repository`;
-    }
-    activeRepoPaths.add(repoPath);
-    return null;
-  };
-
-  const releaseRepoLock = (repoPath: string): void => {
-    activeRepoPaths.delete(repoPath);
-  };
 
   // Helper: resolve a repo by name from the global registry, or default to first
   const resolveRepo = async (repoName?: string) => {
     const repos = await listRegisteredRepos();
     if (repos.length === 0) return null;
-    if (repoName) return repos.find((r) => r.name === repoName) || null;
+    if (repoName) return repos.find(r => r.name === repoName) || null;
     return repos[0]; // default to first
   };
-
-  // SSE heartbeat — clients connect to detect server liveness instantly.
-  // When the server shuts down, the TCP connection drops and the client's
-  // EventSource fires onerror immediately (no polling delay).
-  app.get('/api/heartbeat', (_req, res) => {
-    // Use res.set() instead of res.writeHead() to preserve CORS headers from middleware
-    res.set({
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
-    });
-    res.flushHeaders();
-    // Send initial ping so the client knows it connected
-    res.write(':ok\n\n');
-
-    // Keep-alive ping every 15s to prevent proxy/firewall timeout
-    const interval = setInterval(() => res.write(':ping\n\n'), 15_000);
-
-    _req.on('close', () => clearInterval(interval));
-  });
-
-  // Server info: version and launch context (npx / global / local dev)
-  app.get('/api/info', (_req, res) => {
-    const execPath = process.env.npm_execpath ?? '';
-    const argv0 = process.argv[1] ?? '';
-    let launchContext: 'npx' | 'global' | 'local';
-    if (
-      execPath.includes('npx') ||
-      argv0.includes('_npx') ||
-      process.env.npm_config_prefix?.includes('_npx')
-    ) {
-      launchContext = 'npx';
-    } else if (argv0.includes('node_modules')) {
-      launchContext = 'local';
-    } else {
-      launchContext = 'global';
-    }
-    res.json({ version: pkg.version, launchContext, nodeVersion: process.version });
-  });
 
   // List all registered repos
   app.get('/api/repos', async (_req, res) => {
     try {
       const repos = await listRegisteredRepos();
-      res.json(
-        repos.map((r) => ({
-          name: r.name,
-          path: r.path,
-          indexedAt: r.indexedAt,
-          lastCommit: r.lastCommit,
-          stats: r.stats,
-        })),
-      );
+      res.json(repos.map(r => ({
+        name: r.name, path: r.path, indexedAt: r.indexedAt,
+        lastCommit: r.lastCommit, stats: r.stats,
+      })));
     } catch (err: any) {
       res.status(500).json({ error: err.message || 'Failed to list repos' });
     }
@@ -396,65 +262,6 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
     }
   });
 
-  // Delete a repo — removes index, clone dir (if any), and unregisters it
-  app.delete('/api/repo', async (req, res) => {
-    try {
-      const repoName = requestedRepo(req);
-      if (!repoName) {
-        res.status(400).json({ error: 'Missing repo name' });
-        return;
-      }
-      const entry = await resolveRepo(repoName);
-      if (!entry) {
-        res.status(404).json({ error: 'Repository not found' });
-        return;
-      }
-
-      // Acquire repo lock — prevents deleting while analyze/embed is in flight
-      const lockKey = getStoragePath(entry.path);
-      const lockErr = acquireRepoLock(lockKey);
-      if (lockErr) {
-        res.status(409).json({ error: lockErr });
-        return;
-      }
-
-      try {
-        // Close any open LadybugDB handle before deleting files
-        try {
-          await closeLbug();
-        } catch {}
-
-        // 1. Delete the .gitnexus index/storage directory
-        const storagePath = getStoragePath(entry.path);
-        await fs.rm(storagePath, { recursive: true, force: true }).catch(() => {});
-
-        // 2. Delete the cloned repo dir if it lives under ~/.gitnexus/repos/
-        const cloneDir = getCloneDir(entry.name);
-        try {
-          const stat = await fs.stat(cloneDir);
-          if (stat.isDirectory()) {
-            await fs.rm(cloneDir, { recursive: true, force: true });
-          }
-        } catch {
-          /* clone dir may not exist (local repos) */
-        }
-
-        // 3. Unregister from the global registry
-        const { unregisterRepo } = await import('../storage/repo-manager.js');
-        await unregisterRepo(entry.path);
-
-        // 4. Reinitialize backend to reflect the removal
-        await backend.init().catch(() => {});
-
-        res.json({ deleted: entry.name });
-      } finally {
-        releaseRepoLock(lockKey);
-      }
-    } catch (err: any) {
-      res.status(500).json({ error: err.message || 'Failed to delete repo' });
-    }
-  });
-
   // Get full graph
   app.get('/api/graph', async (req, res) => {
     try {
@@ -464,8 +271,7 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
         return;
       }
       const lbugPath = path.join(entry.storagePath, 'lbug');
-      const includeContent = req.query.includeContent === 'true';
-      const graph = await withLbugDb(lbugPath, async () => buildGraph(includeContent));
+      const graph = await withLbugDb(lbugPath, async () => buildGraph());
       res.json(graph);
     } catch (err: any) {
       res.status(500).json({ error: err.message || 'Failed to build graph' });
@@ -478,11 +284,6 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
       const cypher = req.body.cypher as string;
       if (!cypher) {
         res.status(400).json({ error: 'Missing "cypher" in request body' });
-        return;
-      }
-
-      if (isWriteQuery(cypher)) {
-        res.status(403).json({ error: 'Write queries are not allowed via the HTTP API' });
         return;
       }
 
@@ -499,7 +300,7 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
     }
   });
 
-  // Search (supports mode: 'hybrid' | 'semantic' | 'bm25', and optional enrichment)
+  // Search
   app.post('/api/search', async (req, res) => {
     try {
       const query = (req.body.query ?? '').trim();
@@ -518,129 +319,15 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
       const limit = Number.isFinite(parsedLimit)
         ? Math.max(1, Math.min(100, Math.trunc(parsedLimit)))
         : 10;
-      const mode: string = req.body.mode ?? 'hybrid';
-      const enrich: boolean = req.body.enrich !== false; // default true
 
       const results = await withLbugDb(lbugPath, async () => {
-        let searchResults: any[];
-
-        if (mode === 'semantic') {
-          const { isEmbedderReady } = await import('../core/embeddings/embedder.js');
-          if (!isEmbedderReady()) {
-            return [] as any[];
-          }
-          const { semanticSearch: semSearch } =
-            await import('../core/embeddings/embedding-pipeline.js');
-          searchResults = await semSearch(executeQuery, query, limit);
-          // Normalize semantic results to HybridSearchResult shape
-          searchResults = searchResults.map((r: any, i: number) => ({
-            ...r,
-            score: r.score ?? 1 - (r.distance ?? 0),
-            rank: i + 1,
-            sources: ['semantic'],
-          }));
-        } else if (mode === 'bm25') {
-          searchResults = await searchFTSFromLbug(query, limit);
-          searchResults = searchResults.map((r: any, i: number) => ({
-            ...r,
-            rank: i + 1,
-            sources: ['bm25'],
-          }));
-        } else {
-          // hybrid (default)
-          const { isEmbedderReady } = await import('../core/embeddings/embedder.js');
-          if (isEmbedderReady()) {
-            const { semanticSearch: semSearch } =
-              await import('../core/embeddings/embedding-pipeline.js');
-            searchResults = await hybridSearch(query, limit, executeQuery, semSearch);
-          } else {
-            searchResults = await searchFTSFromLbug(query, limit);
-          }
+        const { isEmbedderReady } = await import('../core/embeddings/embedder.js');
+        if (isEmbedderReady()) {
+          const { semanticSearch } = await import('../core/embeddings/embedding-pipeline.js');
+          return hybridSearch(query, limit, executeQuery, semanticSearch);
         }
-
-        if (!enrich) return searchResults;
-
-        // Server-side enrichment: add connections, cluster, processes per result
-        // Uses parameterized queries to prevent Cypher injection via nodeId
-        const validLabel = (label: string): boolean =>
-          (NODE_TABLES as readonly string[]).includes(label);
-
-        const enriched = await Promise.all(
-          searchResults.slice(0, limit).map(async (r: any) => {
-            const nodeId: string = r.nodeId || r.id || '';
-            const nodeLabel = nodeId.split(':')[0];
-            const enrichment: { connections?: any; cluster?: string; processes?: any[] } = {};
-
-            if (!nodeId || !validLabel(nodeLabel)) return { ...r, ...enrichment };
-
-            // Run connections, cluster, and process queries in parallel
-            // Label is validated against NODE_TABLES (compile-time safe identifiers);
-            // nodeId uses $nid parameter binding to prevent injection
-            const [connRes, clusterRes, procRes] = await Promise.all([
-              executePrepared(
-                `
-              MATCH (n:${nodeLabel} {id: $nid})
-              OPTIONAL MATCH (n)-[r1:CodeRelation]->(dst)
-              OPTIONAL MATCH (src)-[r2:CodeRelation]->(n)
-              RETURN
-                collect(DISTINCT {name: dst.name, type: r1.type, confidence: r1.confidence}) AS outgoing,
-                collect(DISTINCT {name: src.name, type: r2.type, confidence: r2.confidence}) AS incoming
-              LIMIT 1
-            `,
-                { nid: nodeId },
-              ).catch(() => []),
-              executePrepared(
-                `
-              MATCH (n:${nodeLabel} {id: $nid})
-              MATCH (n)-[:CodeRelation {type: 'MEMBER_OF'}]->(c:Community)
-              RETURN c.label AS label, c.description AS description
-              LIMIT 1
-            `,
-                { nid: nodeId },
-              ).catch(() => []),
-              executePrepared(
-                `
-              MATCH (n:${nodeLabel} {id: $nid})
-              MATCH (n)-[rel:CodeRelation {type: 'STEP_IN_PROCESS'}]->(p:Process)
-              RETURN p.id AS id, p.label AS label, rel.step AS step, p.stepCount AS stepCount
-              ORDER BY rel.step
-            `,
-                { nid: nodeId },
-              ).catch(() => []),
-            ]);
-
-            if (connRes.length > 0) {
-              const row = connRes[0];
-              const outgoing = (Array.isArray(row) ? row[0] : row.outgoing || [])
-                .filter((c: any) => c?.name)
-                .slice(0, 5);
-              const incoming = (Array.isArray(row) ? row[1] : row.incoming || [])
-                .filter((c: any) => c?.name)
-                .slice(0, 5);
-              enrichment.connections = { outgoing, incoming };
-            }
-
-            if (clusterRes.length > 0) {
-              const row = clusterRes[0];
-              enrichment.cluster = Array.isArray(row) ? row[0] : row.label;
-            }
-
-            if (procRes.length > 0) {
-              enrichment.processes = procRes
-                .map((row: any) => ({
-                  id: Array.isArray(row) ? row[0] : row.id,
-                  label: Array.isArray(row) ? row[1] : row.label,
-                  step: Array.isArray(row) ? row[2] : row.step,
-                  stepCount: Array.isArray(row) ? row[3] : row.stepCount,
-                }))
-                .filter((p: any) => p.id && p.label);
-            }
-
-            return { ...r, ...enrichment };
-          }),
-        );
-
-        return enriched;
+        // FTS-only fallback when embeddings aren't loaded
+        return searchFTSFromLbug(query, limit);
       });
       res.json({ results });
     } catch (err: any) {
@@ -670,111 +357,14 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
         return;
       }
 
-      const raw = await fs.readFile(fullPath, 'utf-8');
-
-      // Optional line-range support: ?startLine=10&endLine=50
-      // Returns only the requested slice (0-indexed), plus metadata.
-      const startLine = req.query.startLine !== undefined ? Number(req.query.startLine) : undefined;
-      const endLine = req.query.endLine !== undefined ? Number(req.query.endLine) : undefined;
-
-      if (startLine !== undefined && Number.isFinite(startLine)) {
-        const lines = raw.split('\n');
-        const start = Math.max(0, startLine);
-        const end =
-          endLine !== undefined && Number.isFinite(endLine)
-            ? Math.min(lines.length, endLine + 1)
-            : lines.length;
-        res.json({
-          content: lines.slice(start, end).join('\n'),
-          startLine: start,
-          endLine: end - 1,
-          totalLines: lines.length,
-        });
-      } else {
-        res.json({ content: raw, totalLines: raw.split('\n').length });
-      }
+      const content = await fs.readFile(fullPath, 'utf-8');
+      res.json({ content });
     } catch (err: any) {
       if (err.code === 'ENOENT') {
         res.status(404).json({ error: 'File not found' });
       } else {
         res.status(500).json({ error: err.message || 'Failed to read file' });
       }
-    }
-  });
-
-  // Grep — regex search across file contents in the indexed repo
-  // Uses filesystem-based search for memory efficiency (never loads all files into memory)
-  app.get('/api/grep', async (req, res) => {
-    try {
-      const entry = await resolveRepo(requestedRepo(req));
-      if (!entry) {
-        res.status(404).json({ error: 'Repository not found' });
-        return;
-      }
-      const pattern = req.query.pattern as string;
-      if (!pattern) {
-        res.status(400).json({ error: 'Missing "pattern" query parameter' });
-        return;
-      }
-
-      // ReDoS protection: reject overly long or dangerous patterns
-      if (pattern.length > 200) {
-        res.status(400).json({ error: 'Pattern too long (max 200 characters)' });
-        return;
-      }
-
-      // Validate regex syntax
-      let regex: RegExp;
-      try {
-        regex = new RegExp(pattern, 'gim');
-      } catch {
-        res.status(400).json({ error: 'Invalid regex pattern' });
-        return;
-      }
-
-      const parsedLimit = Number(req.query.limit ?? 50);
-      const limit = Number.isFinite(parsedLimit)
-        ? Math.max(1, Math.min(200, Math.trunc(parsedLimit)))
-        : 50;
-
-      const results: { filePath: string; line: number; text: string }[] = [];
-      const repoRoot = path.resolve(entry.path);
-
-      // Get file paths from the graph (lightweight — no content loaded)
-      const lbugPath = path.join(entry.storagePath, 'lbug');
-      const fileRows = await withLbugDb(lbugPath, () =>
-        executeQuery(`MATCH (n:File) WHERE n.content IS NOT NULL RETURN n.filePath AS filePath`),
-      );
-
-      // Search files on disk one at a time (constant memory)
-      for (const row of fileRows) {
-        if (results.length >= limit) break;
-        const filePath: string = row.filePath || '';
-        const fullPath = path.resolve(repoRoot, filePath);
-
-        // Path traversal guard
-        if (!fullPath.startsWith(repoRoot + path.sep) && fullPath !== repoRoot) continue;
-
-        let content: string;
-        try {
-          content = await fs.readFile(fullPath, 'utf-8');
-        } catch {
-          continue; // File may have been deleted since indexing
-        }
-
-        const lines = content.split('\n');
-        for (let i = 0; i < lines.length; i++) {
-          if (results.length >= limit) break;
-          if (regex.test(lines[i])) {
-            results.push({ filePath, line: i + 1, text: lines[i].trim().slice(0, 200) });
-          }
-          regex.lastIndex = 0;
-        }
-      }
-
-      res.json({ results });
-    } catch (err: any) {
-      res.status(500).json({ error: err.message || 'Grep failed' });
     }
   });
 
@@ -804,9 +394,7 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
       }
       res.json(result);
     } catch (err: any) {
-      res
-        .status(statusFromError(err))
-        .json({ error: err.message || 'Failed to query process detail' });
+      res.status(statusFromError(err)).json({ error: err.message || 'Failed to query process detail' });
     }
   });
 
@@ -836,406 +424,8 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
       }
       res.json(result);
     } catch (err: any) {
-      res
-        .status(statusFromError(err))
-        .json({ error: err.message || 'Failed to query cluster detail' });
+      res.status(statusFromError(err)).json({ error: err.message || 'Failed to query cluster detail' });
     }
-  });
-
-  // ── Analyze API ──────────────────────────────────────────────────────
-
-  // POST /api/analyze — start a new analysis job
-  app.post('/api/analyze', async (req, res) => {
-    try {
-      const { url: repoUrl, path: repoLocalPath, force, embeddings } = req.body;
-
-      // Input type validation
-      if (repoUrl !== undefined && typeof repoUrl !== 'string') {
-        res.status(400).json({ error: '"url" must be a string' });
-        return;
-      }
-      if (repoLocalPath !== undefined && typeof repoLocalPath !== 'string') {
-        res.status(400).json({ error: '"path" must be a string' });
-        return;
-      }
-
-      if (!repoUrl && !repoLocalPath) {
-        res.status(400).json({ error: 'Provide "url" (git URL) or "path" (local path)' });
-        return;
-      }
-
-      // Path validation: require absolute path, reject traversal (e.g. /tmp/../etc/passwd)
-      if (repoLocalPath) {
-        if (!path.isAbsolute(repoLocalPath)) {
-          res.status(400).json({ error: '"path" must be an absolute path' });
-          return;
-        }
-        if (path.normalize(repoLocalPath) !== path.resolve(repoLocalPath)) {
-          res.status(400).json({ error: '"path" must not contain traversal sequences' });
-          return;
-        }
-      }
-
-      const job = jobManager.createJob({ repoUrl, repoPath: repoLocalPath });
-
-      // If job was already running (dedup), just return its id
-      if (job.status !== 'queued') {
-        res.status(202).json({ jobId: job.id, status: job.status });
-        return;
-      }
-
-      // Mark as active synchronously to prevent race with concurrent requests
-      jobManager.updateJob(job.id, { status: 'cloning' });
-
-      // Start async work — don't await
-      (async () => {
-        let targetPath = repoLocalPath;
-        try {
-          // Clone if URL provided
-          if (repoUrl && !repoLocalPath) {
-            const repoName = extractRepoName(repoUrl);
-            targetPath = getCloneDir(repoName);
-
-            jobManager.updateJob(job.id, {
-              status: 'cloning',
-              repoName,
-              progress: { phase: 'cloning', percent: 0, message: `Cloning ${repoUrl}...` },
-            });
-
-            await cloneOrPull(repoUrl, targetPath, (progress) => {
-              jobManager.updateJob(job.id, {
-                progress: { phase: progress.phase, percent: 5, message: progress.message },
-              });
-            });
-          }
-
-          if (!targetPath) {
-            throw new Error('No target path resolved');
-          }
-
-          // Acquire shared repo lock (keyed on storagePath to match embed handler)
-          const analyzeLockKey = getStoragePath(targetPath);
-          const lockErr = acquireRepoLock(analyzeLockKey);
-          if (lockErr) {
-            jobManager.updateJob(job.id, { status: 'failed', error: lockErr });
-            return;
-          }
-
-          jobManager.updateJob(job.id, { repoPath: targetPath, status: 'analyzing' });
-
-          // ── Worker fork with auto-retry ──────────────────────────────
-          //
-          // Forks a child process with 8GB heap. If the worker crashes
-          // (OOM, native addon segfault, etc.), it retries up to
-          // MAX_WORKER_RETRIES times with exponential backoff before
-          // marking the job as permanently failed.
-          //
-          // In dev mode (tsx), registers the tsx ESM hook via a file://
-          // URL so the child can compile TypeScript on-the-fly.
-
-          const MAX_WORKER_RETRIES = 2;
-          const callerPath = fileURLToPath(import.meta.url);
-          const isDev = callerPath.endsWith('.ts');
-          const workerFile = isDev ? 'analyze-worker.ts' : 'analyze-worker.js';
-          const workerPath = path.join(path.dirname(callerPath), workerFile);
-          const tsxHookArgs: string[] = isDev
-            ? ['--import', pathToFileURL(_require.resolve('tsx/esm')).href]
-            : [];
-
-          const forkWorker = () => {
-            const currentJob = jobManager.getJob(job.id);
-            if (!currentJob || currentJob.status === 'complete' || currentJob.status === 'failed')
-              return;
-
-            const child = fork(workerPath, [], {
-              execArgv: [...tsxHookArgs, '--max-old-space-size=8192'],
-              stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
-            });
-
-            // Capture stderr for crash diagnostics
-            let stderrChunks = '';
-            child.stderr?.on('data', (chunk: Buffer) => {
-              stderrChunks += chunk.toString();
-              if (stderrChunks.length > 4096) stderrChunks = stderrChunks.slice(-4096);
-            });
-
-            child.on('message', (msg: any) => {
-              if (msg.type === 'progress') {
-                jobManager.updateJob(job.id, {
-                  status: 'analyzing',
-                  progress: { phase: msg.phase, percent: msg.percent, message: msg.message },
-                });
-              } else if (msg.type === 'complete') {
-                releaseRepoLock(analyzeLockKey);
-                // Reinitialize backend BEFORE marking complete — ensures the new
-                // repo is queryable when the client receives the SSE complete event.
-                backend
-                  .init()
-                  .then(() => {
-                    jobManager.updateJob(job.id, {
-                      status: 'complete',
-                      repoName: msg.result.repoName,
-                    });
-                  })
-                  .catch((err) => {
-                    console.error('backend.init() failed after analyze:', err);
-                    jobManager.updateJob(job.id, {
-                      status: 'failed',
-                      error: 'Server failed to reload after analysis. Try again.',
-                    });
-                  });
-              } else if (msg.type === 'error') {
-                releaseRepoLock(analyzeLockKey);
-                jobManager.updateJob(job.id, {
-                  status: 'failed',
-                  error: msg.message,
-                });
-              }
-            });
-
-            child.on('error', (err) => {
-              releaseRepoLock(analyzeLockKey);
-              jobManager.updateJob(job.id, {
-                status: 'failed',
-                error: `Worker process error: ${err.message}`,
-              });
-            });
-
-            child.on('exit', (code) => {
-              const j = jobManager.getJob(job.id);
-              if (!j || j.status === 'complete' || j.status === 'failed') return;
-
-              // Worker crashed — attempt retry if under the limit
-              if (j.retryCount < MAX_WORKER_RETRIES) {
-                j.retryCount++;
-                const delay = 1000 * Math.pow(2, j.retryCount - 1); // 1s, 2s
-                const lastErr = stderrChunks.trim().split('\n').pop() || '';
-                console.warn(
-                  `Analyze worker crashed (code ${code}), retry ${j.retryCount}/${MAX_WORKER_RETRIES} in ${delay}ms` +
-                    (lastErr ? `: ${lastErr}` : ''),
-                );
-                jobManager.updateJob(job.id, {
-                  status: 'analyzing',
-                  progress: {
-                    phase: 'retrying',
-                    percent: j.progress.percent,
-                    message: `Worker crashed, retrying (${j.retryCount}/${MAX_WORKER_RETRIES})...`,
-                  },
-                });
-                stderrChunks = '';
-                setTimeout(forkWorker, delay);
-              } else {
-                // Exhausted retries — permanent failure
-                releaseRepoLock(analyzeLockKey);
-                jobManager.updateJob(job.id, {
-                  status: 'failed',
-                  error: `Worker crashed ${MAX_WORKER_RETRIES + 1} times (code ${code})${stderrChunks ? ': ' + stderrChunks.trim().split('\n').pop() : ''}`,
-                });
-              }
-            });
-
-            // Register child for cancellation + timeout tracking
-            jobManager.registerChild(job.id, child);
-
-            // Send start command to child
-            child.send({
-              type: 'start',
-              repoPath: targetPath,
-              options: { force: !!force, embeddings: !!embeddings },
-            });
-          };
-
-          forkWorker();
-        } catch (err: any) {
-          if (targetPath) releaseRepoLock(getStoragePath(targetPath));
-          jobManager.updateJob(job.id, {
-            status: 'failed',
-            error: err.message || 'Analysis failed',
-          });
-        }
-      })();
-
-      res.status(202).json({ jobId: job.id, status: job.status });
-    } catch (err: any) {
-      if (err.message?.includes('already in progress')) {
-        res.status(409).json({ error: err.message });
-      } else {
-        res.status(500).json({ error: err.message || 'Failed to start analysis' });
-      }
-    }
-  });
-
-  // GET /api/analyze/:jobId — poll job status
-  app.get('/api/analyze/:jobId', (req, res) => {
-    const job = jobManager.getJob(req.params.jobId);
-    if (!job) {
-      res.status(404).json({ error: 'Job not found' });
-      return;
-    }
-    res.json({
-      id: job.id,
-      status: job.status,
-      repoUrl: job.repoUrl,
-      repoPath: job.repoPath,
-      repoName: job.repoName,
-      progress: job.progress,
-      error: job.error,
-      startedAt: job.startedAt,
-      completedAt: job.completedAt,
-    });
-  });
-
-  // GET /api/analyze/:jobId/progress — SSE stream (shared helper)
-  mountSSEProgress(app, '/api/analyze/:jobId/progress', jobManager);
-
-  // DELETE /api/analyze/:jobId — cancel a running analysis job
-  app.delete('/api/analyze/:jobId', (req, res) => {
-    const job = jobManager.getJob(req.params.jobId);
-    if (!job) {
-      res.status(404).json({ error: 'Job not found' });
-      return;
-    }
-    if (job.status === 'complete' || job.status === 'failed') {
-      res.status(400).json({ error: `Job already ${job.status}` });
-      return;
-    }
-    jobManager.cancelJob(req.params.jobId, 'Cancelled by user');
-    res.json({ id: job.id, status: 'failed', error: 'Cancelled by user' });
-  });
-
-  // ── Embedding endpoints ────────────────────────────────────────────
-
-  const embedJobManager = new JobManager();
-
-  // POST /api/embed — trigger server-side embedding generation
-  app.post('/api/embed', async (req, res) => {
-    try {
-      const entry = await resolveRepo(requestedRepo(req));
-      if (!entry) {
-        res.status(404).json({ error: 'Repository not found' });
-        return;
-      }
-
-      // Check shared repo lock — prevent concurrent analyze + embed on same repo
-      const repoLockPath = entry.storagePath;
-      const lockErr = acquireRepoLock(repoLockPath);
-      if (lockErr) {
-        res.status(409).json({ error: lockErr });
-        return;
-      }
-
-      const job = embedJobManager.createJob({ repoPath: entry.storagePath });
-      embedJobManager.updateJob(job.id, {
-        repoName: entry.name,
-        status: 'analyzing' as any,
-        progress: { phase: 'analyzing', percent: 0, message: 'Starting embedding generation...' },
-      });
-
-      // 30-minute timeout for embedding jobs (same as analyze jobs)
-      const EMBED_TIMEOUT_MS = 30 * 60 * 1000;
-      const embedTimeout = setTimeout(() => {
-        const current = embedJobManager.getJob(job.id);
-        if (current && current.status !== 'complete' && current.status !== 'failed') {
-          releaseRepoLock(repoLockPath);
-          embedJobManager.updateJob(job.id, {
-            status: 'failed',
-            error: 'Embedding timed out (30 minute limit)',
-          });
-        }
-      }, EMBED_TIMEOUT_MS);
-
-      // Run embedding pipeline asynchronously
-      (async () => {
-        try {
-          const lbugPath = path.join(entry.storagePath, 'lbug');
-          await withLbugDb(lbugPath, async () => {
-            const { runEmbeddingPipeline } =
-              await import('../core/embeddings/embedding-pipeline.js');
-            await runEmbeddingPipeline(executeQuery, executeWithReusedStatement, (p) => {
-              embedJobManager.updateJob(job.id, {
-                progress: {
-                  phase:
-                    p.phase === 'ready' ? 'complete' : p.phase === 'error' ? 'failed' : p.phase,
-                  percent: p.percent,
-                  message:
-                    p.phase === 'loading-model'
-                      ? 'Loading embedding model...'
-                      : p.phase === 'embedding'
-                        ? `Embedding nodes (${p.percent}%)...`
-                        : p.phase === 'indexing'
-                          ? 'Creating vector index...'
-                          : p.phase === 'ready'
-                            ? 'Embeddings complete'
-                            : `${p.phase} (${p.percent}%)`,
-                },
-              });
-            });
-          });
-
-          clearTimeout(embedTimeout);
-          releaseRepoLock(repoLockPath);
-          // Don't overwrite 'failed' if the job was cancelled while the pipeline was running
-          const current = embedJobManager.getJob(job.id);
-          if (!current || current.status !== 'failed') {
-            embedJobManager.updateJob(job.id, { status: 'complete' });
-          }
-        } catch (err: any) {
-          clearTimeout(embedTimeout);
-          releaseRepoLock(repoLockPath);
-          const current = embedJobManager.getJob(job.id);
-          if (!current || current.status !== 'failed') {
-            embedJobManager.updateJob(job.id, {
-              status: 'failed',
-              error: err.message || 'Embedding generation failed',
-            });
-          }
-        }
-      })();
-
-      res.status(202).json({ jobId: job.id, status: 'analyzing' });
-    } catch (err: any) {
-      if (err.message?.includes('already in progress')) {
-        res.status(409).json({ error: err.message });
-      } else {
-        res.status(500).json({ error: err.message || 'Failed to start embedding generation' });
-      }
-    }
-  });
-
-  // GET /api/embed/:jobId — poll embedding job status
-  app.get('/api/embed/:jobId', (req, res) => {
-    const job = embedJobManager.getJob(req.params.jobId);
-    if (!job) {
-      res.status(404).json({ error: 'Job not found' });
-      return;
-    }
-    res.json({
-      id: job.id,
-      status: job.status,
-      repoName: job.repoName,
-      progress: job.progress,
-      error: job.error,
-      startedAt: job.startedAt,
-      completedAt: job.completedAt,
-    });
-  });
-
-  // GET /api/embed/:jobId/progress — SSE stream (shared helper)
-  mountSSEProgress(app, '/api/embed/:jobId/progress', embedJobManager);
-
-  // DELETE /api/embed/:jobId — cancel embedding job
-  app.delete('/api/embed/:jobId', (req, res) => {
-    const job = embedJobManager.getJob(req.params.jobId);
-    if (!job) {
-      res.status(404).json({ error: 'Job not found' });
-      return;
-    }
-    if (job.status === 'complete' || job.status === 'failed') {
-      res.status(400).json({ error: `Job already ${job.status}` });
-      return;
-    }
-    embedJobManager.cancelJob(req.params.jobId, 'Cancelled by user');
-    res.json({ id: job.id, status: 'failed', error: 'Cancelled by user' });
   });
 
   // Global error handler — catch anything the route handlers miss
@@ -1244,27 +434,18 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
     res.status(500).json({ error: 'Internal server error' });
   });
 
-  // Wrap listen in a promise so errors (EADDRINUSE, EACCES, etc.) propagate
-  // to the caller instead of crashing with an unhandled 'error' event.
-  await new Promise<void>((resolve, reject) => {
-    const server = app.listen(port, host, () => {
-      console.log(`GitNexus server running on http://${host}:${port}`);
-      resolve();
-    });
-    server.on('error', (err) => reject(err));
-
-    // Graceful shutdown — close Express + LadybugDB cleanly
-    const shutdown = async () => {
-      console.log('\nShutting down...');
-      server.close();
-      jobManager.dispose();
-      embedJobManager.dispose();
-      await cleanupMcp();
-      await closeLbug();
-      await backend.disconnect();
-      process.exit(0);
-    };
-    process.once('SIGINT', shutdown);
-    process.once('SIGTERM', shutdown);
+  const server = app.listen(port, host, () => {
+    console.log(`GitNexus server running on http://${host}:${port}`);
   });
+
+  // Graceful shutdown — close Express + LadybugDB cleanly
+  const shutdown = async () => {
+    server.close();
+    await cleanupMcp();
+    await closeLbug();
+    await backend.disconnect();
+    process.exit(0);
+  };
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
 };

--- a/gitnexus/test/helpers/test-indexed-db.ts
+++ b/gitnexus/test/helpers/test-indexed-db.ts
@@ -11,10 +11,15 @@
  * Seed data is NOT included — each test provides its own via options.seed.
  */
 /// <reference path="../vitest.d.ts" />
+import fs from 'fs/promises';
 import path from 'path';
 import { describe, beforeAll, afterAll, inject } from 'vitest';
 import type { TestDBHandle } from './test-db.js';
-import { NODE_TABLES, EMBEDDING_TABLE_NAME } from '../../src/core/lbug/schema.js';
+import { createTempDir } from './test-db.js';
+import {
+  NODE_TABLES,
+  EMBEDDING_TABLE_NAME,
+} from '../../src/core/lbug/schema.js';
 
 export interface IndexedDBHandle {
   /** Path to the LadybugDB database file */
@@ -75,8 +80,12 @@ export function withTestLbugDB(
   const timeout = options?.timeout ?? 30000;
 
   const setup = async () => {
-    // Get shared DB path from globalSetup (created once with full schema)
-    const dbPath = inject<'lbugDbPath'>('lbugDbPath');
+    // Get shared DB template path from globalSetup, then copy it so each test
+    // suite uses its own isolated DB file and avoids cross-worker file locks.
+    const sharedDbPath = inject<'lbugDbPath'>('lbugDbPath');
+    const sharedTmpHandle = await createTempDir(`gitnexus-shared-copy-${prefix}-`);
+    const dbPath = path.join(sharedTmpHandle.dbPath, 'lbug');
+    await fs.copyFile(sharedDbPath, dbPath);
     const repoId = `test-${prefix}-${Date.now()}-${repoCounter++}`;
 
     const adapter = await import('../../src/core/lbug/lbug-adapter.js');
@@ -91,11 +100,7 @@ export function withTestLbugDB(
     // 3. Drop stale FTS indexes from previous test file
     if (options?.ftsIndexes?.length) {
       for (const idx of options.ftsIndexes) {
-        try {
-          await adapter.dropFTSIndex(idx.table, idx.indexName);
-        } catch {
-          /* may not exist */
-        }
+        try { await adapter.dropFTSIndex(idx.table, idx.indexName); } catch { /* may not exist */ }
       }
     }
 
@@ -138,6 +143,7 @@ export function withTestLbugDB(
         await poolAdapter.closeLbug(repoId);
       }
       await adapter.closeLbug();
+      await sharedTmpHandle.cleanup();
     };
 
     // tmpHandle.dbPath → parent temp dir (not the lbug file) so tests
@@ -154,8 +160,7 @@ export function withTestLbugDB(
 
   const lazyHandle = new Proxy({} as IndexedDBHandle, {
     get(_target, prop) {
-      if (!ref.handle)
-        throw new Error('withTestLbugDB: handle not initialized — beforeAll has not run yet');
+      if (!ref.handle) throw new Error('withTestLbugDB: handle not initialized — beforeAll has not run yet');
       return (ref.handle as any)[prop];
     },
   });
@@ -168,9 +173,7 @@ export function withTestLbugDB(
     // native resource cleanup.  The vitest hookTimeout (120s) should apply
     // automatically, but some vitest versions fall back to testTimeout (30s)
     // for afterAll.  Pass 120s explicitly to avoid CI flakes on Windows.
-    afterAll(async () => {
-      if (ref.handle) await ref.handle.cleanup();
-    }, 120_000);
+    afterAll(async () => { if (ref.handle) await ref.handle.cleanup(); }, 120_000);
     fn(lazyHandle);
   });
 }

--- a/gitnexus/test/unit/security-mode.test.ts
+++ b/gitnexus/test/unit/security-mode.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { isLocalOnlyEnabled, isLocalOnlyMode } from '../../src/config/security-mode.js';
+
+const ORIGINAL_LOCAL_ONLY = process.env.GITNEXUS_LOCAL_ONLY;
+
+afterEach(() => {
+  if (ORIGINAL_LOCAL_ONLY === undefined) {
+    delete process.env.GITNEXUS_LOCAL_ONLY;
+  } else {
+    process.env.GITNEXUS_LOCAL_ONLY = ORIGINAL_LOCAL_ONLY;
+  }
+});
+
+describe('security-mode', () => {
+  it('treats unset value as disabled', () => {
+    expect(isLocalOnlyEnabled(undefined)).toBe(false);
+  });
+
+  it('treats explicit falsey values as disabled', () => {
+    expect(isLocalOnlyEnabled('')).toBe(false);
+    expect(isLocalOnlyEnabled('0')).toBe(false);
+    expect(isLocalOnlyEnabled('false')).toBe(false);
+    expect(isLocalOnlyEnabled('FALSE')).toBe(false);
+    expect(isLocalOnlyEnabled(' false ')).toBe(false);
+  });
+
+  it('treats explicit truthy values as enabled', () => {
+    expect(isLocalOnlyEnabled('1')).toBe(true);
+    expect(isLocalOnlyEnabled('true')).toBe(true);
+    expect(isLocalOnlyEnabled('yes')).toBe(true);
+  });
+
+  it('reads process env via isLocalOnlyMode', () => {
+    delete process.env.GITNEXUS_LOCAL_ONLY;
+    expect(isLocalOnlyMode()).toBe(false);
+
+    process.env.GITNEXUS_LOCAL_ONLY = 'true';
+    expect(isLocalOnlyMode()).toBe(true);
+  });
+});


### PR DESCRIPTION
- add centralized security-mode configuration for runtime decisions

- align proxy, LLM settings, clone flow, and API/serve/wiki paths under the same security policy

- reduce misconfiguration risk by making security behavior consistent across entry points

## Summary

This PR enforces a unified security-mode policy across Web and CLI/server/wiki paths, and adds test hardening for local-only provider behavior and integration DB isolation. Together, this reduces config drift and improves test reliability for security-sensitive paths.

## Motivation / context

Runtime security behavior previously varied by entry point, increasing misconfiguration risk. This change makes policy handling consistent across key flows and aligns tests with the intended local-only constraints and shared DB lifecycle behavior.

## Areas touched

- [x] `gitnexus/` (CLI / core / MCP server)
- [x] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- Centralize and enforce security-mode behavior.
- Align proxy/LLM/clone/API/serve/wiki logic to one security policy.
- Fix web unit test expectation for local-only OpenAI config.
- Isolate integration test DB paths to avoid shared-file lock collisions.

**Explicitly out of scope / not done here**

- No auth/provider redesign.
- No CI workflow changes.
- No eval harness updates.
- No feature/UI expansion outside security-policy alignment.

## Implementation notes

- Web test now uses a loopback OpenAI base URL under local-only mode.
- `withTestLbugDB` now copies the shared DB template into per-suite temp paths, reducing cross-suite lock contention.
- Commit validated: `5b5f742`.

## Testing & verification

- [x] `cd gitnexus && npm test`  
  Result: tests passed (`111` files passed, `3995` tests passed, `2` skipped), but Vitest still reports `Errors 1` with unhandled worker exit.
- [x] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*  
  Result: integration files passed (`45` files passed, `1931` tests passed), but same Vitest unhandled worker-exit error remains.
- [x] `cd gitnexus && npx tsc --noEmit`
- [x] `cd gitnexus-web && npm test` *(if web changed)*  
  Result: passed (`11/11` files, `198/198` tests).
- [x] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(not run in this pass)*

## Risk & rollout

Medium risk due to cross-path security behavior alignment, with low code churn in test hardening changes.  
No intended API-breaking change.  
Known residual issue: Vitest pool intermittently reports an unhandled worker-exit error despite passing assertions; worth follow-up in test infra.

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed