### PR TITLE
feat(lang): add Objective-C and Objective-C++ language support

### DIFF
--- a/gitnexus-shared/src/language-detection.ts
+++ b/gitnexus-shared/src/language-detection.ts
@@ -42,6 +42,7 @@ const EXTENSION_MAP: Record<SupportedLanguages, readonly string[]> = {
   [SupportedLanguages.Swift]: ['.swift'],
   [SupportedLanguages.Dart]: ['.dart'],
   [SupportedLanguages.Cobol]: ['.cbl', '.cob', '.cpy', '.cobol'],
+  [SupportedLanguages.ObjectiveC]: ['.m', '.mm'],
 } satisfies Record<SupportedLanguages, readonly string[]>; // Ensure exhaustiveness
 
 /** Pre-built reverse lookup: extension → language (built once at module load). */
@@ -99,6 +100,7 @@ const SYNTAX_MAP: Record<SupportedLanguages, string> = {
   [SupportedLanguages.Swift]: 'swift',
   [SupportedLanguages.Dart]: 'dart',
   [SupportedLanguages.Cobol]: 'cobol',
+  [SupportedLanguages.ObjectiveC]: 'objectivec',
 } satisfies Record<SupportedLanguages, string>; // Ensure exhaustiveness
 
 /** Non-code file extensions → Prism-compatible syntax identifiers */

--- a/gitnexus-shared/src/languages.ts
+++ b/gitnexus-shared/src/languages.ts
@@ -21,4 +21,5 @@ export enum SupportedLanguages {
   Dart = 'dart',
   /** Standalone regex processor — no tree-sitter, no LanguageProvider. */
   Cobol = 'cobol',
+  ObjectiveC = 'objectivec',
 }

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -60,6 +60,7 @@
       "optionalDependencies": {
         "tree-sitter-dart": "github:UserNobody14/tree-sitter-dart#80e23c07b64494f7e21090bb3450223ef0b192f4",
         "tree-sitter-kotlin": "^0.3.8",
+        "tree-sitter-objc": "^3.0.2",
         "tree-sitter-swift": "^0.6.0"
       }
     },
@@ -3317,13 +3318,6 @@
         "graphology-types": ">=0.20.0"
       }
     },
-    "node_modules/graphology-types": {
-      "version": "0.24.8",
-      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
-      "integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/graphology-utils": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.2.tgz",
@@ -5229,6 +5223,57 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/tree-sitter-objc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-objc/-/tree-sitter-objc-3.0.2.tgz",
+      "integrity": "sha512-Hs0ohmx1u5M+0K7efoW+dv/corhBsfjftfIYLtp7dSGeJ+Zj4c33tDIboBYLs6qijRlz6wtHFxa0YX+FibLulA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4",
+        "tree-sitter-c": "^0.23.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-objc/node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/tree-sitter-objc/node_modules/tree-sitter-c": {
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-c/-/tree-sitter-c-0.23.6.tgz",
+      "integrity": "sha512-0dxXKznVyUA0s6PjNolJNs2yF87O5aL538A/eR6njA5oqX3C3vH4vnx3QdOKwuUdpKEcFdHuiDpRKLLCA/tjvQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tree-sitter-php": {
       "version": "0.23.12",

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -84,7 +84,8 @@
   "optionalDependencies": {
     "tree-sitter-dart": "github:UserNobody14/tree-sitter-dart#80e23c07b64494f7e21090bb3450223ef0b192f4",
     "tree-sitter-kotlin": "^0.3.8",
-    "tree-sitter-swift": "^0.6.0"
+    "tree-sitter-swift": "^0.6.0",
+    "tree-sitter-objc": "^3.0.2"
   },
   "devDependencies": {
     "@types/cli-progress": "^3.11.6",

--- a/gitnexus/src/core/ingestion/entry-point-scoring.ts
+++ b/gitnexus/src/core/ingestion/entry-point-scoring.ts
@@ -227,6 +227,27 @@ export const ENTRY_POINT_PATTERNS = {
     /^mapEventToState$/, // Legacy BLoC pattern
   ],
   [SupportedLanguages.Cobol]: [], // Standalone regex processor — no tree-sitter entry points
+  [SupportedLanguages.ObjectiveC]: [
+    // Cocoa/UIKit AppDelegate entry points
+    /^applicationDidFinishLaunching$/,
+    /^application:didFinishLaunchingWithOptions$/,
+    /^applicationWillFinishLaunching$/,
+    // View controller lifecycle
+    /^viewDidLoad$/,
+    /^viewWillAppear$/,
+    /^viewDidAppear$/,
+    /^viewWillDisappear$/,
+    /^viewDidDisappear$/,
+    /^didReceiveMemoryWarning$/,
+    // Initialisation
+    /^initWithNibName:bundle:$/,
+    /^initWithCoder:$/,
+    /^ awakeFromNib$/,
+    // UIApplicationMain entry
+    /^sharedApplication$/,
+    /alloc$/,
+    /^init$/,
+  ],
 } satisfies Record<SupportedLanguages, RegExp[]>;
 
 /** Pre-computed merged patterns (universal + language-specific) to avoid per-call array allocation. */

--- a/gitnexus/src/core/ingestion/field-extractors/configs/objc.ts
+++ b/gitnexus/src/core/ingestion/field-extractors/configs/objc.ts
@@ -1,0 +1,108 @@
+// gitnexus/src/core/ingestion/field-extractors/configs/objc.ts
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { FieldExtractionConfig } from '../generic.js';
+import { hasKeyword } from './helpers.js';
+import { extractSimpleTypeName } from '../../type-extractors/shared.js';
+import type { SyntaxNode } from '../../utils/ast-helpers.js';
+import type { FieldVisibility } from '../../field-types.js';
+
+/**
+ * Detect Objective-C access specifier (@public, @private, @protected)
+ * by walking backwards from the field node through siblings.
+ */
+function objcAccessSpecifier(node: SyntaxNode): FieldVisibility | undefined {
+  let sibling = node.previousNamedSibling;
+  while (sibling) {
+    if (sibling.type === 'visibility_modifier') {
+      const text = sibling.text.replace('@', '').trim();
+      if (text === 'public' || text === 'private' || text === 'protected') return text;
+    }
+    sibling = sibling.previousNamedSibling;
+  }
+  return undefined;
+}
+
+function extractFieldName(node: SyntaxNode): string | undefined {
+  // property_declaration > declarator:(field_identifier | pointer_declarator > field_identifier)
+  const declarator = node.childForFieldName('declarator');
+  if (declarator) {
+    if (declarator.type === 'field_identifier') return declarator.text;
+    // pointer_declarator: *fieldName
+    for (let i = 0; i < declarator.namedChildCount; i++) {
+      const child = declarator.namedChild(i);
+      if (child?.type === 'field_identifier') return child.text;
+    }
+    return declarator.text;
+  }
+  // fallback: look for field_identifier anywhere
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
+    if (child?.type === 'field_identifier') return child.text;
+    // nested declarator
+    const nested = child?.firstNamedChild;
+    if (nested?.type === 'field_identifier') return nested.text;
+  }
+  return undefined;
+}
+
+function extractFieldType(node: SyntaxNode): string | undefined {
+  const typeNode = node.childForFieldName('type');
+  if (typeNode) return extractSimpleTypeName(typeNode) ?? typeNode.text?.trim();
+  // fallback: first child that is a type node
+  const first = node.firstNamedChild;
+  if (
+    first &&
+    (first.type === 'type_identifier' ||
+      first.type === 'primitive_type' ||
+      first.type === 'sized_type_specifier' ||
+      first.type === 'macro_type_specifier')
+  ) {
+    return extractSimpleTypeName(first) ?? first.text?.trim();
+  }
+  return undefined;
+}
+
+// OC property attributes: @property (strong, nonatomic, readonly) etc.
+function hasObjcReadonly(node: SyntaxNode): boolean {
+  let sibling = node.previousNamedSibling;
+  while (sibling) {
+    if (sibling.type === 'property_attribute') {
+      if (sibling.text.includes('readonly')) return true;
+    }
+    sibling = sibling.previousNamedSibling;
+  }
+  return false;
+}
+
+export const objcConfig: FieldExtractionConfig = {
+  language: SupportedLanguages.ObjectiveC,
+  typeDeclarationNodes: [
+    'class_interface_declaration',
+    'class_implementation_declaration',
+    'protocol_declaration',
+    'category_interface_declaration',
+  ],
+  fieldNodeTypes: ['property_declaration', 'instance_variable_declaration'],
+  bodyNodeTypes: ['class_interface_body', 'class_implementation_body', 'protocol_body', 'category_interface_body'],
+  defaultVisibility: 'private', // OC instance variables default to @private
+
+  extractName: extractFieldName,
+  extractType: extractFieldType,
+
+  extractVisibility(node) {
+    const access = objcAccessSpecifier(node);
+    if (access) return access;
+    // Instance variables default to @private inside @implementation
+    return 'private';
+  },
+
+  isStatic(node) {
+    return hasKeyword(node, 'static');
+  },
+
+  isReadonly(node) {
+    if (node.type === 'property_declaration') return hasObjcReadonly(node);
+    return hasKeyword(node, 'const');
+  },
+};

--- a/gitnexus/src/core/ingestion/framework-detection.ts
+++ b/gitnexus/src/core/ingestion/framework-detection.ts
@@ -623,6 +623,24 @@ export const FRAMEWORK_AST_PATTERNS = {
   ],
   vapor: ['app.get', 'app.post', 'req.content.decode', 'Vapor'],
 
+  // Objective-C/Cocoa Touch
+  cocoaTouch: [
+    '@interface',
+    '@implementation',
+    '@protocol',
+    '@property',
+    'UIViewController',
+    'UIApplication',
+    'NSObject',
+    'alloc',
+    'initWith',
+    'ViewController',
+    '@synthesize',
+    '@dynamic',
+    '#import <UIKit',
+    '#import <Foundation',
+  ],
+
   // Ruby patterns (class-level macros in definition text)
   rails: [
     'ApplicationController',
@@ -892,6 +910,15 @@ export const AST_FRAMEWORK_PATTERNS_BY_LANGUAGE = {
     },
   ],
   [SupportedLanguages.Cobol]: [], // Standalone regex processor — no AST framework patterns
+  [SupportedLanguages.ObjectiveC]: [
+    // Cocoa/AppKit/UIKit patterns
+    {
+      framework: 'cocoa-touch',
+      entryPointMultiplier: 2.0,
+      reason: 'cocoa-touch-lifecycle',
+      patterns: FRAMEWORK_AST_PATTERNS.cocoaTouch ?? [],
+    },
+  ],
 } satisfies Record<SupportedLanguages, AstFrameworkPatternConfig[]>;
 
 /** Pre-lowercased patterns for O(1) pattern matching at runtime */

--- a/gitnexus/src/core/ingestion/languages/index.ts
+++ b/gitnexus/src/core/ingestion/languages/index.ts
@@ -24,6 +24,7 @@ import { rubyProvider } from './ruby.js';
 import { swiftProvider } from './swift.js';
 import { dartProvider } from './dart.js';
 import { cobolProvider } from './cobol.js';
+import { objectiveCProvider } from './objective-c.js';
 
 export const providers = {
   [SupportedLanguages.JavaScript]: javascriptProvider,
@@ -41,6 +42,7 @@ export const providers = {
   [SupportedLanguages.Swift]: swiftProvider,
   [SupportedLanguages.Dart]: dartProvider,
   [SupportedLanguages.Cobol]: cobolProvider,
+  [SupportedLanguages.ObjectiveC]: objectiveCProvider,
 } satisfies Record<SupportedLanguages, LanguageProvider>;
 
 /** Get provider by language enum (always succeeds for SupportedLanguages). */

--- a/gitnexus/src/core/ingestion/languages/objective-c.ts
+++ b/gitnexus/src/core/ingestion/languages/objective-c.ts
@@ -1,0 +1,119 @@
+/**
+ * Objective-C and Objective-C++ language providers.
+ *
+ * Both use the same tree-sitter-objc grammar (Obj-C grammar is a superset that
+ * also handles C++/Objective-C++ via #ifdef __OBJC__ guards in headers).
+ *
+ * Import semantics are wildcard (via #import, which is semantically equivalent
+ * to #include with header guard deduplication).
+ *
+ * OC has three container types: @interface, @implementation, @protocol.
+ * MRO is 'leftmost-base' for the same reasons as C++.
+ */
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import { defineLanguage } from '../language-provider.js';
+import { typeConfig as cCppConfig } from '../type-extractors/c-cpp.js';
+import { cCppExportChecker } from '../export-detection.js';
+import { resolveCppImport } from '../import-resolvers/standard.js';
+import { OBJECTIVEC_QUERIES } from '../tree-sitter-queries.js';
+
+import { isObjcInsideContainer } from '../utils/ast-helpers.js';
+import type { LanguageProvider } from '../language-provider.js';
+import { createFieldExtractor } from '../field-extractors/generic.js';
+import { objcConfig } from '../field-extractors/configs/objc.js';
+
+const OBJC_BUILT_INS: ReadonlySet<string> = new Set([
+  'alloc',
+  'init',
+  'dealloc',
+  'retain',
+  'release',
+  'autorelease',
+  'retainCount',
+  'copy',
+  'mutableCopy',
+  'new',
+  'class',
+  'super',
+  'self',
+  '_cmd',
+  'YES',
+  'NO',
+  'nil',
+  'NULL',
+  'NSObject',
+  'NSString',
+  'NSArray',
+  'NSMutableArray',
+  'NSDictionary',
+  'NSMutableDictionary',
+  'NSSet',
+  'NSMutableSet',
+  'NSNumber',
+  'NSData',
+  'NSMutableData',
+  'NSDate',
+  'NSError',
+  'NSException',
+  'NSLog',
+  'NSAssert',
+  'NSParameterAssert',
+  'typeof',
+  'sizeof',
+  'NULL',
+  'nil',
+  'Class',
+  'SEL',
+  'IMP',
+  'Method',
+  'Ivar',
+  'objc_property_t',
+  'Protocol',
+  'object_getClass',
+  'class_getName',
+  'class_getSuperclass',
+  'class_addMethod',
+  'class_replaceMethod',
+  'method_getName',
+  'method_getImplementation',
+  'sel_getName',
+  'sel_registerName',
+  'objc_msgSend',
+  'objc_msgSendSuper',
+  'objc_storeStrong',
+  'objc_loadWeak',
+  'objc_initWeak',
+  'objc_destroyWeak',
+  'CFArray',
+  'CFDictionary',
+  'CFString',
+  'CFNumber',
+  'CFBoolean',
+  'kCFBooleanTrue',
+  'kCFBooleanFalse',
+]);
+
+/** Label override for OC: skip function_definition captures inside @interface/@implementation/@protocol
+ *  bodies (they're duplicates of definition.method captures). */
+const objcLabelOverride: NonNullable<LanguageProvider['labelOverride']> = (
+  functionNode,
+  defaultLabel,
+) => {
+  if (defaultLabel !== 'Function') return defaultLabel;
+  return isObjcInsideContainer(functionNode) ? null : defaultLabel;
+};
+
+export const objectiveCProvider = defineLanguage({
+  id: SupportedLanguages.ObjectiveC,
+  extensions: ['.m', '.mm'],
+  treeSitterQueries: OBJECTIVEC_QUERIES,
+  typeConfig: cCppConfig,
+  exportChecker: cCppExportChecker,
+  importResolver: resolveCppImport,
+  importSemantics: 'wildcard',
+  mroStrategy: 'leftmost-base',
+  fieldExtractor: createFieldExtractor(objcConfig),
+  labelOverride: objcLabelOverride,
+  builtInNames: OBJC_BUILT_INS,
+});

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -1146,6 +1146,95 @@ export const DART_QUERIES = `
       (type_identifier) @heritage.trait))) @heritage
 `;
 
+// Objective-C queries - works with tree-sitter-objc
+export const OBJECTIVEC_QUERIES = `
+; ── Class Interface (@interface) ────────────────────────────────────────────
+(class_interface_declaration
+  name: (type_identifier) @name) @definition.class
+
+; ── Class Implementation (@implementation) ─────────────────────────────────
+(class_implementation_declaration
+  name: (type_identifier) @name) @definition.class
+
+; ── Protocol (@protocol) ────────────────────────────────────────────────────
+(protocol_declaration
+  name: (type_identifier) @name) @definition.interface
+
+; ── Category Interface (@interface Foo (CategoryName)) ──────────────────────
+(category_interface_declaration
+  name: (type_identifier) @name) @definition.class
+
+; ── Instance Variables inside @implementation ────────────────────────────────
+(instance_variable_declaration
+  declarator: (field_identifier) @name) @definition.property
+
+; Pointer ivars: NSString *name
+(instance_variable_declaration
+  declarator: (pointer_declarator
+    declarator: (field_identifier) @name)) @definition.property
+
+; ── Methods inside @interface / @implementation ────────────────────────────
+; Instance method: - (void)foo;
+(method_declaration
+  declarator: (method_d declarator: (identifier) @name)) @definition.method
+
+; Class method: + (void)foo;
+(method_declaration
+  declarator: (class_method_declarator declarator: (identifier) @name)) @definition.method
+
+; Method with return type pointer: - (NSString *)foo
+(method_declaration
+  declarator: (method_d
+    declarator: (pointer_declarator
+      declarator: (identifier) @name))) @definition.method
+
+; ── Property Declaration (@property) ────────────────────────────────────────
+(property_declaration
+  declarator: (property Declarator
+    name: (field_identifier) @name)) @definition.property
+
+; ── Formal Protocol List (conforms to protocols) ────────────────────────────
+(class_interface_declaration
+  name: (type_identifier) @heritage.class
+  (formal_protocol_list
+    (protocol_identifier) @heritage.implements)) @heritage
+
+; ── Superclass (extends BaseClass) ─────────────────────────────────────────
+(class_interface_declaration
+  name: (type_identifier) @heritage.class
+  (superclass
+    (type_identifier) @heritage.extends)) @heritage
+
+; ── #import ─────────────────────────────────────────────────────────────────
+(preproc_include path: (_) @import.source) @import
+
+; ── Calls ──────────────────────────────────────────────────────────────────
+(call_expression function: (identifier) @call.name) @call
+
+; Method calls via dot syntax: [obj methodName] → obj.methodName
+(call_expression
+  function: (message_expression
+    (identifier) @call.name)) @call
+
+; Method calls with receiver: [Foo bar] → Foo.bar
+(message_expression
+  receiver: (identifier) @call.receiver
+  selector: (selector
+    (identifier) @call.name)) @call
+
+; objc_msgSend calls: objc_msgSend(obj, sel)
+(call_expression
+  function: (identifier) @call.name
+  arguments: (argument_list) @call.args) @call
+
+; ── Write access: obj.field = value ────────────────────────────────────────
+(assignment_expression
+  left: (field_expression
+    argument: (_) @assignment.receiver
+    field: (field_identifier) @assignment.property)
+  right: (_)) @assignment
+`;
+
 import { SupportedLanguages } from 'gitnexus-shared';
 
 export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
@@ -1164,4 +1253,5 @@ export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.Swift]: SWIFT_QUERIES,
   [SupportedLanguages.Dart]: DART_QUERIES,
   [SupportedLanguages.Cobol]: '', // Standalone regex processor — no tree-sitter queries
+  [SupportedLanguages.ObjectiveC]: OBJECTIVEC_QUERIES,
 };

--- a/gitnexus/src/core/ingestion/utils/ast-helpers.ts
+++ b/gitnexus/src/core/ingestion/utils/ast-helpers.ts
@@ -125,6 +125,11 @@ export const CLASS_CONTAINER_TYPES = new Set([
   // Kotlin
   'object_declaration',
   'companion_object',
+  // Objective-C
+  'class_interface_declaration',
+  'class_implementation_declaration',
+  'protocol_declaration',
+  'category_interface_declaration',
 ]);
 
 export const CONTAINER_TYPE_TO_LABEL: Record<string, string> = {
@@ -146,6 +151,10 @@ export const CONTAINER_TYPE_TO_LABEL: Record<string, string> = {
   module: 'Module',
   object_declaration: 'Class',
   companion_object: 'Class',
+  // Objective-C
+  class_interface_declaration: 'Class',
+  class_implementation_declaration: 'Class',
+  category_interface_declaration: 'Class',
 };
 
 /** Check if a Kotlin function_declaration capture is inside a class_body (i.e., a method).
@@ -157,6 +166,30 @@ export function isKotlinClassMethod(
   let ancestor = captureNode?.parent;
   while (ancestor) {
     if (ancestor.type === 'class_body') return true;
+    ancestor = ancestor.parent;
+  }
+  return false;
+}
+
+/** Check if an OC function_definition capture is inside @interface/@implementation/@protocol body
+ *  (i.e., a method, not a top-level function).
+ *  OC grammar uses method_declaration inside class bodies; function_definition only appears
+ *  at top level in Obj-C. This guard is a defensive catch-all. */
+export function isObjcInsideContainer(functionNode: SyntaxNode): boolean {
+  let ancestor: SyntaxNode | null = functionNode?.parent ?? null;
+  while (ancestor) {
+    if (
+      ancestor.type === 'class_interface_declaration' ||
+      ancestor.type === 'class_implementation_declaration' ||
+      ancestor.type === 'protocol_declaration' ||
+      ancestor.type === 'category_interface_declaration' ||
+      ancestor.type === 'class_interface_body' ||
+      ancestor.type === 'class_implementation_body' ||
+      ancestor.type === 'protocol_body' ||
+      ancestor.type === 'category_interface_body'
+    ) {
+      return true;
+    }
     ancestor = ancestor.parent;
   }
   return false;

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -38,6 +38,12 @@ let Kotlin: TreeSitterLanguage | null = null;
 try {
   Kotlin = _require('tree-sitter-kotlin');
 } catch {}
+
+// tree-sitter-objc is an optionalDependency — may not be installed
+let Objc: TreeSitterLanguage | null = null;
+try {
+  Objc = _require('tree-sitter-objc');
+} catch {}
 import { getLanguageFromFilename } from 'gitnexus-shared';
 import {
   FUNCTION_NODE_TYPES,
@@ -285,6 +291,7 @@ const languageMap: Record<string, TreeSitterLanguage> = {
   [SupportedLanguages.Ruby]: Ruby,
   ...(Dart ? { [SupportedLanguages.Dart]: Dart } : {}),
   ...(Swift ? { [SupportedLanguages.Swift]: Swift } : {}),
+  ...(Objc ? { [SupportedLanguages.ObjectiveC]: Objc } : {}),
 };
 
 /**


### PR DESCRIPTION
- Add SupportedLanguages.ObjectiveC enum and map .m/.mm extensions
- Add tree-sitter-objc grammar (optional dependency, v3.0.2)
- New objective-c.ts provider reusing cCppConfig/cCppExportChecker
- New OBJECTIVEC_QUERIES: @interface, @implementation, @protocol, @property, #import, method calls
- New objcConfig for @property and instance variable field extraction
- Add OC container types to CLASS_CONTAINER_TYPES and CONTAINER_TYPE_TO_LABEL
- Add isObjcInsideContainer() for method duplicate skipping
- Add cocoaTouch framework patterns and OC entry point patterns

## Summary

<!-- One or two sentences: what does this PR change? -->

## Motivation / context

<!-- Why is this change needed? Link issues, ADRs, or prior discussion. -->

## Areas touched

<!-- Check all that apply -->

- [ ] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- <!-- bullets -->

**Explicitly out of scope / not done here**

- <!-- bullets — prevents reviewers assuming missing work is an oversight -->

## Implementation notes

<!-- Optional: design choices, tradeoffs, follow-ups -->

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [ ] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [ ] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(if web changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

## Risk & rollout

<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->

## Checklist

- [ ] PR body meets repo minimum length (workflow may label short descriptions)
- [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [ ] No secrets, tokens, or machine-specific paths committed
