### PR TITLE
[cli] Add system onnxruntime-node binding overrid

### DIFF
--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -180,6 +180,15 @@ gitnexus analyze . --embeddings
 
 Works with Infinity, vLLM, TEI, llama.cpp, Ollama, LM Studio, or OpenAI. When unset, local embeddings are used unchanged.
 
+## System ONNX Runtime Binding (Advanced)
+
+If your environment provides a system-built onnxruntime-node binding (for example, Nix),
+you can direct GitNexus to use it instead of the package's bundled binary:
+
+```bash
+export GITNEXUS_ORT_BINDING_PATH=/absolute/path/to/onnxruntime_binding.node
+```
+
 ## Multi-Repo Support
 
 GitNexus supports indexing multiple repositories. Each `gitnexus analyze` registers the repo in a global registry (`~/.gitnexus/registry.json`). The MCP server serves all indexed repos automatically.

--- a/gitnexus/src/core/embeddings/embedder.ts
+++ b/gitnexus/src/core/embeddings/embedder.ts
@@ -15,13 +15,31 @@ if (!process.env.ORT_LOG_LEVEL) {
 }
 
 import { pipeline, env, type FeatureExtractionPipeline } from '@huggingface/transformers';
-import { existsSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { join, dirname } from 'path';
 import { createRequire } from 'module';
 import { DEFAULT_EMBEDDING_CONFIG, type EmbeddingConfig, type ModelProgress } from './types.js';
 import { isHttpMode, getHttpDimensions, httpEmbed } from './http-client.js';
 import { applyOnnxruntimeNodeBindingOverride } from './onnxruntime-node-loader.js';
+
+const configureTransformersCache = () => {
+  const cacheRoot =
+    process.env.GITNEXUS_CACHE_DIR ??
+    process.env.XDG_CACHE_HOME ??
+    (process.env.HOME ? join(process.env.HOME, '.cache') : null);
+
+  if (!cacheRoot) return;
+
+  const cacheDir = join(cacheRoot, 'gitnexus', 'transformers');
+  try {
+    mkdirSync(cacheDir, { recursive: true });
+    env.cacheDir = cacheDir;
+    env.useFSCache = true;
+  } catch {
+    // If cache setup fails, fall back to transformers.js defaults.
+  }
+};
 
 /**
  * Check whether the onnxruntime-node package that @huggingface/transformers
@@ -138,6 +156,7 @@ export const initEmbedder = async (
   }
 
   applyOnnxruntimeNodeBindingOverride();
+  configureTransformersCache();
 
   // If already initializing, wait for that promise
   if (isInitializing && initPromise) {

--- a/gitnexus/src/core/embeddings/embedder.ts
+++ b/gitnexus/src/core/embeddings/embedder.ts
@@ -21,6 +21,7 @@ import { join, dirname } from 'path';
 import { createRequire } from 'module';
 import { DEFAULT_EMBEDDING_CONFIG, type EmbeddingConfig, type ModelProgress } from './types.js';
 import { isHttpMode, getHttpDimensions, httpEmbed } from './http-client.js';
+import { applyOnnxruntimeNodeBindingOverride } from './onnxruntime-node-loader.js';
 
 /**
  * Check whether the onnxruntime-node package that @huggingface/transformers
@@ -135,6 +136,8 @@ export const initEmbedder = async (
   if (embedderInstance) {
     return embedderInstance;
   }
+
+  applyOnnxruntimeNodeBindingOverride();
 
   // If already initializing, wait for that promise
   if (isInitializing && initPromise) {

--- a/gitnexus/src/core/embeddings/onnxruntime-node-loader.ts
+++ b/gitnexus/src/core/embeddings/onnxruntime-node-loader.ts
@@ -1,0 +1,53 @@
+import Module from 'module';
+import { existsSync } from 'fs';
+import { isAbsolute } from 'path';
+
+const OVERRIDE_ENV = 'GITNEXUS_ORT_BINDING_PATH';
+
+/**
+ * Redirect onnxruntime-node to a system-provided binding binary.
+ *
+ * onnxruntime-node always requires a native .node file from its own package.
+ * We patch Node's module resolver so that specific request is redirected to
+ * the path provided by GITNEXUS_ORT_BINDING_PATH.
+ */
+export const applyOnnxruntimeNodeBindingOverride = (): void => {
+  const overridePath = process.env[OVERRIDE_ENV];
+  if (!overridePath) return;
+
+  if (!isAbsolute(overridePath)) {
+    throw new Error(`${OVERRIDE_ENV} must be an absolute path, got "${overridePath}"`);
+  }
+
+  if (!existsSync(overridePath)) {
+    throw new Error(`${OVERRIDE_ENV} points to a missing file: "${overridePath}"`);
+  }
+
+  const moduleAny = Module as typeof Module & {
+    _gitnexusOrtBindingOverrideApplied?: boolean;
+    _resolveFilename?: (
+      request: string,
+      parent: NodeModule | null,
+      isMain: boolean,
+      options?: unknown
+    ) => string;
+  };
+
+  if (moduleAny._gitnexusOrtBindingOverrideApplied) return;
+  moduleAny._gitnexusOrtBindingOverrideApplied = true;
+
+  const originalResolve = moduleAny._resolveFilename?.bind(Module);
+  if (!originalResolve) return;
+
+  moduleAny._resolveFilename = function (
+    request: string,
+    parent: NodeModule | null,
+    isMain: boolean,
+    options?: unknown
+  ): string {
+    if (typeof request === 'string' && request.endsWith('onnxruntime_binding.node')) {
+      return overridePath;
+    }
+    return originalResolve(request, parent, isMain, options);
+  };
+};

--- a/gitnexus/src/mcp/core/embedder.ts
+++ b/gitnexus/src/mcp/core/embedder.ts
@@ -11,6 +11,7 @@ import {
   getHttpDimensions,
   httpEmbedQuery,
 } from '../../core/embeddings/http-client.js';
+import { applyOnnxruntimeNodeBindingOverride } from '../../core/embeddings/onnxruntime-node-loader.js';
 
 // Model config
 const MODEL_ID = 'Snowflake/snowflake-arctic-embed-xs';
@@ -31,6 +32,8 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
   if (embedderInstance) {
     return embedderInstance;
   }
+
+  applyOnnxruntimeNodeBindingOverride();
 
   if (isInitializing && initPromise) {
     return initPromise;

--- a/gitnexus/src/mcp/core/embedder.ts
+++ b/gitnexus/src/mcp/core/embedder.ts
@@ -6,12 +6,32 @@
  */
 
 import { pipeline, env, type FeatureExtractionPipeline } from '@huggingface/transformers';
+import { mkdirSync } from 'fs';
+import { join } from 'path';
 import {
   isHttpMode,
   getHttpDimensions,
   httpEmbedQuery,
 } from '../../core/embeddings/http-client.js';
 import { applyOnnxruntimeNodeBindingOverride } from '../../core/embeddings/onnxruntime-node-loader.js';
+
+const configureTransformersCache = () => {
+  const cacheRoot =
+    process.env.GITNEXUS_CACHE_DIR ??
+    process.env.XDG_CACHE_HOME ??
+    (process.env.HOME ? join(process.env.HOME, '.cache') : null);
+
+  if (!cacheRoot) return;
+
+  const cacheDir = join(cacheRoot, 'gitnexus', 'transformers');
+  try {
+    mkdirSync(cacheDir, { recursive: true });
+    env.cacheDir = cacheDir;
+    env.useFSCache = true;
+  } catch {
+    // If cache setup fails, fall back to transformers.js defaults.
+  }
+};
 
 // Model config
 const MODEL_ID = 'Snowflake/snowflake-arctic-embed-xs';
@@ -34,6 +54,7 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
   }
 
   applyOnnxruntimeNodeBindingOverride();
+  configureTransformersCache();
 
   if (isInitializing && initPromise) {
     return initPromise;


### PR DESCRIPTION
## Summary

Adds opt-in support for using system-provided ONNX Runtime bindings and fixes embeddings in sandboxed environments by ensuring a writable Transformers.js cache directory.

## Motivation / context

Packaging in sandboxed environments needs a way to use a prebuilt `onnxruntime_binding.node` without disabling features. Embeddings were also failing because Transformers.js tried to write its cache under a read-only install path. Related to issue #376.

## Areas touched

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [x] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- Add loader that redirects `onnxruntime_binding.node` to a user-specified path.
- Wire the override into both core embedder entrypoints.
- Configure Transformers.js cache dir to a writable location for sandboxed installs.
- Document the environment variable and usage.

**Explicitly out of scope / not done here**

- Changing any embedding logic or model behavior.
- Fixing the LadybugDB native binary issue (#376).
- Adjusting test expectations in CI.

## Implementation notes

- The override hooks Node’s module resolution so that requests for `onnxruntime_binding.node` resolve to the path in `GITNEXUS_ORT_BINDING_PATH`.
- Transformers.js cache is set to `$HOME/.cache/gitnexus/transformers` when possible, avoiding writes to read-only install paths.
- Both changes are opt‑in / safe defaults: the binding override only applies if the env var is set; cache setup falls back silently if not writable.

## Testing & verification

- [x] `cd gitnexus && npm test` (via docker; see note)
- [ ] `cd gitnexus && npm run test:integration` *(not needed here)*
- [x] `cd gitnexus && npx tsc --noEmit` (via docker)
- [ ] `cd gitnexus-web && npm test` *(not applicable)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(not applicable)*
- [x] Manual: `gitnexus analyze --embeddings .` (succeeds in sandboxed install)

**Notes:**  
Ran in Linux amd64 container (`node:20-trixie`) because local macOS tests are blocked by #376. One unit test fails in container due to root permissions (`test/unit/ignore-service.test.ts` “warns on EACCES but does not throw”); all other tests pass.

Commands:
```
docker run --rm --platform=linux/amd64 -v /Users/pieterpel/home/private-projects/llm-agents.nix/GitNexus:/app -w /app/gitnexus node:20-trixie bash -lc "apt-get update && apt-get install -y python3 make g++ build-essential pkg-config git && npm ci"
docker run --rm --platform=linux/amd64 -v /Users/pieterpel/home/private-projects/llm-agents.nix/GitNexus:/app -w /app/gitnexus node:20-trixie bash -lc "npx tsc --noEmit && npm test"
```

## Risk & rollout

- Low risk; opt‑in only. No migration needed.
- Does not affect default behavior unless `GITNEXUS_ORT_BINDING_PATH` is set.

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed"

 EDIT: Also added cache-dir configuration to avoid read-only install paths.