### PR TITLE
fix: resolve CLI path on Windows after gitnexus setup

### DIFF
--- a/gitnexus/hooks/claude/gitnexus-hook.cjs
+++ b/gitnexus/hooks/claude/gitnexus-hook.cjs
@@ -103,20 +103,68 @@ function extractPattern(toolName, toolInput) {
 
 /**
  * Resolve the gitnexus CLI path.
- * 1. Relative path (works when script is inside npm package)
- * 2. require.resolve (works when gitnexus is globally installed)
- * 3. Fall back to npx (returns empty string)
+ * 1. Injected constant (set by `gitnexus setup` when copying this file)
+ * 2. Relative path (works when script is inside npm package)
+ * 3. require.resolve (works when gitnexus is in Node module path)
+ * 4. Discover from installed binary via which/where
+ * 5. npm root -g fallback
+ * 6. Fall back to npx (returns empty string)
  */
 function resolveCliPath() {
-  let cliPath = path.resolve(__dirname, '..', '..', 'dist', 'cli', 'index.js');
-  if (!fs.existsSync(cliPath)) {
-    try {
-      cliPath = require.resolve('gitnexus/dist/cli/index.js');
-    } catch {
-      cliPath = '';
-    }
+  // 1. Injected absolute path (populated by `gitnexus setup`)
+  if (typeof GITNEXUS_CLI_PATH !== 'undefined' && GITNEXUS_CLI_PATH && fs.existsSync(GITNEXUS_CLI_PATH)) {
+    return GITNEXUS_CLI_PATH;
   }
-  return cliPath;
+
+  // 2. Relative path (works when running from inside the npm package tree)
+  let cliPath = path.resolve(__dirname, '..', '..', 'dist', 'cli', 'index.js');
+  if (fs.existsSync(cliPath)) return cliPath;
+
+  // 3. require.resolve
+  try {
+    return require.resolve('gitnexus/dist/cli/index.js');
+  } catch { /* continue */ }
+
+  // 4. Discover from installed binary location
+  const isWin = process.platform === 'win32';
+  try {
+    const whichResult = spawnSync(isWin ? 'where' : 'which', ['gitnexus'], {
+      encoding: 'utf-8',
+      timeout: 3000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const binPath = (whichResult.stdout || '').split(/\r?\n/)[0].trim();
+    if (binPath) {
+      const binDir = path.dirname(binPath);
+      const candidates = [
+        // npm global on Windows: <prefix>/gitnexus -> <prefix>/node_modules/gitnexus/
+        path.join(binDir, 'node_modules', 'gitnexus', 'dist', 'cli', 'index.js'),
+        // npm global on Unix: <prefix>/bin/gitnexus -> <prefix>/lib/node_modules/gitnexus/
+        path.join(binDir, '..', 'lib', 'node_modules', 'gitnexus', 'dist', 'cli', 'index.js'),
+      ];
+      for (const c of candidates) {
+        if (fs.existsSync(c)) return c;
+      }
+    }
+  } catch { /* continue */ }
+
+  // 5. npm root -g fallback (needs shell:true on Windows for .cmd wrapper)
+  try {
+    const npmResult = spawnSync(isWin ? 'npm.cmd' : 'npm', ['root', '-g'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      shell: isWin,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const globalRoot = (npmResult.stdout || '').trim();
+    if (globalRoot) {
+      const candidate = path.join(globalRoot, 'gitnexus', 'dist', 'cli', 'index.js');
+      if (fs.existsSync(candidate)) return candidate;
+    }
+  } catch { /* continue */ }
+
+  // 6. Fall back to npx
+  return '';
 }
 
 /**

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -169,15 +169,16 @@ async function installClaudeCodeHooks(result: SetupResult): Promise<void> {
     const dest = path.join(destHooksDir, 'gitnexus-hook.cjs');
     try {
       let content = await fs.readFile(src, 'utf-8');
-      // Inject resolved CLI path so the copied hook can find the CLI
-      // even when it's no longer inside the npm package tree
+      // Inject resolved CLI path as a constant at the top of the hook file.
+      // Previous approach used String.replace() targeting a specific line, but
+      // failed silently due to indentation mismatch (2-space indent in source
+      // vs no indent in the match string). Prepending a constant is robust
+      // regardless of formatting. See #108, #132.
       const resolvedCli = path.join(__dirname, '..', 'cli', 'index.js');
       const normalizedCli = path.resolve(resolvedCli).replace(/\\/g, '/');
       const jsonCli = JSON.stringify(normalizedCli);
-      content = content.replace(
-        "let cliPath = path.resolve(__dirname, '..', '..', 'dist', 'cli', 'index.js');",
-        `let cliPath = ${jsonCli};`,
-      );
+      content = `const GITNEXUS_CLI_PATH = ${jsonCli};
+` + content;
       await fs.writeFile(dest, content, 'utf-8');
     } catch {
       // Script not found in source — skip


### PR DESCRIPTION
## Summary
- **Fixes #108** — PreToolUse hook breaks after `gitnexus setup` (global npm install)
- **Fixes #132** — Hook fails after setup on Windows — incorrect relative path resolution

## Root Cause

Two independent bugs that compound on Windows:

### 1. `resolveCliPath()` in `gitnexus-hook.cjs` has insufficient fallbacks

When the hook is copied to `~/.claude/hooks/gitnexus/`, the relative path `path.resolve(__dirname, '..', '..', 'dist', 'cli', 'index.js')` resolves to `~/.claude/dist/cli/index.js` (doesn't exist). The `require.resolve()` fallback also fails because `~/.claude/hooks/` is outside Node's module resolution scope for globally-installed packages.

**Fix:** 6-step fallback chain:
1. `GITNEXUS_CLI_PATH` injected constant (set by `gitnexus setup`)
2. Relative path (works when script is inside npm package tree)
3. `require.resolve()` (works when gitnexus is in Node's module path)
4. `which`/`where` binary discovery → derive package root from bin dir
5. `npm root -g` fallback (uses `shell: true` on Windows for `.cmd` wrapper)
6. Fall back to npx

Windows-specific handling:
- Uses `where` instead of `which`
- Splits output with `/\r?\n/` to strip trailing CR
- Uses `npm.cmd` with `shell: true` for the npm fallback

### 2. `setup.ts` path injection silently fails

`installClaudeCodeHooks()` uses `String.replace()` to inject the resolved CLI path into the copied hook file. The match target is:
```
"let cliPath = path.resolve(__dirname, '..', '..', 'dist', 'cli', 'index.js');"
```
But the actual line in `gitnexus-hook.cjs` has 2 spaces of indentation:
```
  let cliPath = path.resolve(__dirname, '..', '..', 'dist', 'cli', 'index.js');
```
`String.replace()` finds no match → hook is copied verbatim without the path injection.

**Fix:** Instead of fragile string matching, prepend `const GITNEXUS_CLI_PATH = "...";` to the top of the copied file. The hook checks this constant first in `resolveCliPath()`. No indentation sensitivity, no silent failures.

## Test Plan
- [x] Tested on Windows 11, Node v22, global npm install
- [x] `where gitnexus` correctly resolves to `<npm_prefix>/node_modules/gitnexus/dist/cli/index.js`
- [x] Hook syntax check passes (`node -c gitnexus-hook.cjs`)
- [ ] Verify on macOS/Linux with global npm install
- [ ] Verify `gitnexus setup` correctly prepends `GITNEXUS_CLI_PATH` to copied hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)