### PR TITLE
Fix/wiki script escape and llm token param

### DIFF
--- a/gitnexus/src/core/wiki/html-viewer.ts
+++ b/gitnexus/src/core/wiki/html-viewer.ts
@@ -61,19 +61,31 @@ function esc(text: string): string {
     .replace(/"/g, '&quot;');
 }
 
+/**
+ * Serialize a value to JSON with HTML-significant characters Unicode-escaped.
+ * `<`, `>`, and `&` are replaced with `\u003c`, `\u003e`, `\u0026` so the
+ * result is safe to embed inside a `<script>` tag without the HTML parser
+ * mis-interpreting the content (e.g. a literal `</script>` in a string).
+ *
+ * Replacement order matters: `<` and `>` are replaced first because their
+ * replacements (`\u003c`, `\u003e`) contain no `&`, so the final `&` pass
+ * cannot double-escape them.
+ */
+export function safeJSON(v: unknown): string {
+  const s = JSON.stringify(v);
+  if (s === undefined) return 'null';
+  return s
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+}
+
 function buildHTML(
   projectName: string,
   moduleTree: ModuleTreeNode[],
   pages: Record<string, string>,
   meta: Record<string, unknown> | null,
 ): string {
-  // Embed data as JSON inside the HTML
-  // Unicode-escape HTML-significant chars so the HTML parser can't misinterpret them
-  const safeJSON = (v: unknown) =>
-    JSON.stringify(v)
-      .replace(/</g, '\\u003c')
-      .replace(/>/g, '\\u003e')
-      .replace(/&/g, '\\u0026');
   const pagesJSON = safeJSON(pages);
   const treeJSON = safeJSON(moduleTree);
   const metaJSON = safeJSON(meta);
@@ -86,7 +98,7 @@ function buildHTML(
   parts.push('<head>');
   parts.push('<meta charset="UTF-8">');
   parts.push('<meta name="viewport" content="width=device-width, initial-scale=1.0">');
-  parts.push('<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; script-src \'unsafe-inline\' https://cdn.jsdelivr.net; style-src \'unsafe-inline\'; img-src data: https:;">');
+  parts.push('<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; script-src \'unsafe-inline\' \'unsafe-eval\' https://cdn.jsdelivr.net; style-src \'unsafe-inline\'; img-src data: https:;">');
   parts.push('<title>' + esc(projectName) + ' — Wiki</title>');
   parts.push('<script src="https://cdn.jsdelivr.net/npm/marked@11.0.0/marked.min.js"><\/script>');
   parts.push(

--- a/gitnexus/src/core/wiki/html-viewer.ts
+++ b/gitnexus/src/core/wiki/html-viewer.ts
@@ -68,9 +68,15 @@ function buildHTML(
   meta: Record<string, unknown> | null,
 ): string {
   // Embed data as JSON inside the HTML
-  const pagesJSON = JSON.stringify(pages);
-  const treeJSON = JSON.stringify(moduleTree);
-  const metaJSON = JSON.stringify(meta);
+  // Unicode-escape HTML-significant chars so the HTML parser can't misinterpret them
+  const safeJSON = (v: unknown) =>
+    JSON.stringify(v)
+      .replace(/</g, '\\u003c')
+      .replace(/>/g, '\\u003e')
+      .replace(/&/g, '\\u0026');
+  const pagesJSON = safeJSON(pages);
+  const treeJSON = safeJSON(moduleTree);
+  const metaJSON = safeJSON(meta);
 
   const parts: string[] = [];
 
@@ -80,6 +86,7 @@ function buildHTML(
   parts.push('<head>');
   parts.push('<meta charset="UTF-8">');
   parts.push('<meta name="viewport" content="width=device-width, initial-scale=1.0">');
+  parts.push('<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; script-src \'unsafe-inline\' https://cdn.jsdelivr.net; style-src \'unsafe-inline\'; img-src data: https:;">');
   parts.push('<title>' + esc(projectName) + ' — Wiki</title>');
   parts.push('<script src="https://cdn.jsdelivr.net/npm/marked@11.0.0/marked.min.js"><\/script>');
   parts.push(

--- a/gitnexus/src/core/wiki/html-viewer.ts
+++ b/gitnexus/src/core/wiki/html-viewer.ts
@@ -5,6 +5,7 @@
  * module tree, and metadata — viewable offline in any browser.
  */
 
+import { randomBytes } from 'crypto';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -90,6 +91,8 @@ function buildHTML(
   const treeJSON = safeJSON(moduleTree);
   const metaJSON = safeJSON(meta);
 
+  const nonce = randomBytes(16).toString('base64');
+
   const parts: string[] = [];
 
   // ── Head ──
@@ -98,11 +101,11 @@ function buildHTML(
   parts.push('<head>');
   parts.push('<meta charset="UTF-8">');
   parts.push('<meta name="viewport" content="width=device-width, initial-scale=1.0">');
-  parts.push('<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; script-src \'unsafe-inline\' \'unsafe-eval\' https://cdn.jsdelivr.net; style-src \'unsafe-inline\'; img-src data: https:;">');
+  parts.push(`<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'unsafe-inline'; img-src data: https:;">`);
   parts.push('<title>' + esc(projectName) + ' — Wiki</title>');
-  parts.push('<script src="https://cdn.jsdelivr.net/npm/marked@11.0.0/marked.min.js"><\/script>');
+  parts.push(`<script nonce="${nonce}" src="https://cdn.jsdelivr.net/npm/marked@11.0.0/marked.min.js"><\/script>`);
   parts.push(
-    '<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"><\/script>',
+    `<script nonce="${nonce}" src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"><\/script>`,
   );
   parts.push('<style>');
   parts.push(CSS);
@@ -136,7 +139,7 @@ function buildHTML(
   parts.push('</div>');
 
   // ── Script ──
-  parts.push('<script>');
+  parts.push(`<script nonce="${nonce}">`);
   parts.push('var PAGES = ' + pagesJSON + ';');
   parts.push('var TREE = ' + treeJSON + ';');
   parts.push('var META = ' + metaJSON + ';');

--- a/gitnexus/src/core/wiki/llm-client.ts
+++ b/gitnexus/src/core/wiki/llm-client.ts
@@ -211,11 +211,16 @@ export async function callLLM(
           continue;
         }
 
-        // Auto-switch max_tokens → max_completion_tokens when the model rejects max_tokens
+        // Auto-switch max_tokens -> max_completion_tokens when the model rejects it
+        let tokenErrMsg = errorText;
+        try {
+          const parsed = JSON.parse(errorText);
+          if (parsed?.error?.message) tokenErrMsg = parsed.error.message;
+        } catch { /* use raw errorText */ }
         if (
           !switchedTokenParam &&
           response.status === 400 &&
-          (errorText.includes("'max_tokens'") || errorText.includes('"max_tokens"')) &&
+          /['"]max_tokens['"]/.test(tokenErrMsg) &&
           body.max_tokens !== undefined
         ) {
           console.warn(

--- a/gitnexus/src/core/wiki/llm-client.ts
+++ b/gitnexus/src/core/wiki/llm-client.ts
@@ -210,6 +210,18 @@ export async function callLLM(
           continue;
         }
 
+        // Auto-switch max_tokens → max_completion_tokens when the model rejects max_tokens
+        if (
+          response.status === 400 &&
+          errorText.includes('max_completion_tokens') &&
+          body.max_tokens !== undefined
+        ) {
+          body.max_completion_tokens = body.max_tokens;
+          delete body.max_tokens;
+          // Retry immediately with the corrected parameter
+          continue;
+        }
+
         throw new Error(`LLM API error (${response.status}): ${errorText.slice(0, 500)}`);
       }
 

--- a/gitnexus/src/core/wiki/llm-client.ts
+++ b/gitnexus/src/core/wiki/llm-client.ts
@@ -169,6 +169,7 @@ export async function callLLM(
 
   const MAX_RETRIES = 3;
   let lastError: Error | null = null;
+  let switchedTokenParam = false;
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
@@ -212,13 +213,18 @@ export async function callLLM(
 
         // Auto-switch max_tokens → max_completion_tokens when the model rejects max_tokens
         if (
+          !switchedTokenParam &&
           response.status === 400 &&
-          errorText.includes('max_completion_tokens') &&
+          (errorText.includes("'max_tokens'") || errorText.includes('"max_tokens"')) &&
           body.max_tokens !== undefined
         ) {
+          console.warn(
+            '[gitnexus] Warning: model rejected max_tokens; retrying with max_completion_tokens.',
+          );
+          switchedTokenParam = true;
           body.max_completion_tokens = body.max_tokens;
           delete body.max_tokens;
-          // Retry immediately with the corrected parameter
+          attempt--;
           continue;
         }
 

--- a/gitnexus/test/unit/wiki-html-viewer.test.ts
+++ b/gitnexus/test/unit/wiki-html-viewer.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { safeJSON, generateHTMLViewer } from '../../src/core/wiki/html-viewer.js';
+
+describe('safeJSON', () => {
+  it('escapes < to \\u003c', () => {
+    expect(safeJSON('a < b')).toContain('\\u003c');
+    expect(safeJSON('a < b')).not.toContain('<');
+  });
+
+  it('escapes > to \\u003e', () => {
+    expect(safeJSON('a > b')).toContain('\\u003e');
+    expect(safeJSON('a > b')).not.toContain('>');
+  });
+
+  it('escapes & to \\u0026', () => {
+    expect(safeJSON('a & b')).toContain('\\u0026');
+    expect(safeJSON('a & b')).not.toContain('&');
+  });
+
+  it('escapes </script> — the primary XSS vector', () => {
+    const result = safeJSON({ content: '</script><img onerror=alert(1)>' });
+    expect(result).not.toContain('</script>');
+    expect(result).not.toContain('<');
+    expect(result).not.toContain('>');
+  });
+
+  it('round-trips through JSON.parse to the original value', () => {
+    const values = [
+      'hello',
+      '<script>alert(1)</script>',
+      { key: 'a < b & c > d' },
+      ['</script>', '&amp;', '<div>'],
+      null,
+      42,
+    ];
+    for (const v of values) {
+      expect(JSON.parse(safeJSON(v))).toEqual(v);
+    }
+  });
+
+  it('does not double-escape — replacement order is safe', () => {
+    const result = safeJSON('&lt;');
+    const parsed = JSON.parse(result);
+    expect(parsed).toBe('&lt;');
+  });
+
+  it('returns "null" for non-serializable values like undefined', () => {
+    expect(safeJSON(undefined)).toBe('null');
+    expect(safeJSON(() => {})).toBe('null');
+  });
+});
+
+describe('generateHTMLViewer — CSP meta tag', () => {
+  it('includes a Content-Security-Policy meta tag in generated HTML', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wiki-csp-'));
+    try {
+      await fs.writeFile(path.join(tmpDir, 'overview.md'), '# Hello');
+      await fs.writeFile(path.join(tmpDir, 'module_tree.json'), '[]');
+      const outputPath = await generateHTMLViewer(tmpDir, 'TestProject');
+      const html = await fs.readFile(outputPath, 'utf-8');
+      expect(html).toContain('Content-Security-Policy');
+      expect(html).toContain("'unsafe-eval'");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/gitnexus/test/unit/wiki-html-viewer.test.ts
+++ b/gitnexus/test/unit/wiki-html-viewer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -54,17 +54,33 @@ describe('safeJSON', () => {
 });
 
 describe('generateHTMLViewer — CSP meta tag', () => {
-  it('includes a Content-Security-Policy meta tag in generated HTML', async () => {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wiki-csp-'));
-    try {
-      await fs.writeFile(path.join(tmpDir, 'overview.md'), '# Hello');
-      await fs.writeFile(path.join(tmpDir, 'module_tree.json'), '[]');
-      const outputPath = await generateHTMLViewer(tmpDir, 'TestProject');
-      const html = await fs.readFile(outputPath, 'utf-8');
-      expect(html).toContain('Content-Security-Policy');
-      expect(html).toContain("'unsafe-eval'");
-    } finally {
-      await fs.rm(tmpDir, { recursive: true, force: true });
-    }
+  let tmpDir: string;
+  let html: string;
+
+  beforeAll(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wiki-csp-'));
+    await fs.writeFile(path.join(tmpDir, 'overview.md'), '# Hello');
+    await fs.writeFile(path.join(tmpDir, 'module_tree.json'), '[]');
+    const outputPath = await generateHTMLViewer(tmpDir, 'TestProject');
+    html = await fs.readFile(outputPath, 'utf-8');
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('includes a nonce-based Content-Security-Policy (no unsafe-inline for scripts)', () => {
+    expect(html).toContain('Content-Security-Policy');
+    expect(html).toContain("'unsafe-eval'");
+    expect(html).toMatch(/script-src 'nonce-[A-Za-z0-9+/=]+'/);;
+    expect(html).not.toMatch(/script-src[^;]*'unsafe-inline'/);
+  });
+
+  it('applies the nonce attribute to every <script> tag', () => {
+    const scriptTags = html.match(/<script[\s>]/g) ?? [];
+    expect(scriptTags.length).toBeGreaterThanOrEqual(3);
+
+    const noncedScripts = html.match(/<script\s+nonce="[A-Za-z0-9+/=]+"[\s>]/g) ?? [];
+    expect(noncedScripts.length).toBe(scriptTags.length);
   });
 });

--- a/gitnexus/test/unit/wiki-llm-client.test.ts
+++ b/gitnexus/test/unit/wiki-llm-client.test.ts
@@ -285,6 +285,144 @@ describe('callLLM — Azure content_filter error', () => {
   });
 });
 
+describe('callLLM — max_tokens auto-switch', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('retries with max_completion_tokens when model rejects max_tokens', async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              message: "Unsupported parameter: 'max_tokens'. Use 'max_completion_tokens' instead.",
+            },
+          }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ choices: [{ message: { content: 'ok' } }], usage: {} }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { callLLM } = await import('../../src/core/wiki/llm-client.js');
+    const result = await callLLM('test', {
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4.1',
+      maxTokens: 1000,
+      temperature: 0,
+    });
+
+    expect(result.content).toBe('ok');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    // Second request should have max_completion_tokens, not max_tokens
+    const secondBody = JSON.parse(fetchSpy.mock.calls[1][1].body as string);
+    expect(secondBody.max_completion_tokens).toBe(1000);
+    expect(secondBody.max_tokens).toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('max_completion_tokens'),
+    );
+  });
+
+  it('does not trigger on unrelated 400 errors', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { message: 'Invalid model: no-such-model' } }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const { callLLM } = await import('../../src/core/wiki/llm-client.js');
+    await expect(
+      callLLM('test', {
+        apiKey: 'sk-test',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'no-such-model',
+        maxTokens: 100,
+        temperature: 0,
+      }),
+    ).rejects.toThrow('LLM API error (400)');
+
+    // Should only have been called once — no retry
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger when already using max_completion_tokens (reasoning model)', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: { message: "Unsupported parameter: use 'max_completion_tokens'" },
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const { callLLM } = await import('../../src/core/wiki/llm-client.js');
+    await expect(
+      callLLM('test', {
+        apiKey: 'sk-test',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'o3-mini',
+        maxTokens: 100,
+        temperature: 0,
+      }),
+    ).rejects.toThrow('LLM API error (400)');
+
+    // Reasoning models already send max_completion_tokens — guard prevents switch
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not consume a retry attempt — full retries remain after switch', async () => {
+    const fetchSpy = vi
+      .fn()
+      // 1st call: 400 triggers auto-switch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: { message: "Unsupported parameter: 'max_tokens'. Use 'max_completion_tokens' instead." },
+          }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+      // 2nd call: succeeds
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ choices: [{ message: { content: 'done' } }], usage: {} }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchSpy);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { callLLM } = await import('../../src/core/wiki/llm-client.js');
+    const result = await callLLM('test', {
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4.1',
+      maxTokens: 500,
+      temperature: 0,
+    });
+
+    expect(result.content).toBe('done');
+    // Only 2 fetch calls: the rejected one + the successful retry
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('readSSEStream — content_filter handling', () => {
   afterEach(() => vi.unstubAllGlobals());
 


### PR DESCRIPTION
These are the same changes as #371. I have created a new merge request.

## Summary

Fix XSS vulnerability in wiki HTML viewer by escaping HTML-significant characters in embedded JSON, and add automatic `max_tokens` → `max_completion_tokens` parameter fallback in the LLM client for models that reject the legacy parameter name.

## Motivation / context

1. **Script injection in wiki HTML:** The wiki viewer embeds page content as JSON inside a `<script>` tag using raw `JSON.stringify`. If any wiki page content contains `</script>`, the HTML parser closes the script block early, enabling XSS. This is especially dangerous because wiki content is LLM-generated and its exact output is unpredictable.
2. **LLM token parameter compatibility:** Newer OpenAI models (e.g. `o3-mini`, `gpt-4.1`) reject the `max_tokens` parameter with a 400 error, requiring `max_completion_tokens` instead. Users hitting this error had no recourse other than manually configuring the correct parameter. The auto-switch makes the wiki generator work out of the box with both old and new model families.

## Areas touched

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- `safeJSON()` helper that Unicode-escapes `<`, `>`, `&` in serialized JSON so it is safe to embed in `<script>` tags
- Content-Security-Policy meta tag added to generated wiki HTML (`default-src 'none'`; allows inline scripts, the marked CDN, and data/https images)
- Auto-retry in `callLLM` that switches `max_tokens` to `max_completion_tokens` on a 400 mentioning `'max_tokens'`, without consuming a retry attempt
- Unit tests for both changes

**Explicitly out of scope / not done here**

- Migrating the wiki viewer away from inline scripts entirely (would require a bundler or separate JS asset)
- Server-side HTML sanitization of LLM-generated markdown (the CSP and JSON escaping are defense-in-depth at the embedding layer)
- Proactively detecting the model family to choose the correct token parameter up front (the reactive fallback is simpler and model-list-agnostic)

## Implementation notes

- **`safeJSON` replacement order matters:** `<` and `>` are replaced before `&` because their replacements (`\u003c`, `\u003e`) contain no `&`, so the final `&` pass cannot double-escape them. The function round-trips cleanly through `JSON.parse`.
- **Token-param switch is one-shot:** A `switchedTokenParam` boolean prevents infinite retry loops. The `attempt--` ensures the switch itself doesn't consume one of the 3 retry budget slots.
- **CSP policy is intentionally permissive for inline scripts** (`'unsafe-inline' 'unsafe-eval'`) because the wiki viewer relies on inline `<script>` blocks and `marked.js` uses `new Function`. This still blocks all other sources (`default-src 'none'`), which is a meaningful improvement over no CSP.

## Testing & verification

- [x] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [x] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(web not changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(web not changed)*
- [ ] Manual / Playwright E2E

**New test coverage:**

- `wiki-html-viewer.test.ts` — 7 tests: `safeJSON` escaping of `<`, `>`, `&`, `</script>` XSS vector, round-trip fidelity, no double-escaping, undefined/non-serializable handling, and CSP meta tag presence in generated HTML
- `wiki-llm-client.test.ts` — 4 new tests: successful auto-switch, no trigger on unrelated 400s, no trigger when already using `max_completion_tokens` (reasoning models), and verification that the switch doesn't consume a retry attempt

## Risk & rollout

- **Low risk.** Both changes are additive/defensive and do not alter the happy path.
- `safeJSON` is a strict superset of `JSON.stringify` — output is always valid JSON that `JSON.parse` can round-trip.
- The token-param auto-switch only activates on a specific 400 error shape that would otherwise be a hard failure, so it cannot make a working request worse.
- No index refresh needed (`npx gitnexus analyze` not required).
- No breaking changes or migrations.

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed
