### PR TITLE
Improve embedding backend safety and retrieval recall

### DIFF
--- a/gitnexus-claude-plugin/hooks/gitnexus-hook.js
+++ b/gitnexus-claude-plugin/hooks/gitnexus-hook.js
@@ -12,8 +12,9 @@
  */
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
-const { spawnSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 
 /**
  * Read JSON input from stdin synchronously.
@@ -102,41 +103,59 @@ function extractPattern(toolName, toolInput) {
 }
 
 /**
- * Spawn a gitnexus CLI command synchronously.
- * Detects binary on PATH once, then runs exactly once.
+ * Spawn the pinned/local gitnexus CLI synchronously.
  *
  * SECURITY: Never use shell: true with user-controlled arguments.
- * On Windows, invoke gitnexus.cmd directly (no shell needed).
+ * Do not fall back to npx. Older published versions can overwrite embedding
+ * backend metadata and can query OpenAI-indexed repos with the wrong runtime.
  */
-function runGitNexusCli(args, cwd, timeout) {
-  const isWin = process.platform === 'win32';
+function resolveGitNexusCommand() {
+  const localBinary = path.join(os.homedir(), '.local', 'bin', 'gitnexus');
+  if (fs.existsSync(localBinary)) return { command: localBinary, args: [] };
 
-  // Detect whether 'gitnexus' is on PATH (cheap check, no execution)
-  let useDirectBinary = false;
+  const isWin = process.platform === 'win32';
   try {
     const which = spawnSync(isWin ? 'where' : 'which', ['gitnexus'], {
       encoding: 'utf-8',
       timeout: 3000,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    useDirectBinary = which.status === 0;
+    const binary = (which.stdout || '').split(/\r?\n/)[0].trim();
+    if (which.status === 0 && binary) return { command: binary, args: [] };
   } catch {
     /* not on PATH */
   }
 
-  if (useDirectBinary) {
-    return spawnSync(isWin ? 'gitnexus.cmd' : 'gitnexus', args, {
+  return null;
+}
+
+function resolveOpenAiApiKey() {
+  if (process.env.OPENAI_API_KEY) return process.env.OPENAI_API_KEY;
+  if (process.platform !== 'darwin') return '';
+  try {
+    return execFileSync('security', ['find-generic-password', '-s', 'openai-api-key', '-w'], {
       encoding: 'utf-8',
-      timeout,
-      cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    }).trim();
+  } catch {
+    return '';
   }
-  // npx fallback needs shell on Windows since npx is a .cmd script
-  return spawnSync(isWin ? 'npx.cmd' : 'npx', ['-y', 'gitnexus', ...args], {
+}
+
+function runGitNexusCli(args, cwd, timeout) {
+  const cliCommand = resolveGitNexusCommand();
+  if (!cliCommand) return { status: 127, error: new Error('gitnexus CLI not found') };
+
+  const openAiApiKey = resolveOpenAiApiKey();
+  return spawnSync(cliCommand.command, [...cliCommand.args, ...args], {
     encoding: 'utf-8',
-    timeout: timeout + 5000,
+    timeout,
     cwd,
+    env: {
+      ...process.env,
+      ...(openAiApiKey ? { OPENAI_API_KEY: openAiApiKey } : {}),
+    },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 }
@@ -237,7 +256,7 @@ function handlePostToolUse(input) {
   // If HEAD matches last indexed commit, no reindex needed
   if (currentHead && currentHead === lastCommit) return;
 
-  const analyzeCmd = `npx gitnexus analyze${hadEmbeddings ? ' --embeddings' : ''}`;
+  const analyzeCmd = `gitnexus analyze${hadEmbeddings ? ' --embeddings' : ''}`;
   sendHookResponse(
     'PostToolUse',
     `GitNexus index is stale (last indexed: ${lastCommit ? lastCommit.slice(0, 7) : 'never'}). ` +

--- a/gitnexus-claude-plugin/hooks/gitnexus-hook.js
+++ b/gitnexus-claude-plugin/hooks/gitnexus-hook.js
@@ -171,6 +171,34 @@ function sendHookResponse(hookEventName, message) {
   );
 }
 
+const GENERATED_INDEX_PATHS = [
+  /^\.gitnexus(?:\/|$)/,
+  /^AGENTS\.md$/,
+  /^CLAUDE\.md$/,
+  /^\.claude\/skills\/gitnexus(?:\/|$)/,
+  /^\.claude\/skills\/generated(?:\/|$)/,
+];
+
+function isGeneratedIndexPath(filePath) {
+  return GENERATED_INDEX_PATHS.some((pattern) => pattern.test(filePath));
+}
+
+function onlyGeneratedIndexArtifactsChanged(cwd, lastCommit) {
+  if (!lastCommit) return false;
+  try {
+    const diffResult = spawnSync('git', ['diff', '--name-only', `${lastCommit}..HEAD`], {
+      encoding: 'utf-8',
+      timeout: 3000,
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const files = (diffResult.stdout || '').trim().split(/\r?\n/).filter(Boolean);
+    return files.length > 0 && files.every(isGeneratedIndexPath);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * PreToolUse handler — augment searches with graph context.
  */
@@ -255,6 +283,7 @@ function handlePostToolUse(input) {
 
   // If HEAD matches last indexed commit, no reindex needed
   if (currentHead && currentHead === lastCommit) return;
+  if (onlyGeneratedIndexArtifactsChanged(cwd, lastCommit)) return;
 
   const analyzeCmd = `gitnexus analyze${hadEmbeddings ? ' --embeddings' : ''}`;
   sendHookResponse(

--- a/gitnexus/hooks/claude/gitnexus-hook.cjs
+++ b/gitnexus/hooks/claude/gitnexus-hook.cjs
@@ -203,6 +203,34 @@ function sendHookResponse(hookEventName, message) {
   );
 }
 
+const GENERATED_INDEX_PATHS = [
+  /^\.gitnexus(?:\/|$)/,
+  /^AGENTS\.md$/,
+  /^CLAUDE\.md$/,
+  /^\.claude\/skills\/gitnexus(?:\/|$)/,
+  /^\.claude\/skills\/generated(?:\/|$)/,
+];
+
+function isGeneratedIndexPath(filePath) {
+  return GENERATED_INDEX_PATHS.some((pattern) => pattern.test(filePath));
+}
+
+function onlyGeneratedIndexArtifactsChanged(cwd, lastCommit) {
+  if (!lastCommit) return false;
+  try {
+    const diffResult = spawnSync('git', ['diff', '--name-only', `${lastCommit}..HEAD`], {
+      encoding: 'utf-8',
+      timeout: 3000,
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const files = (diffResult.stdout || '').trim().split(/\r?\n/).filter(Boolean);
+    return files.length > 0 && files.every(isGeneratedIndexPath);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * PostToolUse handler — detect index staleness after git mutations.
  *
@@ -256,6 +284,7 @@ function handlePostToolUse(input) {
 
   // If HEAD matches last indexed commit, no reindex needed
   if (currentHead && currentHead === lastCommit) return;
+  if (onlyGeneratedIndexArtifactsChanged(cwd, lastCommit)) return;
 
   const analyzeCmd = `gitnexus analyze${hadEmbeddings ? ' --embeddings' : ''}`;
   sendHookResponse(

--- a/gitnexus/hooks/claude/gitnexus-hook.cjs
+++ b/gitnexus/hooks/claude/gitnexus-hook.cjs
@@ -12,8 +12,9 @@
  */
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
-const { spawnSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 
 /**
  * Read JSON input from stdin synchronously.
@@ -102,12 +103,18 @@ function extractPattern(toolName, toolInput) {
 }
 
 /**
- * Resolve the gitnexus CLI path.
- * 1. Relative path (works when script is inside npm package)
- * 2. require.resolve (works when gitnexus is globally installed)
- * 3. Fall back to npx (returns empty string)
+ * Resolve the pinned/local gitnexus CLI command.
+ * 1. ~/.local/bin/gitnexus (team/local patched install)
+ * 2. Relative package CLI path (works when script is inside npm package)
+ * 3. require.resolve (works when gitnexus is globally installed)
+ *
+ * Do not fall back to npx. Older published versions can overwrite embedding
+ * backend metadata and can query OpenAI-indexed repos with the wrong runtime.
  */
-function resolveCliPath() {
+function resolveCliCommand() {
+  const localBinary = path.join(os.homedir(), '.local', 'bin', 'gitnexus');
+  if (fs.existsSync(localBinary)) return { command: localBinary, args: [] };
+
   let cliPath = path.resolve(__dirname, '..', '..', 'dist', 'cli', 'index.js');
   if (!fs.existsSync(cliPath)) {
     try {
@@ -116,28 +123,37 @@ function resolveCliPath() {
       cliPath = '';
     }
   }
-  return cliPath;
+  return cliPath ? { command: process.execPath, args: [cliPath] } : null;
+}
+
+function resolveOpenAiApiKey() {
+  if (process.env.OPENAI_API_KEY) return process.env.OPENAI_API_KEY;
+  if (process.platform !== 'darwin') return '';
+  try {
+    return execFileSync('security', ['find-generic-password', '-s', 'openai-api-key', '-w'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    }).trim();
+  } catch {
+    return '';
+  }
 }
 
 /**
  * Spawn a gitnexus CLI command synchronously.
  * Returns the stderr output (KuzuDB captures stdout at OS level).
  */
-function runGitNexusCli(cliPath, args, cwd, timeout) {
-  const isWin = process.platform === 'win32';
-  if (cliPath) {
-    return spawnSync(process.execPath, [cliPath, ...args], {
-      encoding: 'utf-8',
-      timeout,
-      cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-  }
-  // On Windows, invoke npx.cmd directly (no shell needed)
-  return spawnSync(isWin ? 'npx.cmd' : 'npx', ['-y', 'gitnexus', ...args], {
+function runGitNexusCli(cliCommand, args, cwd, timeout) {
+  const openAiApiKey = resolveOpenAiApiKey();
+  return spawnSync(cliCommand.command, [...cliCommand.args, ...args], {
     encoding: 'utf-8',
-    timeout: timeout + 5000,
+    timeout,
     cwd,
+    env: {
+      ...process.env,
+      ...(openAiApiKey ? { OPENAI_API_KEY: openAiApiKey } : {}),
+    },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 }
@@ -158,10 +174,12 @@ function handlePreToolUse(input) {
   const pattern = extractPattern(toolName, toolInput);
   if (!pattern || pattern.length < 3) return;
 
-  const cliPath = resolveCliPath();
+  const cliCommand = resolveCliCommand();
+  if (!cliCommand) return;
+
   let result = '';
   try {
-    const child = runGitNexusCli(cliPath, ['augment', '--', pattern], cwd, 7000);
+    const child = runGitNexusCli(cliCommand, ['augment', '--', pattern], cwd, 7000);
     if (!child.error && child.status === 0) {
       result = child.stderr || '';
     }
@@ -239,7 +257,7 @@ function handlePostToolUse(input) {
   // If HEAD matches last indexed commit, no reindex needed
   if (currentHead && currentHead === lastCommit) return;
 
-  const analyzeCmd = `npx gitnexus analyze${hadEmbeddings ? ' --embeddings' : ''}`;
+  const analyzeCmd = `gitnexus analyze${hadEmbeddings ? ' --embeddings' : ''}`;
   sendHookResponse(
     'PostToolUse',
     `GitNexus index is stale (last indexed: ${lastCommit ? lastCommit.slice(0, 7) : 'never'}). ` +

--- a/gitnexus/hooks/claude/pre-tool-use.sh
+++ b/gitnexus/hooks/claude/pre-tool-use.sh
@@ -64,7 +64,7 @@ fi
 
 # Run gitnexus augment — must be fast (<500ms target)
 # augment writes to stderr (KuzuDB captures stdout at OS level), so capture stderr and discard stdout
-RESULT=$(cd "$CWD" && npx -y gitnexus augment "$PATTERN" 2>&1 1>/dev/null)
+RESULT=$(cd "$CWD" && gitnexus augment "$PATTERN" 2>&1 1>/dev/null)
 
 if [ -n "$RESULT" ]; then
   ESCAPED=$(echo "$RESULT" | jq -Rs .)

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/skills/gitnexus-cli.md
+++ b/gitnexus/skills/gitnexus-cli.md
@@ -5,14 +5,14 @@ description: "Use when the user needs to run GitNexus CLI commands like analyze/
 
 # GitNexus CLI Commands
 
-All commands work via `npx` — no global install required.
+Use the local `gitnexus` CLI on PATH. Do not use `npx gitnexus ...` in environments that pin a patched/local GitNexus build.
 
 ## Commands
 
 ### analyze — Build or refresh the index
 
 ```bash
-npx gitnexus analyze
+gitnexus analyze
 ```
 
 Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
@@ -27,7 +27,7 @@ Run from the project root. This parses all source files, builds the knowledge gr
 ### status — Check index freshness
 
 ```bash
-npx gitnexus status
+gitnexus status
 ```
 
 Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
@@ -35,7 +35,7 @@ Shows whether the current repo has a GitNexus index, when it was last updated, a
 ### clean — Delete the index
 
 ```bash
-npx gitnexus clean
+gitnexus clean
 ```
 
 Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
@@ -48,7 +48,7 @@ Deletes the `.gitnexus/` directory and unregisters the repo from the global regi
 ### wiki — Generate documentation from the graph
 
 ```bash
-npx gitnexus wiki
+gitnexus wiki
 ```
 
 Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
@@ -65,7 +65,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 ### list — Show all indexed repos
 
 ```bash
-npx gitnexus list
+gitnexus list
 ```
 
 Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.

--- a/gitnexus/skills/gitnexus-debugging.md
+++ b/gitnexus/skills/gitnexus-debugging.md
@@ -22,7 +22,7 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `gitnexus analyze` in terminal.
 
 ## Checklist
 

--- a/gitnexus/skills/gitnexus-exploring.md
+++ b/gitnexus/skills/gitnexus-exploring.md
@@ -23,7 +23,7 @@ description: "Use when the user asks how code works, wants to understand archite
 5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
 ```
 
-> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If step 2 says "Index is stale" → run `gitnexus analyze` in terminal.
 
 ## Checklist
 

--- a/gitnexus/skills/gitnexus-guide.md
+++ b/gitnexus/skills/gitnexus-guide.md
@@ -15,7 +15,7 @@ For any task involving code understanding, debugging, impact analysis, or refact
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+> If step 1 warns the index is stale, run `gitnexus analyze` in the terminal first.
 
 ## Skills
 

--- a/gitnexus/skills/gitnexus-impact-analysis.md
+++ b/gitnexus/skills/gitnexus-impact-analysis.md
@@ -23,7 +23,7 @@ description: "Use when the user wants to know what will break if they change som
 4. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `gitnexus analyze` in terminal.
 
 ## Checklist
 

--- a/gitnexus/skills/gitnexus-pr-review.md
+++ b/gitnexus/skills/gitnexus-pr-review.md
@@ -26,7 +26,7 @@ description: "Use when the user wants to review a pull request, understand what 
 6. Summarize findings with risk assessment
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal before reviewing.
+> If "Index is stale" → run `gitnexus analyze` in terminal before reviewing.
 
 ## Checklist
 

--- a/gitnexus/skills/gitnexus-refactoring.md
+++ b/gitnexus/skills/gitnexus-refactoring.md
@@ -22,7 +22,7 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 4. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `gitnexus analyze` in terminal.
 
 ## Checklists
 

--- a/gitnexus/src/cli/ai-context.ts
+++ b/gitnexus/src/cli/ai-context.ts
@@ -300,10 +300,16 @@ export async function generateAIContextFiles(
     createdFiles.push('CLAUDE.md (skipped via --skip-agents-md)');
   }
 
-  // Install skills to .claude/skills/gitnexus/
-  const installedSkills = await installSkills(repoPath);
-  if (installedSkills.length > 0) {
-    createdFiles.push(`.claude/skills/gitnexus/ (${installedSkills.length} skills)`);
+  // A caller that opts out of instruction-file updates is asking for an
+  // index-only operation. Installing repo-local skills would still mutate the
+  // project's instruction surface and can shadow an existing global catalog.
+  if (!options?.skipAgentsMd) {
+    const installedSkills = await installSkills(repoPath);
+    if (installedSkills.length > 0) {
+      createdFiles.push(`.claude/skills/gitnexus/ (${installedSkills.length} skills)`);
+    }
+  } else {
+    createdFiles.push('.claude/skills/gitnexus/ (skipped via --skip-agents-md)');
   }
 
   return { files: createdFiles };

--- a/gitnexus/src/cli/ai-context.ts
+++ b/gitnexus/src/cli/ai-context.ts
@@ -91,7 +91,7 @@ function generateGitNexusContent(
 
 This project is indexed by GitNexus as **${projectName}**${noStats ? '' : ` (${stats.nodes || 0} symbols, ${stats.edges || 0} relationships, ${stats.processes || 0} execution flows)`}. Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> If any GitNexus tool warns the index is stale, run \`npx gitnexus analyze\` in terminal first.
+> If any GitNexus tool warns the index is stale, run \`gitnexus analyze\` in terminal first. Use the local \`gitnexus\` CLI on PATH; \`npx gitnexus ...\` can resolve an older package.
 
 ## Always Do
 
@@ -121,7 +121,7 @@ ${
   groupNames && groupNames.length > 0
     ? `## Cross-Repo Groups
 
-This repository is listed under GitNexus **group(s): ${groupNames.join(', ')}** (see \`~/.gitnexus/groups/\`). For blast radius across repository boundaries, use MCP tools \`group_impact\`, \`group_sync\`, \`group_query\`, \`group_contracts\`, \`group_status\`, and \`group_list\`. From the terminal: \`npx gitnexus group list\`, \`npx gitnexus group sync <name>\`, \`npx gitnexus group impact <name> --target <symbol> --repo <group-path>\`.
+This repository is listed under GitNexus **group(s): ${groupNames.join(', ')}** (see \`~/.gitnexus/groups/\`). For blast radius across repository boundaries, use MCP tools \`group_impact\`, \`group_sync\`, \`group_query\`, \`group_contracts\`, \`group_status\`, and \`group_list\`. From the terminal: \`gitnexus group list\`, \`gitnexus group sync <name>\`, \`gitnexus group impact <name> --target <symbol> --repo <group-path>\`.
 
 `
     : ''

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -25,7 +25,10 @@ program
   .option('-f, --force', 'Force full re-index even if up to date')
   .option('--embeddings', 'Enable embedding generation for semantic search (off by default)')
   .option('--skills', 'Generate repo-specific skill files from detected communities')
-  .option('--skip-agents-md', 'Skip updating the gitnexus section in AGENTS.md and CLAUDE.md')
+  .option(
+    '--skip-agents-md',
+    'Index only: skip AGENTS.md/CLAUDE.md updates and repo-local bundled skills',
+  )
   .option('--no-stats', 'Omit volatile file/symbol counts from AGENTS.md and CLAUDE.md')
   .option('--skip-git', 'Index a folder without requiring a .git directory')
   .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')

--- a/gitnexus/src/cli/status.ts
+++ b/gitnexus/src/cli/status.ts
@@ -6,6 +6,7 @@
 
 import { findRepo, getStoragePaths, hasKuzuIndex } from '../storage/repo-manager.js';
 import { getCurrentCommit, isGitRepo, getGitRoot } from '../storage/git.js';
+import { checkStaleness } from '../core/git-staleness.js';
 
 export const statusCommand = async () => {
   const cwd = process.cwd();
@@ -31,11 +32,16 @@ export const statusCommand = async () => {
   }
 
   const currentCommit = getCurrentCommit(repo.repoPath);
-  const isUpToDate = currentCommit === repo.meta.lastCommit;
+  const staleness = checkStaleness(repo.repoPath, repo.meta.lastCommit || 'HEAD');
+  const isUpToDate = currentCommit === repo.meta.lastCommit || !staleness.isStale;
 
   console.log(`Repository: ${repo.repoPath}`);
   console.log(`Indexed: ${new Date(repo.meta.indexedAt).toLocaleString()}`);
   console.log(`Indexed commit: ${repo.meta.lastCommit?.slice(0, 7)}`);
   console.log(`Current commit: ${currentCommit?.slice(0, 7)}`);
+  if (isUpToDate && staleness.artifactOnly) {
+    console.log('Status: ✅ up-to-date (only GitNexus-generated index artifacts changed)');
+    return;
+  }
   console.log(`Status: ${isUpToDate ? '✅ up-to-date' : '⚠️ stale (re-run gitnexus analyze)'}`);
 };

--- a/gitnexus/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus/src/core/embeddings/embedding-pipeline.ts
@@ -429,7 +429,7 @@ export const runEmbeddingPipeline = async (
       }
 
       // Embed chunk texts in sub-batches to control memory
-      const EMBED_SUB_BATCH = 8;
+      const EMBED_SUB_BATCH = 32;
       for (let si = 0; si < allTexts.length; si += EMBED_SUB_BATCH) {
         const subTexts = allTexts.slice(si, si + EMBED_SUB_BATCH);
         const subUpdates = allUpdates.slice(si, si + EMBED_SUB_BATCH);

--- a/gitnexus/src/core/embeddings/http-client.ts
+++ b/gitnexus/src/core/embeddings/http-client.ts
@@ -5,10 +5,10 @@
  * Imported by both the core embedder (batch) and MCP embedder (query).
  */
 
-const HTTP_TIMEOUT_MS = 30_000;
+const HTTP_TIMEOUT_MS = 120_000;
 const HTTP_MAX_RETRIES = 2;
 const HTTP_RETRY_BACKOFF_MS = 1_000;
-const HTTP_BATCH_SIZE = 64;
+const HTTP_BATCH_SIZE = 32;
 const DEFAULT_DIMS = 384;
 
 interface HttpConfig {
@@ -148,10 +148,14 @@ const httpEmbedBatch = async (
       body: JSON.stringify(body),
     });
   } catch (err) {
-    // Timeouts should not be retried — the server is unresponsive.
     // AbortSignal.timeout() throws DOMException with name 'TimeoutError'.
     const isTimeout = err instanceof DOMException && err.name === 'TimeoutError';
     if (isTimeout) {
+      if (attempt < HTTP_MAX_RETRIES) {
+        const delay = HTTP_RETRY_BACKOFF_MS * (attempt + 1);
+        await new Promise((r) => setTimeout(r, delay));
+        return httpEmbedBatch(url, batch, model, apiKey, batchIndex, attempt + 1, dimensions);
+      }
       throw new Error(
         `Embedding request timed out after ${HTTP_TIMEOUT_MS}ms (${safeUrl(url)}, batch ${batchIndex})`,
       );
@@ -176,7 +180,18 @@ const httpEmbedBatch = async (
     throw new Error(`Embedding endpoint returned ${status} (${safeUrl(url)}, batch ${batchIndex})`);
   }
 
-  const data = (await resp.json()) as { data: EmbeddingItem[] };
+  let data: { data: EmbeddingItem[] };
+  try {
+    data = (await resp.json()) as { data: EmbeddingItem[] };
+  } catch (err) {
+    if (attempt < HTTP_MAX_RETRIES) {
+      const delay = HTTP_RETRY_BACKOFF_MS * (attempt + 1);
+      await new Promise((r) => setTimeout(r, delay));
+      return httpEmbedBatch(url, batch, model, apiKey, batchIndex, attempt + 1, dimensions);
+    }
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`Embedding response read failed (${safeUrl(url)}, batch ${batchIndex}): ${reason}`);
+  }
   return data.data;
 };
 

--- a/gitnexus/src/core/embeddings/http-client.ts
+++ b/gitnexus/src/core/embeddings/http-client.ts
@@ -18,14 +18,35 @@ interface HttpConfig {
   dimensions?: number;
 }
 
+export interface EmbeddingConfigSummary {
+  provider: 'openai' | 'http' | 'onnx';
+  baseUrl?: string;
+  model: string;
+  dimensions: number;
+}
+
 /**
  * Build config from the current process.env snapshot.
- * Returns null when GITNEXUS_EMBEDDING_URL + GITNEXUS_EMBEDDING_MODEL are unset.
+ * Returns null when no HTTP embedding endpoint is configured. OPENAI_API_KEY
+ * activates a default OpenAI-compatible endpoint for Claude/Codex sessions.
  * Not cached — env vars are read fresh so late configuration takes effect.
  */
 const readConfig = (): HttpConfig | null => {
-  const baseUrl = process.env.GITNEXUS_EMBEDDING_URL;
-  const model = process.env.GITNEXUS_EMBEDDING_MODEL;
+  const openAiKey = process.env.OPENAI_API_KEY;
+  const hasExplicitEndpoint = Boolean(
+    process.env.GITNEXUS_EMBEDDING_URL && process.env.GITNEXUS_EMBEDDING_MODEL,
+  );
+  const useOpenAiDefault = !hasExplicitEndpoint && Boolean(openAiKey);
+  const baseUrl = hasExplicitEndpoint
+    ? process.env.GITNEXUS_EMBEDDING_URL
+    : useOpenAiDefault
+      ? 'https://api.openai.com/v1'
+      : undefined;
+  const model = hasExplicitEndpoint
+    ? process.env.GITNEXUS_EMBEDDING_MODEL
+    : useOpenAiDefault
+      ? 'text-embedding-3-small'
+      : undefined;
   if (!baseUrl || !model) return null;
 
   const rawDims = process.env.GITNEXUS_EMBEDDING_DIMS;
@@ -37,11 +58,14 @@ const readConfig = (): HttpConfig | null => {
     }
     dimensions = parsed;
   }
+  if (dimensions === undefined && useOpenAiDefault) {
+    dimensions = DEFAULT_DIMS;
+  }
 
   return {
     baseUrl: baseUrl.replace(/\/+$/, ''),
     model,
-    apiKey: process.env.GITNEXUS_EMBEDDING_API_KEY ?? 'unused',
+    apiKey: process.env.GITNEXUS_EMBEDDING_API_KEY ?? openAiKey ?? 'unused',
     dimensions,
   };
 };
@@ -56,6 +80,21 @@ export const isHttpMode = (): boolean => readConfig() !== null;
  * if HTTP mode is not active or no explicit dimensions are set.
  */
 export const getHttpDimensions = (): number | undefined => readConfig()?.dimensions;
+
+/**
+ * Return non-secret embedding backend metadata for index/query compatibility.
+ */
+export const getHttpConfigSummary = (): EmbeddingConfigSummary | null => {
+  const config = readConfig();
+  if (!config) return null;
+
+  return {
+    provider: config.baseUrl.includes('api.openai.com') ? 'openai' : 'http',
+    baseUrl: safeUrl(config.baseUrl),
+    model: config.model,
+    dimensions: config.dimensions ?? DEFAULT_DIMS,
+  };
+};
 
 /**
  * Return a safe representation of a URL for error messages.
@@ -91,9 +130,14 @@ const httpEmbedBatch = async (
   apiKey: string,
   batchIndex = 0,
   attempt = 0,
+  dimensions?: number,
 ): Promise<EmbeddingItem[]> => {
   let resp: Response;
   try {
+    const body: { input: string[]; model: string; dimensions?: number } = { input: batch, model };
+    if (dimensions !== undefined) {
+      body.dimensions = dimensions;
+    }
     resp = await fetch(url, {
       method: 'POST',
       signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
@@ -101,7 +145,7 @@ const httpEmbedBatch = async (
         'Content-Type': 'application/json',
         Authorization: `Bearer ${apiKey}`,
       },
-      body: JSON.stringify({ input: batch, model }),
+      body: JSON.stringify(body),
     });
   } catch (err) {
     // Timeouts should not be retried — the server is unresponsive.
@@ -116,7 +160,7 @@ const httpEmbedBatch = async (
     if (attempt < HTTP_MAX_RETRIES) {
       const delay = HTTP_RETRY_BACKOFF_MS * (attempt + 1);
       await new Promise((r) => setTimeout(r, delay));
-      return httpEmbedBatch(url, batch, model, apiKey, batchIndex, attempt + 1);
+      return httpEmbedBatch(url, batch, model, apiKey, batchIndex, attempt + 1, dimensions);
     }
     const reason = err instanceof Error ? err.message : String(err);
     throw new Error(`Embedding request failed (${safeUrl(url)}, batch ${batchIndex}): ${reason}`);
@@ -127,7 +171,7 @@ const httpEmbedBatch = async (
     if ((status === 429 || status >= 500) && attempt < HTTP_MAX_RETRIES) {
       const delay = HTTP_RETRY_BACKOFF_MS * (attempt + 1);
       await new Promise((r) => setTimeout(r, delay));
-      return httpEmbedBatch(url, batch, model, apiKey, batchIndex, attempt + 1);
+      return httpEmbedBatch(url, batch, model, apiKey, batchIndex, attempt + 1, dimensions);
     }
     throw new Error(`Embedding endpoint returned ${status} (${safeUrl(url)}, batch ${batchIndex})`);
   }
@@ -155,7 +199,15 @@ export const httpEmbed = async (texts: string[]): Promise<Float32Array[]> => {
   for (let i = 0; i < texts.length; i += HTTP_BATCH_SIZE) {
     const batch = texts.slice(i, i + HTTP_BATCH_SIZE);
     const batchIndex = Math.floor(i / HTTP_BATCH_SIZE);
-    const items = await httpEmbedBatch(url, batch, config.model, config.apiKey, batchIndex);
+    const items = await httpEmbedBatch(
+      url,
+      batch,
+      config.model,
+      config.apiKey,
+      batchIndex,
+      0,
+      config.dimensions,
+    );
 
     if (items.length !== batch.length) {
       throw new Error(
@@ -198,7 +250,7 @@ export const httpEmbedQuery = async (text: string): Promise<number[]> => {
   if (!config) throw new Error('HTTP embedding not configured');
 
   const url = `${config.baseUrl}/embeddings`;
-  const items = await httpEmbedBatch(url, [text], config.model, config.apiKey);
+  const items = await httpEmbedBatch(url, [text], config.model, config.apiKey, 0, 0, config.dimensions);
   if (!items.length) {
     throw new Error(`Embedding endpoint returned empty response (${safeUrl(url)})`);
   }

--- a/gitnexus/src/core/embeddings/types.ts
+++ b/gitnexus/src/core/embeddings/types.ts
@@ -135,7 +135,7 @@ export interface EmbeddingConfig {
  */
 export const DEFAULT_EMBEDDING_CONFIG: EmbeddingConfig = {
   modelId: 'Snowflake/snowflake-arctic-embed-xs',
-  batchSize: 16,
+  batchSize: 32,
   dimensions: 384,
   device: 'auto',
   maxSnippetLength: 500,

--- a/gitnexus/src/core/git-staleness.ts
+++ b/gitnexus/src/core/git-staleness.ts
@@ -9,10 +9,40 @@ export interface StalenessInfo {
   isStale: boolean;
   commitsBehind: number;
   hint?: string;
+  artifactOnly?: boolean;
+  changedFiles?: string[];
+}
+
+const GENERATED_INDEX_PATHS = [
+  /^\.gitnexus(?:\/|$)/,
+  /^AGENTS\.md$/,
+  /^CLAUDE\.md$/,
+  /^\.claude\/skills\/gitnexus(?:\/|$)/,
+  /^\.claude\/skills\/generated(?:\/|$)/,
+];
+
+export function isGeneratedIndexPath(filePath: string): boolean {
+  return GENERATED_INDEX_PATHS.some((pattern) => pattern.test(filePath));
+}
+
+function getChangedFiles(repoPath: string, lastCommit: string): string[] {
+  const output = execFileSync('git', ['diff', '--name-only', `${lastCommit}..HEAD`], {
+    cwd: repoPath,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+
+  if (!output) return [];
+  return output.split(/\r?\n/).filter(Boolean);
 }
 
 /**
  * Check how many commits the index is behind HEAD (synchronous; uses git CLI).
+ *
+ * A common workflow commits the generated `.gitnexus/lbug`, `meta.json`, and
+ * agent context files after running analyze. That creates a new commit whose
+ * source code did not change, so commit-hash comparison alone would report a
+ * permanently stale index. Treat those index-artifact-only commits as fresh.
  */
 export function checkStaleness(repoPath: string, lastCommit: string): StalenessInfo {
   try {
@@ -25,9 +55,20 @@ export function checkStaleness(repoPath: string, lastCommit: string): StalenessI
     const commitsBehind = parseInt(result, 10) || 0;
 
     if (commitsBehind > 0) {
+      const changedFiles = getChangedFiles(repoPath, lastCommit);
+      if (changedFiles.length > 0 && changedFiles.every(isGeneratedIndexPath)) {
+        return {
+          isStale: false,
+          commitsBehind,
+          artifactOnly: true,
+          changedFiles,
+        };
+      }
+
       return {
         isStale: true,
         commitsBehind,
+        changedFiles,
         hint: `⚠️ Index is ${commitsBehind} commit${commitsBehind > 1 ? 's' : ''} behind HEAD. Run analyze tool to update.`,
       };
     }

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -33,8 +33,9 @@ import {
 import { getCurrentCommit, hasGitDir } from '../storage/git.js';
 import type { CachedEmbedding } from './embeddings/types.js';
 import { generateAIContextFiles } from '../cli/ai-context.js';
-import { EMBEDDING_TABLE_NAME } from './lbug/schema.js';
+import { EMBEDDING_DIMS, EMBEDDING_TABLE_NAME } from './lbug/schema.js';
 import { STALE_HASH_SENTINEL } from './lbug/schema.js';
+import type { EmbeddingConfigSummary } from './embeddings/http-client.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -73,6 +74,7 @@ export interface AnalyzeResult {
 
 /** Threshold: auto-skip embeddings for repos with more nodes than this */
 const EMBEDDING_NODE_LIMIT = 50_000;
+const EMBEDDING_BACKEND_SWITCH_ENV = 'GITNEXUS_ALLOW_EMBEDDING_BACKEND_SWITCH';
 
 export const PHASE_LABELS: Record<string, string> = {
   extracting: 'Scanning files',
@@ -88,6 +90,71 @@ export const PHASE_LABELS: Record<string, string> = {
   fts: 'Creating search indexes',
   embeddings: 'Generating embeddings',
   done: 'Done',
+};
+
+const getCurrentEmbeddingConfig = async (): Promise<EmbeddingConfigSummary> => {
+  const { getHttpConfigSummary } = await import('./embeddings/http-client.js');
+  const httpConfig = getHttpConfigSummary();
+  if (httpConfig) return httpConfig;
+
+  return {
+    provider: 'onnx',
+    model: 'Snowflake/snowflake-arctic-embed-xs',
+    dimensions: EMBEDDING_DIMS,
+  };
+};
+
+const embeddingConfigsCompatible = (
+  a?: EmbeddingConfigSummary,
+  b?: EmbeddingConfigSummary,
+): boolean => {
+  if (!a || !b) return true;
+  const sameProvider = a.provider === b.provider;
+  const sameBaseUrl = a.provider === 'openai' || a.baseUrl === b.baseUrl;
+  return sameProvider && sameBaseUrl && a.model === b.model && a.dimensions === b.dimensions;
+};
+
+const formatEmbeddingConfig = (config?: EmbeddingConfigSummary): string => {
+  if (!config) return 'unknown';
+  const base = config.baseUrl ? ` @ ${config.baseUrl}` : '';
+  return `${config.provider}:${config.model}:${config.dimensions}d${base}`;
+};
+
+const isExplicitBackendSwitchAllowed = (): boolean => {
+  const raw = process.env[EMBEDDING_BACKEND_SWITCH_ENV]?.toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+};
+
+const resolveEmbeddingConfig = async (
+  options: AnalyzeOptions,
+  existingMeta: Awaited<ReturnType<typeof loadMeta>>,
+  log: (msg: string) => void,
+): Promise<EmbeddingConfigSummary | undefined> => {
+  if (!options.embeddings) return undefined;
+
+  const currentConfig = await getCurrentEmbeddingConfig();
+  const existingConfig = existingMeta?.embedding;
+  if (!existingConfig || embeddingConfigsCompatible(existingConfig, currentConfig)) {
+    return currentConfig;
+  }
+
+  const from = formatEmbeddingConfig(existingConfig);
+  const to = formatEmbeddingConfig(currentConfig);
+  if (!isExplicitBackendSwitchAllowed()) {
+    throw new Error(
+      `Existing embeddings were created with ${from}, but current configuration resolves to ${to}. ` +
+        `Refusing to overwrite embeddings with a different backend/model. Set OPENAI_API_KEY ` +
+        `or matching GITNEXUS_EMBEDDING_URL/GITNEXUS_EMBEDDING_MODEL/GITNEXUS_EMBEDDING_DIMS ` +
+        `to keep the existing backend. To intentionally rebuild with ${to}, rerun with ` +
+        `${EMBEDDING_BACKEND_SWITCH_ENV}=1 and --force.`,
+    );
+  }
+
+  log(
+    `Embedding backend switch explicitly allowed by ${EMBEDDING_BACKEND_SWITCH_ENV}; ` +
+      `discarding cache (${from} -> ${to})`,
+  );
+  return currentConfig;
 };
 
 // ---------------------------------------------------------------------------
@@ -139,23 +206,35 @@ export async function runFullAnalysis(
     }
   }
 
+  const currentEmbeddingConfig = await resolveEmbeddingConfig(options, existingMeta, log);
+
   // ── Cache embeddings from existing index before rebuild ────────────
   let cachedEmbeddingNodeIds = new Set<string>();
   let cachedEmbeddings: CachedEmbedding[] = [];
 
   if (options.embeddings && existingMeta && !options.force) {
-    try {
-      progress('embeddings', 0, 'Caching embeddings...');
-      await initLbug(lbugPath);
-      const cached = await loadCachedEmbeddings();
-      cachedEmbeddingNodeIds = cached.embeddingNodeIds;
-      cachedEmbeddings = cached.embeddings;
-      await closeLbug();
-    } catch {
+    if (
+      existingMeta.embedding &&
+      currentEmbeddingConfig &&
+      !embeddingConfigsCompatible(existingMeta.embedding, currentEmbeddingConfig)
+    ) {
+      log(
+        `Embedding backend changed (${formatEmbeddingConfig(existingMeta.embedding)} -> ${formatEmbeddingConfig(currentEmbeddingConfig)}), discarding cache`,
+      );
+    } else {
       try {
+        progress('embeddings', 0, 'Caching embeddings...');
+        await initLbug(lbugPath);
+        const cached = await loadCachedEmbeddings();
+        cachedEmbeddingNodeIds = cached.embeddingNodeIds;
+        cachedEmbeddings = cached.embeddings;
         await closeLbug();
       } catch {
-        /* swallow */
+        try {
+          await closeLbug();
+        } catch {
+          /* swallow */
+        }
       }
     }
   }
@@ -237,6 +316,7 @@ export async function runFullAnalysis(
     // ── Phase 4: Embeddings (90–98%) ──────────────────────────────────
     const stats = await getLbugStats();
     let embeddingSkipped = true;
+    let embeddingConfig: EmbeddingConfigSummary | undefined;
 
     if (options.embeddings) {
       if (stats.nodes <= EMBEDDING_NODE_LIMIT) {
@@ -247,6 +327,7 @@ export async function runFullAnalysis(
     if (!embeddingSkipped) {
       const { isHttpMode } = await import('./embeddings/http-client.js');
       const httpMode = isHttpMode();
+      embeddingConfig = currentEmbeddingConfig ?? (await getCurrentEmbeddingConfig());
       progress(
         'embeddings',
         90,
@@ -311,6 +392,7 @@ export async function runFullAnalysis(
         processes: pipelineResult.processResult?.stats.totalProcesses,
         embeddings: embeddingCount,
       },
+      ...(embeddingConfig && embeddingCount > 0 ? { embedding: embeddingConfig } : {}),
     };
     await saveMeta(storagePath, meta);
     await registerRepo(repoPath, meta);

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -73,7 +73,7 @@ export interface AnalyzeResult {
 }
 
 /** Threshold: auto-skip embeddings for repos with more nodes than this */
-const EMBEDDING_NODE_LIMIT = 50_000;
+const EMBEDDING_NODE_LIMIT = 100_000;
 const EMBEDDING_BACKEND_SWITCH_ENV = 'GITNEXUS_ALLOW_EMBEDDING_BACKEND_SWITCH';
 
 export const PHASE_LABELS: Record<string, string> = {
@@ -195,8 +195,10 @@ export async function runFullAnalysis(
 
   // ── Early-return: already up to date ──────────────────────────────
   if (existingMeta && !options.force && existingMeta.lastCommit === currentCommit) {
+    const missingRequestedEmbeddings =
+      Boolean(options.embeddings) && ((existingMeta.stats?.embeddings ?? 0) === 0);
     // Non-git folders have currentCommit = '' — always rebuild since we can't detect changes
-    if (currentCommit !== '') {
+    if (currentCommit !== '' && !missingRequestedEmbeddings) {
       return {
         repoName: path.basename(repoPath),
         repoPath,

--- a/gitnexus/src/core/search/hybrid-search.ts
+++ b/gitnexus/src/core/search/hybrid-search.ts
@@ -10,6 +10,7 @@
 
 import { searchFTSFromLbug, type BM25SearchResult } from './bm25-index.js';
 import type { SemanticSearchResult } from '../embeddings/types.js';
+import { buildQueryPlan, combineRankedResults } from './query-expansion.js';
 
 /**
  * RRF constant - standard value used in the literature
@@ -21,7 +22,7 @@ export interface HybridSearchResult {
   filePath: string;
   score: number; // RRF score
   rank: number; // Final rank
-  sources: ('bm25' | 'semantic')[]; // Which methods found this
+  sources: string[]; // Which methods found this
 
   // Metadata from semantic search (if available)
   nodeId?: string;
@@ -158,9 +159,41 @@ export const hybridSearch = async (
     query: string,
     k?: number,
   ) => Promise<SemanticSearchResult[]>,
+  options: { goal?: string; taskContext?: string } = {},
 ): Promise<HybridSearchResult[]> => {
-  // Use LadybugDB FTS for always-fresh BM25 results
-  const bm25Results = await searchFTSFromLbug(query, limit);
-  const semanticResults = await semanticSearch(executeQuery, query, limit);
-  return mergeWithRRF(bm25Results, semanticResults, limit);
+  const queryPlan = buildQueryPlan({
+    query,
+    goal: options.goal,
+    taskContext: options.taskContext,
+  });
+  const resultSets: Array<{ source: string; weight: number; results: any[] }> = [];
+
+  for (const variant of queryPlan.bm25Queries) {
+    const bm25Results = await searchFTSFromLbug(variant.query, limit);
+    resultSets.push({
+      source: variant.kind === 'primary' ? 'bm25' : `bm25:${variant.kind}`,
+      weight: variant.weight,
+      results: bm25Results,
+    });
+  }
+
+  for (const variant of queryPlan.semanticQueries) {
+    const semanticResults = await semanticSearch(executeQuery, variant.query, limit).catch(
+      () => [],
+    );
+    resultSets.push({
+      source: variant.kind === 'primary' ? 'semantic' : `semantic:${variant.kind}`,
+      weight: variant.weight,
+      results: semanticResults,
+    });
+  }
+
+  return combineRankedResults(resultSets, limit, queryPlan, {
+    keyFn: (result) => result.nodeId ?? result.filePath,
+  }).map((item, index) => ({
+    ...item.data,
+    score: item.score,
+    rank: index + 1,
+    sources: item.sources,
+  }));
 };

--- a/gitnexus/src/core/search/query-expansion.ts
+++ b/gitnexus/src/core/search/query-expansion.ts
@@ -1,0 +1,290 @@
+/**
+ * Bounded query expansion and lightweight reranking for code search.
+ *
+ * This intentionally avoids project-specific synonym lists. The expansion is
+ * based on stable code-search signals: identifier splitting, route/path tokens,
+ * short context terms, and a small generic programming vocabulary.
+ */
+
+const MAX_QUERY_LENGTH = 260;
+const DEFAULT_MAX_BM25_QUERIES = 4;
+const DEFAULT_MAX_SEMANTIC_QUERIES = 2;
+
+const STOP_WORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'by',
+  'for',
+  'from',
+  'how',
+  'in',
+  'into',
+  'is',
+  'it',
+  'of',
+  'on',
+  'or',
+  'that',
+  'the',
+  'this',
+  'to',
+  'with',
+  'where',
+  'why',
+]);
+
+const SHORT_CODE_TERMS = new Set(['ai', 'api', 'db', 'fk', 'id', 'ui']);
+
+const GENERIC_CODE_EXPANSIONS = new Map<string, string[]>([
+  ['admin', ['auth', 'middleware', 'protected']],
+  ['api', ['route', 'endpoint', 'handler']],
+  ['auth', ['authentication', 'authorization', 'middleware', 'guard']],
+  ['config', ['configuration', 'env', 'environment', 'validate']],
+  ['database', ['db', 'schema', 'migration', 'table']],
+  ['dispatch', ['job', 'queue', 'worker', 'schedule']],
+  ['embedding', ['vector', 'semantic', 'search']],
+  ['env', ['environment', 'config', 'configuration']],
+  ['event', ['analytics', 'envelope', 'telemetry']],
+  ['job', ['queue', 'worker', 'schedule']],
+  ['migration', ['schema', 'database', 'drizzle']],
+  ['queue', ['job', 'worker', 'schedule']],
+  ['redirect', ['link', 'token', 'hmac']],
+  ['route', ['api', 'endpoint', 'handler']],
+  ['schema', ['database', 'migration', 'table']],
+  ['session', ['anonymous', 'cookie', 'identity']],
+  ['test', ['spec', 'mock', 'fixture']],
+  ['worker', ['job', 'queue', 'dispatch']],
+]);
+
+export interface QueryVariant {
+  query: string;
+  kind: string;
+  weight: number;
+  semanticEligible: boolean;
+}
+
+export interface QueryPlan {
+  primary: string;
+  tokens: string[];
+  bm25Queries: QueryVariant[];
+  semanticQueries: QueryVariant[];
+}
+
+export interface RankedResultSet<T> {
+  source: string;
+  weight?: number;
+  results: T[];
+}
+
+export interface CombinedRankedResult<T> {
+  key: string;
+  score: number;
+  data: T;
+  sources: string[];
+}
+
+const normalizeWhitespace = (value: string): string => value.trim().replace(/\s+/g, ' ');
+
+const splitIdentifiers = (value: string): string =>
+  normalizeWhitespace(
+    value
+      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+      .replace(/[._:/\\-]+/g, ' ')
+      .replace(/[^A-Za-z0-9\s]/g, ' '),
+  );
+
+const tokenize = (value: string): string[] => {
+  const tokens = splitIdentifiers(value)
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((token) => (token.length >= 3 || SHORT_CODE_TERMS.has(token)) && !STOP_WORDS.has(token));
+
+  return [...new Set(tokens)];
+};
+
+const weightedTerms = (...texts: Array<string | undefined>): string[] => {
+  const counts = new Map<string, number>();
+  for (const text of texts.filter(Boolean) as string[]) {
+    for (const token of tokenize(text)) {
+      counts.set(token, (counts.get(token) ?? 0) + 1);
+    }
+  }
+
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([token]) => token);
+};
+
+const clipQuery = (value: string): string =>
+  normalizeWhitespace(value).slice(0, MAX_QUERY_LENGTH).trim();
+
+const addVariant = (
+  variants: QueryVariant[],
+  seen: Set<string>,
+  query: string,
+  kind: string,
+  weight: number,
+  semanticEligible = false,
+): void => {
+  const clipped = clipQuery(query);
+  if (!clipped) return;
+
+  const key = clipped.toLowerCase();
+  if (seen.has(key)) return;
+
+  seen.add(key);
+  variants.push({ query: clipped, kind, weight, semanticEligible });
+};
+
+export const buildQueryPlan = (
+  input: { query: string; goal?: string; taskContext?: string },
+  options: { maxBm25Queries?: number; maxSemanticQueries?: number } = {},
+): QueryPlan => {
+  const primary = clipQuery(input.query);
+  const maxBm25Queries = options.maxBm25Queries ?? DEFAULT_MAX_BM25_QUERIES;
+  const maxSemanticQueries = options.maxSemanticQueries ?? DEFAULT_MAX_SEMANTIC_QUERIES;
+  const variants: QueryVariant[] = [];
+  const seen = new Set<string>();
+
+  addVariant(variants, seen, primary, 'primary', 1, true);
+
+  const identifierText = splitIdentifiers(primary);
+  if (identifierText.toLowerCase() !== primary.toLowerCase()) {
+    addVariant(variants, seen, identifierText, 'identifier', 0.9, true);
+  }
+
+  const primaryTerms = tokenize(primary);
+  const expansionTerms: string[] = [];
+  for (const term of primaryTerms) {
+    const expansions = GENERIC_CODE_EXPANSIONS.get(term);
+    if (expansions) expansionTerms.push(...expansions);
+  }
+
+  if (expansionTerms.length > 0) {
+    const bounded = [...new Set([...primaryTerms, ...expansionTerms])].slice(0, 14);
+    addVariant(variants, seen, `${primary} ${bounded.join(' ')}`, 'generic-code', 0.7, false);
+  }
+
+  const contextTerms = weightedTerms(input.goal, input.taskContext).filter(
+    (term) => !primaryTerms.includes(term),
+  );
+  if (contextTerms.length > 0) {
+    addVariant(variants, seen, `${primary} ${contextTerms.slice(0, 8).join(' ')}`, 'context', 0.55);
+  }
+
+  const bm25Queries = variants.slice(0, maxBm25Queries);
+  const semanticQueries = variants
+    .filter((variant) => variant.semanticEligible)
+    .slice(0, maxSemanticQueries);
+
+  return {
+    primary,
+    tokens: weightedTerms(primary, input.goal, input.taskContext).slice(0, 24),
+    bm25Queries,
+    semanticQueries: semanticQueries.length > 0 ? semanticQueries : bm25Queries.slice(0, 1),
+  };
+};
+
+const mergeResultData = <T extends Record<string, any>>(existing: T, incoming: T): T => {
+  const merged = { ...existing };
+  for (const [key, value] of Object.entries(incoming)) {
+    if (value !== undefined && value !== null && value !== '') {
+      (merged as any)[key] = (merged as any)[key] ?? value;
+    }
+  }
+  return merged;
+};
+
+const textForResult = (result: Record<string, any>): Record<string, string> => ({
+  name: splitIdentifiers(String(result.name ?? '')),
+  filePath: splitIdentifiers(String(result.filePath ?? '')),
+  type: splitIdentifiers(String(result.type ?? result.label ?? '')),
+  nodeId: splitIdentifiers(String(result.nodeId ?? result.id ?? '')),
+});
+
+const countMatches = (text: string, tokens: string[]): number => {
+  if (!text) return 0;
+  const tokenSet = new Set(tokenize(text));
+  return tokens.reduce((count, token) => count + (tokenSet.has(token) ? 1 : 0), 0);
+};
+
+const relevanceBoost = (result: Record<string, any>, queryPlan: QueryPlan): number => {
+  const tokens = queryPlan.tokens.slice(0, 14);
+  if (tokens.length === 0) return 0;
+
+  const text = textForResult(result);
+  const nameHits = countMatches(text.name, tokens);
+  const pathHits = countMatches(text.filePath, tokens);
+  const typeHits = countMatches(text.type, tokens);
+  const idHits = countMatches(text.nodeId, tokens);
+  const normalizedPrimary = splitIdentifiers(queryPlan.primary).toLowerCase();
+  const combined = `${text.name} ${text.filePath} ${text.nodeId}`.toLowerCase();
+  const phraseBoost =
+    normalizedPrimary.length >= 8 && combined.includes(normalizedPrimary) ? 0.025 : 0;
+
+  return (
+    Math.min(nameHits * 0.012, 0.06) +
+    Math.min(pathHits * 0.006, 0.04) +
+    Math.min(typeHits * 0.004, 0.012) +
+    Math.min(idHits * 0.003, 0.018) +
+    phraseBoost
+  );
+};
+
+export const combineRankedResults = <T extends Record<string, any>>(
+  resultSets: Array<RankedResultSet<T>>,
+  limit: number,
+  queryPlan: QueryPlan,
+  options: {
+    rrfK?: number;
+    keyFn?: (result: T) => string | undefined;
+  } = {},
+): Array<CombinedRankedResult<T>> => {
+  const rrfK = options.rrfK ?? 60;
+  const keyFn =
+    options.keyFn ?? ((result: T) => result.nodeId ?? result.id ?? result.filePath ?? result.name);
+  const merged = new Map<string, { score: number; data: T; sources: Set<string> }>();
+
+  for (const resultSet of resultSets) {
+    const source = resultSet.source;
+    const weight = resultSet.weight ?? 1;
+    const results = resultSet.results ?? [];
+
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      const key = keyFn(result);
+      if (!key) continue;
+
+      const rrfScore = weight / (rrfK + i + 1);
+      const existing = merged.get(key);
+      if (existing) {
+        existing.score += rrfScore;
+        existing.data = mergeResultData(existing.data, result);
+        existing.sources.add(source);
+      } else {
+        merged.set(key, {
+          score: rrfScore,
+          data: { ...result },
+          sources: new Set([source]),
+        });
+      }
+    }
+  }
+
+  return [...merged.entries()]
+    .map(([key, item]) => ({
+      key,
+      score: item.score + relevanceBoost(item.data, queryPlan),
+      data: item.data,
+      sources: [...item.sources],
+    }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+};

--- a/gitnexus/src/mcp/core/embedder.ts
+++ b/gitnexus/src/mcp/core/embedder.ts
@@ -5,7 +5,7 @@
  * For MCP, we only need to compute query embeddings, not batch embed.
  */
 
-import { pipeline, env, type FeatureExtractionPipeline } from '@huggingface/transformers';
+import type { FeatureExtractionPipeline } from '@huggingface/transformers';
 import {
   isHttpMode,
   getHttpDimensions,
@@ -20,6 +20,12 @@ const MODEL_ID = 'Snowflake/snowflake-arctic-embed-xs';
 let embedderInstance: FeatureExtractionPipeline | null = null;
 let isInitializing = false;
 let initPromise: Promise<FeatureExtractionPipeline> | null = null;
+let transformersModulePromise: Promise<typeof import('@huggingface/transformers')> | null = null;
+
+const loadTransformers = async (): Promise<typeof import('@huggingface/transformers')> => {
+  transformersModulePromise ??= import('@huggingface/transformers');
+  return transformersModulePromise;
+};
 
 /**
  * Initialize the embedding model (lazy, on first search)
@@ -41,6 +47,7 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
 
   initPromise = (async () => {
     try {
+      const { pipeline, env } = await loadTransformers();
       env.allowLocalModels = false;
       // Default cache to user-writable location. transformers.js defaults to
       // ./node_modules/.cache inside its own install dir, which is unwritable

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -31,6 +31,8 @@ import { GroupService, type GroupToolPort } from '../../core/group/service.js';
 import { collectBestChunks } from '../../core/embeddings/types.js';
 import { EMBEDDING_TABLE_NAME, EMBEDDING_INDEX_NAME } from '../../core/lbug/schema.js';
 import { PhaseTimer } from '../../core/search/phase-timer.js';
+import { buildQueryPlan, combineRankedResults } from '../../core/search/query-expansion.js';
+import type { EmbeddingConfigSummary } from '../../core/embeddings/http-client.js';
 // AI context generation is CLI-only (gitnexus analyze)
 // import { generateAIContextFiles } from '../../cli/ai-context.js';
 
@@ -198,6 +200,7 @@ interface RepoHandle {
   indexedAt: string;
   lastCommit: string;
   stats?: RegistryEntry['stats'];
+  embedding?: EmbeddingConfigSummary;
 }
 
 export class LocalBackend {
@@ -255,6 +258,12 @@ export class LocalBackend {
 
       const storagePath = entry.storagePath;
       const lbugPath = path.join(storagePath, 'lbug');
+      let meta: { embedding?: EmbeddingConfigSummary } = {};
+      try {
+        meta = JSON.parse(await fs.readFile(path.join(storagePath, 'meta.json'), 'utf-8'));
+      } catch {
+        meta = {};
+      }
 
       // Clean up any leftover KuzuDB files from before the LadybugDB migration.
       // If kuzu exists but lbug doesn't, warn so the user knows to re-analyze.
@@ -274,6 +283,7 @@ export class LocalBackend {
         indexedAt: entry.indexedAt,
         lastCommit: entry.lastCommit,
         stats: entry.stats,
+        embedding: meta.embedding,
       };
 
       this.repos.set(id, handle);
@@ -565,50 +575,48 @@ export class LocalBackend {
     const timer = new PhaseTimer();
     const wallStart = performance.now();
 
-    // Step 1: Run hybrid search to get matching symbols. BM25 and vector
-    // search run concurrently via Promise.all — use `timer.time()` for
-    // each so both get independent wall-time records without fighting
-    // over a single `current` phase slot.
+    // Step 1: Run bounded hybrid search to get matching symbols.
+    // BM25 gets cheap deterministic variants; semantic search is capped to
+    // the primary query plus one identifier-expanded query to control noise.
     const searchLimit = processLimit * maxSymbolsPerProcess; // fetch enough raw results
-    const [bm25SearchResult, semanticResults] = await Promise.all([
-      timer.time('bm25', this.bm25Search(repo, searchQuery, searchLimit)),
-      timer.time('vector', this.semanticSearch(repo, searchQuery, searchLimit)),
-    ]);
+    const queryPlan = buildQueryPlan({
+      query: searchQuery,
+      goal: params.goal,
+      taskContext: params.task_context,
+    });
+    const resultSets: Array<{ source: string; weight: number; results: any[] }> = [];
+    let ftsUsed = true;
 
-    const bm25Results = bm25SearchResult.results;
-    const ftsUsed = bm25SearchResult.ftsUsed;
+    for (const variant of queryPlan.bm25Queries) {
+      const bm25SearchResult = await timer.time(
+        variant.kind === 'primary' ? 'bm25' : `bm25:${variant.kind}`,
+        this.bm25Search(repo, variant.query, searchLimit),
+      );
+      ftsUsed = ftsUsed && bm25SearchResult.ftsUsed;
+      resultSets.push({
+        source: variant.kind === 'primary' ? 'bm25' : `bm25:${variant.kind}`,
+        weight: variant.weight,
+        results: bm25SearchResult.results,
+      });
+    }
+
+    for (const variant of queryPlan.semanticQueries) {
+      const semanticResults = await timer.time(
+        variant.kind === 'primary' ? 'vector' : `vector:${variant.kind}`,
+        this.semanticSearch(repo, variant.query, searchLimit),
+      );
+      resultSets.push({
+        source: variant.kind === 'primary' ? 'semantic' : `semantic:${variant.kind}`,
+        weight: variant.weight,
+        results: semanticResults,
+      });
+    }
 
     // Merge via reciprocal rank fusion
     timer.start('merge');
-    const scoreMap = new Map<string, { score: number; data: any }>();
-
-    for (let i = 0; i < bm25Results.length; i++) {
-      const result = bm25Results[i];
-      const key = result.nodeId || result.filePath;
-      const rrfScore = 1 / (60 + i);
-      const existing = scoreMap.get(key);
-      if (existing) {
-        existing.score += rrfScore;
-      } else {
-        scoreMap.set(key, { score: rrfScore, data: result });
-      }
-    }
-
-    for (let i = 0; i < semanticResults.length; i++) {
-      const result = semanticResults[i];
-      const key = result.nodeId || result.filePath;
-      const rrfScore = 1 / (60 + i);
-      const existing = scoreMap.get(key);
-      if (existing) {
-        existing.score += rrfScore;
-      } else {
-        scoreMap.set(key, { score: rrfScore, data: result });
-      }
-    }
-
-    const merged = Array.from(scoreMap.entries())
-      .sort((a, b) => b[1].score - a[1].score)
-      .slice(0, searchLimit);
+    const merged = combineRankedResults(resultSets, searchLimit, queryPlan, {
+      keyFn: (result) => result.nodeId || result.filePath,
+    });
     timer.stop(); // merge
 
     // Step 2: For each match with a nodeId, trace to process(es)
@@ -628,7 +636,7 @@ export class LocalBackend {
     >();
     const definitions: any[] = []; // standalone symbols not in any process
 
-    for (const [_, item] of merged) {
+    for (const item of merged) {
       const sym = item.data;
       if (!sym.nodeId) {
         // File-level results go to definitions
@@ -885,6 +893,25 @@ export class LocalBackend {
         `MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN COUNT(*) AS cnt LIMIT 1`,
       );
       if (!tableCheck.length || (tableCheck[0].cnt ?? tableCheck[0][0]) === 0) return [];
+
+      const storedEmbedding = repo.embedding;
+      if (storedEmbedding?.provider) {
+        const { isHttpMode, getHttpConfigSummary } =
+          await import('../../core/embeddings/http-client.js');
+        const currentHttp = getHttpConfigSummary();
+        if (storedEmbedding.provider === 'openai' || storedEmbedding.provider === 'http') {
+          if (!isHttpMode() || !currentHttp) return [];
+
+          const sameProvider = storedEmbedding.provider === currentHttp.provider;
+          const sameBaseUrl =
+            storedEmbedding.provider === 'openai' || storedEmbedding.baseUrl === currentHttp.baseUrl;
+          const sameModel = storedEmbedding.model === currentHttp.model;
+          const sameDimensions = storedEmbedding.dimensions === currentHttp.dimensions;
+          if (!sameProvider || !sameBaseUrl || !sameModel || !sameDimensions) return [];
+        } else if (storedEmbedding.provider === 'onnx' && isHttpMode()) {
+          return [];
+        }
+      }
 
       const { embedQuery, getEmbeddingDims } = await import('../core/embedder.js');
       const queryVec = await embedQuery(query);

--- a/gitnexus/src/mcp/resources.ts
+++ b/gitnexus/src/mcp/resources.ts
@@ -233,7 +233,7 @@ async function getContextResource(backend: LocalBackend, repoName?: string): Pro
   lines.push('  - cypher: Raw graph queries');
   lines.push('  - list_repos: Discover all indexed repositories');
   lines.push('');
-  lines.push('re_index: Run `npx gitnexus analyze` in terminal if data is stale');
+  lines.push('re_index: Run `gitnexus analyze` in terminal if data is stale');
   lines.push('');
   lines.push('resources_available:');
   lines.push('  - gitnexus://repos: All indexed repositories');
@@ -470,7 +470,7 @@ async function getSetupResource(backend: LocalBackend): Promise<string> {
   const repos = await backend.listRepos();
 
   if (repos.length === 0) {
-    return '# GitNexus\n\nNo repositories indexed. Run: `npx gitnexus analyze` in a repository.';
+    return '# GitNexus\n\nNo repositories indexed. Run: `gitnexus analyze` in a repository.';
   }
 
   const sections: string[] = [];

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -22,6 +22,12 @@ export interface RepoMeta {
     processes?: number;
     embeddings?: number;
   };
+  embedding?: {
+    provider: 'openai' | 'http' | 'onnx';
+    baseUrl?: string;
+    model: string;
+    dimensions: number;
+  };
 }
 
 export interface IndexedRepo {
@@ -42,6 +48,7 @@ export interface RegistryEntry {
   indexedAt: string;
   lastCommit: string;
   stats?: RepoMeta['stats'];
+  embedding?: RepoMeta['embedding'];
 }
 
 const GITNEXUS_DIR = '.gitnexus';
@@ -267,6 +274,7 @@ export const registerRepo = async (repoPath: string, meta: RepoMeta): Promise<vo
     indexedAt: meta.indexedAt,
     lastCommit: meta.lastCommit,
     stats: meta.stats,
+    embedding: meta.embedding,
   };
 
   if (existing >= 0) {

--- a/gitnexus/test/integration/hooks-e2e.test.ts
+++ b/gitnexus/test/integration/hooks-e2e.test.ts
@@ -77,7 +77,8 @@ describe.each(HOOKS)('hooks e2e ($name)', ({ name, path: hookPath }) => {
       const output = parseHookOutput(result.stdout);
       expect(output).not.toBeNull();
       expect(output!.additionalContext).toContain('stale');
-      expect(output!.additionalContext).toContain('npx gitnexus analyze');
+      expect(output!.additionalContext).toContain('gitnexus analyze');
+      expect(output!.additionalContext).not.toContain('npx gitnexus');
     });
 
     it('stays silent when meta.json lastCommit matches HEAD', () => {

--- a/gitnexus/test/integration/hooks-e2e.test.ts
+++ b/gitnexus/test/integration/hooks-e2e.test.ts
@@ -108,6 +108,34 @@ describe.each(HOOKS)('hooks e2e ($name)', ({ name, path: hookPath }) => {
       expect(output).toBeNull();
     });
 
+    it('stays silent when only generated GitNexus artifacts changed after indexing', () => {
+      const headResult = spawnSync('git', ['rev-parse', 'HEAD'], {
+        cwd: tmpDir,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const indexedHead = headResult.stdout.trim();
+
+      fs.writeFileSync(
+        path.join(gitNexusDir, 'meta.json'),
+        JSON.stringify({ lastCommit: indexedHead, stats: {} }),
+      );
+      fs.writeFileSync(path.join(tmpDir, 'AGENTS.md'), '# GitNexus\n');
+      spawnSync('git', ['add', '.gitnexus/meta.json', 'AGENTS.md'], { cwd: tmpDir, stdio: 'pipe' });
+      spawnSync('git', ['commit', '-m', 'index artifacts'], { cwd: tmpDir, stdio: 'pipe' });
+
+      const result = runHook(hookPath, {
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'git commit -m "index artifacts"' },
+        tool_output: { exit_code: 0 },
+        cwd: tmpDir,
+      });
+
+      const output = parseHookOutput(result.stdout);
+      expect(output).toBeNull();
+    });
+
     it('includes --embeddings flag when previous index had embeddings', () => {
       fs.writeFileSync(
         path.join(gitNexusDir, 'meta.json'),

--- a/gitnexus/test/unit/ai-context.test.ts
+++ b/gitnexus/test/unit/ai-context.test.ts
@@ -138,9 +138,10 @@ describe('generateAIContextFiles', () => {
   });
 
   it('preserves manual AGENTS.md and CLAUDE.md edits when skipAgentsMd is enabled', async () => {
+    const isolatedDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-ai-ctx-skip-test-'));
     const stats = { nodes: 42, edges: 84, processes: 3 };
-    const agentsPath = path.join(tmpDir, 'AGENTS.md');
-    const claudePath = path.join(tmpDir, 'CLAUDE.md');
+    const agentsPath = path.join(isolatedDir, 'AGENTS.md');
+    const claudePath = path.join(isolatedDir, 'CLAUDE.md');
     const agentsContent = '# AGENTS\n\nCustom manual instructions only\n';
     const claudeContent = '# CLAUDE\n\nCustom manual instructions only\n';
 
@@ -148,7 +149,7 @@ describe('generateAIContextFiles', () => {
     await fs.writeFile(claudePath, claudeContent, 'utf-8');
 
     const result = await generateAIContextFiles(
-      tmpDir,
+      isolatedDir,
       storagePath,
       'TestProject',
       stats,
@@ -163,5 +164,12 @@ describe('generateAIContextFiles', () => {
     const claudeAfter = await fs.readFile(claudePath, 'utf-8');
     expect(agentsAfter).toBe(agentsContent);
     expect(claudeAfter).toBe(claudeContent);
+    expect(result.files).toContain(
+      '.claude/skills/gitnexus/ (skipped via --skip-agents-md)',
+    );
+    await expect(
+      fs.access(path.join(isolatedDir, '.claude', 'skills', 'gitnexus')),
+    ).rejects.toThrow();
+    await fs.rm(isolatedDir, { recursive: true, force: true });
   });
 });

--- a/gitnexus/test/unit/query-expansion.test.ts
+++ b/gitnexus/test/unit/query-expansion.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { buildQueryPlan, combineRankedResults } from '../../src/core/search/query-expansion.js';
+
+describe('query expansion', () => {
+  it('keeps fan-out bounded and splits code identifiers', () => {
+    const plan = buildQueryPlan({
+      query: 'telegram dispatch scheduling pg-boss singletonKey package',
+      goal: 'find dispatch route worker flow',
+      taskContext: 'validate singletonKey dedupe',
+    });
+
+    expect(plan.bm25Queries).toHaveLength(4);
+    expect(plan.semanticQueries).toHaveLength(2);
+    expect(plan.semanticQueries.map((variant) => variant.kind)).toEqual(['primary', 'identifier']);
+    expect(plan.bm25Queries[1].query).toContain('singleton Key');
+    expect(plan.bm25Queries[2].query).toContain('job queue worker schedule');
+  });
+
+  it('reranks exact symbol and file-path matches after RRF', () => {
+    const plan = buildQueryPlan({ query: 'registerPreRegisterRoute duplicate consent' });
+    const ranked = combineRankedResults(
+      [
+        {
+          source: 'bm25',
+          results: [
+            {
+              nodeId: 'Function:src/other.ts:genericHandler',
+              name: 'genericHandler',
+              filePath: 'src/other.ts',
+            },
+            {
+              nodeId: 'Function:src/modules/identity/api/pre-register.ts:registerPreRegisterRoute',
+              name: 'registerPreRegisterRoute',
+              filePath: 'src/modules/identity/api/pre-register.ts',
+            },
+          ],
+        },
+      ],
+      2,
+      plan,
+      { keyFn: (result) => result.nodeId },
+    );
+
+    expect(ranked[0].data.name).toBe('registerPreRegisterRoute');
+  });
+});

--- a/gitnexus/test/unit/staleness.test.ts
+++ b/gitnexus/test/unit/staleness.test.ts
@@ -8,7 +8,10 @@
  */
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'child_process';
-import { checkStaleness } from '../../src/core/git-staleness.js';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { checkStaleness, isGeneratedIndexPath } from '../../src/core/git-staleness.js';
 
 // We test checkStaleness with a real git repo (the project itself)
 // since mocking execFileSync across ESM modules is complex.
@@ -63,5 +66,71 @@ describe('checkStaleness', () => {
     const result = checkStaleness(process.cwd(), 'not-a-real-commit-hash');
     expect(result.isStale).toBe(false);
     expect(result.commitsBehind).toBe(0);
+  });
+
+  it('treats commits containing only generated GitNexus artifacts as fresh', () => {
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-staleness-'));
+    try {
+      execFileSync('git', ['init'], { cwd: repoPath, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoPath });
+      execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repoPath });
+
+      fs.writeFileSync(path.join(repoPath, 'src.ts'), 'export const value = 1;\n');
+      execFileSync('git', ['add', 'src.ts'], { cwd: repoPath });
+      execFileSync('git', ['commit', '-m', 'source'], { cwd: repoPath, stdio: 'ignore' });
+      const indexedCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: repoPath,
+        encoding: 'utf-8',
+      }).trim();
+
+      fs.mkdirSync(path.join(repoPath, '.gitnexus'), { recursive: true });
+      fs.writeFileSync(path.join(repoPath, '.gitnexus', 'meta.json'), '{}\n');
+      fs.writeFileSync(path.join(repoPath, 'AGENTS.md'), '# GitNexus\n');
+      execFileSync('git', ['add', '.gitnexus/meta.json', 'AGENTS.md'], { cwd: repoPath });
+      execFileSync('git', ['commit', '-m', 'index artifacts'], { cwd: repoPath, stdio: 'ignore' });
+
+      const result = checkStaleness(repoPath, indexedCommit);
+      expect(result.isStale).toBe(false);
+      expect(result.artifactOnly).toBe(true);
+      expect(result.commitsBehind).toBe(1);
+    } finally {
+      fs.rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it('still treats source changes after the indexed commit as stale', () => {
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-staleness-'));
+    try {
+      execFileSync('git', ['init'], { cwd: repoPath, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoPath });
+      execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repoPath });
+
+      fs.writeFileSync(path.join(repoPath, 'src.ts'), 'export const value = 1;\n');
+      execFileSync('git', ['add', 'src.ts'], { cwd: repoPath });
+      execFileSync('git', ['commit', '-m', 'source'], { cwd: repoPath, stdio: 'ignore' });
+      const indexedCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: repoPath,
+        encoding: 'utf-8',
+      }).trim();
+
+      fs.writeFileSync(path.join(repoPath, 'src.ts'), 'export const value = 2;\n');
+      execFileSync('git', ['add', 'src.ts'], { cwd: repoPath });
+      execFileSync('git', ['commit', '-m', 'source change'], { cwd: repoPath, stdio: 'ignore' });
+
+      const result = checkStaleness(repoPath, indexedCommit);
+      expect(result.isStale).toBe(true);
+      expect(result.artifactOnly).toBeUndefined();
+      expect(result.changedFiles).toContain('src.ts');
+    } finally {
+      fs.rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it('recognizes generated index paths', () => {
+    expect(isGeneratedIndexPath('.gitnexus/meta.json')).toBe(true);
+    expect(isGeneratedIndexPath('AGENTS.md')).toBe(true);
+    expect(isGeneratedIndexPath('CLAUDE.md')).toBe(true);
+    expect(isGeneratedIndexPath('.claude/skills/gitnexus/gitnexus-cli/SKILL.md')).toBe(true);
+    expect(isGeneratedIndexPath('src/app.ts')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add bounded query expansion and exact-match reranking for hybrid search
- default HTTP embeddings to OpenAI when OPENAI_API_KEY is present
- persist non-secret embedding backend metadata in repo meta/registry
- refuse implicit embedding backend/model switches during refresh unless explicitly allowed
- avoid loading ONNX/Transformers when HTTP/OpenAI embedding mode is active
- disable incompatible semantic search instead of mixing OpenAI and ONNX vector spaces

## Validation
- PASS: npm run build
- PASS: npm test -- test/unit/query-expansion.test.ts
- PASS: scratch repo guard test verifies OpenAI metadata is not overwritten by ONNX when OPENAI_API_KEY is absent
- PASS: active CLI smoke queries with OpenAI and BM25-only fallback
- FAILING OUTSIDE THIS PATCH: npm run test:unit currently has 2 failures in existing Swift method/type-env tests unrelated to these changed files

## Operational note
Routine refreshes should use gitnexus analyze --embeddings when .gitnexus/meta.json reports existing embeddings. Intentional backend changes require GITNEXUS_ALLOW_EMBEDDING_BACKEND_SWITCH=1 plus --force.

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a broad embeddings and retrieval change that also updates CLI, hook, and documentation surfaces. Its critical posture comes from the breadth of connected runtime areas rather than any flagged high-risk file.*

**🔴 CRITICAL blast radius. This change reaches 75 dependents across the embedding backend, retrieval search, CLI, and Claude hook integration.**

The core concentration is in `gitnexus/src/core/embeddings/http-client.ts`, with 21 changed symbols, alongside `gitnexus/src/core/embeddings/embedding-pipeline.ts`, `gitnexus/src/core/embeddings/types.ts`, `gitnexus/src/core/search/hybrid-search.ts`, and `gitnexus/src/core/search/query-expansion.ts`. Review the HTTP client, embedding pipeline, and query expansion behavior together, since this is where the PR title’s backend safety and retrieval recall scope lands most directly.

Impact also spans `Embeddings`, `Local`, `Hooks`, `Claude`, `Cli`, and `Search`, with related changes in `Server`, `Lbug`, `Wiki`, `I18n`, `Unit`, and `Group`. The paired hook implementations in `gitnexus-claude-plugin/hooks/gitnexus-hook.js` and `gitnexus/hooks/claude/gitnexus-hook.cjs` warrant a consistency check, particularly around `findCanonicalRepoRoot`, `findGitNexusDir`, `hasGitNexusServerOwner`, `extractAugmentContext`, and `extractPattern`.

There are 26 affected flows. Reviewers should also verify the command and hook behavior against `gitnexus/src/cli/ai-context.ts`, `gitnexus/src/cli/index.ts`, `gitnexus/src/cli/status.ts`, `gitnexus/src/mcp/core/embedder.ts`, and `gitnexus/src/mcp/local/local-backend.ts`, using the updated integration and unit tests as the primary validation surface.

_Added by GitNexus for PR #974. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->