### PR TITLE
fix(group): attribute Spring routes to concrete controllers

### DIFF
--- a/gitnexus/src/core/group/extractors/http-route-extractor.ts
+++ b/gitnexus/src/core/group/extractors/http-route-extractor.ts
@@ -114,6 +114,99 @@ function pickSymbolUid(
   };
 }
 
+type SpringRouteBinding = {
+  method: string;
+  path: string;
+};
+
+type SpringMethodModel = {
+  name: string;
+  routes: SpringRouteBinding[];
+};
+
+type SpringFileModel = {
+  filePath: string;
+  kind: 'class' | 'interface' | 'other';
+  className: string | null;
+  implementedInterfaces: string[];
+  isController: boolean;
+  classPrefix: string;
+  methods: SpringMethodModel[];
+};
+
+function combineSpringPaths(prefix: string, methodPath: string): string {
+  const classPrefix = prefix.trim();
+  const routePart = methodPath.trim();
+  if (!classPrefix && !routePart) return '/';
+  if (!classPrefix) return routePart.startsWith('/') ? routePart : `/${routePart}`;
+  if (!routePart) return classPrefix.startsWith('/') ? classPrefix : `/${classPrefix}`;
+  const normalizedPrefix = classPrefix.startsWith('/') ? classPrefix : `/${classPrefix}`;
+  return `${normalizedPrefix.replace(/\/+$/, '')}/${routePart.replace(/^\//, '')}`;
+}
+
+function parseSpringRouteBindings(annotationBlock: string): SpringRouteBinding[] {
+  const routes: SpringRouteBinding[] = [];
+  const shortcutRe = /@(Get|Post|Put|Delete|Patch)Mapping\s*\(\s*"([^"]*)"/g;
+  let shortcut: RegExpExecArray | null;
+  while ((shortcut = shortcutRe.exec(annotationBlock)) !== null) {
+    routes.push({
+      method: shortcut[1].toUpperCase(),
+      path: shortcut[2],
+    });
+  }
+  return routes;
+}
+
+function parseSpringFileModel(content: string, filePath: string): SpringFileModel | null {
+  const interfaceMatch = content.match(/\binterface\s+(\w+)/);
+  const classMatch = content.match(/\bclass\s+(\w+)/);
+  const kind = interfaceMatch ? 'interface' : classMatch ? 'class' : 'other';
+  const className = interfaceMatch?.[1] ?? classMatch?.[1] ?? null;
+  if (!className || kind === 'other') return null;
+
+  const typeMatch = interfaceMatch || classMatch;
+  const declIndex = typeMatch ? typeMatch.index ?? 0 : 0;
+  const prelude = content.slice(0, declIndex);
+
+  let classPrefix = '';
+  const classPrefixMatches = prelude.matchAll(/@RequestMapping\s*\(\s*"([^"]*)"/g);
+  for (const match of classPrefixMatches) classPrefix = match[1];
+
+  let implementedInterfaces: string[] = [];
+  if (kind === 'class') {
+    const implMatch = content.match(/\bclass\s+\w+[^{]*\bimplements\s+([^{]+)/);
+    if (implMatch?.[1]) {
+      implementedInterfaces = implMatch[1]
+        .split(',')
+        .map((name) => name.trim().split(/\s+/)[0])
+        .filter(Boolean);
+    }
+  }
+
+  const methodPattern =
+    /((?:@[A-Za-z_]\w*(?:\s*\([^)]*\))?\s*)+)\s*(?:public|protected|private)?\s*(?:static\s+)?(?:final\s+)?(?:default\s+)?[\w<>,\s\[\]?]+\s+(\w+)\s*\([^)]*\)\s*(?:\{|;)/gms;
+  const methods: SpringMethodModel[] = [];
+  let methodMatch: RegExpExecArray | null;
+  while ((methodMatch = methodPattern.exec(content)) !== null) {
+    const annotationBlock = methodMatch[1] ?? '';
+    const routes = parseSpringRouteBindings(annotationBlock);
+    methods.push({
+      name: methodMatch[2],
+      routes,
+    });
+  }
+
+  return {
+    filePath,
+    kind,
+    className,
+    implementedInterfaces,
+    isController: /@RestController\b|@Controller\b/.test(prelude),
+    classPrefix,
+    methods,
+  };
+}
+
 export class HttpRouteExtractor implements ContractExtractor {
   type = 'http' as const;
 
@@ -232,14 +325,19 @@ export class HttpRouteExtractor implements ContractExtractor {
       nodir: true,
     });
     const out: ExtractedContract[] = [];
+    const springFiles = new Map<string, string>();
     for (const rel of files) {
       const content = readSafe(repoPath, rel);
       if (!content) continue;
-      out.push(...this.scanSpringProviders(content, rel));
+      if (rel.endsWith('.java')) {
+        springFiles.set(rel, content);
+        continue;
+      }
       out.push(...this.scanExpressProviders(content, rel));
       out.push(...this.scanLaravelProviders(content, rel));
       out.push(...this.scanFastApiProviders(content, rel));
     }
+    out.push(...this.scanSpringProvidersProject(springFiles));
     return this.dedupeContracts(out);
   }
 
@@ -273,6 +371,68 @@ export class HttpRouteExtractor implements ContractExtractor {
       const name = nameM ? nameM[1] : m[0];
       out.push(this.makeProvider(filePath, method, pathNorm, name, 0.8));
     }
+    return out;
+  }
+
+  private scanSpringProvidersProject(files: ReadonlyMap<string, string>): ExtractedContract[] {
+    const out: ExtractedContract[] = [];
+    const models = [...files.entries()]
+      .map(([filePath, content]) => parseSpringFileModel(content, filePath))
+      .filter((model): model is SpringFileModel => model !== null);
+
+    const interfaceRoutes = new Map<string, Map<string, SpringRouteBinding[]>>();
+    for (const model of models) {
+      if (model.kind !== 'interface' || !model.className) continue;
+      const methodMap = new Map<string, SpringRouteBinding[]>();
+      for (const method of model.methods) {
+        if (method.routes.length === 0) continue;
+        methodMap.set(
+          method.name,
+          method.routes.map((route) => ({
+            method: route.method,
+            path: model.classPrefix
+              ? combineSpringPaths(model.classPrefix, route.path)
+              : route.path,
+          })),
+        );
+      }
+      interfaceRoutes.set(model.className, methodMap);
+    }
+
+    for (const model of models) {
+      if (model.kind !== 'class' || !model.isController) continue;
+      for (const method of model.methods) {
+        const ownRoutes =
+          method.routes.length > 0
+            ? method.routes.map((route) => ({
+                method: route.method,
+                path: combineSpringPaths(model.classPrefix, route.path),
+              }))
+            : [];
+
+        const inheritedRoutes =
+          ownRoutes.length > 0
+            ? []
+            : model.implementedInterfaces.flatMap((interfaceName) => {
+                const methodMap = interfaceRoutes.get(interfaceName);
+                if (!methodMap) return [];
+                const routes = methodMap.get(method.name) ?? [];
+                return routes.map((route) => ({
+                  method: route.method,
+                  path: route.path.startsWith('/')
+                    ? route.path
+                    : combineSpringPaths(model.classPrefix, route.path),
+                }));
+              });
+
+        const effectiveRoutes = ownRoutes.length > 0 ? ownRoutes : inheritedRoutes;
+        for (const route of effectiveRoutes) {
+          const pathNorm = normalizeHttpPath(route.path);
+          out.push(this.makeProvider(model.filePath, route.method, pathNorm, method.name, 0.8));
+        }
+      }
+    }
+
     return out;
   }
 

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -130,6 +130,107 @@ public class UserController {
       expect(getByIdRoute).toBeDefined();
     });
 
+    it('attributes annotated interface routes to concrete Spring controllers', async () => {
+      const dir = path.join(tmpDir, 'spring-interface-impl');
+      fs.mkdirSync(path.join(dir, 'src/rest'), { recursive: true });
+      fs.mkdirSync(path.join(dir, 'src/controller'), { recursive: true });
+
+      fs.writeFileSync(
+        path.join(dir, 'src/rest/DepartmentRestInterface.java'),
+        `
+package com.example.rest;
+import org.springframework.web.bind.annotation.*;
+
+public interface DepartmentRestInterface {
+    @GetMapping("/department")
+    Object getDepartmentList();
+
+    @GetMapping("/department/{name}")
+    Object getDepartmentByName(@PathVariable String name);
+}
+`,
+      );
+
+      fs.writeFileSync(
+        path.join(dir, 'src/controller/DepartmentController.java'),
+        `
+package com.example.controller;
+import com.example.rest.DepartmentRestInterface;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/department")
+public class DepartmentController implements DepartmentRestInterface {
+    @Override
+    @GetMapping("")
+    public Object getDepartmentList() { return null; }
+
+    @Override
+    @GetMapping("/{name}")
+    public Object getDepartmentByName(@PathVariable String name) { return null; }
+}
+`,
+      );
+
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      const providers = contracts.filter((c) => c.role === 'provider');
+
+      const rootRoute = providers.find((c) => c.contractId === 'http::GET::/department');
+      expect(rootRoute).toBeDefined();
+      expect(rootRoute!.symbolRef.filePath).toBe('src/controller/DepartmentController.java');
+
+      const byNameRoute = providers.find((c) => c.contractId === 'http::GET::/department/{param}');
+      expect(byNameRoute).toBeDefined();
+      expect(byNameRoute!.symbolRef.filePath).toBe('src/controller/DepartmentController.java');
+
+      const interfaceProviders = providers.filter((c) =>
+        c.symbolRef.filePath.includes('DepartmentRestInterface.java'),
+      );
+      expect(interfaceProviders).toHaveLength(0);
+    });
+
+    it('inherits Spring interface route mappings when concrete controller omits method annotations', async () => {
+      const dir = path.join(tmpDir, 'spring-interface-inherit');
+      fs.mkdirSync(path.join(dir, 'src/rest'), { recursive: true });
+      fs.mkdirSync(path.join(dir, 'src/controller'), { recursive: true });
+
+      fs.writeFileSync(
+        path.join(dir, 'src/rest/StatusRestInterface.java'),
+        `
+package com.example.rest;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/status")
+public interface StatusRestInterface {
+    @GetMapping("")
+    Object getStatus();
+}
+`,
+      );
+
+      fs.writeFileSync(
+        path.join(dir, 'src/controller/StatusController.java'),
+        `
+package com.example.controller;
+import com.example.rest.StatusRestInterface;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class StatusController implements StatusRestInterface {
+    @Override
+    public Object getStatus() { return null; }
+}
+`,
+      );
+
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      const providers = contracts.filter((c) => c.role === 'provider');
+
+      const statusRoute = providers.find((c) => c.contractId === 'http::GET::/status');
+      expect(statusRoute).toBeDefined();
+      expect(statusRoute!.symbolRef.filePath).toBe('src/controller/StatusController.java');
+    });
+
     it('extracts Express router.get patterns', async () => {
       const dir = path.join(tmpDir, 'express');
       fs.mkdirSync(path.join(dir, 'src/routes'), { recursive: true });


### PR DESCRIPTION
## Summary

Fix Spring HTTP provider attribution in `group sync` when route mappings are declared on shared interfaces and implemented by concrete controllers.

Fixes #714.

## What changed

- stop treating annotated Spring interfaces as concrete HTTP providers during group HTTP source-scan
- attribute provider contracts to concrete `@RestController` / `@Controller` classes instead
- inherit interface-declared method mappings when a concrete controller implements an annotated interface but omits method-level mappings locally
- support empty-string method mappings like `@GetMapping("")` so class-level prefixes resolve to the root route correctly
- add focused unit coverage for both the interface-attribution case and the inherited-mapping case

## Why

The existing Spring source-scan in `core/group/extractors/http-route-extractor.ts` was regex-based and flattened contract declaration with concrete provider attribution.

In Spring / Feign-style projects, this can produce incorrect provider ownership:

- shared annotated interfaces are emitted as providers
- the concrete implementation module is not selected as the provider
- root routes using `@GetMapping("")` can be missed

That breaks service attribution in multi-module projects and makes downstream group matching less accurate.

## Testing

- `cd gitnexus && npx vitest run test/unit/group/http-route-extractor.test.ts`
- `cd gitnexus && npx tsc --noEmit`
