### PR TITLE
fix(cli): translate Commander --no-stats into noStats option (#704)

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -228,7 +228,7 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
         embeddings: options?.embeddings,
         skipGit: options?.skipGit,
         skipAgentsMd: options?.skipAgentsMd,
-        noStats: options?.noStats,
+        noStats: options?.noStats ?? (options?.stats === false),
         registryName: options?.name,
         // Registry-collision bypass — its own CLI flag, intentionally NOT
         // overloading --force. A user who hits the collision guard should
@@ -298,7 +298,7 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
               processes: s.processes,
             },
             skillResult.skills,
-            { skipAgentsMd: options?.skipAgentsMd, noStats: options?.noStats },
+            { skipAgentsMd: options?.skipAgentsMd, noStats: options?.noStats ?? (options?.stats === false) },
           );
         }
       } catch {

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -379,7 +379,7 @@ export async function runFullAnalysis(
           processes: pipelineResult.processResult?.stats.totalProcesses,
         },
         undefined,
-        { skipAgentsMd: options.skipAgentsMd, noStats: options.noStats },
+        { skipAgentsMd: options.skipAgentsMd, noStats: options.noStats ?? (options.stats === false) },
       );
     } catch {
       // Best-effort — don't fail the entire analysis for context file issues


### PR DESCRIPTION
## Problem

Commander's negatable-boolean convention sets `options.stats = false` when `--no-stats` is passed — **not** `options.noStats = true`. The three call sites that forward CLI options into `runFullAnalysis` / `generateAIContextFiles` all read `options.noStats`, so the flag was silently ignored and volatile symbol/file counts always got written into `AGENTS.md` / `CLAUDE.md`.

Confirmed broken on 1.6.1 and 1.6.2.

## Fix

Add `?? (options?.stats === false)` fallback at all three call sites:

- `gitnexus/src/cli/analyze.ts:231` — `runFullAnalysis` options
- `gitnexus/src/cli/analyze.ts:301` — `generateAIContextFiles` in skills path
- `gitnexus/src/core/run-analyze.ts:382` — `generateAIContextFiles` in core path

No new API surface, no behaviour change when `--no-stats` is not passed (`options.stats` is `undefined` in that case, so `undefined === false` is `false` and the fallback doesn't fire).

Closes #704