### PR TITLE
feat: gitnexus:keep marker preserves custom context sections

### DIFF
--- a/gitnexus/src/cli/ai-context.ts
+++ b/gitnexus/src/cli/ai-context.ts
@@ -200,12 +200,21 @@ async function upsertGitNexusSection(
   if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
     const existingSection = existingContent.substring(startIdx, endIdx + GITNEXUS_END_MARKER.length);
 
-    // If the existing section contains <!-- gitnexus:keep -->, only update the stats line
-    // This lets users customize the section without it being overwritten on every analyze
+    // If the existing section contains <!-- gitnexus:keep -->, preserve the user's
+    // custom layout and only update the stats line (node/edge/flow counts).
+    // This lets teams trim the verbose default template to a lean format without
+    // having it overwritten on every `gitnexus analyze`.
     if (existingSection.includes('<!-- gitnexus:keep -->')) {
-      // Update just the "Indexed as **Name** (N nodes, M edges, P flows)" line
-      const statsPattern = /Indexed as \*\*[^*]+\*\* \([^)]+\)/;
-      const statsLine = `Indexed as **${(content.match(/\*\*([^*]+)\*\*/)?.[1]) || 'unknown'}** (${(content.match(/\(([^)]+)\)/)?.[1]) || '0 nodes'})`;
+      // Match both formats:
+      //   "Indexed as **name** (N symbols, M relationships, P execution flows)"
+      //   "This project is indexed by GitNexus as **name** (N symbols, ...)"
+      const statsPattern = /(?:Indexed as|indexed by GitNexus as) \*\*[^*]+\*\* \([^)]+\)/;
+
+      // Extract fresh stats from the newly generated content
+      const newName = (content.match(/\*\*([^*]+)\*\*/) || [])[1] || 'unknown';
+      const newStats = (content.match(/\((\d[\d,]* symbols[^)]+)\)/) || content.match(/\(([^)]+)\)/) || [])[1] || '0 nodes';
+      const statsLine = `Indexed as **${newName}** (${newStats})`;
+
       if (statsPattern.test(existingSection)) {
         const updatedSection = existingSection.replace(statsPattern, statsLine);
         const before = existingContent.substring(0, startIdx);
@@ -213,6 +222,8 @@ async function upsertGitNexusSection(
         await fs.writeFile(filePath, (before + updatedSection + after).trim() + '\n', 'utf-8');
         return 'updated';
       }
+      // Keep marker present but no stats line found — preserve section as-is
+      return 'updated';
     }
 
     // No keep marker — replace existing section with full verbose content

--- a/gitnexus/src/cli/ai-context.ts
+++ b/gitnexus/src/cli/ai-context.ts
@@ -198,7 +198,24 @@ async function upsertGitNexusSection(
   const endIdx = existingContent.indexOf(GITNEXUS_END_MARKER);
 
   if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
-    // Replace existing section
+    const existingSection = existingContent.substring(startIdx, endIdx + GITNEXUS_END_MARKER.length);
+
+    // If the existing section contains <!-- gitnexus:keep -->, only update the stats line
+    // This lets users customize the section without it being overwritten on every analyze
+    if (existingSection.includes('<!-- gitnexus:keep -->')) {
+      // Update just the "Indexed as **Name** (N nodes, M edges, P flows)" line
+      const statsPattern = /Indexed as \*\*[^*]+\*\* \([^)]+\)/;
+      const statsLine = `Indexed as **${(content.match(/\*\*([^*]+)\*\*/)?.[1]) || 'unknown'}** (${(content.match(/\(([^)]+)\)/)?.[1]) || '0 nodes'})`;
+      if (statsPattern.test(existingSection)) {
+        const updatedSection = existingSection.replace(statsPattern, statsLine);
+        const before = existingContent.substring(0, startIdx);
+        const after = existingContent.substring(endIdx + GITNEXUS_END_MARKER.length);
+        await fs.writeFile(filePath, (before + updatedSection + after).trim() + '\n', 'utf-8');
+        return 'updated';
+      }
+    }
+
+    // No keep marker — replace existing section with full verbose content
     const before = existingContent.substring(0, startIdx);
     const after = existingContent.substring(endIdx + GITNEXUS_END_MARKER.length);
     const newContent = before + content + after;

--- a/gitnexus/test/unit/ai-context.test.ts
+++ b/gitnexus/test/unit/ai-context.test.ts
@@ -66,6 +66,77 @@ describe('generateAIContextFiles', () => {
     expect(starts).toBe(1);
   });
 
+  it('preserves custom section when gitnexus:keep is present', async () => {
+    const claudeMdPath = path.join(tmpDir, 'CLAUDE.md');
+
+    // Write a custom lean section with keep marker
+    const customContent = `# My Project
+
+Some project docs here.
+
+<!-- gitnexus:start -->
+<!-- gitnexus:keep -->
+# GitNexus — Code Knowledge Graph
+
+Indexed as **TestProject** (50 symbols, 100 relationships, 5 execution flows). MCP tools.
+
+| Tool | Use for |
+|------|---------|
+| query | Find flows |
+
+Resources: gitnexus://repo/TestProject/context
+<!-- gitnexus:end -->
+`;
+    await fs.writeFile(claudeMdPath, customContent, 'utf-8');
+
+    // Run analyze with new stats — should only update the stats line
+    const stats = { nodes: 999, edges: 1234, processes: 42 };
+    await generateAIContextFiles(tmpDir, storagePath, 'TestProject', stats);
+
+    const result = await fs.readFile(claudeMdPath, 'utf-8');
+
+    // Stats should be updated
+    expect(result).toContain('999 symbols');
+    expect(result).toContain('1234 relationships');
+    expect(result).toContain('42 execution flows');
+
+    // Custom layout should be preserved (not replaced with verbose template)
+    expect(result).toContain('<!-- gitnexus:keep -->');
+    expect(result).toContain('Code Knowledge Graph');
+    expect(result).toContain('| query | Find flows |');
+
+    // Verbose template sections should NOT be present
+    expect(result).not.toContain('## Always Do');
+    expect(result).not.toContain('## Never Do');
+    expect(result).not.toContain('## When Debugging');
+
+    // Non-GitNexus content should be preserved
+    expect(result).toContain('# My Project');
+    expect(result).toContain('Some project docs here.');
+  });
+
+  it('replaces section when no keep marker is present', async () => {
+    const agentsPath = path.join(tmpDir, 'AGENTS.md');
+
+    // Write a section WITHOUT keep marker
+    const content = `<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+Old content here.
+<!-- gitnexus:end -->
+`;
+    await fs.writeFile(agentsPath, content, 'utf-8');
+
+    const stats = { nodes: 100, edges: 200, processes: 10 };
+    await generateAIContextFiles(tmpDir, storagePath, 'TestProject', stats);
+
+    const result = await fs.readFile(agentsPath, 'utf-8');
+
+    // Should have the full verbose template
+    expect(result).toContain('## Always Do');
+    expect(result).not.toContain('Old content here');
+  });
+
   it('installs skills files', async () => {
     const stats = { nodes: 10 };
     const result = await generateAIContextFiles(tmpDir, storagePath, 'TestProject', stats);


### PR DESCRIPTION
## Summary

When `<!-- gitnexus:keep -->` is placed inside the GitNexus-generated block in CLAUDE.md or AGENTS.md, `analyze` only updates the stats line (node/edge/flow counts) instead of replacing the entire section with the verbose default template.

This lets users trim the auto-generated context to a lean custom format without it being overwritten on every reindex.

## Problem

Every `analyze` run regenerates the full GitNexus section in CLAUDE.md/AGENTS.md with the verbose template (tool descriptions, usage instructions, risk levels, etc.). Teams that maintain a lean custom format have to re-edit the file after every reindex.

## Solution

- If `<!-- gitnexus:keep -->` is present inside the GitNexus block, only the stats line is updated (e.g., "Indexed as **repo** (N symbols, N relationships, N execution flows)")
- If no keep marker is present, behavior is unchanged — full template replacement
- Broadened stats-line regex to match both "Indexed as" and "indexed by GitNexus as" formats
- If keep marker is present but no stats line is found, the section is preserved as-is

## Files changed

- `gitnexus/src/cli/ai-context.ts` — keep marker detection + stats-only update logic
- `gitnexus/test/unit/ai-context.test.ts` — unit tests for keep preservation and no-keep replacement

## Test plan

- [x] Unit tests for keep marker preservation
- [x] Unit tests for no-keep full replacement
- [x] Verified on 10+ repos in the dp-web4 collective with custom CLAUDE.md formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)