### PR TITLE
feat(cli): add --skip-skills and --index-only flags to analyze

### DIFF
--- a/gitnexus/src/cli/ai-context.ts
+++ b/gitnexus/src/cli/ai-context.ts
@@ -27,6 +27,7 @@ interface RepoStats {
 export interface AIContextOptions {
   skipAgentsMd?: boolean;
   noStats?: boolean;
+  skipSkills?: boolean;
 }
 
 const GITNEXUS_START_MARKER = '<!-- gitnexus:start -->';
@@ -300,10 +301,14 @@ export async function generateAIContextFiles(
     createdFiles.push('CLAUDE.md (skipped via --skip-agents-md)');
   }
 
-  // Install skills to .claude/skills/gitnexus/
-  const installedSkills = await installSkills(repoPath);
-  if (installedSkills.length > 0) {
-    createdFiles.push(`.claude/skills/gitnexus/ (${installedSkills.length} skills)`);
+  // Install skills to .claude/skills/gitnexus/ (unless --skip-skills)
+  if (!options?.skipSkills) {
+    const installedSkills = await installSkills(repoPath);
+    if (installedSkills.length > 0) {
+      createdFiles.push(`.claude/skills/gitnexus/ (${installedSkills.length} skills)`);
+    }
+  } else {
+    createdFiles.push('.claude/skills/gitnexus/ (skipped via --skip-skills)');
   }
 
   return { files: createdFiles };

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -61,6 +61,10 @@ export interface AnalyzeOptions {
   skipAgentsMd?: boolean;
   /** Omit volatile symbol/relationship counts from AGENTS.md and CLAUDE.md. */
   noStats?: boolean;
+  /** Skip installing standard GitNexus skill files to .claude/skills/gitnexus/. */
+  skipSkills?: boolean;
+  /** Pure index mode: skip all file injection (AGENTS.md, CLAUDE.md, skills). */
+  indexOnly?: boolean;
   /** Index the folder even when no .git directory is present. */
   skipGit?: boolean;
   /**
@@ -202,6 +206,9 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
 
   // ── Run shared analysis orchestrator ───────────────────────────────
   try {
+    const skipAll = options?.indexOnly;
+    const skipAgentsMd = skipAll || options?.skipAgentsMd;
+    const skipSkills = skipAll || options?.skipSkills;
     const result = await runFullAnalysis(
       repoPath,
       {
@@ -211,7 +218,8 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
         force: options?.force || options?.skills,
         embeddings: options?.embeddings,
         skipGit: options?.skipGit,
-        skipAgentsMd: options?.skipAgentsMd,
+        skipAgentsMd,
+        skipSkills,
         noStats: options?.noStats,
         registryName: options?.name,
         // Registry-collision bypass — its own CLI flag, intentionally NOT
@@ -282,7 +290,7 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
               processes: s.processes,
             },
             skillResult.skills,
-            { skipAgentsMd: options?.skipAgentsMd, noStats: options?.noStats },
+            { skipAgentsMd, skipSkills, noStats: options?.noStats },
           );
         }
       } catch {

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -27,6 +27,8 @@ program
   .option('--skills', 'Generate repo-specific skill files from detected communities')
   .option('--skip-agents-md', 'Skip updating the gitnexus section in AGENTS.md and CLAUDE.md')
   .option('--no-stats', 'Omit volatile file/symbol counts from AGENTS.md and CLAUDE.md')
+  .option('--skip-skills', 'Skip installing standard GitNexus skill files to .claude/skills/gitnexus/')
+  .option('--index-only', 'Pure index mode: skip all file injection (AGENTS.md, CLAUDE.md, skills)')
   .option('--skip-git', 'Index a folder without requiring a .git directory')
   .option(
     '--name <alias>',

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -58,6 +58,8 @@ export interface AnalyzeOptions {
   skipAgentsMd?: boolean;
   /** Omit volatile symbol/relationship counts from AGENTS.md and CLAUDE.md. */
   noStats?: boolean;
+  /** Skip installing standard GitNexus skill files to .claude/skills/gitnexus/. */
+  skipSkills?: boolean;
   /**
    * User-provided alias for the registry `name` (#829). When set,
    * forwarded to `registerRepo` so the indexed repo is stored under
@@ -372,7 +374,11 @@ export async function runFullAnalysis(
           processes: pipelineResult.processResult?.stats.totalProcesses,
         },
         undefined,
-        { skipAgentsMd: options.skipAgentsMd, noStats: options.noStats },
+        {
+          skipAgentsMd: options.skipAgentsMd,
+          skipSkills: options.skipSkills,
+          noStats: options.noStats,
+        },
       );
     } catch {
       // Best-effort — don't fail the entire analysis for context file issues


### PR DESCRIPTION
## Summary

- `gitnexus analyze --skip-agents-md` correctly suppresses AGENTS.md/CLAUDE.md, but **unconditionally injects 6 skill files** into `.claude/skills/gitnexus/` in every analyzed repo
- This PR adds two new flags:
  - `--skip-skills` — suppress standard GitNexus skill file injection
  - `--index-only` — pure index mode: skip **all** file injection (AGENTS.md, CLAUDE.md, skills), writing only to `.gitnexus/`

## Motivation

While bulk-indexing 176 repos with `--skip-agents-md`, all 144 indexed repos were contaminated with `.claude/skills/gitnexus/` files that had to be cleaned up manually. The `--skip-agents-md` flag name implies it controls all AI context injection, but skills bypass it entirely.

## Changes

| File | Change |
|------|--------|
| `src/cli/index.ts` | Add `--skip-skills` and `--index-only` CLI options |
| `src/cli/analyze.ts` | Resolve `--index-only` into both skip flags, pass through call chain |
| `src/core/run-analyze.ts` | Add `skipSkills` to `AnalyzeOptions`, pass to `generateAIContextFiles` |
| `src/cli/ai-context.ts` | Add `skipSkills` to `AIContextOptions`, guard `installSkills()` call |

## Three levels of control

```bash
gitnexus analyze --skip-agents-md .  # suppress only AGENTS.md/CLAUDE.md
gitnexus analyze --skip-skills .     # suppress only skill injection
gitnexus analyze --index-only .      # suppress everything, pure indexing
```

## Test plan

- [ ] Default: `gitnexus analyze .` creates AGENTS.md, CLAUDE.md, and 6 skill dirs
- [ ] `--skip-skills`: AGENTS.md/CLAUDE.md created, no `.claude/skills/gitnexus/`
- [ ] `--skip-agents-md`: skills created, no AGENTS.md/CLAUDE.md
- [ ] `--index-only`: only `.gitnexus/` created, nothing else
- [ ] `--skills --skip-skills`: community-derived skills also suppressed