### PR TITLE
fix(web): avoid reload loop when /api/heartbeat is missing

### DIFF
--- a/gitnexus-web/src/services/backend-client.ts
+++ b/gitnexus-web/src/services/backend-client.ts
@@ -301,21 +301,45 @@ export const fetchServerInfo = async (): Promise<ServerInfo> => {
   return response.json() as Promise<ServerInfo>;
 };
 
+export interface HeartbeatOptions {
+  /**
+   * Liveness probe cadence when SSE heartbeat is unavailable.
+   * Defaults to 5000ms.
+   */
+  probeIntervalMs?: number;
+  /**
+   * Number of consecutive probe failures before considering backend disconnected.
+   * Defaults to 3 (with 5s probe interval this is ~15s grace).
+   */
+  maxProbeFailures?: number;
+  /**
+   * Forces polling fallback mode immediately (primarily for tests).
+   */
+  forcePollingFallback?: boolean;
+}
+
 /**
  * Connect an SSE heartbeat to the backend. Fires `onDisconnect` when the
  * server goes down (after one retry to avoid false positives from transient
  * network hiccups). Returns a cleanup function.
  */
-export const connectHeartbeat = (onConnect: () => void, onDisconnect: () => void): (() => void) => {
+export const connectHeartbeat = (
+  onConnect: () => void,
+  onDisconnect: () => void,
+  options: HeartbeatOptions = {},
+): (() => void) => {
+  const probeIntervalMs = options.probeIntervalMs ?? 5_000;
+  const maxProbeFailures = options.maxProbeFailures ?? 3;
+
   let closed = false;
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
   let livenessTimer: ReturnType<typeof setInterval> | null = null;
   let es: EventSource | null = null;
   let attempt = 0;
-  let heartbeatUnsupported = false;
+  let heartbeatUnsupported = options.forcePollingFallback ?? false;
   let consecutiveProbeFailures = 0;
+  let probeInFlight = false;
   const MAX_RETRIES = 3;
-  const MAX_PROBE_FAILURES = 3;
 
   const stopLivenessProbe = () => {
     if (livenessTimer) {
@@ -328,17 +352,23 @@ export const connectHeartbeat = (onConnect: () => void, onDisconnect: () => void
     if (closed || livenessTimer) return;
 
     const check = async () => {
-      const ok = await probeBackend();
-      if (closed) return;
-      if (ok) {
-        consecutiveProbeFailures = 0;
-        return;
-      }
+      if (probeInFlight || closed) return;
+      probeInFlight = true;
+      try {
+        const ok = await probeBackend();
+        if (closed) return;
+        if (ok) {
+          consecutiveProbeFailures = 0;
+          return;
+        }
 
-      consecutiveProbeFailures += 1;
-      if (consecutiveProbeFailures >= MAX_PROBE_FAILURES) {
-        stopLivenessProbe();
-        onDisconnect();
+        consecutiveProbeFailures += 1;
+        if (consecutiveProbeFailures >= maxProbeFailures) {
+          stopLivenessProbe();
+          onDisconnect();
+        }
+      } finally {
+        probeInFlight = false;
       }
     };
 
@@ -346,13 +376,14 @@ export const connectHeartbeat = (onConnect: () => void, onDisconnect: () => void
     void check();
     livenessTimer = setInterval(() => {
       void check();
-    }, 5_000);
+    }, probeIntervalMs);
   };
 
   const connect = () => {
     if (closed) return;
     if (heartbeatUnsupported) {
       startLivenessProbe();
+      onConnect();
       return;
     }
 
@@ -376,7 +407,7 @@ export const connectHeartbeat = (onConnect: () => void, onDisconnect: () => void
         return;
       }
 
-      // Backward-compat: older servers may not expose /api/heartbeat.
+      // Backward-compat: older servers (pre-1.5.x) may not expose /api/heartbeat.
       // If normal API probing still succeeds, keep the app connected and use
       // lightweight polling-based liveness instead of forcing onboarding.
       void probeBackend().then((ok) => {

--- a/gitnexus-web/src/services/backend-client.ts
+++ b/gitnexus-web/src/services/backend-client.ts
@@ -309,16 +309,59 @@ export const fetchServerInfo = async (): Promise<ServerInfo> => {
 export const connectHeartbeat = (onConnect: () => void, onDisconnect: () => void): (() => void) => {
   let closed = false;
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let livenessTimer: ReturnType<typeof setInterval> | null = null;
   let es: EventSource | null = null;
   let attempt = 0;
+  let heartbeatUnsupported = false;
+  let consecutiveProbeFailures = 0;
   const MAX_RETRIES = 3;
+  const MAX_PROBE_FAILURES = 3;
+
+  const stopLivenessProbe = () => {
+    if (livenessTimer) {
+      clearInterval(livenessTimer);
+      livenessTimer = null;
+    }
+  };
+
+  const startLivenessProbe = () => {
+    if (closed || livenessTimer) return;
+
+    const check = async () => {
+      const ok = await probeBackend();
+      if (closed) return;
+      if (ok) {
+        consecutiveProbeFailures = 0;
+        return;
+      }
+
+      consecutiveProbeFailures += 1;
+      if (consecutiveProbeFailures >= MAX_PROBE_FAILURES) {
+        stopLivenessProbe();
+        onDisconnect();
+      }
+    };
+
+    // immediate check so we don't wait for the first interval tick
+    void check();
+    livenessTimer = setInterval(() => {
+      void check();
+    }, 5_000);
+  };
 
   const connect = () => {
     if (closed) return;
+    if (heartbeatUnsupported) {
+      startLivenessProbe();
+      return;
+    }
+
     es = new EventSource(`${_backendUrl}/api/heartbeat`);
     es.onopen = () => {
       if (!closed) {
         attempt = 0;
+        consecutiveProbeFailures = 0;
+        stopLivenessProbe();
         onConnect();
       }
     };
@@ -330,9 +373,23 @@ export const connectHeartbeat = (onConnect: () => void, onDisconnect: () => void
         const delay = 1_000 * Math.pow(2, attempt);
         attempt++;
         retryTimer = setTimeout(connect, delay);
-      } else {
-        onDisconnect();
+        return;
       }
+
+      // Backward-compat: older servers may not expose /api/heartbeat.
+      // If normal API probing still succeeds, keep the app connected and use
+      // lightweight polling-based liveness instead of forcing onboarding.
+      void probeBackend().then((ok) => {
+        if (closed) return;
+        if (ok) {
+          heartbeatUnsupported = true;
+          consecutiveProbeFailures = 0;
+          startLivenessProbe();
+          onConnect();
+        } else {
+          onDisconnect();
+        }
+      });
     };
   };
 
@@ -341,6 +398,7 @@ export const connectHeartbeat = (onConnect: () => void, onDisconnect: () => void
   return () => {
     closed = true;
     es?.close();
+    stopLivenessProbe();
     if (retryTimer) clearTimeout(retryTimer);
   };
 };

--- a/gitnexus-web/test/unit/heartbeat-fallback.test.ts
+++ b/gitnexus-web/test/unit/heartbeat-fallback.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { connectHeartbeat } from '../../src/services/backend-client';
+
+const realEventSource = globalThis.EventSource;
+const realSetInterval = globalThis.setInterval;
+const realClearInterval = globalThis.clearInterval;
+
+class ThrowingEventSource {
+  constructor() {
+    throw new Error('EventSource is unavailable in this test mode');
+  }
+  onopen: ((this: EventSource, ev: Event) => any) | null = null;
+  onerror: ((this: EventSource, ev: Event) => any) | null = null;
+  onmessage: ((this: EventSource, ev: MessageEvent) => any) | null = null;
+  readyState = 2;
+  url = '';
+  withCredentials = false;
+  close() {}
+  addEventListener(): void {}
+  dispatchEvent(): boolean {
+    return true;
+  }
+  removeEventListener(): void {}
+}
+
+describe('connectHeartbeat fallback probe', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.EventSource = realEventSource;
+    globalThis.setInterval = realSetInterval;
+    globalThis.clearInterval = realClearInterval;
+  });
+
+  it('does not overlap probe requests during polling fallback', async () => {
+    globalThis.EventSource = ThrowingEventSource as unknown as typeof EventSource;
+
+    let activeProbeCount = 0;
+    let maxActiveProbeCount = 0;
+    const fetchMock = vi.fn(async () => {
+      activeProbeCount += 1;
+      maxActiveProbeCount = Math.max(maxActiveProbeCount, activeProbeCount);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      activeProbeCount -= 1;
+      return new Response('{}', { status: 500 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const intervalCallbacks: Array<() => void> = [];
+    globalThis.setInterval = ((cb: TimerHandler) => {
+      intervalCallbacks.push(cb as () => void);
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    }) as typeof setInterval;
+    globalThis.clearInterval = vi.fn() as unknown as typeof clearInterval;
+
+    const onConnect = vi.fn();
+    const onDisconnect = vi.fn();
+
+    const cleanup = connectHeartbeat(onConnect, onDisconnect, {
+      forcePollingFallback: true,
+      maxProbeFailures: 99,
+      probeIntervalMs: 1,
+    });
+
+    expect(onConnect).toHaveBeenCalledTimes(1);
+
+    // Let immediate check start
+    await new Promise((resolve) => setTimeout(resolve, 1));
+
+    // Trigger multiple timer ticks while first probe is still in-flight
+    intervalCallbacks.forEach((cb) => {
+      cb();
+      cb();
+      cb();
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    expect(maxActiveProbeCount).toBe(1);
+    cleanup();
+  });
+
+  it('disconnects after configured number of failed probes', async () => {
+    globalThis.EventSource = ThrowingEventSource as unknown as typeof EventSource;
+
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 500 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const intervalCallbacks: Array<() => void> = [];
+    globalThis.setInterval = ((cb: TimerHandler) => {
+      intervalCallbacks.push(cb as () => void);
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    }) as typeof setInterval;
+    globalThis.clearInterval = vi.fn() as unknown as typeof clearInterval;
+
+    const onConnect = vi.fn();
+    const onDisconnect = vi.fn();
+
+    const cleanup = connectHeartbeat(onConnect, onDisconnect, {
+      forcePollingFallback: true,
+      maxProbeFailures: 2,
+      probeIntervalMs: 1,
+    });
+
+    expect(onConnect).toHaveBeenCalledTimes(1);
+
+    // Wait for immediate failed probe
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    expect(onDisconnect).toHaveBeenCalledTimes(0);
+
+    // Second failed probe should trigger disconnect
+    intervalCallbacks.forEach((cb) => cb());
+    await new Promise((resolve) => setTimeout(resolve, 1));
+
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+});


### PR DESCRIPTION
## Summary
- fixes the reload loop reported when `EventSource(/api/heartbeat)` returns 404
- keeps compatibility with older backends that don't yet expose the heartbeat endpoint

## What changed
- updated `connectHeartbeat` in `gitnexus-web/src/services/backend-client.ts`
- after EventSource retries are exhausted, the client now probes `/api/repos`
- if probe succeeds, it switches to a lightweight liveness poll (5s interval)
- only disconnects after 3 consecutive probe failures

## Why this works
If the backend is reachable but simply lacks `/api/heartbeat`, previous behavior treated it as hard disconnect and forced onboarding reloads. The new fallback treats that case as compatible and keeps the session alive.

## Testing
- ✅ `npm --prefix gitnexus-shared run build`
- ✅ `npm --prefix gitnexus-web run test -- test/unit/server-connection.test.ts`
- ⚠️ full `npm --prefix gitnexus-web run test` has one pre-existing environment/package-resolution failure unrelated to this change (`security-guards.test.ts` import resolution)

Fixes #583
