### PR TITLE
fix(security): block IPv4-compatible IPv6 and NAT64 SSRF bypasses in validateGitUrl

### DIFF
--- a/gitnexus/src/server/git-clone.ts
+++ b/gitnexus/src/server/git-clone.ts
@@ -153,7 +153,23 @@ function assertNotPrivateIPv6(ip: string): void {
   // 64:ff9b:1::/48 from RFC 8215). Maps any IPv4 address — including private
   // ranges — into IPv6, so a host with NAT64 can reach the embedded IPv4 via
   // e.g. 64:ff9b::7f00:1 → 127.0.0.1.
+  // The check intentionally covers the full 64:ff9b::/32 block (broader than
+  // the two cited ranges): IANA reserves it for IPv4-IPv6 translation, so
+  // blocking the whole prefix is defensively sound and prevents a narrower
+  // CIDR check from quietly re-opening the bypass for 64:ff9b:1::/48 or any
+  // future translation assignment.
   if (lower.startsWith('64:ff9b:')) {
+    throw new Error('Cloning from private/internal addresses is not allowed');
+  }
+
+  // 6to4 (RFC 3056, 2002::/16). Encodes an IPv4 address in bits 17-48, so
+  // 2002:7f00:0001::1 routes to 127.0.0.1 on 6to4-capable stacks. The
+  // protocol was deprecated by RFC 7526 and the public relay anycast
+  // (192.88.99.1) has been retired, so broad-blocking the prefix has near-
+  // zero false-positive cost while closing the IPv4-embedded bypass.
+  // Teredo (2001::/32) embeds IPv4 obfuscated by XOR; precise blocking is
+  // impractical and is out of scope here.
+  if (lower.startsWith('2002:')) {
     throw new Error('Cloning from private/internal addresses is not allowed');
   }
 }

--- a/gitnexus/src/server/git-clone.ts
+++ b/gitnexus/src/server/git-clone.ts
@@ -139,6 +139,23 @@ function assertNotPrivateIPv6(ip: string): void {
   if (lower.includes(':ffff:')) {
     throw new Error('Cloning from private/internal addresses is not allowed');
   }
+
+  // IPv4-compatible IPv6 (RFC 4291 § 2.5.5.1, deprecated form: ::w.x.y.z).
+  // Node's URL parser collapses http://[::127.0.0.1]/ to "::7f00:1" — the IPv4
+  // is hidden in the last 32 bits without the ::ffff: marker, so the check
+  // above misses it. The form is still routable to the embedded IPv4 on most
+  // network stacks, so any address compressed to ::xxxx[:yyyy] must be blocked.
+  if (/^::[0-9a-f]{1,4}(:[0-9a-f]{1,4})?$/.test(lower)) {
+    throw new Error('Cloning from private/internal addresses is not allowed');
+  }
+
+  // NAT64 well-known prefix (RFC 6052 § 2.1: 64:ff9b::/96, plus the local
+  // 64:ff9b:1::/48 from RFC 8215). Maps any IPv4 address — including private
+  // ranges — into IPv6, so a host with NAT64 can reach the embedded IPv4 via
+  // e.g. 64:ff9b::7f00:1 → 127.0.0.1.
+  if (lower.startsWith('64:ff9b:')) {
+    throw new Error('Cloning from private/internal addresses is not allowed');
+  }
 }
 
 function assertNotPrivateIPv4(ip: string): void {

--- a/gitnexus/test/unit/git-clone.test.ts
+++ b/gitnexus/test/unit/git-clone.test.ts
@@ -96,6 +96,25 @@ describe('git-clone', () => {
       );
     });
 
+    it('blocks IPv4-compatible IPv6 (RFC 4291 deprecated, ::w.x.y.z)', () => {
+      // Node's URL parser collapses ::127.0.0.1 to ::7f00:1 — no ::ffff: marker,
+      // but still routable to 127.0.0.1 on most stacks.
+      expect(() => validateGitUrl('http://[::127.0.0.1]/repo.git')).toThrow('private/internal');
+      expect(() => validateGitUrl('http://[::7f00:1]/repo.git')).toThrow('private/internal');
+      // 169.254.169.254 (cloud metadata) embedded as IPv4-compatible
+      expect(() => validateGitUrl('http://[::a9fe:a9fe]/repo.git')).toThrow('private/internal');
+    });
+
+    it('blocks NAT64 well-known prefix (64:ff9b::/96)', () => {
+      // 64:ff9b::7f00:1 → 127.0.0.1 via NAT64 translation
+      expect(() => validateGitUrl('http://[64:ff9b::7f00:1]/repo.git')).toThrow('private/internal');
+      expect(() => validateGitUrl('http://[64:ff9b::a9fe:a9fe]/repo.git')).toThrow(
+        'private/internal',
+      );
+      // RFC 8215 local NAT64 prefix
+      expect(() => validateGitUrl('http://[64:ff9b:1::1]/repo.git')).toThrow('private/internal');
+    });
+
     it('does not block valid public IPs', () => {
       expect(() => validateGitUrl('https://140.82.121.4/repo.git')).not.toThrow();
     });

--- a/gitnexus/test/unit/git-clone.test.ts
+++ b/gitnexus/test/unit/git-clone.test.ts
@@ -105,6 +105,23 @@ describe('git-clone', () => {
       expect(() => validateGitUrl('http://[::a9fe:a9fe]/repo.git')).toThrow('private/internal');
     });
 
+    it('blocks IPv4-compatible IPv6 in expanded / zero-padded forms', () => {
+      // The compressed-form check above relies on the WHATWG URL parser
+      // normalising fully-expanded inputs to ::xxxx[:yyyy]. These cases pin
+      // that assumption: if a future Node release stops collapsing them, a
+      // bypass would silently re-open without these tests catching it.
+      expect(() => validateGitUrl('http://[0:0:0:0:0:0:7f00:1]/repo.git')).toThrow(
+        'private/internal',
+      );
+      expect(() =>
+        validateGitUrl('http://[0000:0000:0000:0000:0000:0000:7f00:0001]/repo.git'),
+      ).toThrow('private/internal');
+      // Mixed notation: trailing IPv4 quad in an otherwise expanded address.
+      expect(() => validateGitUrl('http://[0:0:0:0:0:0:127.0.0.1]/repo.git')).toThrow(
+        'private/internal',
+      );
+    });
+
     it('blocks NAT64 well-known prefix (64:ff9b::/96)', () => {
       // 64:ff9b::7f00:1 → 127.0.0.1 via NAT64 translation
       expect(() => validateGitUrl('http://[64:ff9b::7f00:1]/repo.git')).toThrow('private/internal');
@@ -115,8 +132,41 @@ describe('git-clone', () => {
       expect(() => validateGitUrl('http://[64:ff9b:1::1]/repo.git')).toThrow('private/internal');
     });
 
-    it('does not block valid public IPs', () => {
+    it('blocks NAT64 with embedded RFC1918 addresses', () => {
+      // The startsWith('64:ff9b:') check covers any embedded IPv4. These
+      // explicit RFC1918 cases document SSRF coverage for the full private
+      // IPv4 surface — not just loopback and cloud metadata.
+      expect(() => validateGitUrl('http://[64:ff9b::a00:1]/repo.git')).toThrow('private/internal'); // 10.0.0.1
+      expect(() => validateGitUrl('http://[64:ff9b::ac10:1]/repo.git')).toThrow(
+        'private/internal',
+      ); // 172.16.0.1
+      expect(() => validateGitUrl('http://[64:ff9b::c0a8:101]/repo.git')).toThrow(
+        'private/internal',
+      ); // 192.168.1.1
+    });
+
+    it('blocks 6to4 prefix (2002::/16, RFC 3056)', () => {
+      // 6to4 encodes an IPv4 address in bits 17-48, so 2002:WWXX:YYZZ::*
+      // routes to W.X.Y.Z on 6to4-capable stacks. The protocol is deprecated
+      // (RFC 7526), so the entire 2002::/16 block is defensively rejected.
+      expect(() => validateGitUrl('http://[2002:7f00:1::1]/repo.git')).toThrow(
+        'private/internal',
+      ); // 127.0.0.1
+      expect(() => validateGitUrl('http://[2002:a9fe:a9fe::1]/repo.git')).toThrow(
+        'private/internal',
+      ); // 169.254.169.254
+      expect(() => validateGitUrl('http://[2002:c0a8:101::1]/repo.git')).toThrow(
+        'private/internal',
+      ); // 192.168.1.1
+    });
+
+    it('does not block valid public IPs (IPv4 and IPv6)', () => {
       expect(() => validateGitUrl('https://140.82.121.4/repo.git')).not.toThrow();
+      // Regression guard against over-blocking legitimate public IPv6.
+      // Cloudflare DNS (2606:4700::/32) and Google DNS (2001:4860::/32) —
+      // chosen because their prefixes don't collide with any block above.
+      expect(() => validateGitUrl('https://[2606:4700:4700::1111]/repo.git')).not.toThrow();
+      expect(() => validateGitUrl('https://[2001:4860:4860::8888]/repo.git')).not.toThrow();
     });
 
     it('blocks CGN range (100.64.0.0/10)', () => {

--- a/gitnexus/test/unit/git-clone.test.ts
+++ b/gitnexus/test/unit/git-clone.test.ts
@@ -137,9 +137,7 @@ describe('git-clone', () => {
       // explicit RFC1918 cases document SSRF coverage for the full private
       // IPv4 surface — not just loopback and cloud metadata.
       expect(() => validateGitUrl('http://[64:ff9b::a00:1]/repo.git')).toThrow('private/internal'); // 10.0.0.1
-      expect(() => validateGitUrl('http://[64:ff9b::ac10:1]/repo.git')).toThrow(
-        'private/internal',
-      ); // 172.16.0.1
+      expect(() => validateGitUrl('http://[64:ff9b::ac10:1]/repo.git')).toThrow('private/internal'); // 172.16.0.1
       expect(() => validateGitUrl('http://[64:ff9b::c0a8:101]/repo.git')).toThrow(
         'private/internal',
       ); // 192.168.1.1
@@ -149,9 +147,7 @@ describe('git-clone', () => {
       // 6to4 encodes an IPv4 address in bits 17-48, so 2002:WWXX:YYZZ::*
       // routes to W.X.Y.Z on 6to4-capable stacks. The protocol is deprecated
       // (RFC 7526), so the entire 2002::/16 block is defensively rejected.
-      expect(() => validateGitUrl('http://[2002:7f00:1::1]/repo.git')).toThrow(
-        'private/internal',
-      ); // 127.0.0.1
+      expect(() => validateGitUrl('http://[2002:7f00:1::1]/repo.git')).toThrow('private/internal'); // 127.0.0.1
       expect(() => validateGitUrl('http://[2002:a9fe:a9fe::1]/repo.git')).toThrow(
         'private/internal',
       ); // 169.254.169.254


### PR DESCRIPTION
## Security Vulnerability Report

**Type:** SSRF — IPv6 forms that embed IPv4 addresses bypass the private-address blocklist
**Severity:** High
**Location:** `gitnexus/src/server/git-clone.ts` — `assertNotPrivateIPv6`

### Description

`validateGitUrl()` is the gate that protects `/api/analyze` and the `cloneOrPull` path from SSRF when a caller supplies a clone URL. It already blocks IPv4-mapped IPv6 (`::ffff:127.0.0.1` / `::ffff:7f00:1`), but two related forms still slip through and remain routable to the embedded IPv4 on common stacks:

1. **IPv4-compatible IPv6** (RFC 4291 § 2.5.5.1, deprecated form: `::w.x.y.z`).
   Node's URL parser collapses `http://[::127.0.0.1]/` to hostname `::7f00:1`. There is no `::ffff:` marker, so the existing `:ffff:` checks miss it. The Linux kernel and many other stacks still route this to `127.0.0.1`.

2. **NAT64 well-known prefix** (RFC 6052: `64:ff9b::/96`, plus RFC 8215's local `64:ff9b:1::/48`).
   On any host with NAT64 resolution enabled, `64:ff9b::7f00:1` translates to `127.0.0.1` and `64:ff9b::a9fe:a9fe` translates to `169.254.169.254` (cloud metadata).

### Reproduction

Before this patch, all of the following pass `validateGitUrl`:

```ts
validateGitUrl('http://[::127.0.0.1]/repo.git');     // ::7f00:1 — loopback
validateGitUrl('http://[::a9fe:a9fe]/repo.git');     // ::169.254.169.254 — metadata
validateGitUrl('http://[64:ff9b::7f00:1]/repo.git'); // NAT64 → 127.0.0.1
validateGitUrl('http://[64:ff9b:1::1]/repo.git');    // NAT64 local prefix
```

Any caller that can reach `/api/analyze` (CORS allows localhost, RFC 1918 LAN, and `https://gitnexus.vercel.app`) could submit one of these URLs, and on any host with the right kernel/NAT64 config the underlying `git clone` would attempt to connect to the embedded private IPv4. stderr is suppressed, but timing side-channels and redirect-based probes against the clone target remain viable.

### Fix

Extend `assertNotPrivateIPv6` with two additional checks:

- Reject any address compressed to `::xxxx` or `::xxxx:yyyy` — the only legitimate addresses in that range (`::1`, `::`) are already blocked by the loopback/unspecified checks above, and every remaining value in that compressed range is either IPv4-compatible IPv6 (deprecated, embeds an IPv4 in the last 32 bits) or extremely low-numbered IPv6 that no public host should be hosted on.
- Reject any address starting with `64:ff9b:` (covers RFC 6052 well-known and RFC 8215 local NAT64 prefixes).

### Tests

Added cases in `gitnexus/test/unit/git-clone.test.ts` for IPv4-compatible IPv6 (`::127.0.0.1`, `::7f00:1`, `::a9fe:a9fe`) and NAT64 (`64:ff9b::7f00:1`, `64:ff9b::a9fe:a9fe`, `64:ff9b:1::1`). Verified manually that legitimate public IPv6 (e.g. `2606:4700:4700::1111`, `2001:db8::1`) still passes.

### Impact

Without this fix, a caller able to submit clone URLs to `/api/analyze` (or use `cloneOrPull` directly) can direct `git clone` at loopback (`127.0.0.1`) or link-local cloud metadata (`169.254.169.254`) via IPv6 forms. Combined with the recently fixed `::ffff:` IPv4-mapped form, this closes the IPv6-side bypass surface to known-routable embedded-IPv4 representations.

---
Found by [Aeon](https://github.com/aaronjmars/aeon-aaron) — automated security scanner