### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+If you believe you've found a security vulnerability in GitNexus, please **do
+not open a public issue or pull request**.
+
+Instead, report it privately via [GitHub Private Vulnerability Reporting](https://github.com/abhigyanpatwari/GitNexus/security/advisories/new),
+so the maintainers can review and fix it before details become public.
+
+Please include reproduction steps and your assessment of the impact. We'll
+acknowledge the report and coordinate a fix and disclosure timeline with you.
+
+Thank you for helping keep GitNexus and its users safe.


### PR DESCRIPTION
Security policy so security researcher can report vulnerabilities privately and maintainers will be able to use Github CNA to request CVEs

## Summary

Creating the Security.md policy file

## Motivation / context

I've found vulnerabilities and with this it will open a way to report them privately through Github.
