### PR TITLE
fix(web): clarify local folder onboarding

### DIFF
--- a/gitnexus-web/src/components/AnalyzeOnboarding.tsx
+++ b/gitnexus-web/src/components/AnalyzeOnboarding.tsx
@@ -50,8 +50,9 @@ export const AnalyzeOnboarding = ({ onComplete }: AnalyzeOnboardingProps) => {
             Analyze your first repository
           </h2>
           <p className="mx-auto mt-1.5 max-w-xs text-sm leading-relaxed text-text-secondary">
-            Paste a GitHub URL and GitNexus will clone it, parse the code, and build a live
-            knowledge graph — right in your browser.
+            Paste a GitHub URL or an absolute local folder path from the machine running
+            GitNexus. GitHub repos are cloned locally by the server, and local folders are
+            analyzed in place.
           </p>
         </div>
       </div>
@@ -63,7 +64,8 @@ export const AnalyzeOnboarding = ({ onComplete }: AnalyzeOnboardingProps) => {
 
       {/* Footer hint */}
       <p className="mt-5 text-center text-[11px] leading-relaxed text-text-muted">
-        Public repos only &middot; Cloned locally by the server &middot; No data leaves your machine
+        GitHub URLs: public repos only, cloned locally by the server &middot; Local folders:
+        analyzed in place from the server path &middot; No data leaves your machine
       </p>
     </div>
   );

--- a/gitnexus-web/src/components/RepoAnalyzer.tsx
+++ b/gitnexus-web/src/components/RepoAnalyzer.tsx
@@ -3,7 +3,7 @@
  *
  * Two input modes:
  *   - "github"  → GitHub URL (https://github.com/owner/repo)
- *   - "local"   → Select a local folder via the browser's native directory picker
+ *   - "local"   → Paste an absolute folder path from the machine running GitNexus
  */
 
 import { useState, useRef, useEffect, useId } from 'react';
@@ -23,6 +23,7 @@ import {
   type JobProgress,
 } from '../services/backend-client';
 import { AnalyzeProgress } from './AnalyzeProgress';
+import { isValidLocalAnalyzePath } from '../lib/local-analyze-input';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -135,7 +136,6 @@ export interface RepoAnalyzerProps {
 
 export const RepoAnalyzer = ({ variant, onComplete, onCancel }: RepoAnalyzerProps) => {
   const inputId = useId();
-  const folderInputRef = useRef<HTMLInputElement>(null);
   const [mode, setMode] = useState<InputMode>('github');
   const [githubUrl, setGithubUrl] = useState('');
   const [localPath, setLocalPath] = useState('');
@@ -166,24 +166,20 @@ export const RepoAnalyzer = ({ variant, onComplete, onCancel }: RepoAnalyzerProp
     setValidationError(null);
   };
 
-  // Use the browser's native directory picker (webkitdirectory doesn't give paths,
-  // so we use a text input + a "Browse" button that opens a standard file input
-  // to let users pick files from the folder — the path is typed manually since
-  // browsers don't expose absolute paths for security reasons).
-  // For local paths, the user types or pastes the absolute path.
-
   const canSubmit =
     mode === 'github'
       ? isValidGithubUrl(githubUrl) && (phase === 'input' || phase === 'error')
-      : localPath.trim().length > 1 && (phase === 'input' || phase === 'error');
+      : isValidLocalAnalyzePath(localPath) && (phase === 'input' || phase === 'error');
 
   const handleAnalyze = async () => {
     if (mode === 'github' && !isValidGithubUrl(githubUrl)) {
       setValidationError('Please enter a valid GitHub repository URL.');
       return;
     }
-    if (mode === 'local' && localPath.trim().length < 2) {
-      setValidationError('Please enter a folder path.');
+    if (mode === 'local' && !isValidLocalAnalyzePath(localPath)) {
+      setValidationError(
+        'Enter an absolute folder path from the machine running the GitNexus server.',
+      );
       return;
     }
 
@@ -304,13 +300,13 @@ export const RepoAnalyzer = ({ variant, onComplete, onCancel }: RepoAnalyzerProp
             htmlFor={`${inputId}-local`}
             className="block text-xs font-medium tracking-wider text-text-secondary uppercase"
           >
-            Local Folder Path
+            Absolute Local Folder Path
           </label>
           <div
             className={`flex items-center gap-3 rounded-xl border bg-void px-4 py-3.5 transition-all duration-200 ${
               validationError && phase === 'error'
                 ? 'border-red-500/50'
-                : localPath.trim().length > 1
+                : isValidLocalAnalyzePath(localPath)
                   ? 'border-accent/50 shadow-[0_0_0_3px_rgba(124,58,237,0.08)]'
                   : 'border-border-default focus-within:border-accent/40'
             } `}
@@ -336,39 +332,16 @@ export const RepoAnalyzer = ({ variant, onComplete, onCancel }: RepoAnalyzerProp
               spellCheck={false}
               className="flex-1 border-none bg-transparent font-mono text-sm text-text-primary outline-none placeholder:text-text-muted disabled:opacity-50"
             />
-            {localPath.trim().length > 1 && (
+            {isValidLocalAnalyzePath(localPath) && (
               <Check className="h-3.5 w-3.5 shrink-0 text-emerald-400" />
             )}
           </div>
-          {/* Native folder picker + Browse button — below the input */}
-          <input
-            ref={folderInputRef}
-            type="file"
-            // @ts-expect-error -- webkitdirectory is non-standard but widely supported
-            webkitdirectory=""
-            className="hidden"
-            onChange={(e) => {
-              const files = e.target.files;
-              if (files && files.length > 0) {
-                const rel = files[0].webkitRelativePath;
-                const folderName = rel.split('/')[0];
-                if (folderName) {
-                  setLocalPath(folderName);
-                  setValidationError(null);
-                }
-              }
-              e.target.value = '';
-            }}
-          />
-          <button
-            type="button"
-            onClick={() => folderInputRef.current?.click()}
-            disabled={isLoading}
-            className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-border-subtle bg-elevated px-3 py-2 text-xs font-medium text-text-secondary transition-all duration-150 hover:bg-hover hover:text-text-primary disabled:opacity-50"
-          >
-            <FolderOpen className="h-3.5 w-3.5" />
-            Browse for folder
-          </button>
+          <div className="rounded-xl border border-border-subtle bg-elevated/70 px-3 py-2.5 text-xs leading-relaxed text-text-secondary">
+            GitNexus analyzes local folders directly on the machine running the server. Paste the
+            absolute path here, like {isWindows ? 'C:\\Users\\you\\project' : '/home/you/project'}.
+            Browsers cannot provide a server-usable folder path, so this flow does not use a
+            native folder picker.
+          </div>
         </div>
       )}
 

--- a/gitnexus-web/src/components/RepoLanding.tsx
+++ b/gitnexus-web/src/components/RepoLanding.tsx
@@ -140,8 +140,8 @@ export const RepoLanding = ({ repos, onSelectRepo, onAnalyzeComplete }: RepoLand
 
       {/* Footer hint */}
       <p className="mt-5 text-center text-[11px] leading-relaxed text-text-muted">
-        Public &amp; private repos &middot; Cloned locally by the server &middot; No data leaves
-        your machine
+        GitHub URLs are cloned locally by the server &middot; Local folders are analyzed in
+        place from the server path &middot; No data leaves your machine
       </p>
     </div>
   );

--- a/gitnexus-web/src/lib/local-analyze-input.ts
+++ b/gitnexus-web/src/lib/local-analyze-input.ts
@@ -1,0 +1,13 @@
+const WINDOWS_DRIVE_PATH_RE = /^[a-zA-Z]:[\\/]/;
+const WINDOWS_UNC_PATH_RE = /^\\\\[^\\/]+[\\/][^\\/]+/;
+
+export const isValidLocalAnalyzePath = (value: string): boolean => {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+
+  return (
+    trimmed.startsWith('/') ||
+    WINDOWS_DRIVE_PATH_RE.test(trimmed) ||
+    WINDOWS_UNC_PATH_RE.test(trimmed)
+  );
+};

--- a/gitnexus-web/test/unit/local-analyze-input.test.ts
+++ b/gitnexus-web/test/unit/local-analyze-input.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { isValidLocalAnalyzePath } from '../../src/lib/local-analyze-input';
+
+describe('isValidLocalAnalyzePath', () => {
+  it('accepts Unix absolute paths', () => {
+    expect(isValidLocalAnalyzePath('/mnt/projects/gitnexus')).toBe(true);
+  });
+
+  it('accepts Windows drive-letter paths', () => {
+    expect(isValidLocalAnalyzePath('C:\\Users\\you\\project')).toBe(true);
+    expect(isValidLocalAnalyzePath('D:/work/repo')).toBe(true);
+  });
+
+  it('accepts Windows UNC paths', () => {
+    expect(isValidLocalAnalyzePath('\\\\server\\share\\repo')).toBe(true);
+  });
+
+  it('rejects relative or shell-expanded paths', () => {
+    expect(isValidLocalAnalyzePath('project')).toBe(false);
+    expect(isValidLocalAnalyzePath('./project')).toBe(false);
+    expect(isValidLocalAnalyzePath('../project')).toBe(false);
+    expect(isValidLocalAnalyzePath('~/project')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Clarify the server-backed local-folder onboarding flow in the web UI so it asks for an absolute path on the machine running GitNexus, instead of implying the browser will upload or hand the server a usable directory path. This removes the misleading folder-picker path, tightens local-path validation, and updates the onboarding copy to explain that GitHub URLs are cloned locally while local folders are analyzed in place.

## Motivation / context

The current onboarding UI mixes two different models: GitHub URLs really do go through the backend, but the local-folder tab still suggests a browser-driven folder selection flow even though the backend expects a server-local absolute path. In practice that means users can choose a folder in the browser, see upload-style wording, and still end up with an unusable path value. This PR keeps the existing backend contract intact and fixes the UX around it.

## Areas touched

- [ ] `gitnexus/` (CLI / core / MCP server)
- [x] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- Update onboarding copy to describe GitHub URLs vs local folders accurately
- Require absolute local paths in the local-folder analyzer flow
- Remove the misleading browser folder-picker path from the local-folder input
- Add a small path-validation helper with focused unit tests
- Keep the backend API contract unchanged (`POST /api/analyze` with `{ path }`)

**Explicitly out of scope / not done here**

- Any backend/server changes
- A new native localhost folder-browsing endpoint
- Changes to the hosted vs self-hosted server commands
- Redesigning the broader onboarding layout beyond the local-folder copy/validation

## Implementation notes

- The local-folder tab now validates only absolute paths (`/repo`, `C:\\repo`, or UNC paths) before enabling analysis.
- The browser folder picker was removed because it can only provide browser-relative names, not a path the GitNexus server can analyze.
- Copy in both the empty-state onboarding card and landing card now distinguishes cloned GitHub URLs from local folders analyzed in place.

## Testing & verification

- [ ] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [ ] `cd gitnexus && npx tsc --noEmit`
- [x] `cd gitnexus-web && npm test` *(if web changed)*
- [x] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)

Commands run locally:

- `cd gitnexus-web && npm test`
- `cd gitnexus-web && npx tsc -b --noEmit`

## Risk & rollout

- Low-risk web-only change: this updates copy and front-end validation without changing the analyze API.
- The main user-visible behavior change is that local-folder analysis now explicitly requires a server-local absolute path instead of allowing misleading partial values.
- No reindex or migration is required.

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed