### PR TITLE
docs: add Cypher query rules to GitNexus rules section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 <!--
   Metadata: version, last reviewed, scope, model policy, reference docs, changelog.
   Last updated: 2026-03-22
+  | 2026-04-22 | 1.4.0 | Added Cypher query rules under GitNexus rules section. |
 -->
 
 Last reviewed: 2026-04-13
@@ -52,3 +53,12 @@ If always-on instructions grow, load deep conventions via conditional reads (e.g
 ## GitNexus rules
 
 See the `<!-- gitnexus:start --> … <!-- gitnexus:end -->` block in **[AGENTS.md](AGENTS.md)** for the canonical MCP tools, impact analysis rules, and index instructions.
+
+### Cypher Query Rules (Global)
+
+When using the `gitnexus_cypher` tool in ANY project:
+
+- **NEVER** use native relationship syntax like `-[:CALLS]->` or `-[:DEFINES]->`
+- **ALWAYS** use `-[:CodeRelation {type: 'CALLS'}]->` syntax
+- Classes connect to Methods via `HAS_METHOD` (not `DEFINES`)
+- Read `gitnexus://repo/{repo-name}/schema` if unsure about the schema


### PR DESCRIPTION
Adds a Cypher Query Rules subsection under ## GitNexus rules so that Claude Code and other agents always use the correct CodeRelation property-based syntax when writing Cypher queries, rather than native typed relationship syntax which doesn't match the graph schema.

Also bumps version to 1.4.0 and adds a changelog entry.

## Summary

<!-- One or two sentences: what does this PR change? -->

## Motivation / context

<!-- Why is this change needed? Link issues, ADRs, or prior discussion. -->

## Areas touched

<!-- Check all that apply -->

- [ ] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- <!-- bullets -->

**Explicitly out of scope / not done here**

- <!-- bullets — prevents reviewers assuming missing work is an oversight -->

## Implementation notes

<!-- Optional: design choices, tradeoffs, follow-ups -->

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [ ] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [ ] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(if web changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

## Risk & rollout

<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->

## Checklist

- [ ] PR body meets repo minimum length (workflow may label short descriptions)
- [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [ ] No secrets, tokens, or machine-specific paths committed
