### PR TITLE
Security hardening: fix Cypher injection, ReDoS, and N+1 queries

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -2044,8 +2044,7 @@ export class LocalBackend {
     },
   ): Promise<any> {
     const { maxDepth, relationTypes, includeTests, minConfidence } = opts;
-    const relTypeFilter = relationTypes.map((t) => `'${t}'`).join(', ');
-    const confidenceFilter = minConfidence > 0 ? ` AND r.confidence >= ${minConfidence}` : '';
+    const safeMinConfidence = typeof minConfidence === 'number' && isFinite(minConfidence) ? minConfidence : 0;
 
     const symId = sym.id || sym[0];
 
@@ -2110,14 +2109,17 @@ export class LocalBackend {
       const nextFrontier: string[] = [];
 
       // Batch frontier nodes into a single Cypher query per depth level
-      const idList = frontier.map((id) => `'${id.replace(/'/g, "''")}'`).join(', ');
       const query =
         direction === 'upstream'
-          ? `MATCH (caller)-[r:CodeRelation]->(n) WHERE n.id IN [${idList}] AND r.type IN [${relTypeFilter}]${confidenceFilter} RETURN n.id AS sourceId, caller.id AS id, caller.name AS name, labels(caller)[0] AS type, caller.filePath AS filePath, r.type AS relType, r.confidence AS confidence`
-          : `MATCH (n)-[r:CodeRelation]->(callee) WHERE n.id IN [${idList}] AND r.type IN [${relTypeFilter}]${confidenceFilter} RETURN n.id AS sourceId, callee.id AS id, callee.name AS name, labels(callee)[0] AS type, callee.filePath AS filePath, r.type AS relType, r.confidence AS confidence`;
+          ? `MATCH (caller)-[r:CodeRelation]->(n) WHERE n.id IN $ids AND r.type IN $relTypes${safeMinConfidence > 0 ? ' AND r.confidence >= $minConf' : ''} RETURN n.id AS sourceId, caller.id AS id, caller.name AS name, labels(caller)[0] AS type, caller.filePath AS filePath, r.type AS relType, r.confidence AS confidence`
+          : `MATCH (n)-[r:CodeRelation]->(callee) WHERE n.id IN $ids AND r.type IN $relTypes${safeMinConfidence > 0 ? ' AND r.confidence >= $minConf' : ''} RETURN n.id AS sourceId, callee.id AS id, callee.name AS name, labels(callee)[0] AS type, callee.filePath AS filePath, r.type AS relType, r.confidence AS confidence`;
 
       try {
-        const related = await executeQuery(repo.id, query);
+        const related = await executeParameterized(repo.id, query, {
+          ids: frontier,
+          relTypes: relationTypes,
+          minConf: safeMinConfidence,
+        });
 
         for (const rel of related) {
           const relId = rel.id || rel[1];

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -852,7 +852,9 @@ export class LocalBackend {
 
       if (embResults.length === 0) return [];
 
-      const results: any[] = [];
+      // Group embedding results by node label to batch lookups (eliminates N+1)
+      const distanceMap = new Map<string, number>();
+      const labelGroups = new Map<string, string[]>();
 
       for (const embRow of embResults) {
         const nodeId = embRow.nodeId ?? embRow[0];
@@ -861,29 +863,49 @@ export class LocalBackend {
         const labelEndIdx = nodeId.indexOf(':');
         const label = labelEndIdx > 0 ? nodeId.substring(0, labelEndIdx) : 'Unknown';
 
-        // Validate label against known node types to prevent Cypher injection
         if (!VALID_NODE_LABELS.has(label)) continue;
 
-        try {
-          const nodeQuery =
-            label === 'File'
-              ? `MATCH (n:File {id: $nodeId}) RETURN n.name AS name, n.filePath AS filePath`
-              : `MATCH (n:\`${label}\` {id: $nodeId}) RETURN n.name AS name, n.filePath AS filePath, n.startLine AS startLine, n.endLine AS endLine`;
+        distanceMap.set(nodeId, distance);
+        const group = labelGroups.get(label) ?? [];
+        group.push(nodeId);
+        labelGroups.set(label, group);
+      }
 
-          const nodeRows = await executeParameterized(repo.id, nodeQuery, { nodeId });
-          if (nodeRows.length > 0) {
-            const nodeRow = nodeRows[0];
-            results.push({
-              nodeId,
-              name: nodeRow.name ?? nodeRow[0] ?? '',
-              type: label,
-              filePath: nodeRow.filePath ?? nodeRow[1] ?? '',
-              distance,
-              startLine: label !== 'File' ? (nodeRow.startLine ?? nodeRow[2]) : undefined,
-              endLine: label !== 'File' ? (nodeRow.endLine ?? nodeRow[3]) : undefined,
-            });
+      // Batch-fetch node details: one query per label instead of one per result
+      const nodeMap = new Map<string, any>();
+
+      for (const [label, nodeIds] of labelGroups) {
+        try {
+          const batchQuery =
+            label === 'File'
+              ? `MATCH (n:File) WHERE n.id IN $nodeIds RETURN n.id AS id, n.name AS name, n.filePath AS filePath`
+              : `MATCH (n:\`${label}\`) WHERE n.id IN $nodeIds RETURN n.id AS id, n.name AS name, n.filePath AS filePath, n.startLine AS startLine, n.endLine AS endLine`;
+
+          const rows = await executeParameterized(repo.id, batchQuery, { nodeIds });
+          for (const row of rows) {
+            const id = row.id ?? row[0];
+            nodeMap.set(id, { ...row, label });
           }
         } catch {}
+      }
+
+      // Join embedding distances with node details in-memory
+      const results: any[] = [];
+
+      for (const [nodeId, distance] of distanceMap) {
+        const node = nodeMap.get(nodeId);
+        if (!node) continue;
+
+        const label = node.label;
+        results.push({
+          nodeId,
+          name: node.name ?? node[1] ?? '',
+          type: label,
+          filePath: node.filePath ?? node[2] ?? '',
+          distance,
+          startLine: label !== 'File' ? (node.startLine ?? node[3]) : undefined,
+          endLine: label !== 'File' ? (node.endLine ?? node[4]) : undefined,
+        });
       }
 
       return results;
@@ -2044,7 +2066,8 @@ export class LocalBackend {
     },
   ): Promise<any> {
     const { maxDepth, relationTypes, includeTests, minConfidence } = opts;
-    const safeMinConfidence = typeof minConfidence === 'number' && isFinite(minConfidence) ? minConfidence : 0;
+    const safeMinConfidence =
+      typeof minConfidence === 'number' && isFinite(minConfidence) ? minConfidence : 0;
 
     const symId = sym.id || sym[0];
 

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -1013,7 +1013,10 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
       let hasInnerQuantifier = false;
       for (let i = 0; i < pattern.length; i++) {
         const ch = pattern[i];
-        if (ch === '\\') { i++; continue; } // skip escaped chars
+        if (ch === '\\') {
+          i++;
+          continue;
+        } // skip escaped chars
         if (ch === '(') {
           depth++;
           hasInnerQuantifier = false;
@@ -1057,7 +1060,9 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
 
       // ReDoS protection: reject patterns with nested quantifiers
       if (!isSafeRegex(pattern)) {
-        res.status(400).json({ error: 'Pattern rejected: potential catastrophic backtracking detected' });
+        res
+          .status(400)
+          .json({ error: 'Pattern rejected: potential catastrophic backtracking detected' });
         return;
       }
 

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -1000,6 +1000,40 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
     }
   });
 
+  /**
+   * Detect regex patterns likely to cause catastrophic backtracking (ReDoS).
+   * Rejects patterns with nested quantifiers like (a+)+, (.*)*b, ([a-z]+)* etc.
+   */
+  function isSafeRegex(pattern: string): boolean {
+    // Nested quantifier detection: a quantifier (+, *, {n}) applied to a group
+    // that itself contains a quantifier
+    try {
+      // Quick structural check for nested quantifiers
+      let depth = 0;
+      let hasInnerQuantifier = false;
+      for (let i = 0; i < pattern.length; i++) {
+        const ch = pattern[i];
+        if (ch === '\\') { i++; continue; } // skip escaped chars
+        if (ch === '(') {
+          depth++;
+          hasInnerQuantifier = false;
+        } else if (ch === ')') {
+          depth--;
+          // Check if this closing paren is followed by a quantifier
+          const next = pattern[i + 1];
+          if (hasInnerQuantifier && (next === '+' || next === '*' || next === '{')) {
+            return false;
+          }
+        } else if (depth > 0 && (ch === '+' || ch === '*')) {
+          hasInnerQuantifier = true;
+        }
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   // Grep — regex search across file contents in the indexed repo
   // Uses filesystem-based search for memory efficiency (never loads all files into memory)
   app.get('/api/grep', async (req, res) => {
@@ -1018,6 +1052,12 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
       // ReDoS protection: reject overly long or dangerous patterns
       if (pattern.length > 200) {
         res.status(400).json({ error: 'Pattern too long (max 200 characters)' });
+        return;
+      }
+
+      // ReDoS protection: reject patterns with nested quantifiers
+      if (!isSafeRegex(pattern)) {
+        res.status(400).json({ error: 'Pattern rejected: potential catastrophic backtracking detected' });
         return;
       }
 

--- a/gitnexus/test/unit/impact-batching-grouping.test.ts
+++ b/gitnexus/test/unit/impact-batching-grouping.test.ts
@@ -114,6 +114,20 @@ describe('impact: batching and grouping', () => {
           },
         ];
       }
+      // BFS depth traversal (now uses executeParameterized after security hardening)
+      if (query.includes('r.type IN')) {
+        const res: any[] = [];
+        for (let i = 0; i < 250; i++) {
+          res.push({
+            id: `node-${i}`,
+            name: `n${i}`,
+            filePath: `file-${i}.js`,
+            relType: 'CALLS',
+            confidence: null,
+          });
+        }
+        return res;
+      }
       // Default target resolution
       return [{ id: 'sym1', name: 'Target', filePath: 'f' }];
     });
@@ -148,50 +162,45 @@ describe('impact: batching and grouping', () => {
 
     executeParameterizedMock.mockImplementation(async (...args: any[]) => {
       const query = typeof args[1] === 'string' ? args[1] : String(args[0] ?? '');
-      if (!query.includes('STEP_IN_PROCESS'))
-        return [{ id: 'symA', name: 'TargetA', filePath: 'f' }];
-      // For STEP_IN_PROCESS in this test, return grouping rows
-      return [
-        {
-          entryPointId: 'ep-1',
-          epName: 'EP1',
-          epType: 'Function',
-          epFilePath: '/p/1',
-          hits: 2,
-          minStep: 1,
-        },
-        {
-          entryPointId: 'ep-2',
-          epName: 'EP2',
-          epType: 'Function',
-          epFilePath: '/p/2',
-          hits: 2,
-          minStep: 2,
-        },
-        {
-          entryPointId: 'ep-1',
-          epName: 'EP1',
-          epType: 'Function',
-          epFilePath: '/p/1',
-          hits: 1,
-          minStep: 3,
-        },
-        {
-          entryPointId: 'ep-3',
-          epName: 'EP3',
-          epType: 'Function',
-          epFilePath: '/p/3',
-          hits: 1,
-          minStep: 1,
-        },
-      ];
-    });
-
-    // Prepare impacted nodes: smaller set for clarity (6 nodes -> chunk size default 100 so single chunk)
-    executeQueryMock.mockImplementation(async (...args: any[]) => {
-      const query = typeof args[1] === 'string' ? args[1] : String(args[0] ?? '');
-      if (query.includes('r.type IN') && !query.includes('STEP_IN_PROCESS')) {
-        // return 6 nodes
+      if (query.includes('STEP_IN_PROCESS')) {
+        // For STEP_IN_PROCESS in this test, return grouping rows
+        return [
+          {
+            entryPointId: 'ep-1',
+            epName: 'EP1',
+            epType: 'Function',
+            epFilePath: '/p/1',
+            hits: 2,
+            minStep: 1,
+          },
+          {
+            entryPointId: 'ep-2',
+            epName: 'EP2',
+            epType: 'Function',
+            epFilePath: '/p/2',
+            hits: 2,
+            minStep: 2,
+          },
+          {
+            entryPointId: 'ep-1',
+            epName: 'EP1',
+            epType: 'Function',
+            epFilePath: '/p/1',
+            hits: 1,
+            minStep: 3,
+          },
+          {
+            entryPointId: 'ep-3',
+            epName: 'EP3',
+            epType: 'Function',
+            epFilePath: '/p/3',
+            hits: 1,
+            minStep: 1,
+          },
+        ];
+      }
+      // BFS depth traversal (now uses executeParameterized after security hardening)
+      if (query.includes('r.type IN')) {
         const res: any[] = [];
         for (let i = 0; i < 6; i++)
           res.push({
@@ -203,8 +212,8 @@ describe('impact: batching and grouping', () => {
           });
         return res;
       }
-
-      return [];
+      // Default target resolution
+      return [{ id: 'symA', name: 'TargetA', filePath: 'f' }];
     });
 
     const params = { target: 'TargetA', direction: 'downstream', maxDepth: 1 } as any;
@@ -240,24 +249,6 @@ describe('impact: batching and grouping', () => {
     (backend as any).repos.set(repoHandle.id, repoHandle);
     (backend as any).ensureInitialized = vi.fn().mockResolvedValue(undefined);
 
-    // Depth traversal returns 500 impacted nodes
-    executeQueryMock.mockImplementation(async (...args: any[]) => {
-      const query = typeof args[1] === 'string' ? args[1] : String(args[0] ?? '');
-      if (query.includes('r.type IN') && !query.includes('STEP_IN_PROCESS')) {
-        const res: any[] = [];
-        for (let i = 0; i < 500; i++)
-          res.push({
-            id: `node-${i}`,
-            name: `n${i}`,
-            filePath: `file-${i}.js`,
-            relType: 'CALLS',
-            confidence: null,
-          });
-        return res;
-      }
-      return [];
-    });
-
     const chunkSizes: number[] = [];
 
     executeParameterizedMock.mockImplementation(async (...args: any[]) => {
@@ -276,6 +267,20 @@ describe('impact: batching and grouping', () => {
             minStep: 1,
           },
         ];
+      }
+
+      // BFS depth traversal (now uses executeParameterized after security hardening)
+      if (query.includes('r.type IN')) {
+        const res: any[] = [];
+        for (let i = 0; i < 500; i++)
+          res.push({
+            id: `node-${i}`,
+            name: `n${i}`,
+            filePath: `file-${i}.js`,
+            relType: 'CALLS',
+            confidence: null,
+          });
+        return res;
       }
 
       if (query.includes('COUNT(DISTINCT s.id)')) {


### PR DESCRIPTION
## Summary

Found these issues while reading through the query execution paths. Three commits, each addressing a different concern.

## Changes

### 1. Cypher injection in BFS impact analysis (`local-backend.ts`)

The `_runImpactBFS` function constructed Cypher queries via string interpolation for `idList`, `relTypeFilter`, and `confidenceFilter`. The `confidenceFilter` value was not type-validated, so a string value could inject arbitrary Cypher.

Converted to `executeParameterized` with `$ids`, `$relTypes`, `$minConf` parameter binding -- the same pattern already used in the enrichment code elsewhere in the file.

### 2. ReDoS in grep API (`api.ts`)

The `/api/grep` endpoint compiled user-supplied regex with only a 200-char length limit. Patterns like `(a+)+$` (7 chars) cause catastrophic backtracking when tested per-line across every file. Added a structural analysis that detects nested quantifiers and rejects dangerous patterns before compilation.

### 3. N+1 queries in semantic search (`local-backend.ts`)

Each embedding search result triggered a separate `executeParameterized` call to fetch node details (N+1 pattern). With 50 results, that is 51 serial round-trips. Batched all node IDs into a single `WHERE n.id IN $nodeIds` query and joined in-memory via Map.

## Testing

All changes are backwards-compatible. The parameterized queries produce identical results. The regex check is purely additive (rejects a class of dangerous patterns that would have blocked the event loop). The batched query returns the same data as N individual queries.