### PR TITLE
fix(embeddings): dispose ONNX Runtime session before process exit

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -290,5 +290,7 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
   // LadybugDB's native module holds open handles that prevent Node from exiting.
   // ONNX Runtime also registers native atexit hooks that segfault on some
   // platforms (#38, #40). Force-exit to ensure clean termination.
+  // The ONNX session is disposed in runFullAnalysis after embeddings complete
+  // to prevent C++ atexit destructors from racing with closed DB handles.
   process.exit(0);
 };

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -290,7 +290,5 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
   // LadybugDB's native module holds open handles that prevent Node from exiting.
   // ONNX Runtime also registers native atexit hooks that segfault on some
   // platforms (#38, #40). Force-exit to ensure clean termination.
-  // The ONNX session is disposed in runFullAnalysis after embeddings complete
-  // to prevent C++ atexit destructors from racing with closed DB handles.
   process.exit(0);
 };

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -268,12 +268,16 @@ export async function runFullAnalysis(
 
       // Release ONNX Runtime session to prevent its C++ atexit handlers from
       // racing with LadybugDB cleanup during process.exit() (#38, #40).
-      try {
-        const { disposeEmbedder } = await import('./embeddings/embedder.js');
-        await disposeEmbedder();
-      } catch {
-        /* best-effort */
-      }
+      const disposeEmbedderBestEffort = async (): Promise<void> => {
+        try {
+          const { disposeEmbedder } = await import('./embeddings/embedder.js');
+          await disposeEmbedder();
+        } catch {
+          /* best-effort */
+        }
+      };
+
+      await disposeEmbedderBestEffort();
     }
 
     // ── Phase 5: Finalize (98–100%) ───────────────────────────────────

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -356,11 +356,13 @@ export async function runFullAnalysis(
   } catch (err) {
     // Ensure native resources are closed even on error to prevent
     // C++ atexit destructor races during process.exit() (#38, #40).
-    try {
-      const { disposeEmbedder } = await import('./embeddings/embedder.js');
-      await disposeEmbedder();
-    } catch {
-      /* swallow */
+    if (options.embeddings) {
+      try {
+        const { disposeEmbedder } = await import('./embeddings/embedder.js');
+        await disposeEmbedder();
+      } catch {
+        /* swallow */
+      }
     }
     try {
       await closeLbug();

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -354,7 +354,14 @@ export async function runFullAnalysis(
       pipelineResult,
     };
   } catch (err) {
-    // Ensure LadybugDB is closed even on error
+    // Ensure native resources are closed even on error to prevent
+    // C++ atexit destructor races during process.exit() (#38, #40).
+    try {
+      const { disposeEmbedder } = await import('./embeddings/embedder.js');
+      await disposeEmbedder();
+    } catch {
+      /* swallow */
+    }
     try {
       await closeLbug();
     } catch {

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -265,6 +265,15 @@ export async function runFullAnalysis(
         {},
         cachedEmbeddingNodeIds.size > 0 ? cachedEmbeddingNodeIds : undefined,
       );
+
+      // Release ONNX Runtime session to prevent its C++ atexit handlers from
+      // racing with LadybugDB cleanup during process.exit() (#38, #40).
+      try {
+        const { disposeEmbedder } = await import('./embeddings/embedder.js');
+        await disposeEmbedder();
+      } catch {
+        /* best-effort */
+      }
     }
 
     // ── Phase 5: Finalize (98–100%) ───────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #151

- Fixes `libc++abi: terminating due to uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument` crash when running `gitnexus analyze --embeddings --skills`
- The ONNX Runtime inference session was never disposed after the embedding pipeline completed
- When `process.exit(0)` fires, both ONNX Runtime's and LadybugDB's C++ `atexit` destructors race with each other, crashing on a mutex that's already been invalidated

## Fix

Call `disposeEmbedder()` in `run-analyze.ts` in two places:

1. **Happy path** — immediately after `runEmbeddingPipeline()` completes, inside the `if (!embeddingSkipped)` block
2. **Error path** — in the outer `catch` block, before `closeLbug()`, so a failed embedding run also cleans up the ONNX session

This ensures the ONNX Runtime session is released before LadybugDB closes and before `process.exit(0)`, eliminating the C++ destructor race on both success and failure paths.

## Verification

- Tested against a repo that consistently reproduced the crash (`v0-quorum-report-redesign-concep`)
- Full `--force --embeddings --skills` re-index completed cleanly (exit code 0, no crash)
- Full test suite passes (4,555 tests passed)

## Test plan

- [x] `gitnexus analyze --embeddings --skills --force` completes without mutex crash
- [x] `gitnexus analyze` (no embeddings) still exits cleanly
- [x] Full test suite passes (4,555 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)