### PR TITLE
feat: print skipped large file paths in verbose analyze output

### DIFF
--- a/gitnexus/src/core/ingestion/filesystem-walker.ts
+++ b/gitnexus/src/core/ingestion/filesystem-walker.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { glob } from 'glob';
 import { createIgnoreFilter } from '../../config/ignore-service.js';
+import { isVerboseIngestionEnabled } from './utils/verbose.js';
 
 export interface FileEntry {
   path: string;
@@ -43,6 +44,7 @@ export const walkRepositoryPaths = async (
   const entries: ScannedFile[] = [];
   let processed = 0;
   let skippedLarge = 0;
+  const skippedLargePaths: string[] = [];
 
   for (let start = 0; start < filtered.length; start += READ_CONCURRENCY) {
     const batch = filtered.slice(start, start + READ_CONCURRENCY);
@@ -52,6 +54,7 @@ export const walkRepositoryPaths = async (
         const stat = await fs.stat(fullPath);
         if (stat.size > MAX_FILE_SIZE) {
           skippedLarge++;
+          skippedLargePaths.push(relativePath.replace(/\\/g, '/'));
           return null;
         }
         return { path: relativePath.replace(/\\/g, '/'), size: stat.size };
@@ -73,6 +76,11 @@ export const walkRepositoryPaths = async (
     console.warn(
       `  Skipped ${skippedLarge} large files (>${MAX_FILE_SIZE / 1024}KB, likely generated/vendored)`,
     );
+    if (isVerboseIngestionEnabled()) {
+      for (const skippedPath of skippedLargePaths) {
+        console.warn(`    - ${skippedPath}`);
+      }
+    }
   }
 
   return entries;


### PR DESCRIPTION
## Summary

This PR makes `gitnexus analyze` more actionable in verbose mode by printing the relative paths of files skipped for exceeding the 512KB threshold.

Fixes #689.

## What changed

- keep the existing default summary output unchanged
- when verbose ingestion logging is enabled, print each skipped large file path under the summary line

## Why

When indexing large repositories, the existing message only shows a count:

```text
Skipped 49 large files (>512KB, likely generated/vendored)
```

That makes it hard to tell whether the skipped set is expected or whether an important source file was excluded. Printing the paths in verbose mode gives users immediate visibility without adding noise to normal runs.

## Validation

- inspected the staged diff locally
- did not run `npm test` or `npx tsc --noEmit` in this checkout because `gitnexus/node_modules` is not installed in the current environment
