### PR TITLE
feat(group): workspace extractors for Node, Python, Go, Java, Elixir

### DIFF
--- a/gitnexus/src/core/group/config-parser.ts
+++ b/gitnexus/src/core/group/config-parser.ts
@@ -13,7 +13,7 @@ const DEFAULT_DETECT = {
   topics: true,
   shared_libs: true,
   embedding_fallback: true,
-  workspace_deps: true,
+  workspace_deps: false,
 };
 
 const DEFAULT_MATCHING = {

--- a/gitnexus/src/core/group/extractors/elixir-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/elixir-workspace-extractor.ts
@@ -235,6 +235,9 @@ export async function extractElixirWorkspaceLinks(
       if (seen.has(key)) continue;
       seen.add(key);
 
+      // V1: Elixir contracts use the full module name (e.g. "Core.Schema") without
+      // an "appName::" prefix. resolveSymbol will query the graph with this full
+      // string — resolution depends on Elixir indexer storing fully-qualified names.
       const link: GroupManifestLink = {
         from: providerApp.groupPath,
         to: app.groupPath,

--- a/gitnexus/src/core/group/extractors/elixir-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/elixir-workspace-extractor.ts
@@ -87,12 +87,17 @@ async function scanElixirImports(
     }
 
     // Direct module reference: MyApp.Module.func() or MyApp.Module
+    // Strip comment lines and string literals to avoid false positives
+    const codeOnly = content
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('#'))
+      .join('\n');
     for (const [prefix, appName] of knownApps) {
       const refRegex = new RegExp(
         `\\b(${escapeRegex(prefix)}\\.[A-Z][A-Za-z0-9]*(?:\\.[A-Z][A-Za-z0-9]*)*)`,
         'g',
       );
-      while ((match = refRegex.exec(content)) !== null) {
+      while ((match = refRegex.exec(codeOnly)) !== null) {
         const mod = match[1];
         if (!results.some((r) => r.moduleName === mod && r.filePath === relFile)) {
           results.push({ appName, moduleName: mod, filePath: relFile });

--- a/gitnexus/src/core/group/extractors/elixir-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/elixir-workspace-extractor.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { CypherExecutor } from '../contract-extractor.js';
 import type { GroupManifestLink, ContractRole } from '../types.js';
+import { shouldIgnorePath, loadIgnoreRules } from '../../../config/ignore-service.js';
 
 interface ElixirAppMeta {
   appName: string;
@@ -142,15 +143,7 @@ function extractTopModule(moduleName: string, prefix: string): string {
 
 async function findElixirFiles(repoPath: string): Promise<string[]> {
   const results: string[] = [];
-  const IGNORE = new Set([
-    '_build',
-    'deps',
-    'node_modules',
-    '.git',
-    '.gitnexus',
-    '.elixir_ls',
-    'cover',
-  ]);
+  const ig = await loadIgnoreRules(repoPath);
 
   async function walk(dir: string, rel: string): Promise<void> {
     let entries;
@@ -160,14 +153,16 @@ async function findElixirFiles(repoPath: string): Promise<string[]> {
       return;
     }
     for (const entry of entries) {
-      if (IGNORE.has(entry.name)) continue;
       const childRel = rel ? `${rel}/${entry.name}` : entry.name;
       if (entry.isDirectory()) {
+        if (shouldIgnorePath(childRel)) continue;
+        if (ig && ig.ignores(childRel + '/')) continue;
         await walk(path.join(dir, entry.name), childRel);
       } else if (entry.name.endsWith('.ex') || entry.name.endsWith('.exs')) {
-        if (entry.name !== 'mix.exs' && entry.name !== 'mix.lock') {
-          results.push(childRel);
-        }
+        if (entry.name === 'mix.exs' || entry.name === 'mix.lock') continue;
+        if (shouldIgnorePath(childRel)) continue;
+        if (ig && ig.ignores(childRel)) continue;
+        results.push(childRel);
       }
     }
   }
@@ -203,6 +198,13 @@ export async function extractElixirWorkspaceLinks(
       repoPath,
       deps: manifest.deps,
     };
+    const existing = appsByName.get(manifest.appName);
+    if (existing) {
+      console.warn(
+        `[elixir-workspace-extractor] duplicate app "${manifest.appName}" in "${groupPath}" and "${existing.groupPath}" — skipping "${groupPath}"`,
+      );
+      continue;
+    }
     appsByName.set(manifest.appName, meta);
     appsByGroupPath.set(groupPath, meta);
   }

--- a/gitnexus/src/core/group/extractors/elixir-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/elixir-workspace-extractor.ts
@@ -117,10 +117,7 @@ function expandAlias(expr: string): string[] {
   return [expr];
 }
 
-function matchModuleToApp(
-  moduleName: string,
-  knownApps: Map<string, string>,
-): string | null {
+function matchModuleToApp(moduleName: string, knownApps: Map<string, string>): string | null {
   for (const [prefix, appName] of knownApps) {
     if (moduleName === prefix || moduleName.startsWith(prefix + '.')) {
       return appName;

--- a/gitnexus/src/core/group/extractors/elixir-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/elixir-workspace-extractor.ts
@@ -1,0 +1,246 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { CypherExecutor } from '../contract-extractor.js';
+import type { GroupManifestLink, ContractRole } from '../types.js';
+
+interface ElixirAppMeta {
+  appName: string;
+  modulePrefix: string;
+  groupPath: string;
+  repoPath: string;
+  deps: string[];
+}
+
+interface ImportedModule {
+  appName: string;
+  moduleName: string;
+  filePath: string;
+}
+
+async function parseMixExs(
+  repoPath: string,
+): Promise<{ appName: string; modulePrefix: string; deps: string[] } | null> {
+  const mixPath = path.join(repoPath, 'mix.exs');
+  let content: string;
+  try {
+    content = await fs.readFile(mixPath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  // app: :my_app
+  const appMatch = content.match(/app:\s*:(\w+)/);
+  if (!appMatch) return null;
+  const appName = appMatch[1];
+
+  // Derive module prefix: my_app -> MyApp
+  const modulePrefix = appName
+    .split('_')
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join('');
+
+  const deps: string[] = [];
+
+  // {:dep_name, "~> 1.0"} or {:dep_name, in_umbrella: true}
+  // {:dep_name, git: "..."} or {:dep_name, path: "..."}
+  const depMatches = content.matchAll(
+    /\{:(\w+)\s*,\s*(?:"[^"]*"|~[^}]*|[^}]*(?:in_umbrella|path|git)\s*:[^}]*)\}/g,
+  );
+  for (const m of depMatches) {
+    deps.push(m[1]);
+  }
+
+  return { appName, modulePrefix, deps: [...new Set(deps)] };
+}
+
+async function scanElixirImports(
+  repoPath: string,
+  knownApps: Map<string, string>,
+): Promise<ImportedModule[]> {
+  const results: ImportedModule[] = [];
+  const sourceFiles = await findElixirFiles(repoPath);
+
+  for (const relFile of sourceFiles) {
+    const absPath = path.join(repoPath, relFile);
+    let content: string;
+    try {
+      content = await fs.readFile(absPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    // alias MyApp.SomeModule
+    // alias MyApp.SomeModule, as: Short
+    // alias MyApp.{ModA, ModB}
+    const aliasRegex = /^\s*alias\s+([A-Z]\w+(?:\.[A-Z]\w+)*(?:\.\{[^}]+\})?)/gm;
+    let match;
+    while ((match = aliasRegex.exec(content)) !== null) {
+      const aliasExpr = match[1];
+      const modules = expandAlias(aliasExpr);
+      for (const mod of modules) {
+        const appName = matchModuleToApp(mod, knownApps);
+        if (appName) {
+          results.push({ appName, moduleName: mod, filePath: relFile });
+        }
+      }
+    }
+
+    // Direct module reference: MyApp.Module.func() or MyApp.Module
+    for (const [prefix, appName] of knownApps) {
+      const refRegex = new RegExp(
+        `\\b(${escapeRegex(prefix)}\\.[A-Z][A-Za-z0-9]*(?:\\.[A-Z][A-Za-z0-9]*)*)`,
+        'g',
+      );
+      while ((match = refRegex.exec(content)) !== null) {
+        const mod = match[1];
+        if (!results.some((r) => r.moduleName === mod && r.filePath === relFile)) {
+          results.push({ appName, moduleName: mod, filePath: relFile });
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+function expandAlias(expr: string): string[] {
+  const braceMatch = expr.match(/^([A-Z][\w.]*)\.\{([^}]+)\}$/);
+  if (braceMatch) {
+    const prefix = braceMatch[1];
+    return braceMatch[2]
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => `${prefix}.${s}`);
+  }
+  return [expr];
+}
+
+function matchModuleToApp(
+  moduleName: string,
+  knownApps: Map<string, string>,
+): string | null {
+  for (const [prefix, appName] of knownApps) {
+    if (moduleName === prefix || moduleName.startsWith(prefix + '.')) {
+      return appName;
+    }
+  }
+  return null;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractTopModule(moduleName: string, prefix: string): string {
+  const rest = moduleName.slice(prefix.length);
+  if (!rest || rest === '.') return moduleName;
+  const afterDot = rest.startsWith('.') ? rest.slice(1) : rest;
+  const parts = afterDot.split('.');
+  return `${prefix}.${parts[0]}`;
+}
+
+async function findElixirFiles(repoPath: string): Promise<string[]> {
+  const results: string[] = [];
+  const IGNORE = new Set([
+    '_build',
+    'deps',
+    'node_modules',
+    '.git',
+    '.gitnexus',
+    '.elixir_ls',
+    'cover',
+  ]);
+
+  async function walk(dir: string, rel: string): Promise<void> {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (IGNORE.has(entry.name)) continue;
+      const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(path.join(dir, entry.name), childRel);
+      } else if (entry.name.endsWith('.ex') || entry.name.endsWith('.exs')) {
+        if (entry.name !== 'mix.exs' && entry.name !== 'mix.lock') {
+          results.push(childRel);
+        }
+      }
+    }
+  }
+
+  await walk(repoPath, '');
+  return results;
+}
+
+export interface ElixirWorkspaceResult {
+  links: GroupManifestLink[];
+  discoveredApps: Map<string, ElixirAppMeta>;
+}
+
+export async function extractElixirWorkspaceLinks(
+  repos: Record<string, string>,
+  repoPaths: Map<string, string>,
+  _dbExecutors?: Map<string, CypherExecutor>,
+): Promise<ElixirWorkspaceResult> {
+  const appsByName = new Map<string, ElixirAppMeta>();
+  const appsByGroupPath = new Map<string, ElixirAppMeta>();
+
+  for (const [groupPath] of Object.entries(repos)) {
+    const repoPath = repoPaths.get(groupPath);
+    if (!repoPath) continue;
+
+    const manifest = await parseMixExs(repoPath);
+    if (!manifest) continue;
+
+    const meta: ElixirAppMeta = {
+      appName: manifest.appName,
+      modulePrefix: manifest.modulePrefix,
+      groupPath,
+      repoPath,
+      deps: manifest.deps,
+    };
+    appsByName.set(manifest.appName, meta);
+    appsByGroupPath.set(groupPath, meta);
+  }
+
+  const links: GroupManifestLink[] = [];
+  const seen = new Set<string>();
+
+  for (const [, app] of appsByGroupPath) {
+    const groupDeps = app.deps.filter((d) => appsByName.has(d));
+    if (groupDeps.length === 0) continue;
+
+    const knownApps = new Map<string, string>();
+    for (const dep of groupDeps) {
+      const depMeta = appsByName.get(dep);
+      if (depMeta) knownApps.set(depMeta.modulePrefix, dep);
+    }
+
+    const imports = await scanElixirImports(app.repoPath, knownApps);
+
+    for (const imp of imports) {
+      const providerApp = appsByName.get(imp.appName);
+      if (!providerApp) continue;
+
+      const topModule = extractTopModule(imp.moduleName, providerApp.modulePrefix);
+      const key = `${app.groupPath}→${providerApp.groupPath}::${topModule}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const link: GroupManifestLink = {
+        from: providerApp.groupPath,
+        to: app.groupPath,
+        type: 'custom',
+        contract: topModule,
+        role: 'provider' as ContractRole,
+      };
+      links.push(link);
+    }
+  }
+
+  return { links, discoveredApps: appsByGroupPath };
+}

--- a/gitnexus/src/core/group/extractors/go-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/go-workspace-extractor.ts
@@ -238,8 +238,7 @@ export async function extractGoWorkspaceLinks(
       const providerMod = modulesByPath.get(imp.modulePath);
       if (!providerMod) continue;
 
-      const shortModule = imp.modulePath.split('/').pop() || imp.modulePath;
-      const qualifiedContract = `${shortModule}::${imp.symbolName}`;
+      const qualifiedContract = `${imp.modulePath}::${imp.symbolName}`;
       const key = `${mod.groupPath}→${providerMod.groupPath}::${qualifiedContract}`;
       if (seen.has(key)) continue;
       seen.add(key);

--- a/gitnexus/src/core/group/extractors/go-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/go-workspace-extractor.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { CypherExecutor } from '../contract-extractor.js';
 import type { GroupManifestLink, ContractRole } from '../types.js';
+import { shouldIgnorePath, loadIgnoreRules } from '../../../config/ignore-service.js';
 
 interface GoModuleMeta {
   modulePath: string;
@@ -163,13 +164,7 @@ function escapeRegex(s: string): string {
 
 async function findGoFiles(repoPath: string): Promise<string[]> {
   const results: string[] = [];
-  const IGNORE = new Set([
-    'vendor',
-    'node_modules',
-    '.git',
-    '.gitnexus',
-    'testdata',
-  ]);
+  const ig = await loadIgnoreRules(repoPath);
 
   async function walk(dir: string, rel: string): Promise<void> {
     let entries;
@@ -179,11 +174,14 @@ async function findGoFiles(repoPath: string): Promise<string[]> {
       return;
     }
     for (const entry of entries) {
-      if (IGNORE.has(entry.name)) continue;
       const childRel = rel ? `${rel}/${entry.name}` : entry.name;
       if (entry.isDirectory()) {
+        if (shouldIgnorePath(childRel)) continue;
+        if (ig && ig.ignores(childRel + '/')) continue;
         await walk(path.join(dir, entry.name), childRel);
       } else if (entry.name.endsWith('.go') && !entry.name.endsWith('_test.go')) {
+        if (shouldIgnorePath(childRel)) continue;
+        if (ig && ig.ignores(childRel)) continue;
         results.push(childRel);
       }
     }
@@ -219,6 +217,13 @@ export async function extractGoWorkspaceLinks(
       repoPath,
       requires: manifest.requires,
     };
+    const existing = modulesByPath.get(manifest.modulePath);
+    if (existing) {
+      console.warn(
+        `[go-workspace-extractor] duplicate module "${manifest.modulePath}" in "${groupPath}" and "${existing.groupPath}" — skipping "${groupPath}"`,
+      );
+      continue;
+    }
     modulesByPath.set(manifest.modulePath, meta);
     modulesByGroupPath.set(groupPath, meta);
   }
@@ -241,7 +246,9 @@ export async function extractGoWorkspaceLinks(
       const providerMod = modulesByPath.get(imp.modulePath);
       if (!providerMod) continue;
 
-      const key = `${mod.groupPath}→${providerMod.groupPath}::${imp.symbolName}`;
+      const shortModule = imp.modulePath.split('/').pop() || imp.modulePath;
+      const qualifiedContract = `${shortModule}::${imp.symbolName}`;
+      const key = `${mod.groupPath}→${providerMod.groupPath}::${qualifiedContract}`;
       if (seen.has(key)) continue;
       seen.add(key);
 
@@ -249,7 +256,7 @@ export async function extractGoWorkspaceLinks(
         from: providerMod.groupPath,
         to: mod.groupPath,
         type: 'custom',
-        contract: imp.symbolName,
+        contract: qualifiedContract,
         role: 'provider' as ContractRole,
       };
       links.push(link);

--- a/gitnexus/src/core/group/extractors/go-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/go-workspace-extractor.ts
@@ -1,0 +1,260 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { CypherExecutor } from '../contract-extractor.js';
+import type { GroupManifestLink, ContractRole } from '../types.js';
+
+interface GoModuleMeta {
+  modulePath: string;
+  groupPath: string;
+  repoPath: string;
+  requires: string[];
+}
+
+interface ImportedSymbol {
+  modulePath: string;
+  symbolName: string;
+  filePath: string;
+}
+
+async function parseGoMod(
+  repoPath: string,
+): Promise<{ modulePath: string; requires: string[] } | null> {
+  const goModPath = path.join(repoPath, 'go.mod');
+  let content: string;
+  try {
+    content = await fs.readFile(goModPath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  const moduleMatch = content.match(/^module\s+(\S+)/m);
+  if (!moduleMatch) return null;
+  const modulePath = moduleMatch[1];
+
+  const requires: string[] = [];
+
+  // Single-line: require github.com/org/repo v1.2.3
+  const singleReqs = content.matchAll(/^require\s+(\S+)\s+/gm);
+  for (const m of singleReqs) requires.push(m[1]);
+
+  // Block: require ( ... )
+  const blockReqs = content.matchAll(/^require\s*\(\s*\n([\s\S]*?)\)/gm);
+  for (const block of blockReqs) {
+    const lines = block[1].split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('//')) continue;
+      const parts = trimmed.split(/\s+/);
+      if (parts[0]) requires.push(parts[0]);
+    }
+  }
+
+  // replace directives (local path deps)
+  const replaceLines = content.matchAll(
+    /^replace\s+(\S+)\s+=>\s+\.\//gm,
+  );
+  for (const m of replaceLines) {
+    if (!requires.includes(m[1])) requires.push(m[1]);
+  }
+
+  const replaceBlocks = content.matchAll(/^replace\s*\(\s*\n([\s\S]*?)\)/gm);
+  for (const block of replaceBlocks) {
+    const lines = block[1].split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('//')) continue;
+      const match = trimmed.match(/^(\S+)\s+=>\s+\.\//);
+      if (match && !requires.includes(match[1])) requires.push(match[1]);
+    }
+  }
+
+  return { modulePath, requires: [...new Set(requires)] };
+}
+
+async function scanGoImports(
+  repoPath: string,
+  knownModules: Map<string, string>,
+): Promise<ImportedSymbol[]> {
+  const results: ImportedSymbol[] = [];
+  const sourceFiles = await findGoFiles(repoPath);
+
+  for (const relFile of sourceFiles) {
+    const absPath = path.join(repoPath, relFile);
+    let content: string;
+    try {
+      content = await fs.readFile(absPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const importPaths = extractImportPaths(content);
+    for (const importPath of importPaths) {
+      const matchedModule = findMatchingModule(importPath, knownModules);
+      if (!matchedModule) continue;
+
+      const symbols = extractUsedTypes(content, importPath);
+      for (const sym of symbols) {
+        results.push({ modulePath: matchedModule, symbolName: sym, filePath: relFile });
+      }
+    }
+  }
+
+  return results;
+}
+
+function extractImportPaths(content: string): string[] {
+  const paths: string[] = [];
+
+  // Single: import "path"
+  const singleImports = content.matchAll(/^import\s+"([^"]+)"/gm);
+  for (const m of singleImports) paths.push(m[1]);
+
+  // Single aliased: import alias "path"
+  const aliasedImports = content.matchAll(/^import\s+\w+\s+"([^"]+)"/gm);
+  for (const m of aliasedImports) paths.push(m[1]);
+
+  // Block: import ( ... )
+  const blockImports = content.matchAll(/^import\s*\(\s*\n([\s\S]*?)\)/gm);
+  for (const block of blockImports) {
+    const lines = block[1].split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('//')) continue;
+      const pathMatch = trimmed.match(/"([^"]+)"/);
+      if (pathMatch) paths.push(pathMatch[1]);
+    }
+  }
+
+  return [...new Set(paths)];
+}
+
+function findMatchingModule(
+  importPath: string,
+  knownModules: Map<string, string>,
+): string | null {
+  for (const [modPath] of knownModules) {
+    if (importPath === modPath || importPath.startsWith(modPath + '/')) {
+      return modPath;
+    }
+  }
+  return null;
+}
+
+function extractUsedTypes(content: string, importPath: string): string[] {
+  const pkgName = importPath.split('/').pop() || '';
+  if (!pkgName) return [];
+
+  // Match pkg.TypeName where TypeName is PascalCase (exported)
+  const typeRegex = new RegExp(
+    `\\b${escapeRegex(pkgName)}\\.([A-Z][A-Za-z0-9]*)`,
+    'g',
+  );
+  const types = new Set<string>();
+  let match;
+  while ((match = typeRegex.exec(content)) !== null) {
+    types.add(match[1]);
+  }
+  return [...types];
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function findGoFiles(repoPath: string): Promise<string[]> {
+  const results: string[] = [];
+  const IGNORE = new Set([
+    'vendor',
+    'node_modules',
+    '.git',
+    '.gitnexus',
+    'testdata',
+  ]);
+
+  async function walk(dir: string, rel: string): Promise<void> {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (IGNORE.has(entry.name)) continue;
+      const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(path.join(dir, entry.name), childRel);
+      } else if (entry.name.endsWith('.go') && !entry.name.endsWith('_test.go')) {
+        results.push(childRel);
+      }
+    }
+  }
+
+  await walk(repoPath, '');
+  return results;
+}
+
+export interface GoWorkspaceResult {
+  links: GroupManifestLink[];
+  discoveredModules: Map<string, GoModuleMeta>;
+}
+
+export async function extractGoWorkspaceLinks(
+  repos: Record<string, string>,
+  repoPaths: Map<string, string>,
+  _dbExecutors?: Map<string, CypherExecutor>,
+): Promise<GoWorkspaceResult> {
+  const modulesByPath = new Map<string, GoModuleMeta>();
+  const modulesByGroupPath = new Map<string, GoModuleMeta>();
+
+  for (const [groupPath] of Object.entries(repos)) {
+    const repoPath = repoPaths.get(groupPath);
+    if (!repoPath) continue;
+
+    const manifest = await parseGoMod(repoPath);
+    if (!manifest) continue;
+
+    const meta: GoModuleMeta = {
+      modulePath: manifest.modulePath,
+      groupPath,
+      repoPath,
+      requires: manifest.requires,
+    };
+    modulesByPath.set(manifest.modulePath, meta);
+    modulesByGroupPath.set(groupPath, meta);
+  }
+
+  const links: GroupManifestLink[] = [];
+  const seen = new Set<string>();
+
+  for (const [, mod] of modulesByGroupPath) {
+    const groupModDeps = mod.requires.filter((r) => modulesByPath.has(r));
+    if (groupModDeps.length === 0) continue;
+
+    const knownModules = new Map<string, string>();
+    for (const dep of groupModDeps) {
+      knownModules.set(dep, dep);
+    }
+
+    const imports = await scanGoImports(mod.repoPath, knownModules);
+
+    for (const imp of imports) {
+      const providerMod = modulesByPath.get(imp.modulePath);
+      if (!providerMod) continue;
+
+      const key = `${mod.groupPath}→${providerMod.groupPath}::${imp.symbolName}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const link: GroupManifestLink = {
+        from: providerMod.groupPath,
+        to: mod.groupPath,
+        type: 'custom',
+        contract: imp.symbolName,
+        role: 'provider' as ContractRole,
+      };
+      links.push(link);
+    }
+  }
+
+  return { links, discoveredModules: modulesByGroupPath };
+}

--- a/gitnexus/src/core/group/extractors/go-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/go-workspace-extractor.ts
@@ -51,9 +51,7 @@ async function parseGoMod(
   }
 
   // replace directives (local path deps)
-  const replaceLines = content.matchAll(
-    /^replace\s+(\S+)\s+=>\s+\.\//gm,
-  );
+  const replaceLines = content.matchAll(/^replace\s+(\S+)\s+=>\s+\.\//gm);
   for (const m of replaceLines) {
     if (!requires.includes(m[1])) requires.push(m[1]);
   }
@@ -129,10 +127,7 @@ function extractImportPaths(content: string): string[] {
   return [...new Set(paths)];
 }
 
-function findMatchingModule(
-  importPath: string,
-  knownModules: Map<string, string>,
-): string | null {
+function findMatchingModule(importPath: string, knownModules: Map<string, string>): string | null {
   for (const [modPath] of knownModules) {
     if (importPath === modPath || importPath.startsWith(modPath + '/')) {
       return modPath;
@@ -146,10 +141,7 @@ function extractUsedTypes(content: string, importPath: string): string[] {
   if (!pkgName) return [];
 
   // Match pkg.TypeName where TypeName is PascalCase (exported)
-  const typeRegex = new RegExp(
-    `\\b${escapeRegex(pkgName)}\\.([A-Z][A-Za-z0-9]*)`,
-    'g',
-  );
+  const typeRegex = new RegExp(`\\b${escapeRegex(pkgName)}\\.([A-Z][A-Za-z0-9]*)`, 'g');
   const types = new Set<string>();
   let match;
   while ((match = typeRegex.exec(content)) !== null) {

--- a/gitnexus/src/core/group/extractors/java-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/java-workspace-extractor.ts
@@ -1,0 +1,264 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { CypherExecutor } from '../contract-extractor.js';
+import type { GroupManifestLink, ContractRole } from '../types.js';
+
+interface JavaProjectMeta {
+  groupId: string;
+  artifactId: string;
+  basePackage: string;
+  groupPath: string;
+  repoPath: string;
+  deps: string[];
+}
+
+interface ImportedSymbol {
+  artifactKey: string;
+  symbolName: string;
+  filePath: string;
+}
+
+async function parseJavaManifest(
+  repoPath: string,
+): Promise<{ groupId: string; artifactId: string; deps: string[] } | null> {
+  const pomPath = path.join(repoPath, 'pom.xml');
+  try {
+    const content = await fs.readFile(pomPath, 'utf-8');
+    return parsePom(content);
+  } catch {
+    // fall through to Gradle
+  }
+
+  for (const name of ['build.gradle.kts', 'build.gradle']) {
+    const gradlePath = path.join(repoPath, name);
+    try {
+      const content = await fs.readFile(gradlePath, 'utf-8');
+      return parseGradle(content, repoPath);
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function parsePom(
+  content: string,
+): { groupId: string; artifactId: string; deps: string[] } | null {
+  const projectGroupMatch = content.match(
+    /<project[^>]*>[\s\S]*?<groupId>([^<]+)<\/groupId>/,
+  );
+  const projectArtifactMatch = content.match(
+    /<project[^>]*>[\s\S]*?<artifactId>([^<]+)<\/artifactId>/,
+  );
+  if (!projectGroupMatch || !projectArtifactMatch) return null;
+
+  const groupId = projectGroupMatch[1].trim();
+  const artifactId = projectArtifactMatch[1].trim();
+
+  const deps: string[] = [];
+  const depBlocks = content.matchAll(
+    /<dependency>\s*([\s\S]*?)<\/dependency>/g,
+  );
+  for (const block of depBlocks) {
+    const gMatch = block[1].match(/<groupId>([^<]+)<\/groupId>/);
+    const aMatch = block[1].match(/<artifactId>([^<]+)<\/artifactId>/);
+    if (gMatch && aMatch) {
+      deps.push(`${gMatch[1].trim()}:${aMatch[1].trim()}`);
+    }
+  }
+
+  return { groupId, artifactId, deps: [...new Set(deps)] };
+}
+
+function parseGradle(
+  content: string,
+  repoPath: string,
+): { groupId: string; artifactId: string; deps: string[] } | null {
+  const groupMatch = content.match(/group\s*=\s*['"]([^'"]+)['"]/);
+  const dirName = path.basename(repoPath);
+  const groupId = groupMatch ? groupMatch[1] : '';
+  if (!groupId) return null;
+
+  const artifactId = dirName;
+
+  const deps: string[] = [];
+  // implementation("group:artifact:version") or api("group:artifact:version")
+  const depMatches = content.matchAll(
+    /(?:implementation|api|compileOnly|runtimeOnly)\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+  );
+  for (const m of depMatches) {
+    const parts = m[1].split(':');
+    if (parts.length >= 2) {
+      deps.push(`${parts[0]}:${parts[1]}`);
+    }
+  }
+
+  // implementation(project(":subproject"))
+  const projDeps = content.matchAll(
+    /(?:implementation|api)\s*\(\s*project\s*\(\s*['"]([^'"]+)['"]\s*\)\s*\)/g,
+  );
+  for (const m of projDeps) {
+    const subName = m[1].replace(/^:/, '');
+    deps.push(`${groupId}:${subName}`);
+  }
+
+  return { groupId, artifactId, deps: [...new Set(deps)] };
+}
+
+function deriveBasePackage(groupId: string, artifactId: string): string {
+  const sanitized = artifactId.replace(/-/g, '.');
+  if (groupId.endsWith(`.${sanitized}`) || groupId === sanitized) {
+    return groupId;
+  }
+  return `${groupId}.${sanitized}`;
+}
+
+async function scanJavaImports(
+  repoPath: string,
+  knownPackages: Map<string, string>,
+): Promise<ImportedSymbol[]> {
+  const results: ImportedSymbol[] = [];
+  const sourceFiles = await findJavaFiles(repoPath);
+
+  for (const relFile of sourceFiles) {
+    const absPath = path.join(repoPath, relFile);
+    let content: string;
+    try {
+      content = await fs.readFile(absPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const importRegex = /^import\s+(?:static\s+)?([a-zA-Z][\w.]*\.[A-Z]\w*)/gm;
+    let match;
+    while ((match = importRegex.exec(content)) !== null) {
+      const fullImport = match[1];
+      for (const [basePkg, artifactKey] of knownPackages) {
+        if (fullImport.startsWith(basePkg + '.') || fullImport === basePkg) {
+          const parts = fullImport.split('.');
+          const className = parts[parts.length - 1];
+          if (isPascalCase(className)) {
+            results.push({
+              artifactKey,
+              symbolName: className,
+              filePath: relFile,
+            });
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+function isPascalCase(name: string): boolean {
+  return /^[A-Z][A-Za-z0-9]*$/.test(name);
+}
+
+async function findJavaFiles(repoPath: string): Promise<string[]> {
+  const results: string[] = [];
+  const IGNORE = new Set([
+    'node_modules',
+    '.git',
+    '.gitnexus',
+    'build',
+    'target',
+    '.gradle',
+    '.idea',
+    'bin',
+  ]);
+
+  async function walk(dir: string, rel: string): Promise<void> {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (IGNORE.has(entry.name)) continue;
+      const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(path.join(dir, entry.name), childRel);
+      } else if (entry.name.endsWith('.java') || entry.name.endsWith('.kt')) {
+        results.push(childRel);
+      }
+    }
+  }
+
+  await walk(repoPath, '');
+  return results;
+}
+
+export interface JavaWorkspaceResult {
+  links: GroupManifestLink[];
+  discoveredProjects: Map<string, JavaProjectMeta>;
+}
+
+export async function extractJavaWorkspaceLinks(
+  repos: Record<string, string>,
+  repoPaths: Map<string, string>,
+  _dbExecutors?: Map<string, CypherExecutor>,
+): Promise<JavaWorkspaceResult> {
+  const projectsByKey = new Map<string, JavaProjectMeta>();
+  const projectsByGroupPath = new Map<string, JavaProjectMeta>();
+
+  for (const [groupPath] of Object.entries(repos)) {
+    const repoPath = repoPaths.get(groupPath);
+    if (!repoPath) continue;
+
+    const manifest = await parseJavaManifest(repoPath);
+    if (!manifest) continue;
+
+    const key = `${manifest.groupId}:${manifest.artifactId}`;
+    const meta: JavaProjectMeta = {
+      groupId: manifest.groupId,
+      artifactId: manifest.artifactId,
+      basePackage: deriveBasePackage(manifest.groupId, manifest.artifactId),
+      groupPath,
+      repoPath,
+      deps: manifest.deps,
+    };
+    projectsByKey.set(key, meta);
+    projectsByGroupPath.set(groupPath, meta);
+  }
+
+  const links: GroupManifestLink[] = [];
+  const seen = new Set<string>();
+
+  for (const [, proj] of projectsByGroupPath) {
+    const groupDeps = proj.deps.filter((d) => projectsByKey.has(d));
+    if (groupDeps.length === 0) continue;
+
+    const knownPackages = new Map<string, string>();
+    for (const dep of groupDeps) {
+      const depMeta = projectsByKey.get(dep);
+      if (depMeta) knownPackages.set(depMeta.basePackage, dep);
+    }
+
+    const imports = await scanJavaImports(proj.repoPath, knownPackages);
+
+    for (const imp of imports) {
+      const providerProj = projectsByKey.get(imp.artifactKey);
+      if (!providerProj) continue;
+
+      const key = `${proj.groupPath}→${providerProj.groupPath}::${imp.symbolName}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const link: GroupManifestLink = {
+        from: providerProj.groupPath,
+        to: proj.groupPath,
+        type: 'custom',
+        contract: imp.symbolName,
+        role: 'provider' as ContractRole,
+      };
+      links.push(link);
+    }
+  }
+
+  return { links, discoveredProjects: projectsByGroupPath };
+}

--- a/gitnexus/src/core/group/extractors/java-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/java-workspace-extractor.ts
@@ -43,12 +43,8 @@ async function parseJavaManifest(
   return null;
 }
 
-function parsePom(
-  content: string,
-): { groupId: string; artifactId: string; deps: string[] } | null {
-  const projectGroupMatch = content.match(
-    /<project[^>]*>[\s\S]*?<groupId>([^<]+)<\/groupId>/,
-  );
+function parsePom(content: string): { groupId: string; artifactId: string; deps: string[] } | null {
+  const projectGroupMatch = content.match(/<project[^>]*>[\s\S]*?<groupId>([^<]+)<\/groupId>/);
   const projectArtifactMatch = content.match(
     /<project[^>]*>[\s\S]*?<artifactId>([^<]+)<\/artifactId>/,
   );
@@ -58,9 +54,7 @@ function parsePom(
   const artifactId = projectArtifactMatch[1].trim();
 
   const deps: string[] = [];
-  const depBlocks = content.matchAll(
-    /<dependency>\s*([\s\S]*?)<\/dependency>/g,
-  );
+  const depBlocks = content.matchAll(/<dependency>\s*([\s\S]*?)<\/dependency>/g);
   for (const block of depBlocks) {
     const gMatch = block[1].match(/<groupId>([^<]+)<\/groupId>/);
     const aMatch = block[1].match(/<artifactId>([^<]+)<\/artifactId>/);

--- a/gitnexus/src/core/group/extractors/java-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/java-workspace-extractor.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { CypherExecutor } from '../contract-extractor.js';
 import type { GroupManifestLink, ContractRole } from '../types.js';
+import { shouldIgnorePath, loadIgnoreRules } from '../../../config/ignore-service.js';
 
 interface JavaProjectMeta {
   groupId: string;
@@ -160,16 +161,7 @@ function isPascalCase(name: string): boolean {
 
 async function findJavaFiles(repoPath: string): Promise<string[]> {
   const results: string[] = [];
-  const IGNORE = new Set([
-    'node_modules',
-    '.git',
-    '.gitnexus',
-    'build',
-    'target',
-    '.gradle',
-    '.idea',
-    'bin',
-  ]);
+  const ig = await loadIgnoreRules(repoPath);
 
   async function walk(dir: string, rel: string): Promise<void> {
     let entries;
@@ -179,11 +171,14 @@ async function findJavaFiles(repoPath: string): Promise<string[]> {
       return;
     }
     for (const entry of entries) {
-      if (IGNORE.has(entry.name)) continue;
       const childRel = rel ? `${rel}/${entry.name}` : entry.name;
       if (entry.isDirectory()) {
+        if (shouldIgnorePath(childRel)) continue;
+        if (ig && ig.ignores(childRel + '/')) continue;
         await walk(path.join(dir, entry.name), childRel);
       } else if (entry.name.endsWith('.java') || entry.name.endsWith('.kt')) {
+        if (shouldIgnorePath(childRel)) continue;
+        if (ig && ig.ignores(childRel)) continue;
         results.push(childRel);
       }
     }
@@ -222,6 +217,13 @@ export async function extractJavaWorkspaceLinks(
       repoPath,
       deps: manifest.deps,
     };
+    const existing = projectsByKey.get(key);
+    if (existing) {
+      console.warn(
+        `[java-workspace-extractor] duplicate artifact "${key}" in "${groupPath}" and "${existing.groupPath}" — skipping "${groupPath}"`,
+      );
+      continue;
+    }
     projectsByKey.set(key, meta);
     projectsByGroupPath.set(groupPath, meta);
   }
@@ -245,15 +247,16 @@ export async function extractJavaWorkspaceLinks(
       const providerProj = projectsByKey.get(imp.artifactKey);
       if (!providerProj) continue;
 
-      const key = `${proj.groupPath}→${providerProj.groupPath}::${imp.symbolName}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
+      const qualifiedContract = `${providerProj.artifactId}::${imp.symbolName}`;
+      const dedupKey = `${proj.groupPath}→${providerProj.groupPath}::${qualifiedContract}`;
+      if (seen.has(dedupKey)) continue;
+      seen.add(dedupKey);
 
       const link: GroupManifestLink = {
         from: providerProj.groupPath,
         to: proj.groupPath,
         type: 'custom',
-        contract: imp.symbolName,
+        contract: qualifiedContract,
         role: 'provider' as ContractRole,
       };
       links.push(link);

--- a/gitnexus/src/core/group/extractors/manifest-extractor.ts
+++ b/gitnexus/src/core/group/extractors/manifest-extractor.ts
@@ -269,17 +269,19 @@ export class ManifestExtractor {
           { contract: link.contract },
         );
       } else if (link.type === 'custom') {
-        // V1: exact name-only match on code-definition nodes.
-        // Positive allowlist mirrors other contract types. If multiple code
-        // symbols share the same name, ORDER BY filePath ASC LIMIT 1 picks
-        // the alphabetically-first occurrence deterministically.
+        // Workspace extractors produce qualified contracts like "mathlex::Expression".
+        // Graph nodes store the unqualified symbol name ("Expression"), so strip
+        // the "provider::" prefix before querying.
+        const symbolName = link.contract.includes('::')
+          ? link.contract.split('::').pop()!
+          : link.contract;
         rows = await executor(
           `MATCH (n:Function|Method|Class|Interface|Struct|Enum|Trait|Constructor|TypeAlias|Impl|Macro|Union|Typedef|Property|Record|Delegate|Annotation|Template|Const|Static|CodeElement)
-           WHERE n.name = $contract
+           WHERE n.name = $symbolName
            RETURN n.id AS uid, n.name AS name, n.filePath AS filePath
            ORDER BY n.filePath ASC
            LIMIT 1`,
-          { contract: link.contract },
+          { symbolName },
         );
       } else {
         return null;

--- a/gitnexus/src/core/group/extractors/node-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/node-workspace-extractor.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { CypherExecutor } from '../contract-extractor.js';
 import type { GroupManifestLink, ContractRole } from '../types.js';
+import { shouldIgnorePath, loadIgnoreRules } from '../../../config/ignore-service.js';
 
 interface PackageMeta {
   name: string;
@@ -148,18 +149,8 @@ function isExportedName(name: string): boolean {
 
 async function findSourceFiles(repoPath: string): Promise<string[]> {
   const results: string[] = [];
-  const IGNORE = new Set([
-    'node_modules',
-    '.git',
-    '.gitnexus',
-    'dist',
-    'build',
-    'coverage',
-    '.next',
-    '.nuxt',
-    'vendor',
-  ]);
   const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.mts', '.cts']);
+  const ig = await loadIgnoreRules(repoPath);
 
   async function walk(dir: string, rel: string): Promise<void> {
     let entries;
@@ -169,13 +160,16 @@ async function findSourceFiles(repoPath: string): Promise<string[]> {
       return;
     }
     for (const entry of entries) {
-      if (IGNORE.has(entry.name)) continue;
       const childRel = rel ? `${rel}/${entry.name}` : entry.name;
       if (entry.isDirectory()) {
+        if (shouldIgnorePath(childRel)) continue;
+        if (ig && ig.ignores(childRel + '/')) continue;
         await walk(path.join(dir, entry.name), childRel);
       } else {
         const ext = path.extname(entry.name);
         if (EXTENSIONS.has(ext)) {
+          if (shouldIgnorePath(childRel)) continue;
+          if (ig && ig.ignores(childRel)) continue;
           results.push(childRel);
         }
       }
@@ -212,6 +206,13 @@ export async function extractNodeWorkspaceLinks(
       repoPath,
       workspaceDeps: manifest.workspaceDeps,
     };
+    const existing = packagesByName.get(manifest.name);
+    if (existing) {
+      console.warn(
+        `[node-workspace-extractor] duplicate package name "${manifest.name}" in "${groupPath}" and "${existing.groupPath}" — skipping "${groupPath}"`,
+      );
+      continue;
+    }
     packagesByName.set(manifest.name, meta);
     packagesByGroupPath.set(groupPath, meta);
   }
@@ -230,7 +231,8 @@ export async function extractNodeWorkspaceLinks(
       const providerPkg = packagesByName.get(imp.packageName);
       if (!providerPkg) continue;
 
-      const key = `${pkg.groupPath}→${providerPkg.groupPath}::${imp.symbolName}`;
+      const qualifiedContract = `${imp.packageName}::${imp.symbolName}`;
+      const key = `${pkg.groupPath}→${providerPkg.groupPath}::${qualifiedContract}`;
       if (seen.has(key)) continue;
       seen.add(key);
 
@@ -238,7 +240,7 @@ export async function extractNodeWorkspaceLinks(
         from: providerPkg.groupPath,
         to: pkg.groupPath,
         type: 'custom',
-        contract: imp.symbolName,
+        contract: qualifiedContract,
         role: 'provider' as ContractRole,
       };
       links.push(link);

--- a/gitnexus/src/core/group/extractors/node-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/node-workspace-extractor.ts
@@ -1,0 +1,249 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { CypherExecutor } from '../contract-extractor.js';
+import type { GroupManifestLink, ContractRole } from '../types.js';
+
+interface PackageMeta {
+  name: string;
+  groupPath: string;
+  repoPath: string;
+  workspaceDeps: string[];
+}
+
+interface ImportedSymbol {
+  packageName: string;
+  symbolName: string;
+  filePath: string;
+}
+
+async function parsePackageManifest(
+  repoPath: string,
+): Promise<{ name: string; workspaceDeps: string[] } | null> {
+  const pkgPath = path.join(repoPath, 'package.json');
+  let content: string;
+  try {
+    content = await fs.readFile(pkgPath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  let pkg: Record<string, unknown>;
+  try {
+    pkg = JSON.parse(content);
+  } catch {
+    return null;
+  }
+
+  const name = typeof pkg.name === 'string' ? pkg.name : '';
+  if (!name) return null;
+
+  const deps: string[] = [];
+  for (const field of ['dependencies', 'devDependencies', 'peerDependencies']) {
+    const section = pkg[field];
+    if (section && typeof section === 'object') {
+      deps.push(...Object.keys(section as Record<string, unknown>));
+    }
+  }
+
+  return { name, workspaceDeps: [...new Set(deps)] };
+}
+
+async function scanImports(
+  repoPath: string,
+  knownPackages: Set<string>,
+): Promise<ImportedSymbol[]> {
+  const results: ImportedSymbol[] = [];
+  const sourceFiles = await findSourceFiles(repoPath);
+
+  for (const relFile of sourceFiles) {
+    const absPath = path.join(repoPath, relFile);
+    let content: string;
+    try {
+      content = await fs.readFile(absPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    // ES import: import { Foo, Bar } from '<pkg>'
+    // Also: import { Foo as Baz } from '<pkg>'
+    const esImportRegex =
+      /^import\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/gm;
+    let match;
+    while ((match = esImportRegex.exec(content)) !== null) {
+      const importClause = match[1];
+      const modulePath = match[2];
+      const pkgName = resolvePackageName(modulePath);
+      if (!pkgName || !knownPackages.has(pkgName)) continue;
+
+      const symbols = parseImportClause(importClause);
+      for (const sym of symbols) {
+        if (isExportedName(sym)) {
+          results.push({ packageName: pkgName, symbolName: sym, filePath: relFile });
+        }
+      }
+    }
+
+    // ES import default: import Foo from '<pkg>'
+    const defaultImportRegex =
+      /^import\s+([A-Z][A-Za-z0-9]*)\s+from\s+['"]([^'"]+)['"]/gm;
+    while ((match = defaultImportRegex.exec(content)) !== null) {
+      const symbolName = match[1];
+      const modulePath = match[2];
+      const pkgName = resolvePackageName(modulePath);
+      if (!pkgName || !knownPackages.has(pkgName)) continue;
+
+      if (isExportedName(symbolName)) {
+        results.push({ packageName: pkgName, symbolName, filePath: relFile });
+      }
+    }
+
+    // CommonJS: const { Foo, Bar } = require('<pkg>')
+    const cjsRegex =
+      /(?:const|let|var)\s+\{([^}]+)\}\s*=\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)/gm;
+    while ((match = cjsRegex.exec(content)) !== null) {
+      const importClause = match[1];
+      const modulePath = match[2];
+      const pkgName = resolvePackageName(modulePath);
+      if (!pkgName || !knownPackages.has(pkgName)) continue;
+
+      const symbols = parseImportClause(importClause);
+      for (const sym of symbols) {
+        if (isExportedName(sym)) {
+          results.push({ packageName: pkgName, symbolName: sym, filePath: relFile });
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+function resolvePackageName(modulePath: string): string | null {
+  if (modulePath.startsWith('.') || modulePath.startsWith('/')) return null;
+  // Scoped: @scope/pkg or @scope/pkg/sub
+  if (modulePath.startsWith('@')) {
+    const parts = modulePath.split('/');
+    if (parts.length >= 2) return `${parts[0]}/${parts[1]}`;
+    return null;
+  }
+  // Unscoped: pkg or pkg/sub
+  return modulePath.split('/')[0];
+}
+
+function parseImportClause(clause: string): string[] {
+  return clause
+    .split(',')
+    .map((s) => {
+      const trimmed = s.trim();
+      // Handle `Foo as Bar` — use the original export name
+      const asMatch = trimmed.match(/^(\S+)\s+as\s+/);
+      return asMatch ? asMatch[1] : trimmed;
+    })
+    .filter(Boolean);
+}
+
+function isExportedName(name: string): boolean {
+  return /^[A-Z][A-Za-z0-9]*$/.test(name);
+}
+
+async function findSourceFiles(repoPath: string): Promise<string[]> {
+  const results: string[] = [];
+  const IGNORE = new Set([
+    'node_modules',
+    '.git',
+    '.gitnexus',
+    'dist',
+    'build',
+    'coverage',
+    '.next',
+    '.nuxt',
+    'vendor',
+  ]);
+  const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.mts', '.cts']);
+
+  async function walk(dir: string, rel: string): Promise<void> {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (IGNORE.has(entry.name)) continue;
+      const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(path.join(dir, entry.name), childRel);
+      } else {
+        const ext = path.extname(entry.name);
+        if (EXTENSIONS.has(ext)) {
+          results.push(childRel);
+        }
+      }
+    }
+  }
+
+  await walk(repoPath, '');
+  return results;
+}
+
+export interface NodeWorkspaceResult {
+  links: GroupManifestLink[];
+  discoveredPackages: Map<string, PackageMeta>;
+}
+
+export async function extractNodeWorkspaceLinks(
+  repos: Record<string, string>,
+  repoPaths: Map<string, string>,
+  _dbExecutors?: Map<string, CypherExecutor>,
+): Promise<NodeWorkspaceResult> {
+  const packagesByName = new Map<string, PackageMeta>();
+  const packagesByGroupPath = new Map<string, PackageMeta>();
+
+  for (const [groupPath] of Object.entries(repos)) {
+    const repoPath = repoPaths.get(groupPath);
+    if (!repoPath) continue;
+
+    const manifest = await parsePackageManifest(repoPath);
+    if (!manifest) continue;
+
+    const meta: PackageMeta = {
+      name: manifest.name,
+      groupPath,
+      repoPath,
+      workspaceDeps: manifest.workspaceDeps,
+    };
+    packagesByName.set(manifest.name, meta);
+    packagesByGroupPath.set(groupPath, meta);
+  }
+
+  const links: GroupManifestLink[] = [];
+  const seen = new Set<string>();
+
+  for (const [, pkg] of packagesByGroupPath) {
+    const groupPkgDeps = pkg.workspaceDeps.filter((d) => packagesByName.has(d));
+    if (groupPkgDeps.length === 0) continue;
+
+    const knownPackages = new Set(groupPkgDeps);
+    const imports = await scanImports(pkg.repoPath, knownPackages);
+
+    for (const imp of imports) {
+      const providerPkg = packagesByName.get(imp.packageName);
+      if (!providerPkg) continue;
+
+      const key = `${pkg.groupPath}→${providerPkg.groupPath}::${imp.symbolName}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const link: GroupManifestLink = {
+        from: providerPkg.groupPath,
+        to: pkg.groupPath,
+        type: 'custom',
+        contract: imp.symbolName,
+        role: 'provider' as ContractRole,
+      };
+      links.push(link);
+    }
+  }
+
+  return { links, discoveredPackages: packagesByGroupPath };
+}

--- a/gitnexus/src/core/group/extractors/node-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/node-workspace-extractor.ts
@@ -67,8 +67,7 @@ async function scanImports(
 
     // ES import: import { Foo, Bar } from '<pkg>'
     // Also: import { Foo as Baz } from '<pkg>'
-    const esImportRegex =
-      /^import\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/gm;
+    const esImportRegex = /^import\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/gm;
     let match;
     while ((match = esImportRegex.exec(content)) !== null) {
       const importClause = match[1];
@@ -85,8 +84,7 @@ async function scanImports(
     }
 
     // ES import default: import Foo from '<pkg>'
-    const defaultImportRegex =
-      /^import\s+([A-Z][A-Za-z0-9]*)\s+from\s+['"]([^'"]+)['"]/gm;
+    const defaultImportRegex = /^import\s+([A-Z][A-Za-z0-9]*)\s+from\s+['"]([^'"]+)['"]/gm;
     while ((match = defaultImportRegex.exec(content)) !== null) {
       const symbolName = match[1];
       const modulePath = match[2];
@@ -99,8 +97,7 @@ async function scanImports(
     }
 
     // CommonJS: const { Foo, Bar } = require('<pkg>')
-    const cjsRegex =
-      /(?:const|let|var)\s+\{([^}]+)\}\s*=\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)/gm;
+    const cjsRegex = /(?:const|let|var)\s+\{([^}]+)\}\s*=\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)/gm;
     while ((match = cjsRegex.exec(content)) !== null) {
       const importClause = match[1];
       const modulePath = match[2];

--- a/gitnexus/src/core/group/extractors/python-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/python-workspace-extractor.ts
@@ -1,0 +1,260 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { CypherExecutor } from '../contract-extractor.js';
+import type { GroupManifestLink, ContractRole } from '../types.js';
+
+interface PythonPackageMeta {
+  name: string;
+  importName: string;
+  groupPath: string;
+  repoPath: string;
+  workspaceDeps: string[];
+}
+
+interface ImportedSymbol {
+  packageName: string;
+  symbolName: string;
+  filePath: string;
+}
+
+async function parsePythonManifest(
+  repoPath: string,
+): Promise<{ name: string; importName: string; deps: string[] } | null> {
+  const pyprojectPath = path.join(repoPath, 'pyproject.toml');
+  let content: string | null = null;
+  try {
+    content = await fs.readFile(pyprojectPath, 'utf-8');
+  } catch {
+    // fall through to setup.py
+  }
+
+  if (content) return parsePyproject(content);
+
+  const setupPyPath = path.join(repoPath, 'setup.py');
+  try {
+    content = await fs.readFile(setupPyPath, 'utf-8');
+  } catch {
+    return null;
+  }
+  return parseSetupPy(content);
+}
+
+function parsePyproject(content: string): { name: string; importName: string; deps: string[] } | null {
+  const nameMatch = content.match(
+    /^\[project\]\s*\n(?:[^\[]*?\n)*?name\s*=\s*"([^"]+)"/m,
+  );
+  if (!nameMatch) return null;
+  const name = nameMatch[1];
+  const importName = name.replace(/-/g, '_');
+
+  const deps: string[] = [];
+  const depsMatch = content.match(
+    /^\[project\]\s*\n[\s\S]*?dependencies\s*=\s*\[([\s\S]*?)\]/m,
+  );
+  if (depsMatch) {
+    const depLines = depsMatch[1].matchAll(/"([^"]+)"/g);
+    for (const m of depLines) {
+      deps.push(extractPepName(m[1]));
+    }
+  }
+
+  const optMatch = content.match(
+    /\[project\.optional-dependencies\]\s*\n([\s\S]*?)(?=\n\[|$)/,
+  );
+  if (optMatch) {
+    const optDeps = optMatch[1].matchAll(/"([^"]+)"/g);
+    for (const m of optDeps) {
+      deps.push(extractPepName(m[1]));
+    }
+  }
+
+  return { name, importName, deps: [...new Set(deps)] };
+}
+
+function parseSetupPy(content: string): { name: string; importName: string; deps: string[] } | null {
+  const nameMatch = content.match(/name\s*=\s*['"]([^'"]+)['"]/);
+  if (!nameMatch) return null;
+  const name = nameMatch[1];
+  const importName = name.replace(/-/g, '_');
+
+  const deps: string[] = [];
+  const installMatch = content.match(
+    /install_requires\s*=\s*\[([\s\S]*?)\]/,
+  );
+  if (installMatch) {
+    const depLines = installMatch[1].matchAll(/['"]([^'"]+)['"]/g);
+    for (const m of depLines) {
+      deps.push(extractPepName(m[1]));
+    }
+  }
+
+  return { name, importName, deps: [...new Set(deps)] };
+}
+
+function extractPepName(spec: string): string {
+  return spec.split(/[><=!~;\[]/)[0].trim();
+}
+
+async function scanPythonImports(
+  repoPath: string,
+  knownPackages: Map<string, string>,
+): Promise<ImportedSymbol[]> {
+  const results: ImportedSymbol[] = [];
+  const sourceFiles = await findPythonFiles(repoPath);
+
+  for (const relFile of sourceFiles) {
+    const absPath = path.join(repoPath, relFile);
+    let content: string;
+    try {
+      content = await fs.readFile(absPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    // from <pkg> import Foo, Bar
+    // from <pkg>.module import Foo
+    const fromImportRegex =
+      /^from\s+(\w[\w.]*)\s+import\s+(.+)/gm;
+    let match;
+    while ((match = fromImportRegex.exec(content)) !== null) {
+      const modulePath = match[1];
+      const importClause = match[2];
+      const rootModule = modulePath.split('.')[0];
+      const originalName = knownPackages.get(rootModule);
+      if (!originalName) continue;
+
+      if (importClause.trim() === '(') continue;
+
+      const symbols = importClause
+        .replace(/\(|\)/g, '')
+        .split(',')
+        .map((s) => {
+          const trimmed = s.trim();
+          const asMatch = trimmed.match(/^(\S+)\s+as\s+/);
+          return asMatch ? asMatch[1] : trimmed;
+        })
+        .filter(Boolean);
+
+      for (const sym of symbols) {
+        if (isPascalCase(sym)) {
+          results.push({ packageName: originalName, symbolName: sym, filePath: relFile });
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+function isPascalCase(name: string): boolean {
+  return /^[A-Z][A-Za-z0-9]*$/.test(name);
+}
+
+async function findPythonFiles(repoPath: string): Promise<string[]> {
+  const results: string[] = [];
+  const IGNORE = new Set([
+    '__pycache__',
+    '.git',
+    '.gitnexus',
+    'node_modules',
+    '.venv',
+    'venv',
+    '.tox',
+    '.eggs',
+    'dist',
+    'build',
+    '.mypy_cache',
+    '.pytest_cache',
+  ]);
+
+  async function walk(dir: string, rel: string): Promise<void> {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (IGNORE.has(entry.name)) continue;
+      const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(path.join(dir, entry.name), childRel);
+      } else if (entry.name.endsWith('.py')) {
+        results.push(childRel);
+      }
+    }
+  }
+
+  await walk(repoPath, '');
+  return results;
+}
+
+export interface PythonWorkspaceResult {
+  links: GroupManifestLink[];
+  discoveredPackages: Map<string, PythonPackageMeta>;
+}
+
+export async function extractPythonWorkspaceLinks(
+  repos: Record<string, string>,
+  repoPaths: Map<string, string>,
+  _dbExecutors?: Map<string, CypherExecutor>,
+): Promise<PythonWorkspaceResult> {
+  const packagesByImportName = new Map<string, PythonPackageMeta>();
+  const packagesByGroupPath = new Map<string, PythonPackageMeta>();
+
+  for (const [groupPath] of Object.entries(repos)) {
+    const repoPath = repoPaths.get(groupPath);
+    if (!repoPath) continue;
+
+    const manifest = await parsePythonManifest(repoPath);
+    if (!manifest) continue;
+
+    const meta: PythonPackageMeta = {
+      name: manifest.name,
+      importName: manifest.importName,
+      groupPath,
+      repoPath,
+      workspaceDeps: manifest.deps,
+    };
+    packagesByImportName.set(manifest.importName, meta);
+    packagesByGroupPath.set(groupPath, meta);
+  }
+
+  const links: GroupManifestLink[] = [];
+  const seen = new Set<string>();
+
+  for (const [, pkg] of packagesByGroupPath) {
+    const normalizedDeps = pkg.workspaceDeps.map((d) => d.replace(/-/g, '_'));
+    const groupPkgDeps = normalizedDeps.filter((d) => packagesByImportName.has(d));
+    if (groupPkgDeps.length === 0) continue;
+
+    const knownPackages = new Map<string, string>();
+    for (const dep of groupPkgDeps) {
+      const meta = packagesByImportName.get(dep);
+      if (meta) knownPackages.set(dep, meta.name);
+    }
+
+    const imports = await scanPythonImports(pkg.repoPath, knownPackages);
+
+    for (const imp of imports) {
+      const providerImportName = imp.packageName.replace(/-/g, '_');
+      const providerPkg = packagesByImportName.get(providerImportName);
+      if (!providerPkg) continue;
+
+      const key = `${pkg.groupPath}→${providerPkg.groupPath}::${imp.symbolName}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const link: GroupManifestLink = {
+        from: providerPkg.groupPath,
+        to: pkg.groupPath,
+        type: 'custom',
+        contract: imp.symbolName,
+        role: 'provider' as ContractRole,
+      };
+      links.push(link);
+    }
+  }
+
+  return { links, discoveredPackages: packagesByGroupPath };
+}

--- a/gitnexus/src/core/group/extractors/python-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/python-workspace-extractor.ts
@@ -43,7 +43,7 @@ async function parsePythonManifest(
 function parsePyproject(
   content: string,
 ): { name: string; importName: string; deps: string[] } | null {
-  const nameMatch = content.match(/^\[project\]\s*\n(?:[^\[]*?\n)*?name\s*=\s*"([^"]+)"/m);
+  const nameMatch = content.match(/^\[project\]\s*\n(?:[^\n\[]*\n)*?name\s*=\s*"([^"]+)"/m);
   if (!nameMatch) return null;
   const name = nameMatch[1];
   const importName = name.replace(/-/g, '_');

--- a/gitnexus/src/core/group/extractors/python-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/python-workspace-extractor.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { CypherExecutor } from '../contract-extractor.js';
 import type { GroupManifestLink, ContractRole } from '../types.js';
+import { shouldIgnorePath, loadIgnoreRules } from '../../../config/ignore-service.js';
 
 interface PythonPackageMeta {
   name: string;
@@ -152,20 +153,7 @@ function isPascalCase(name: string): boolean {
 
 async function findPythonFiles(repoPath: string): Promise<string[]> {
   const results: string[] = [];
-  const IGNORE = new Set([
-    '__pycache__',
-    '.git',
-    '.gitnexus',
-    'node_modules',
-    '.venv',
-    'venv',
-    '.tox',
-    '.eggs',
-    'dist',
-    'build',
-    '.mypy_cache',
-    '.pytest_cache',
-  ]);
+  const ig = await loadIgnoreRules(repoPath);
 
   async function walk(dir: string, rel: string): Promise<void> {
     let entries;
@@ -175,11 +163,14 @@ async function findPythonFiles(repoPath: string): Promise<string[]> {
       return;
     }
     for (const entry of entries) {
-      if (IGNORE.has(entry.name)) continue;
       const childRel = rel ? `${rel}/${entry.name}` : entry.name;
       if (entry.isDirectory()) {
+        if (shouldIgnorePath(childRel)) continue;
+        if (ig && ig.ignores(childRel + '/')) continue;
         await walk(path.join(dir, entry.name), childRel);
       } else if (entry.name.endsWith('.py')) {
+        if (shouldIgnorePath(childRel)) continue;
+        if (ig && ig.ignores(childRel)) continue;
         results.push(childRel);
       }
     }
@@ -216,6 +207,13 @@ export async function extractPythonWorkspaceLinks(
       repoPath,
       workspaceDeps: manifest.deps,
     };
+    const existing = packagesByImportName.get(manifest.importName);
+    if (existing) {
+      console.warn(
+        `[python-workspace-extractor] duplicate package "${manifest.name}" in "${groupPath}" and "${existing.groupPath}" — skipping "${groupPath}"`,
+      );
+      continue;
+    }
     packagesByImportName.set(manifest.importName, meta);
     packagesByGroupPath.set(groupPath, meta);
   }
@@ -241,7 +239,8 @@ export async function extractPythonWorkspaceLinks(
       const providerPkg = packagesByImportName.get(providerImportName);
       if (!providerPkg) continue;
 
-      const key = `${pkg.groupPath}→${providerPkg.groupPath}::${imp.symbolName}`;
+      const qualifiedContract = `${providerPkg.name}::${imp.symbolName}`;
+      const key = `${pkg.groupPath}→${providerPkg.groupPath}::${qualifiedContract}`;
       if (seen.has(key)) continue;
       seen.add(key);
 
@@ -249,7 +248,7 @@ export async function extractPythonWorkspaceLinks(
         from: providerPkg.groupPath,
         to: pkg.groupPath,
         type: 'custom',
-        contract: imp.symbolName,
+        contract: qualifiedContract,
         role: 'provider' as ContractRole,
       };
       links.push(link);

--- a/gitnexus/src/core/group/extractors/python-workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/python-workspace-extractor.ts
@@ -40,18 +40,16 @@ async function parsePythonManifest(
   return parseSetupPy(content);
 }
 
-function parsePyproject(content: string): { name: string; importName: string; deps: string[] } | null {
-  const nameMatch = content.match(
-    /^\[project\]\s*\n(?:[^\[]*?\n)*?name\s*=\s*"([^"]+)"/m,
-  );
+function parsePyproject(
+  content: string,
+): { name: string; importName: string; deps: string[] } | null {
+  const nameMatch = content.match(/^\[project\]\s*\n(?:[^\[]*?\n)*?name\s*=\s*"([^"]+)"/m);
   if (!nameMatch) return null;
   const name = nameMatch[1];
   const importName = name.replace(/-/g, '_');
 
   const deps: string[] = [];
-  const depsMatch = content.match(
-    /^\[project\]\s*\n[\s\S]*?dependencies\s*=\s*\[([\s\S]*?)\]/m,
-  );
+  const depsMatch = content.match(/^\[project\]\s*\n[\s\S]*?dependencies\s*=\s*\[([\s\S]*?)\]/m);
   if (depsMatch) {
     const depLines = depsMatch[1].matchAll(/"([^"]+)"/g);
     for (const m of depLines) {
@@ -59,9 +57,7 @@ function parsePyproject(content: string): { name: string; importName: string; de
     }
   }
 
-  const optMatch = content.match(
-    /\[project\.optional-dependencies\]\s*\n([\s\S]*?)(?=\n\[|$)/,
-  );
+  const optMatch = content.match(/\[project\.optional-dependencies\]\s*\n([\s\S]*?)(?=\n\[|$)/);
   if (optMatch) {
     const optDeps = optMatch[1].matchAll(/"([^"]+)"/g);
     for (const m of optDeps) {
@@ -72,16 +68,16 @@ function parsePyproject(content: string): { name: string; importName: string; de
   return { name, importName, deps: [...new Set(deps)] };
 }
 
-function parseSetupPy(content: string): { name: string; importName: string; deps: string[] } | null {
+function parseSetupPy(
+  content: string,
+): { name: string; importName: string; deps: string[] } | null {
   const nameMatch = content.match(/name\s*=\s*['"]([^'"]+)['"]/);
   if (!nameMatch) return null;
   const name = nameMatch[1];
   const importName = name.replace(/-/g, '_');
 
   const deps: string[] = [];
-  const installMatch = content.match(
-    /install_requires\s*=\s*\[([\s\S]*?)\]/,
-  );
+  const installMatch = content.match(/install_requires\s*=\s*\[([\s\S]*?)\]/);
   if (installMatch) {
     const depLines = installMatch[1].matchAll(/['"]([^'"]+)['"]/g);
     for (const m of depLines) {
@@ -114,8 +110,7 @@ async function scanPythonImports(
 
     // from <pkg> import Foo, Bar
     // from <pkg>.module import Foo
-    const fromImportRegex =
-      /^from\s+(\w[\w.]*)\s+import\s+(.+)/gm;
+    const fromImportRegex = /^from\s+(\w[\w.]*)\s+import\s+(.+)/gm;
     let match;
     while ((match = fromImportRegex.exec(content)) !== null) {
       const modulePath = match[1];

--- a/gitnexus/src/core/group/extractors/workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/workspace-extractor.ts
@@ -5,6 +5,7 @@ import { extractNodeWorkspaceLinks } from './node-workspace-extractor.js';
 import { extractPythonWorkspaceLinks } from './python-workspace-extractor.js';
 import { extractGoWorkspaceLinks } from './go-workspace-extractor.js';
 import { extractJavaWorkspaceLinks } from './java-workspace-extractor.js';
+import { extractElixirWorkspaceLinks } from './elixir-workspace-extractor.js';
 
 export interface WorkspaceDiscoveryResult {
   links: GroupManifestLink[];
@@ -72,6 +73,16 @@ export async function discoverWorkspaceLinks(
       ecosystem: 'Java',
       linkCount: javaResult.links.length,
       projectCount: javaResult.discoveredProjects.size,
+    });
+  }
+
+  const elixirResult = await extractElixirWorkspaceLinks(repos, repoPaths, dbExecutors);
+  if (elixirResult.links.length > 0) {
+    links.push(...elixirResult.links);
+    stats.push({
+      ecosystem: 'Elixir',
+      linkCount: elixirResult.links.length,
+      projectCount: elixirResult.discoveredApps.size,
     });
   }
 

--- a/gitnexus/src/core/group/extractors/workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/workspace-extractor.ts
@@ -1,0 +1,68 @@
+import type { CypherExecutor } from '../contract-extractor.js';
+import type { GroupManifestLink } from '../types.js';
+import { extractRustWorkspaceLinks } from './rust-workspace-extractor.js';
+import { extractNodeWorkspaceLinks } from './node-workspace-extractor.js';
+import { extractPythonWorkspaceLinks } from './python-workspace-extractor.js';
+import { extractGoWorkspaceLinks } from './go-workspace-extractor.js';
+
+export interface WorkspaceDiscoveryResult {
+  links: GroupManifestLink[];
+  stats: WorkspaceExtractorStats[];
+}
+
+interface WorkspaceExtractorStats {
+  ecosystem: string;
+  linkCount: number;
+  projectCount: number;
+}
+
+export async function discoverWorkspaceLinks(
+  repos: Record<string, string>,
+  repoPaths: Map<string, string>,
+  dbExecutors?: Map<string, CypherExecutor>,
+): Promise<WorkspaceDiscoveryResult> {
+  const links: GroupManifestLink[] = [];
+  const stats: WorkspaceExtractorStats[] = [];
+
+  const rustResult = await extractRustWorkspaceLinks(repos, repoPaths, dbExecutors);
+  if (rustResult.links.length > 0) {
+    links.push(...rustResult.links);
+    stats.push({
+      ecosystem: 'Rust',
+      linkCount: rustResult.links.length,
+      projectCount: rustResult.discoveredCrates.size,
+    });
+  }
+
+  const nodeResult = await extractNodeWorkspaceLinks(repos, repoPaths, dbExecutors);
+  if (nodeResult.links.length > 0) {
+    links.push(...nodeResult.links);
+    stats.push({
+      ecosystem: 'Node',
+      linkCount: nodeResult.links.length,
+      projectCount: nodeResult.discoveredPackages.size,
+    });
+  }
+
+  const pyResult = await extractPythonWorkspaceLinks(repos, repoPaths, dbExecutors);
+  if (pyResult.links.length > 0) {
+    links.push(...pyResult.links);
+    stats.push({
+      ecosystem: 'Python',
+      linkCount: pyResult.links.length,
+      projectCount: pyResult.discoveredPackages.size,
+    });
+  }
+
+  const goResult = await extractGoWorkspaceLinks(repos, repoPaths, dbExecutors);
+  if (goResult.links.length > 0) {
+    links.push(...goResult.links);
+    stats.push({
+      ecosystem: 'Go',
+      linkCount: goResult.links.length,
+      projectCount: goResult.discoveredModules.size,
+    });
+  }
+
+  return { links, stats };
+}

--- a/gitnexus/src/core/group/extractors/workspace-extractor.ts
+++ b/gitnexus/src/core/group/extractors/workspace-extractor.ts
@@ -4,6 +4,7 @@ import { extractRustWorkspaceLinks } from './rust-workspace-extractor.js';
 import { extractNodeWorkspaceLinks } from './node-workspace-extractor.js';
 import { extractPythonWorkspaceLinks } from './python-workspace-extractor.js';
 import { extractGoWorkspaceLinks } from './go-workspace-extractor.js';
+import { extractJavaWorkspaceLinks } from './java-workspace-extractor.js';
 
 export interface WorkspaceDiscoveryResult {
   links: GroupManifestLink[];
@@ -61,6 +62,16 @@ export async function discoverWorkspaceLinks(
       ecosystem: 'Go',
       linkCount: goResult.links.length,
       projectCount: goResult.discoveredModules.size,
+    });
+  }
+
+  const javaResult = await extractJavaWorkspaceLinks(repos, repoPaths, dbExecutors);
+  if (javaResult.links.length > 0) {
+    links.push(...javaResult.links);
+    stats.push({
+      ecosystem: 'Java',
+      linkCount: javaResult.links.length,
+      projectCount: javaResult.discoveredProjects.size,
     });
   }
 

--- a/gitnexus/src/core/group/sync.ts
+++ b/gitnexus/src/core/group/sync.ts
@@ -10,6 +10,7 @@ import { TopicExtractor } from './extractors/topic-extractor.js';
 import { ManifestExtractor } from './extractors/manifest-extractor.js';
 import { extractRustWorkspaceLinks } from './extractors/rust-workspace-extractor.js';
 import { extractNodeWorkspaceLinks } from './extractors/node-workspace-extractor.js';
+import { extractPythonWorkspaceLinks } from './extractors/python-workspace-extractor.js';
 import { runExactMatch } from './matching.js';
 import { detectServiceBoundaries, assignService } from './service-boundary-detector.js';
 import type { CypherExecutor } from './contract-extractor.js';
@@ -210,6 +211,16 @@ export async function syncGroup(config: GroupConfig, opts?: SyncOptions): Promis
       if (opts?.verbose) {
         console.log(
           `  workspace-deps: discovered ${nodeResult.links.length} cross-package links from ${nodeResult.discoveredPackages.size} Node packages`,
+        );
+      }
+    }
+
+    const pyResult = await extractPythonWorkspaceLinks(config.repos, repoPaths, dbExecutors);
+    if (pyResult.links.length > 0) {
+      allLinks = [...allLinks, ...pyResult.links];
+      if (opts?.verbose) {
+        console.log(
+          `  workspace-deps: discovered ${pyResult.links.length} cross-package links from ${pyResult.discoveredPackages.size} Python packages`,
         );
       }
     }

--- a/gitnexus/src/core/group/sync.ts
+++ b/gitnexus/src/core/group/sync.ts
@@ -9,6 +9,7 @@ import { GrpcExtractor } from './extractors/grpc-extractor.js';
 import { TopicExtractor } from './extractors/topic-extractor.js';
 import { ManifestExtractor } from './extractors/manifest-extractor.js';
 import { extractRustWorkspaceLinks } from './extractors/rust-workspace-extractor.js';
+import { extractNodeWorkspaceLinks } from './extractors/node-workspace-extractor.js';
 import { runExactMatch } from './matching.js';
 import { detectServiceBoundaries, assignService } from './service-boundary-detector.js';
 import type { CypherExecutor } from './contract-extractor.js';
@@ -193,12 +194,22 @@ export async function syncGroup(config: GroupConfig, opts?: SyncOptions): Promis
       if (e) repoPaths.set(groupPath, e.path);
     }
 
-    const wsResult = await extractRustWorkspaceLinks(config.repos, repoPaths, dbExecutors);
-    if (wsResult.links.length > 0) {
-      allLinks = [...allLinks, ...wsResult.links];
+    const rustResult = await extractRustWorkspaceLinks(config.repos, repoPaths, dbExecutors);
+    if (rustResult.links.length > 0) {
+      allLinks = [...allLinks, ...rustResult.links];
       if (opts?.verbose) {
         console.log(
-          `  workspace-deps: discovered ${wsResult.links.length} cross-crate links from ${wsResult.discoveredCrates.size} Rust crates`,
+          `  workspace-deps: discovered ${rustResult.links.length} cross-crate links from ${rustResult.discoveredCrates.size} Rust crates`,
+        );
+      }
+    }
+
+    const nodeResult = await extractNodeWorkspaceLinks(config.repos, repoPaths, dbExecutors);
+    if (nodeResult.links.length > 0) {
+      allLinks = [...allLinks, ...nodeResult.links];
+      if (opts?.verbose) {
+        console.log(
+          `  workspace-deps: discovered ${nodeResult.links.length} cross-package links from ${nodeResult.discoveredPackages.size} Node packages`,
         );
       }
     }

--- a/gitnexus/src/core/group/sync.ts
+++ b/gitnexus/src/core/group/sync.ts
@@ -11,6 +11,7 @@ import { ManifestExtractor } from './extractors/manifest-extractor.js';
 import { extractRustWorkspaceLinks } from './extractors/rust-workspace-extractor.js';
 import { extractNodeWorkspaceLinks } from './extractors/node-workspace-extractor.js';
 import { extractPythonWorkspaceLinks } from './extractors/python-workspace-extractor.js';
+import { extractGoWorkspaceLinks } from './extractors/go-workspace-extractor.js';
 import { runExactMatch } from './matching.js';
 import { detectServiceBoundaries, assignService } from './service-boundary-detector.js';
 import type { CypherExecutor } from './contract-extractor.js';
@@ -221,6 +222,16 @@ export async function syncGroup(config: GroupConfig, opts?: SyncOptions): Promis
       if (opts?.verbose) {
         console.log(
           `  workspace-deps: discovered ${pyResult.links.length} cross-package links from ${pyResult.discoveredPackages.size} Python packages`,
+        );
+      }
+    }
+
+    const goResult = await extractGoWorkspaceLinks(config.repos, repoPaths, dbExecutors);
+    if (goResult.links.length > 0) {
+      allLinks = [...allLinks, ...goResult.links];
+      if (opts?.verbose) {
+        console.log(
+          `  workspace-deps: discovered ${goResult.links.length} cross-module links from ${goResult.discoveredModules.size} Go modules`,
         );
       }
     }

--- a/gitnexus/src/core/group/sync.ts
+++ b/gitnexus/src/core/group/sync.ts
@@ -8,10 +8,7 @@ import { HttpRouteExtractor } from './extractors/http-route-extractor.js';
 import { GrpcExtractor } from './extractors/grpc-extractor.js';
 import { TopicExtractor } from './extractors/topic-extractor.js';
 import { ManifestExtractor } from './extractors/manifest-extractor.js';
-import { extractRustWorkspaceLinks } from './extractors/rust-workspace-extractor.js';
-import { extractNodeWorkspaceLinks } from './extractors/node-workspace-extractor.js';
-import { extractPythonWorkspaceLinks } from './extractors/python-workspace-extractor.js';
-import { extractGoWorkspaceLinks } from './extractors/go-workspace-extractor.js';
+import { discoverWorkspaceLinks } from './extractors/workspace-extractor.js';
 import { runExactMatch } from './matching.js';
 import { detectServiceBoundaries, assignService } from './service-boundary-detector.js';
 import type { CypherExecutor } from './contract-extractor.js';
@@ -196,43 +193,15 @@ export async function syncGroup(config: GroupConfig, opts?: SyncOptions): Promis
       if (e) repoPaths.set(groupPath, e.path);
     }
 
-    const rustResult = await extractRustWorkspaceLinks(config.repos, repoPaths, dbExecutors);
-    if (rustResult.links.length > 0) {
-      allLinks = [...allLinks, ...rustResult.links];
+    const wsResult = await discoverWorkspaceLinks(config.repos, repoPaths, dbExecutors);
+    if (wsResult.links.length > 0) {
+      allLinks = [...allLinks, ...wsResult.links];
       if (opts?.verbose) {
-        console.log(
-          `  workspace-deps: discovered ${rustResult.links.length} cross-crate links from ${rustResult.discoveredCrates.size} Rust crates`,
-        );
-      }
-    }
-
-    const nodeResult = await extractNodeWorkspaceLinks(config.repos, repoPaths, dbExecutors);
-    if (nodeResult.links.length > 0) {
-      allLinks = [...allLinks, ...nodeResult.links];
-      if (opts?.verbose) {
-        console.log(
-          `  workspace-deps: discovered ${nodeResult.links.length} cross-package links from ${nodeResult.discoveredPackages.size} Node packages`,
-        );
-      }
-    }
-
-    const pyResult = await extractPythonWorkspaceLinks(config.repos, repoPaths, dbExecutors);
-    if (pyResult.links.length > 0) {
-      allLinks = [...allLinks, ...pyResult.links];
-      if (opts?.verbose) {
-        console.log(
-          `  workspace-deps: discovered ${pyResult.links.length} cross-package links from ${pyResult.discoveredPackages.size} Python packages`,
-        );
-      }
-    }
-
-    const goResult = await extractGoWorkspaceLinks(config.repos, repoPaths, dbExecutors);
-    if (goResult.links.length > 0) {
-      allLinks = [...allLinks, ...goResult.links];
-      if (opts?.verbose) {
-        console.log(
-          `  workspace-deps: discovered ${goResult.links.length} cross-module links from ${goResult.discoveredModules.size} Go modules`,
-        );
+        for (const s of wsResult.stats) {
+          console.log(
+            `  workspace-deps: discovered ${s.linkCount} cross-${s.ecosystem.toLowerCase()} links from ${s.projectCount} ${s.ecosystem} projects`,
+          );
+        }
       }
     }
   }

--- a/gitnexus/test/unit/group/elixir-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/elixir-workspace-extractor.test.ts
@@ -26,10 +26,7 @@ describe('ElixirWorkspaceExtractor', () => {
       'core/mix.exs',
       'defmodule Core.MixProject do\n  use Mix.Project\n  def project do\n    [app: :core, version: "0.1.0"]\n  end\nend\n',
     );
-    await writeFile(
-      'core/lib/core/schema.ex',
-      'defmodule Core.Schema do\nend\n',
-    );
+    await writeFile('core/lib/core/schema.ex', 'defmodule Core.Schema do\nend\n');
 
     await writeFile(
       'web/mix.exs',
@@ -121,19 +118,13 @@ describe('ElixirWorkspaceExtractor', () => {
       'data-store/mix.exs',
       'defmodule DataStore.MixProject do\n  use Mix.Project\n  def project do\n    [app: :data_store, version: "0.1.0"]\n  end\nend\n',
     );
-    await writeFile(
-      'data-store/lib/data_store/repo.ex',
-      'defmodule DataStore.Repo do\nend\n',
-    );
+    await writeFile('data-store/lib/data_store/repo.ex', 'defmodule DataStore.Repo do\nend\n');
 
     await writeFile(
       'web/mix.exs',
       'defmodule Web.MixProject do\n  use Mix.Project\n  def project do\n    [app: :web, version: "0.1.0"]\n  end\n  defp deps do\n    [{:data_store, in_umbrella: true}]\n  end\nend\n',
     );
-    await writeFile(
-      'web/lib/web/page.ex',
-      'defmodule Web.Page do\n  alias DataStore.Repo\nend\n',
-    );
+    await writeFile('web/lib/web/page.ex', 'defmodule Web.Page do\n  alias DataStore.Repo\nend\n');
 
     const repos = { store: 'data_store', web: 'web' };
     const repoPaths = new Map([

--- a/gitnexus/test/unit/group/elixir-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/elixir-workspace-extractor.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { extractElixirWorkspaceLinks } from '../../../src/core/group/extractors/elixir-workspace-extractor.js';
+
+describe('ElixirWorkspaceExtractor', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-ex-ws-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeFile(relPath: string, content: string) {
+    const absPath = path.join(tmpDir, relPath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, content, 'utf-8');
+  }
+
+  it('discovers cross-app alias imports', async () => {
+    await writeFile(
+      'core/mix.exs',
+      'defmodule Core.MixProject do\n  use Mix.Project\n  def project do\n    [app: :core, version: "0.1.0"]\n  end\nend\n',
+    );
+    await writeFile(
+      'core/lib/core/schema.ex',
+      'defmodule Core.Schema do\nend\n',
+    );
+
+    await writeFile(
+      'web/mix.exs',
+      'defmodule Web.MixProject do\n  use Mix.Project\n  def project do\n    [app: :web, version: "0.1.0"]\n  end\n  defp deps do\n    [{:core, in_umbrella: true}]\n  end\nend\n',
+    );
+    await writeFile(
+      'web/lib/web/controller.ex',
+      'defmodule Web.Controller do\n  alias Core.Schema\nend\n',
+    );
+
+    const repos = { core: 'core', web: 'web' };
+    const repoPaths = new Map([
+      ['core', path.join(tmpDir, 'core')],
+      ['web', path.join(tmpDir, 'web')],
+    ]);
+
+    const result = await extractElixirWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0]).toEqual({
+      from: 'core',
+      to: 'web',
+      type: 'custom',
+      contract: 'Core.Schema',
+      role: 'provider',
+    });
+  });
+
+  it('handles grouped alias (alias MyApp.{ModA, ModB})', async () => {
+    await writeFile(
+      'shared/mix.exs',
+      'defmodule Shared.MixProject do\n  use Mix.Project\n  def project do\n    [app: :shared, version: "0.1.0"]\n  end\nend\n',
+    );
+    await writeFile('shared/lib/shared/config.ex', 'defmodule Shared.Config do\nend\n');
+    await writeFile('shared/lib/shared/logger.ex', 'defmodule Shared.Logger do\nend\n');
+
+    await writeFile(
+      'app/mix.exs',
+      'defmodule App.MixProject do\n  use Mix.Project\n  def project do\n    [app: :app, version: "0.1.0"]\n  end\n  defp deps do\n    [{:shared, "~> 0.1"}]\n  end\nend\n',
+    );
+    await writeFile(
+      'app/lib/app/main.ex',
+      'defmodule App.Main do\n  alias Shared.{Config, Logger}\nend\n',
+    );
+
+    const repos = { shared: 'shared', app: 'app' };
+    const repoPaths = new Map([
+      ['shared', path.join(tmpDir, 'shared')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractElixirWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(2);
+    const contracts = result.links.map((l) => l.contract).sort();
+    expect(contracts).toEqual(['Shared.Config', 'Shared.Logger']);
+  });
+
+  it('handles direct module references (no alias)', async () => {
+    await writeFile(
+      'auth/mix.exs',
+      'defmodule Auth.MixProject do\n  use Mix.Project\n  def project do\n    [app: :auth, version: "0.1.0"]\n  end\nend\n',
+    );
+    await writeFile('auth/lib/auth/token.ex', 'defmodule Auth.Token do\nend\n');
+
+    await writeFile(
+      'api/mix.exs',
+      'defmodule Api.MixProject do\n  use Mix.Project\n  def project do\n    [app: :api, version: "0.1.0"]\n  end\n  defp deps do\n    [{:auth, path: "../auth"}]\n  end\nend\n',
+    );
+    await writeFile(
+      'api/lib/api/handler.ex',
+      'defmodule Api.Handler do\n  def verify do\n    Auth.Token.verify()\n  end\nend\n',
+    );
+
+    const repos = { auth: 'auth', api: 'api' };
+    const repoPaths = new Map([
+      ['auth', path.join(tmpDir, 'auth')],
+      ['api', path.join(tmpDir, 'api')],
+    ]);
+
+    const result = await extractElixirWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Auth.Token');
+  });
+
+  it('handles underscore app names (my_app -> MyApp)', async () => {
+    await writeFile(
+      'data-store/mix.exs',
+      'defmodule DataStore.MixProject do\n  use Mix.Project\n  def project do\n    [app: :data_store, version: "0.1.0"]\n  end\nend\n',
+    );
+    await writeFile(
+      'data-store/lib/data_store/repo.ex',
+      'defmodule DataStore.Repo do\nend\n',
+    );
+
+    await writeFile(
+      'web/mix.exs',
+      'defmodule Web.MixProject do\n  use Mix.Project\n  def project do\n    [app: :web, version: "0.1.0"]\n  end\n  defp deps do\n    [{:data_store, in_umbrella: true}]\n  end\nend\n',
+    );
+    await writeFile(
+      'web/lib/web/page.ex',
+      'defmodule Web.Page do\n  alias DataStore.Repo\nend\n',
+    );
+
+    const repos = { store: 'data_store', web: 'web' };
+    const repoPaths = new Map([
+      ['store', path.join(tmpDir, 'data-store')],
+      ['web', path.join(tmpDir, 'web')],
+    ]);
+
+    const result = await extractElixirWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('DataStore.Repo');
+  });
+
+  it('skips repos without mix.exs', async () => {
+    await writeFile('js-app/package.json', '{"name": "js-app"}');
+
+    const repos = { app: 'js-app' };
+    const repoPaths = new Map([['app', path.join(tmpDir, 'js-app')]]);
+
+    const result = await extractElixirWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(0);
+    expect(result.discoveredApps.size).toBe(0);
+  });
+
+  it('deduplicates identical module refs from multiple files', async () => {
+    await writeFile(
+      'lib/mix.exs',
+      'defmodule Lib.MixProject do\n  use Mix.Project\n  def project do\n    [app: :lib, version: "0.1.0"]\n  end\nend\n',
+    );
+    await writeFile('lib/lib/lib/config.ex', 'defmodule Lib.Config do\nend\n');
+
+    await writeFile(
+      'app/mix.exs',
+      'defmodule App.MixProject do\n  use Mix.Project\n  def project do\n    [app: :app, version: "0.1.0"]\n  end\n  defp deps do\n    [{:lib, "~> 0.1"}]\n  end\nend\n',
+    );
+    await writeFile('app/lib/app/a.ex', 'defmodule App.A do\n  alias Lib.Config\nend\n');
+    await writeFile('app/lib/app/b.ex', 'defmodule App.B do\n  alias Lib.Config\nend\n');
+
+    const repos = { lib: 'lib', app: 'app' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractElixirWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+  });
+
+  it('collapses nested submodules to top-level module contract', async () => {
+    await writeFile(
+      'core/mix.exs',
+      'defmodule Core.MixProject do\n  use Mix.Project\n  def project do\n    [app: :core, version: "0.1.0"]\n  end\nend\n',
+    );
+    await writeFile('core/lib/core/auth/token.ex', 'defmodule Core.Auth.Token do\nend\n');
+    await writeFile('core/lib/core/auth/session.ex', 'defmodule Core.Auth.Session do\nend\n');
+
+    await writeFile(
+      'web/mix.exs',
+      'defmodule Web.MixProject do\n  use Mix.Project\n  def project do\n    [app: :web, version: "0.1.0"]\n  end\n  defp deps do\n    [{:core, in_umbrella: true}]\n  end\nend\n',
+    );
+    await writeFile(
+      'web/lib/web/ctrl.ex',
+      'defmodule Web.Ctrl do\n  alias Core.Auth.Token\n  alias Core.Auth.Session\nend\n',
+    );
+
+    const repos = { core: 'core', web: 'web' };
+    const repoPaths = new Map([
+      ['core', path.join(tmpDir, 'core')],
+      ['web', path.join(tmpDir, 'web')],
+    ]);
+
+    const result = await extractElixirWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Core.Auth');
+  });
+
+  it('handles git and path deps alongside umbrella deps', async () => {
+    await writeFile(
+      'utils/mix.exs',
+      'defmodule Utils.MixProject do\n  use Mix.Project\n  def project do\n    [app: :utils, version: "0.1.0"]\n  end\nend\n',
+    );
+    await writeFile('utils/lib/utils/helper.ex', 'defmodule Utils.Helper do\nend\n');
+
+    await writeFile(
+      'svc/mix.exs',
+      'defmodule Svc.MixProject do\n  use Mix.Project\n  def project do\n    [app: :svc, version: "0.1.0"]\n  end\n  defp deps do\n    [{:utils, git: "https://github.com/org/utils.git"}]\n  end\nend\n',
+    );
+    await writeFile(
+      'svc/lib/svc/worker.ex',
+      'defmodule Svc.Worker do\n  alias Utils.Helper\nend\n',
+    );
+
+    const repos = { utils: 'utils', svc: 'svc' };
+    const repoPaths = new Map([
+      ['utils', path.join(tmpDir, 'utils')],
+      ['svc', path.join(tmpDir, 'svc')],
+    ]);
+
+    const result = await extractElixirWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Utils.Helper');
+  });
+});

--- a/gitnexus/test/unit/group/elixir-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/elixir-workspace-extractor.test.ts
@@ -204,6 +204,33 @@ describe('ElixirWorkspaceExtractor', () => {
     expect(result.links[0].contract).toBe('Core.Auth');
   });
 
+  it('does not produce false positives from module references in comments', async () => {
+    await writeFile(
+      'auth/mix.exs',
+      'defmodule Auth.MixProject do\n  use Mix.Project\n  def project do\n    [app: :auth, version: "0.1.0"]\n  end\nend\n',
+    );
+    await writeFile('auth/lib/auth/token.ex', 'defmodule Auth.Token do\nend\n');
+
+    await writeFile(
+      'api/mix.exs',
+      'defmodule Api.MixProject do\n  use Mix.Project\n  def project do\n    [app: :api, version: "0.1.0"]\n  end\n  defp deps do\n    [{:auth, path: "../auth"}]\n  end\nend\n',
+    );
+    await writeFile(
+      'api/lib/api/handler.ex',
+      'defmodule Api.Handler do\n  # See Auth.Token for details\n  # Auth.Token.verify() is deprecated\n  def handle, do: :ok\nend\n',
+    );
+
+    const repos = { auth: 'auth', api: 'api' };
+    const repoPaths = new Map([
+      ['auth', path.join(tmpDir, 'auth')],
+      ['api', path.join(tmpDir, 'api')],
+    ]);
+
+    const result = await extractElixirWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(0);
+  });
+
   it('handles git and path deps alongside umbrella deps', async () => {
     await writeFile(
       'utils/mix.exs',

--- a/gitnexus/test/unit/group/go-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/go-workspace-extractor.test.ts
@@ -155,6 +155,30 @@ describe('GoWorkspaceExtractor', () => {
     expect(result.links[0].contract).toBe('github.com/org/lib::Config');
   });
 
+  it('does not produce links for aliased imports (V1 false-negative limitation)', async () => {
+    await writeFile('shared/go.mod', 'module github.com/org/shared\n\ngo 1.21\n');
+    await writeFile('shared/config.go', 'package shared\n\ntype Config struct {}\n');
+
+    await writeFile(
+      'app/go.mod',
+      'module github.com/org/app\n\ngo 1.21\n\nrequire github.com/org/shared v0.1.0\n',
+    );
+    await writeFile(
+      'app/main.go',
+      'package main\n\nimport cfg "github.com/org/shared"\n\nvar c cfg.Config\n',
+    );
+
+    const repos = { shared: 'shared', app: 'app' };
+    const repoPaths = new Map([
+      ['shared', path.join(tmpDir, 'shared')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractGoWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(0);
+  });
+
   it('skips repos without go.mod', async () => {
     await writeFile('js-app/package.json', '{"name": "js-app"}');
 

--- a/gitnexus/test/unit/group/go-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/go-workspace-extractor.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { extractGoWorkspaceLinks } from '../../../src/core/group/extractors/go-workspace-extractor.js';
+
+describe('GoWorkspaceExtractor', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-go-ws-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeFile(relPath: string, content: string) {
+    const absPath = path.join(tmpDir, relPath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, content, 'utf-8');
+  }
+
+  it('discovers cross-module type usage via require', async () => {
+    await writeFile(
+      'models/go.mod',
+      'module github.com/org/models\n\ngo 1.21\n',
+    );
+    await writeFile(
+      'models/schema.go',
+      'package models\n\ntype Schema struct {}\n',
+    );
+
+    await writeFile(
+      'api/go.mod',
+      'module github.com/org/api\n\ngo 1.21\n\nrequire github.com/org/models v0.1.0\n',
+    );
+    await writeFile(
+      'api/main.go',
+      'package main\n\nimport "github.com/org/models"\n\nfunc main() {\n\tvar s models.Schema\n\t_ = s\n}\n',
+    );
+
+    const repos = {
+      'libs/models': 'models',
+      'services/api': 'api',
+    };
+    const repoPaths = new Map([
+      ['libs/models', path.join(tmpDir, 'models')],
+      ['services/api', path.join(tmpDir, 'api')],
+    ]);
+
+    const result = await extractGoWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0]).toEqual({
+      from: 'libs/models',
+      to: 'services/api',
+      type: 'custom',
+      contract: 'Schema',
+      role: 'provider',
+    });
+  });
+
+  it('handles block require syntax', async () => {
+    await writeFile(
+      'auth/go.mod',
+      'module github.com/org/auth\n\ngo 1.21\n',
+    );
+    await writeFile('auth/token.go', 'package auth\n\ntype Token struct {}\n');
+
+    await writeFile(
+      'svc/go.mod',
+      'module github.com/org/svc\n\ngo 1.21\n\nrequire (\n\tgithub.com/org/auth v1.0.0\n)\n',
+    );
+    await writeFile(
+      'svc/main.go',
+      'package main\n\nimport (\n\t"github.com/org/auth"\n)\n\nfunc handle() auth.Token { return auth.Token{} }\n',
+    );
+
+    const repos = { auth: 'auth', svc: 'svc' };
+    const repoPaths = new Map([
+      ['auth', path.join(tmpDir, 'auth')],
+      ['svc', path.join(tmpDir, 'svc')],
+    ]);
+
+    const result = await extractGoWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Token');
+  });
+
+  it('handles subpackage imports (module/pkg)', async () => {
+    await writeFile(
+      'core/go.mod',
+      'module github.com/org/core\n\ngo 1.21\n',
+    );
+    await writeFile(
+      'core/types/entity.go',
+      'package types\n\ntype Entity struct {}\n',
+    );
+
+    await writeFile(
+      'app/go.mod',
+      'module github.com/org/app\n\ngo 1.21\n\nrequire github.com/org/core v0.1.0\n',
+    );
+    await writeFile(
+      'app/main.go',
+      'package main\n\nimport "github.com/org/core/types"\n\nvar e types.Entity\n',
+    );
+
+    const repos = { core: 'core', app: 'app' };
+    const repoPaths = new Map([
+      ['core', path.join(tmpDir, 'core')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractGoWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Entity');
+  });
+
+  it('handles replace directive with local paths', async () => {
+    await writeFile(
+      'lib/go.mod',
+      'module github.com/org/lib\n\ngo 1.21\n',
+    );
+    await writeFile('lib/config.go', 'package lib\n\ntype Config struct {}\n');
+
+    await writeFile(
+      'app/go.mod',
+      'module github.com/org/app\n\ngo 1.21\n\nrequire github.com/org/lib v0.0.0\n\nreplace github.com/org/lib => ./lib\n',
+    );
+    await writeFile(
+      'app/main.go',
+      'package main\n\nimport "github.com/org/lib"\n\nvar c lib.Config\n',
+    );
+
+    const repos = { lib: 'lib', app: 'app' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractGoWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Config');
+  });
+
+  it('ignores unexported (lowercase) identifiers', async () => {
+    await writeFile(
+      'lib/go.mod',
+      'module github.com/org/lib\n\ngo 1.21\n',
+    );
+    await writeFile(
+      'lib/util.go',
+      'package lib\n\nfunc helper() {}\ntype Config struct {}\n',
+    );
+
+    await writeFile(
+      'app/go.mod',
+      'module github.com/org/app\n\ngo 1.21\n\nrequire github.com/org/lib v0.1.0\n',
+    );
+    await writeFile(
+      'app/main.go',
+      'package main\n\nimport "github.com/org/lib"\n\nvar c lib.Config\n',
+    );
+
+    const repos = { lib: 'lib', app: 'app' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractGoWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Config');
+  });
+
+  it('skips repos without go.mod', async () => {
+    await writeFile('js-app/package.json', '{"name": "js-app"}');
+
+    const repos = { app: 'js-app' };
+    const repoPaths = new Map([['app', path.join(tmpDir, 'js-app')]]);
+
+    const result = await extractGoWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(0);
+    expect(result.discoveredModules.size).toBe(0);
+  });
+
+  it('deduplicates identical type usage from multiple files', async () => {
+    await writeFile(
+      'lib/go.mod',
+      'module github.com/org/lib\n\ngo 1.21\n',
+    );
+    await writeFile('lib/model.go', 'package lib\n\ntype Model struct {}\n');
+
+    await writeFile(
+      'app/go.mod',
+      'module github.com/org/app\n\ngo 1.21\n\nrequire github.com/org/lib v0.1.0\n',
+    );
+    await writeFile(
+      'app/a.go',
+      'package main\n\nimport "github.com/org/lib"\n\nvar x lib.Model\n',
+    );
+    await writeFile(
+      'app/b.go',
+      'package main\n\nimport "github.com/org/lib"\n\nvar y lib.Model\n',
+    );
+
+    const repos = { lib: 'lib', app: 'app' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractGoWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+  });
+
+  it('discovers multiple types from the same module', async () => {
+    await writeFile(
+      'lib/go.mod',
+      'module github.com/org/lib\n\ngo 1.21\n',
+    );
+    await writeFile(
+      'lib/types.go',
+      'package lib\n\ntype Request struct {}\ntype Response struct {}\n',
+    );
+
+    await writeFile(
+      'app/go.mod',
+      'module github.com/org/app\n\ngo 1.21\n\nrequire github.com/org/lib v0.1.0\n',
+    );
+    await writeFile(
+      'app/main.go',
+      'package main\n\nimport "github.com/org/lib"\n\nfunc handle(r lib.Request) lib.Response { return lib.Response{} }\n',
+    );
+
+    const repos = { lib: 'lib', app: 'app' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractGoWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(2);
+    const contracts = result.links.map((l) => l.contract).sort();
+    expect(contracts).toEqual(['Request', 'Response']);
+  });
+});

--- a/gitnexus/test/unit/group/go-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/go-workspace-extractor.test.ts
@@ -22,14 +22,8 @@ describe('GoWorkspaceExtractor', () => {
   }
 
   it('discovers cross-module type usage via require', async () => {
-    await writeFile(
-      'models/go.mod',
-      'module github.com/org/models\n\ngo 1.21\n',
-    );
-    await writeFile(
-      'models/schema.go',
-      'package models\n\ntype Schema struct {}\n',
-    );
+    await writeFile('models/go.mod', 'module github.com/org/models\n\ngo 1.21\n');
+    await writeFile('models/schema.go', 'package models\n\ntype Schema struct {}\n');
 
     await writeFile(
       'api/go.mod',
@@ -62,10 +56,7 @@ describe('GoWorkspaceExtractor', () => {
   });
 
   it('handles block require syntax', async () => {
-    await writeFile(
-      'auth/go.mod',
-      'module github.com/org/auth\n\ngo 1.21\n',
-    );
+    await writeFile('auth/go.mod', 'module github.com/org/auth\n\ngo 1.21\n');
     await writeFile('auth/token.go', 'package auth\n\ntype Token struct {}\n');
 
     await writeFile(
@@ -90,14 +81,8 @@ describe('GoWorkspaceExtractor', () => {
   });
 
   it('handles subpackage imports (module/pkg)', async () => {
-    await writeFile(
-      'core/go.mod',
-      'module github.com/org/core\n\ngo 1.21\n',
-    );
-    await writeFile(
-      'core/types/entity.go',
-      'package types\n\ntype Entity struct {}\n',
-    );
+    await writeFile('core/go.mod', 'module github.com/org/core\n\ngo 1.21\n');
+    await writeFile('core/types/entity.go', 'package types\n\ntype Entity struct {}\n');
 
     await writeFile(
       'app/go.mod',
@@ -121,10 +106,7 @@ describe('GoWorkspaceExtractor', () => {
   });
 
   it('handles replace directive with local paths', async () => {
-    await writeFile(
-      'lib/go.mod',
-      'module github.com/org/lib\n\ngo 1.21\n',
-    );
+    await writeFile('lib/go.mod', 'module github.com/org/lib\n\ngo 1.21\n');
     await writeFile('lib/config.go', 'package lib\n\ntype Config struct {}\n');
 
     await writeFile(
@@ -149,14 +131,8 @@ describe('GoWorkspaceExtractor', () => {
   });
 
   it('ignores unexported (lowercase) identifiers', async () => {
-    await writeFile(
-      'lib/go.mod',
-      'module github.com/org/lib\n\ngo 1.21\n',
-    );
-    await writeFile(
-      'lib/util.go',
-      'package lib\n\nfunc helper() {}\ntype Config struct {}\n',
-    );
+    await writeFile('lib/go.mod', 'module github.com/org/lib\n\ngo 1.21\n');
+    await writeFile('lib/util.go', 'package lib\n\nfunc helper() {}\ntype Config struct {}\n');
 
     await writeFile(
       'app/go.mod',
@@ -192,24 +168,15 @@ describe('GoWorkspaceExtractor', () => {
   });
 
   it('deduplicates identical type usage from multiple files', async () => {
-    await writeFile(
-      'lib/go.mod',
-      'module github.com/org/lib\n\ngo 1.21\n',
-    );
+    await writeFile('lib/go.mod', 'module github.com/org/lib\n\ngo 1.21\n');
     await writeFile('lib/model.go', 'package lib\n\ntype Model struct {}\n');
 
     await writeFile(
       'app/go.mod',
       'module github.com/org/app\n\ngo 1.21\n\nrequire github.com/org/lib v0.1.0\n',
     );
-    await writeFile(
-      'app/a.go',
-      'package main\n\nimport "github.com/org/lib"\n\nvar x lib.Model\n',
-    );
-    await writeFile(
-      'app/b.go',
-      'package main\n\nimport "github.com/org/lib"\n\nvar y lib.Model\n',
-    );
+    await writeFile('app/a.go', 'package main\n\nimport "github.com/org/lib"\n\nvar x lib.Model\n');
+    await writeFile('app/b.go', 'package main\n\nimport "github.com/org/lib"\n\nvar y lib.Model\n');
 
     const repos = { lib: 'lib', app: 'app' };
     const repoPaths = new Map([
@@ -223,10 +190,7 @@ describe('GoWorkspaceExtractor', () => {
   });
 
   it('discovers multiple types from the same module', async () => {
-    await writeFile(
-      'lib/go.mod',
-      'module github.com/org/lib\n\ngo 1.21\n',
-    );
+    await writeFile('lib/go.mod', 'module github.com/org/lib\n\ngo 1.21\n');
     await writeFile(
       'lib/types.go',
       'package lib\n\ntype Request struct {}\ntype Response struct {}\n',

--- a/gitnexus/test/unit/group/go-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/go-workspace-extractor.test.ts
@@ -56,7 +56,7 @@ describe('GoWorkspaceExtractor', () => {
       from: 'libs/models',
       to: 'services/api',
       type: 'custom',
-      contract: 'Schema',
+      contract: 'models::Schema',
       role: 'provider',
     });
   });
@@ -86,7 +86,7 @@ describe('GoWorkspaceExtractor', () => {
     const result = await extractGoWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Token');
+    expect(result.links[0].contract).toBe('auth::Token');
   });
 
   it('handles subpackage imports (module/pkg)', async () => {
@@ -117,7 +117,7 @@ describe('GoWorkspaceExtractor', () => {
     const result = await extractGoWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Entity');
+    expect(result.links[0].contract).toBe('core::Entity');
   });
 
   it('handles replace directive with local paths', async () => {
@@ -145,7 +145,7 @@ describe('GoWorkspaceExtractor', () => {
     const result = await extractGoWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Config');
+    expect(result.links[0].contract).toBe('lib::Config');
   });
 
   it('ignores unexported (lowercase) identifiers', async () => {
@@ -176,7 +176,7 @@ describe('GoWorkspaceExtractor', () => {
     const result = await extractGoWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Config');
+    expect(result.links[0].contract).toBe('lib::Config');
   });
 
   it('skips repos without go.mod', async () => {
@@ -251,6 +251,6 @@ describe('GoWorkspaceExtractor', () => {
 
     expect(result.links).toHaveLength(2);
     const contracts = result.links.map((l) => l.contract).sort();
-    expect(contracts).toEqual(['Request', 'Response']);
+    expect(contracts).toEqual(['lib::Request', 'lib::Response']);
   });
 });

--- a/gitnexus/test/unit/group/go-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/go-workspace-extractor.test.ts
@@ -50,7 +50,7 @@ describe('GoWorkspaceExtractor', () => {
       from: 'libs/models',
       to: 'services/api',
       type: 'custom',
-      contract: 'models::Schema',
+      contract: 'github.com/org/models::Schema',
       role: 'provider',
     });
   });
@@ -77,7 +77,7 @@ describe('GoWorkspaceExtractor', () => {
     const result = await extractGoWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('auth::Token');
+    expect(result.links[0].contract).toBe('github.com/org/auth::Token');
   });
 
   it('handles subpackage imports (module/pkg)', async () => {
@@ -102,7 +102,7 @@ describe('GoWorkspaceExtractor', () => {
     const result = await extractGoWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('core::Entity');
+    expect(result.links[0].contract).toBe('github.com/org/core::Entity');
   });
 
   it('handles replace directive with local paths', async () => {
@@ -127,7 +127,7 @@ describe('GoWorkspaceExtractor', () => {
     const result = await extractGoWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('lib::Config');
+    expect(result.links[0].contract).toBe('github.com/org/lib::Config');
   });
 
   it('ignores unexported (lowercase) identifiers', async () => {
@@ -152,7 +152,7 @@ describe('GoWorkspaceExtractor', () => {
     const result = await extractGoWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('lib::Config');
+    expect(result.links[0].contract).toBe('github.com/org/lib::Config');
   });
 
   it('skips repos without go.mod', async () => {
@@ -215,6 +215,6 @@ describe('GoWorkspaceExtractor', () => {
 
     expect(result.links).toHaveLength(2);
     const contracts = result.links.map((l) => l.contract).sort();
-    expect(contracts).toEqual(['lib::Request', 'lib::Response']);
+    expect(contracts).toEqual(['github.com/org/lib::Request', 'github.com/org/lib::Response']);
   });
 });

--- a/gitnexus/test/unit/group/java-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/java-workspace-extractor.test.ts
@@ -38,10 +38,7 @@ describe('JavaWorkspaceExtractor', () => {
       'package com.acme.models;\npublic class User {}\n',
     );
 
-    await writeFile(
-      'api/pom.xml',
-      pomTemplate('com.acme', 'api', ['com.acme:models']),
-    );
+    await writeFile('api/pom.xml', pomTemplate('com.acme', 'api', ['com.acme:models']));
     await writeFile(
       'api/src/main/java/com/acme/api/UserService.java',
       'package com.acme.api;\nimport com.acme.models.User;\npublic class UserService {}\n',
@@ -66,10 +63,7 @@ describe('JavaWorkspaceExtractor', () => {
   });
 
   it('handles Gradle build files', async () => {
-    await writeFile(
-      'core/build.gradle.kts',
-      "group = \"com.acme\"\nversion = \"1.0\"\n",
-    );
+    await writeFile('core/build.gradle.kts', 'group = "com.acme"\nversion = "1.0"\n');
     await writeFile(
       'core/src/main/java/com/acme/core/Config.java',
       'package com.acme.core;\npublic class Config {}\n',
@@ -77,7 +71,7 @@ describe('JavaWorkspaceExtractor', () => {
 
     await writeFile(
       'svc/build.gradle.kts',
-      "group = \"com.acme\"\nversion = \"1.0\"\ndependencies {\n  implementation(\"com.acme:core:1.0\")\n}\n",
+      'group = "com.acme"\nversion = "1.0"\ndependencies {\n  implementation("com.acme:core:1.0")\n}\n',
     );
     await writeFile(
       'svc/src/main/java/com/acme/svc/App.java',
@@ -97,10 +91,7 @@ describe('JavaWorkspaceExtractor', () => {
   });
 
   it('handles Gradle project dependencies', async () => {
-    await writeFile(
-      'common/build.gradle',
-      "group = 'com.org'\nversion = '1.0'\n",
-    );
+    await writeFile('common/build.gradle', "group = 'com.org'\nversion = '1.0'\n");
     await writeFile(
       'common/src/main/java/com/org/common/Entity.java',
       'package com.org.common;\npublic class Entity {}\n',
@@ -134,10 +125,7 @@ describe('JavaWorkspaceExtractor', () => {
       'package com.acme.lib;\npublic class Constants {}\n',
     );
 
-    await writeFile(
-      'app/pom.xml',
-      pomTemplate('com.acme', 'app', ['com.acme:lib']),
-    );
+    await writeFile('app/pom.xml', pomTemplate('com.acme', 'app', ['com.acme:lib']));
     await writeFile(
       'app/src/main/java/com/acme/app/Main.java',
       'package com.acme.app;\nimport static com.acme.lib.Constants;\npublic class Main {}\n',
@@ -174,10 +162,7 @@ describe('JavaWorkspaceExtractor', () => {
       'package com.acme.lib;\npublic class Token {}\n',
     );
 
-    await writeFile(
-      'app/pom.xml',
-      pomTemplate('com.acme', 'app', ['com.acme:lib']),
-    );
+    await writeFile('app/pom.xml', pomTemplate('com.acme', 'app', ['com.acme:lib']));
     await writeFile(
       'app/src/main/java/com/acme/app/A.java',
       'package com.acme.app;\nimport com.acme.lib.Token;\npublic class A {}\n',
@@ -205,10 +190,7 @@ describe('JavaWorkspaceExtractor', () => {
       'package com.acme.lib\ndata class Model(val id: Int)\n',
     );
 
-    await writeFile(
-      'app/pom.xml',
-      pomTemplate('com.acme', 'app', ['com.acme:lib']),
-    );
+    await writeFile('app/pom.xml', pomTemplate('com.acme', 'app', ['com.acme:lib']));
     await writeFile(
       'app/src/main/kotlin/com/acme/app/Main.kt',
       'package com.acme.app\nimport com.acme.lib.Model\nfun main() {}\n',
@@ -237,10 +219,7 @@ describe('JavaWorkspaceExtractor', () => {
       'package com.acme.lib;\npublic class Response {}\n',
     );
 
-    await writeFile(
-      'app/pom.xml',
-      pomTemplate('com.acme', 'app', ['com.acme:lib']),
-    );
+    await writeFile('app/pom.xml', pomTemplate('com.acme', 'app', ['com.acme:lib']));
     await writeFile(
       'app/src/main/java/com/acme/app/Handler.java',
       'package com.acme.app;\nimport com.acme.lib.Request;\nimport com.acme.lib.Response;\npublic class Handler {}\n',

--- a/gitnexus/test/unit/group/java-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/java-workspace-extractor.test.ts
@@ -60,7 +60,7 @@ describe('JavaWorkspaceExtractor', () => {
       from: 'models',
       to: 'api',
       type: 'custom',
-      contract: 'User',
+      contract: 'models::User',
       role: 'provider',
     });
   });
@@ -93,7 +93,7 @@ describe('JavaWorkspaceExtractor', () => {
     const result = await extractJavaWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Config');
+    expect(result.links[0].contract).toBe('core::Config');
   });
 
   it('handles Gradle project dependencies', async () => {
@@ -124,7 +124,7 @@ describe('JavaWorkspaceExtractor', () => {
     const result = await extractJavaWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Entity');
+    expect(result.links[0].contract).toBe('common::Entity');
   });
 
   it('handles static imports', async () => {
@@ -152,7 +152,7 @@ describe('JavaWorkspaceExtractor', () => {
     const result = await extractJavaWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Constants');
+    expect(result.links[0].contract).toBe('lib::Constants');
   });
 
   it('skips repos without Java manifest', async () => {
@@ -223,7 +223,7 @@ describe('JavaWorkspaceExtractor', () => {
     const result = await extractJavaWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Model');
+    expect(result.links[0].contract).toBe('lib::Model');
   });
 
   it('discovers multiple types from the same dependency', async () => {
@@ -256,6 +256,6 @@ describe('JavaWorkspaceExtractor', () => {
 
     expect(result.links).toHaveLength(2);
     const contracts = result.links.map((l) => l.contract).sort();
-    expect(contracts).toEqual(['Request', 'Response']);
+    expect(contracts).toEqual(['lib::Request', 'lib::Response']);
   });
 });

--- a/gitnexus/test/unit/group/java-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/java-workspace-extractor.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { extractJavaWorkspaceLinks } from '../../../src/core/group/extractors/java-workspace-extractor.js';
+
+describe('JavaWorkspaceExtractor', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-java-ws-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeFile(relPath: string, content: string) {
+    const absPath = path.join(tmpDir, relPath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, content, 'utf-8');
+  }
+
+  const pomTemplate = (g: string, a: string, deps: string[] = []) => {
+    const depXml = deps
+      .map((d) => {
+        const [gid, aid] = d.split(':');
+        return `<dependency><groupId>${gid}</groupId><artifactId>${aid}</artifactId></dependency>`;
+      })
+      .join('\n');
+    return `<project><groupId>${g}</groupId><artifactId>${a}</artifactId><dependencies>${depXml}</dependencies></project>`;
+  };
+
+  it('discovers cross-project imports via Maven pom.xml', async () => {
+    await writeFile('models/pom.xml', pomTemplate('com.acme', 'models'));
+    await writeFile(
+      'models/src/main/java/com/acme/models/User.java',
+      'package com.acme.models;\npublic class User {}\n',
+    );
+
+    await writeFile(
+      'api/pom.xml',
+      pomTemplate('com.acme', 'api', ['com.acme:models']),
+    );
+    await writeFile(
+      'api/src/main/java/com/acme/api/UserService.java',
+      'package com.acme.api;\nimport com.acme.models.User;\npublic class UserService {}\n',
+    );
+
+    const repos = { models: 'models', api: 'api' };
+    const repoPaths = new Map([
+      ['models', path.join(tmpDir, 'models')],
+      ['api', path.join(tmpDir, 'api')],
+    ]);
+
+    const result = await extractJavaWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0]).toEqual({
+      from: 'models',
+      to: 'api',
+      type: 'custom',
+      contract: 'User',
+      role: 'provider',
+    });
+  });
+
+  it('handles Gradle build files', async () => {
+    await writeFile(
+      'core/build.gradle.kts',
+      "group = \"com.acme\"\nversion = \"1.0\"\n",
+    );
+    await writeFile(
+      'core/src/main/java/com/acme/core/Config.java',
+      'package com.acme.core;\npublic class Config {}\n',
+    );
+
+    await writeFile(
+      'svc/build.gradle.kts',
+      "group = \"com.acme\"\nversion = \"1.0\"\ndependencies {\n  implementation(\"com.acme:core:1.0\")\n}\n",
+    );
+    await writeFile(
+      'svc/src/main/java/com/acme/svc/App.java',
+      'package com.acme.svc;\nimport com.acme.core.Config;\npublic class App {}\n',
+    );
+
+    const repos = { core: 'core', svc: 'svc' };
+    const repoPaths = new Map([
+      ['core', path.join(tmpDir, 'core')],
+      ['svc', path.join(tmpDir, 'svc')],
+    ]);
+
+    const result = await extractJavaWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Config');
+  });
+
+  it('handles Gradle project dependencies', async () => {
+    await writeFile(
+      'common/build.gradle',
+      "group = 'com.org'\nversion = '1.0'\n",
+    );
+    await writeFile(
+      'common/src/main/java/com/org/common/Entity.java',
+      'package com.org.common;\npublic class Entity {}\n',
+    );
+
+    await writeFile(
+      'app/build.gradle',
+      "group = 'com.org'\nversion = '1.0'\ndependencies {\n  implementation(project(':common'))\n}\n",
+    );
+    await writeFile(
+      'app/src/main/java/com/org/app/Main.java',
+      'package com.org.app;\nimport com.org.common.Entity;\npublic class Main {}\n',
+    );
+
+    const repos = { common: 'common', app: 'app' };
+    const repoPaths = new Map([
+      ['common', path.join(tmpDir, 'common')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractJavaWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Entity');
+  });
+
+  it('handles static imports', async () => {
+    await writeFile('lib/pom.xml', pomTemplate('com.acme', 'lib'));
+    await writeFile(
+      'lib/src/main/java/com/acme/lib/Constants.java',
+      'package com.acme.lib;\npublic class Constants {}\n',
+    );
+
+    await writeFile(
+      'app/pom.xml',
+      pomTemplate('com.acme', 'app', ['com.acme:lib']),
+    );
+    await writeFile(
+      'app/src/main/java/com/acme/app/Main.java',
+      'package com.acme.app;\nimport static com.acme.lib.Constants;\npublic class Main {}\n',
+    );
+
+    const repos = { lib: 'lib', app: 'app' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractJavaWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Constants');
+  });
+
+  it('skips repos without Java manifest', async () => {
+    await writeFile('rs-app/Cargo.toml', '[package]\nname = "rapp"\n');
+
+    const repos = { app: 'rapp' };
+    const repoPaths = new Map([['app', path.join(tmpDir, 'rs-app')]]);
+
+    const result = await extractJavaWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(0);
+    expect(result.discoveredProjects.size).toBe(0);
+  });
+
+  it('deduplicates identical imports from multiple files', async () => {
+    await writeFile('lib/pom.xml', pomTemplate('com.acme', 'lib'));
+    await writeFile(
+      'lib/src/main/java/com/acme/lib/Token.java',
+      'package com.acme.lib;\npublic class Token {}\n',
+    );
+
+    await writeFile(
+      'app/pom.xml',
+      pomTemplate('com.acme', 'app', ['com.acme:lib']),
+    );
+    await writeFile(
+      'app/src/main/java/com/acme/app/A.java',
+      'package com.acme.app;\nimport com.acme.lib.Token;\npublic class A {}\n',
+    );
+    await writeFile(
+      'app/src/main/java/com/acme/app/B.java',
+      'package com.acme.app;\nimport com.acme.lib.Token;\npublic class B {}\n',
+    );
+
+    const repos = { lib: 'lib', app: 'app' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractJavaWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+  });
+
+  it('discovers Kotlin file imports from Java projects', async () => {
+    await writeFile('lib/pom.xml', pomTemplate('com.acme', 'lib'));
+    await writeFile(
+      'lib/src/main/kotlin/com/acme/lib/Model.kt',
+      'package com.acme.lib\ndata class Model(val id: Int)\n',
+    );
+
+    await writeFile(
+      'app/pom.xml',
+      pomTemplate('com.acme', 'app', ['com.acme:lib']),
+    );
+    await writeFile(
+      'app/src/main/kotlin/com/acme/app/Main.kt',
+      'package com.acme.app\nimport com.acme.lib.Model\nfun main() {}\n',
+    );
+
+    const repos = { lib: 'lib', app: 'app' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractJavaWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Model');
+  });
+
+  it('discovers multiple types from the same dependency', async () => {
+    await writeFile('lib/pom.xml', pomTemplate('com.acme', 'lib'));
+    await writeFile(
+      'lib/src/main/java/com/acme/lib/Request.java',
+      'package com.acme.lib;\npublic class Request {}\n',
+    );
+    await writeFile(
+      'lib/src/main/java/com/acme/lib/Response.java',
+      'package com.acme.lib;\npublic class Response {}\n',
+    );
+
+    await writeFile(
+      'app/pom.xml',
+      pomTemplate('com.acme', 'app', ['com.acme:lib']),
+    );
+    await writeFile(
+      'app/src/main/java/com/acme/app/Handler.java',
+      'package com.acme.app;\nimport com.acme.lib.Request;\nimport com.acme.lib.Response;\npublic class Handler {}\n',
+    );
+
+    const repos = { lib: 'lib', app: 'app' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractJavaWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(2);
+    const contracts = result.links.map((l) => l.contract).sort();
+    expect(contracts).toEqual(['Request', 'Response']);
+  });
+});

--- a/gitnexus/test/unit/group/manifest-extractor.test.ts
+++ b/gitnexus/test/unit/group/manifest-extractor.test.ts
@@ -596,7 +596,7 @@ describe('ManifestExtractor', () => {
       [
         'engine/thales',
         async (_cypher, params) => {
-          if (params?.contract === 'Expression') {
+          if (params?.symbolName === 'Expression') {
             return [
               {
                 uid: 'uid-expression-struct',
@@ -611,7 +611,7 @@ describe('ManifestExtractor', () => {
       [
         'parser/mathlex',
         async (_cypher, params) => {
-          if (params?.contract === 'Expression') {
+          if (params?.symbolName === 'Expression') {
             return [
               {
                 uid: 'uid-expression-enum',
@@ -638,6 +638,42 @@ describe('ManifestExtractor', () => {
 
     expect(result.crossLinks).toHaveLength(1);
     expect(result.crossLinks[0].matchType).toBe('manifest');
+  });
+
+  it('custom contract with qualified name (provider::Symbol) strips prefix before graph query', async () => {
+    const links: GroupManifestLink[] = [
+      {
+        from: 'parser/mathlex',
+        to: 'engine/thales',
+        type: 'custom',
+        contract: 'mathlex::Expression',
+        role: 'provider',
+      },
+    ];
+
+    let capturedParams: Record<string, unknown> | undefined;
+    const dbExecutors = new Map<
+      string,
+      (cypher: string, params?: Record<string, unknown>) => Promise<Record<string, unknown>[]>
+    >([
+      [
+        'parser/mathlex',
+        async (_cypher, params) => {
+          capturedParams = params;
+          if (params?.symbolName === 'Expression') {
+            return [{ uid: 'uid-expr', name: 'Expression', filePath: 'src/ast.rs' }];
+          }
+          return [];
+        },
+      ],
+      ['engine/thales', async () => []],
+    ]);
+
+    const result = await extractor.extractFromManifest(links, dbExecutors);
+    const provider = result.contracts.find((c) => c.role === 'provider');
+
+    expect(capturedParams?.symbolName).toBe('Expression');
+    expect(provider?.symbolUid).toBe('uid-expr');
   });
 
   it('falls back to synthetic uid when custom symbol not found in graph', async () => {
@@ -714,7 +750,7 @@ describe('ManifestExtractor', () => {
       [
         'parser/mathlex',
         async (_cypher, params) => {
-          if (params?.contract === 'Token') {
+          if (params?.symbolName === 'Token') {
             return [{ uid: 'uid-token-first', name: 'Token', filePath: 'src/ast.rs' }];
           }
           return [];
@@ -723,7 +759,7 @@ describe('ManifestExtractor', () => {
       [
         'engine/thales',
         async (_cypher, params) => {
-          if (params?.contract === 'Token') {
+          if (params?.symbolName === 'Token') {
             return [{ uid: 'uid-token-consumer', name: 'Token', filePath: 'src/lexer.rs' }];
           }
           return [];

--- a/gitnexus/test/unit/group/node-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/node-workspace-extractor.test.ts
@@ -95,10 +95,7 @@ describe('NodeWorkspaceExtractor', () => {
   });
 
   it('handles CommonJS destructured require', async () => {
-    await writeFile(
-      'lib/package.json',
-      JSON.stringify({ name: 'auth-lib', version: '1.0.0' }),
-    );
+    await writeFile('lib/package.json', JSON.stringify({ name: 'auth-lib', version: '1.0.0' }));
     await writeFile('lib/src/index.js', 'module.exports = { Authenticator: class {} };\n');
 
     await writeFile(
@@ -109,10 +106,7 @@ describe('NodeWorkspaceExtractor', () => {
         dependencies: { 'auth-lib': 'workspace:*' },
       }),
     );
-    await writeFile(
-      'svc/src/handler.js',
-      "const { Authenticator } = require('auth-lib');\n",
-    );
+    await writeFile('svc/src/handler.js', "const { Authenticator } = require('auth-lib');\n");
 
     const repos = { lib: 'auth-lib', svc: 'api-svc' };
     const repoPaths = new Map([
@@ -127,10 +121,7 @@ describe('NodeWorkspaceExtractor', () => {
   });
 
   it('handles scoped package imports with subpaths', async () => {
-    await writeFile(
-      'core/package.json',
-      JSON.stringify({ name: '@acme/core', version: '2.0.0' }),
-    );
+    await writeFile('core/package.json', JSON.stringify({ name: '@acme/core', version: '2.0.0' }));
     await writeFile('core/src/models.ts', 'export class User {}\n');
 
     await writeFile(
@@ -141,10 +132,7 @@ describe('NodeWorkspaceExtractor', () => {
         dependencies: { '@acme/core': 'workspace:*' },
       }),
     );
-    await writeFile(
-      'web/src/routes.ts',
-      "import { User } from '@acme/core/models';\n",
-    );
+    await writeFile('web/src/routes.ts', "import { User } from '@acme/core/models';\n");
 
     const repos = { core: '@acme/core', web: '@acme/web' };
     const repoPaths = new Map([
@@ -159,10 +147,7 @@ describe('NodeWorkspaceExtractor', () => {
   });
 
   it('ignores camelCase/snake_case imports (non-type exports)', async () => {
-    await writeFile(
-      'lib/package.json',
-      JSON.stringify({ name: 'utils', version: '1.0.0' }),
-    );
+    await writeFile('lib/package.json', JSON.stringify({ name: 'utils', version: '1.0.0' }));
     await writeFile('lib/src/index.ts', 'export function helper() {}\nexport class Formatter {}\n');
 
     await writeFile(
@@ -173,10 +158,7 @@ describe('NodeWorkspaceExtractor', () => {
         dependencies: { utils: 'workspace:*' },
       }),
     );
-    await writeFile(
-      'app/src/main.ts',
-      "import { helper, Formatter } from 'utils';\n",
-    );
+    await writeFile('app/src/main.ts', "import { helper, Formatter } from 'utils';\n");
 
     const repos = { lib: 'utils', app: 'myapp' };
     const repoPaths = new Map([
@@ -204,10 +186,7 @@ describe('NodeWorkspaceExtractor', () => {
   });
 
   it('deduplicates identical imports from multiple files', async () => {
-    await writeFile(
-      'lib/package.json',
-      JSON.stringify({ name: 'shared', version: '1.0.0' }),
-    );
+    await writeFile('lib/package.json', JSON.stringify({ name: 'shared', version: '1.0.0' }));
     await writeFile('lib/src/index.ts', 'export class Config {}\n');
 
     await writeFile(
@@ -233,10 +212,7 @@ describe('NodeWorkspaceExtractor', () => {
   });
 
   it('handles aliased imports (import { Foo as Bar })', async () => {
-    await writeFile(
-      'lib/package.json',
-      JSON.stringify({ name: 'models', version: '1.0.0' }),
-    );
+    await writeFile('lib/package.json', JSON.stringify({ name: 'models', version: '1.0.0' }));
     await writeFile('lib/src/index.ts', 'export class Entity {}\n');
 
     await writeFile(
@@ -247,10 +223,7 @@ describe('NodeWorkspaceExtractor', () => {
         dependencies: { models: 'workspace:*' },
       }),
     );
-    await writeFile(
-      'app/src/main.ts',
-      "import { Entity as BaseEntity } from 'models';\n",
-    );
+    await writeFile('app/src/main.ts', "import { Entity as BaseEntity } from 'models';\n");
 
     const repos = { lib: 'models', app: 'myapp' };
     const repoPaths = new Map([

--- a/gitnexus/test/unit/group/node-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/node-workspace-extractor.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { extractNodeWorkspaceLinks } from '../../../src/core/group/extractors/node-workspace-extractor.js';
+
+describe('NodeWorkspaceExtractor', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-node-ws-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeFile(relPath: string, content: string) {
+    const absPath = path.join(tmpDir, relPath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, content, 'utf-8');
+  }
+
+  it('discovers cross-package ES imports', async () => {
+    await writeFile(
+      'pkg-a/package.json',
+      JSON.stringify({ name: '@myorg/shared', version: '1.0.0' }),
+    );
+    await writeFile('pkg-a/src/index.ts', 'export class Config {}\nexport class Logger {}\n');
+
+    await writeFile(
+      'pkg-b/package.json',
+      JSON.stringify({
+        name: '@myorg/api',
+        version: '1.0.0',
+        dependencies: { '@myorg/shared': 'workspace:*' },
+      }),
+    );
+    await writeFile(
+      'pkg-b/src/server.ts',
+      "import { Config } from '@myorg/shared';\nconst c = new Config();\n",
+    );
+
+    const repos = {
+      'libs/shared': '@myorg/shared',
+      'services/api': '@myorg/api',
+    };
+    const repoPaths = new Map([
+      ['libs/shared', path.join(tmpDir, 'pkg-a')],
+      ['services/api', path.join(tmpDir, 'pkg-b')],
+    ]);
+
+    const result = await extractNodeWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0]).toEqual({
+      from: 'libs/shared',
+      to: 'services/api',
+      type: 'custom',
+      contract: 'Config',
+      role: 'provider',
+    });
+  });
+
+  it('handles default imports (PascalCase)', async () => {
+    await writeFile(
+      'ui-lib/package.json',
+      JSON.stringify({ name: 'ui-components', version: '1.0.0' }),
+    );
+    await writeFile('ui-lib/src/index.ts', 'export default class Button {}\n');
+
+    await writeFile(
+      'app/package.json',
+      JSON.stringify({
+        name: 'web-app',
+        version: '1.0.0',
+        dependencies: { 'ui-components': '^1.0.0' },
+      }),
+    );
+    await writeFile(
+      'app/src/page.tsx',
+      "import Button from 'ui-components';\nexport default function Page() { return <Button />; }\n",
+    );
+
+    const repos = { 'libs/ui': 'ui-components', 'apps/web': 'web-app' };
+    const repoPaths = new Map([
+      ['libs/ui', path.join(tmpDir, 'ui-lib')],
+      ['apps/web', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractNodeWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Button');
+  });
+
+  it('handles CommonJS destructured require', async () => {
+    await writeFile(
+      'lib/package.json',
+      JSON.stringify({ name: 'auth-lib', version: '1.0.0' }),
+    );
+    await writeFile('lib/src/index.js', 'module.exports = { Authenticator: class {} };\n');
+
+    await writeFile(
+      'svc/package.json',
+      JSON.stringify({
+        name: 'api-svc',
+        version: '1.0.0',
+        dependencies: { 'auth-lib': 'workspace:*' },
+      }),
+    );
+    await writeFile(
+      'svc/src/handler.js',
+      "const { Authenticator } = require('auth-lib');\n",
+    );
+
+    const repos = { lib: 'auth-lib', svc: 'api-svc' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['svc', path.join(tmpDir, 'svc')],
+    ]);
+
+    const result = await extractNodeWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Authenticator');
+  });
+
+  it('handles scoped package imports with subpaths', async () => {
+    await writeFile(
+      'core/package.json',
+      JSON.stringify({ name: '@acme/core', version: '2.0.0' }),
+    );
+    await writeFile('core/src/models.ts', 'export class User {}\n');
+
+    await writeFile(
+      'web/package.json',
+      JSON.stringify({
+        name: '@acme/web',
+        version: '1.0.0',
+        dependencies: { '@acme/core': 'workspace:*' },
+      }),
+    );
+    await writeFile(
+      'web/src/routes.ts',
+      "import { User } from '@acme/core/models';\n",
+    );
+
+    const repos = { core: '@acme/core', web: '@acme/web' };
+    const repoPaths = new Map([
+      ['core', path.join(tmpDir, 'core')],
+      ['web', path.join(tmpDir, 'web')],
+    ]);
+
+    const result = await extractNodeWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('User');
+  });
+
+  it('ignores camelCase/snake_case imports (non-type exports)', async () => {
+    await writeFile(
+      'lib/package.json',
+      JSON.stringify({ name: 'utils', version: '1.0.0' }),
+    );
+    await writeFile('lib/src/index.ts', 'export function helper() {}\nexport class Formatter {}\n');
+
+    await writeFile(
+      'app/package.json',
+      JSON.stringify({
+        name: 'myapp',
+        version: '1.0.0',
+        dependencies: { utils: 'workspace:*' },
+      }),
+    );
+    await writeFile(
+      'app/src/main.ts',
+      "import { helper, Formatter } from 'utils';\n",
+    );
+
+    const repos = { lib: 'utils', app: 'myapp' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractNodeWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Formatter');
+  });
+
+  it('skips repos without package.json', async () => {
+    await writeFile('rust-app/Cargo.toml', '[package]\nname = "rapp"\nversion = "0.1.0"\n');
+    await writeFile('rust-app/src/main.rs', 'fn main() {}\n');
+
+    const repos = { app: 'rapp' };
+    const repoPaths = new Map([['app', path.join(tmpDir, 'rust-app')]]);
+
+    const result = await extractNodeWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(0);
+    expect(result.discoveredPackages.size).toBe(0);
+  });
+
+  it('deduplicates identical imports from multiple files', async () => {
+    await writeFile(
+      'lib/package.json',
+      JSON.stringify({ name: 'shared', version: '1.0.0' }),
+    );
+    await writeFile('lib/src/index.ts', 'export class Config {}\n');
+
+    await writeFile(
+      'app/package.json',
+      JSON.stringify({
+        name: 'myapp',
+        version: '1.0.0',
+        dependencies: { shared: 'workspace:*' },
+      }),
+    );
+    await writeFile('app/src/a.ts', "import { Config } from 'shared';\n");
+    await writeFile('app/src/b.ts', "import { Config } from 'shared';\n");
+
+    const repos = { lib: 'shared', app: 'myapp' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractNodeWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+  });
+
+  it('handles aliased imports (import { Foo as Bar })', async () => {
+    await writeFile(
+      'lib/package.json',
+      JSON.stringify({ name: 'models', version: '1.0.0' }),
+    );
+    await writeFile('lib/src/index.ts', 'export class Entity {}\n');
+
+    await writeFile(
+      'app/package.json',
+      JSON.stringify({
+        name: 'myapp',
+        version: '1.0.0',
+        dependencies: { models: 'workspace:*' },
+      }),
+    );
+    await writeFile(
+      'app/src/main.ts',
+      "import { Entity as BaseEntity } from 'models';\n",
+    );
+
+    const repos = { lib: 'models', app: 'myapp' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractNodeWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Entity');
+  });
+
+  it('handles multiple packages importing from the same provider', async () => {
+    await writeFile(
+      'shared/package.json',
+      JSON.stringify({ name: '@org/shared', version: '1.0.0' }),
+    );
+    await writeFile('shared/src/index.ts', 'export class Schema {}\n');
+
+    await writeFile(
+      'api/package.json',
+      JSON.stringify({
+        name: '@org/api',
+        version: '1.0.0',
+        dependencies: { '@org/shared': 'workspace:*' },
+      }),
+    );
+    await writeFile('api/src/index.ts', "import { Schema } from '@org/shared';\n");
+
+    await writeFile(
+      'worker/package.json',
+      JSON.stringify({
+        name: '@org/worker',
+        version: '1.0.0',
+        dependencies: { '@org/shared': 'workspace:*' },
+      }),
+    );
+    await writeFile('worker/src/index.ts', "import { Schema } from '@org/shared';\n");
+
+    const repos = {
+      libs: '@org/shared',
+      api: '@org/api',
+      worker: '@org/worker',
+    };
+    const repoPaths = new Map([
+      ['libs', path.join(tmpDir, 'shared')],
+      ['api', path.join(tmpDir, 'api')],
+      ['worker', path.join(tmpDir, 'worker')],
+    ]);
+
+    const result = await extractNodeWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(2);
+    const targets = result.links.map((l) => l.to).sort();
+    expect(targets).toEqual(['api', 'worker']);
+    expect(result.links.every((l) => l.contract === 'Schema')).toBe(true);
+  });
+});

--- a/gitnexus/test/unit/group/node-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/node-workspace-extractor.test.ts
@@ -57,7 +57,7 @@ describe('NodeWorkspaceExtractor', () => {
       from: 'libs/shared',
       to: 'services/api',
       type: 'custom',
-      contract: 'Config',
+      contract: '@myorg/shared::Config',
       role: 'provider',
     });
   });
@@ -91,7 +91,7 @@ describe('NodeWorkspaceExtractor', () => {
     const result = await extractNodeWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Button');
+    expect(result.links[0].contract).toBe('ui-components::Button');
   });
 
   it('handles CommonJS destructured require', async () => {
@@ -123,7 +123,7 @@ describe('NodeWorkspaceExtractor', () => {
     const result = await extractNodeWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Authenticator');
+    expect(result.links[0].contract).toBe('auth-lib::Authenticator');
   });
 
   it('handles scoped package imports with subpaths', async () => {
@@ -155,7 +155,7 @@ describe('NodeWorkspaceExtractor', () => {
     const result = await extractNodeWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('User');
+    expect(result.links[0].contract).toBe('@acme/core::User');
   });
 
   it('ignores camelCase/snake_case imports (non-type exports)', async () => {
@@ -187,7 +187,7 @@ describe('NodeWorkspaceExtractor', () => {
     const result = await extractNodeWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Formatter');
+    expect(result.links[0].contract).toBe('utils::Formatter');
   });
 
   it('skips repos without package.json', async () => {
@@ -261,7 +261,7 @@ describe('NodeWorkspaceExtractor', () => {
     const result = await extractNodeWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Entity');
+    expect(result.links[0].contract).toBe('models::Entity');
   });
 
   it('handles multiple packages importing from the same provider', async () => {
@@ -307,6 +307,6 @@ describe('NodeWorkspaceExtractor', () => {
     expect(result.links).toHaveLength(2);
     const targets = result.links.map((l) => l.to).sort();
     expect(targets).toEqual(['api', 'worker']);
-    expect(result.links.every((l) => l.contract === 'Schema')).toBe(true);
+    expect(result.links.every((l) => l.contract === '@org/shared::Schema')).toBe(true);
   });
 });

--- a/gitnexus/test/unit/group/python-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/python-workspace-extractor.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { extractPythonWorkspaceLinks } from '../../../src/core/group/extractors/python-workspace-extractor.js';
+
+describe('PythonWorkspaceExtractor', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-py-ws-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeFile(relPath: string, content: string) {
+    const absPath = path.join(tmpDir, relPath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, content, 'utf-8');
+  }
+
+  it('discovers cross-package imports via pyproject.toml', async () => {
+    await writeFile(
+      'models/pyproject.toml',
+      '[project]\nname = "shared-models"\nversion = "0.1.0"\ndependencies = []\n',
+    );
+    await writeFile('models/shared_models/__init__.py', 'class Schema: pass\n');
+
+    await writeFile(
+      'api/pyproject.toml',
+      '[project]\nname = "api-server"\nversion = "0.1.0"\ndependencies = [\n  "shared-models>=0.1.0",\n]\n',
+    );
+    await writeFile(
+      'api/api_server/main.py',
+      'from shared_models import Schema\n',
+    );
+
+    const repos = { models: 'shared-models', api: 'api-server' };
+    const repoPaths = new Map([
+      ['models', path.join(tmpDir, 'models')],
+      ['api', path.join(tmpDir, 'api')],
+    ]);
+
+    const result = await extractPythonWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0]).toEqual({
+      from: 'models',
+      to: 'api',
+      type: 'custom',
+      contract: 'Schema',
+      role: 'provider',
+    });
+  });
+
+  it('discovers imports via setup.py', async () => {
+    await writeFile(
+      'core/setup.py',
+      "from setuptools import setup\nsetup(name='mycore', version='1.0', install_requires=[])\n",
+    );
+    await writeFile('core/mycore/__init__.py', 'class Engine: pass\n');
+
+    await writeFile(
+      'app/setup.py',
+      "from setuptools import setup\nsetup(name='myapp', version='1.0', install_requires=['mycore>=1.0'])\n",
+    );
+    await writeFile('app/myapp/run.py', 'from mycore import Engine\n');
+
+    const repos = { core: 'mycore', app: 'myapp' };
+    const repoPaths = new Map([
+      ['core', path.join(tmpDir, 'core')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractPythonWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Engine');
+  });
+
+  it('handles hyphenated package names (normalized to underscore in imports)', async () => {
+    await writeFile(
+      'lib/pyproject.toml',
+      '[project]\nname = "my-utils"\nversion = "0.1.0"\ndependencies = []\n',
+    );
+    await writeFile('lib/my_utils/__init__.py', 'class Helper: pass\n');
+
+    await writeFile(
+      'svc/pyproject.toml',
+      '[project]\nname = "my-service"\nversion = "0.1.0"\ndependencies = [\n  "my-utils",\n]\n',
+    );
+    await writeFile('svc/my_service/main.py', 'from my_utils import Helper\n');
+
+    const repos = { lib: 'my-utils', svc: 'my-service' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['svc', path.join(tmpDir, 'svc')],
+    ]);
+
+    const result = await extractPythonWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Helper');
+  });
+
+  it('handles submodule imports (from pkg.sub import Class)', async () => {
+    await writeFile(
+      'lib/pyproject.toml',
+      '[project]\nname = "datalib"\nversion = "0.1.0"\ndependencies = []\n',
+    );
+    await writeFile('lib/datalib/models.py', 'class Record: pass\n');
+
+    await writeFile(
+      'app/pyproject.toml',
+      '[project]\nname = "myapp"\nversion = "0.1.0"\ndependencies = [\n  "datalib",\n]\n',
+    );
+    await writeFile('app/myapp/main.py', 'from datalib.models import Record\n');
+
+    const repos = { lib: 'datalib', app: 'myapp' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractPythonWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Record');
+  });
+
+  it('ignores snake_case imports (functions, not types)', async () => {
+    await writeFile(
+      'lib/pyproject.toml',
+      '[project]\nname = "utils"\nversion = "0.1.0"\ndependencies = []\n',
+    );
+    await writeFile('lib/utils/__init__.py', 'def helper(): pass\nclass Config: pass\n');
+
+    await writeFile(
+      'app/pyproject.toml',
+      '[project]\nname = "myapp"\nversion = "0.1.0"\ndependencies = [\n  "utils",\n]\n',
+    );
+    await writeFile('app/myapp/main.py', 'from utils import helper, Config\n');
+
+    const repos = { lib: 'utils', app: 'myapp' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractPythonWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Config');
+  });
+
+  it('skips repos without Python manifest', async () => {
+    await writeFile('js-app/package.json', '{"name": "js-app"}');
+
+    const repos = { app: 'js-app' };
+    const repoPaths = new Map([['app', path.join(tmpDir, 'js-app')]]);
+
+    const result = await extractPythonWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(0);
+    expect(result.discoveredPackages.size).toBe(0);
+  });
+
+  it('deduplicates identical imports from multiple files', async () => {
+    await writeFile(
+      'lib/pyproject.toml',
+      '[project]\nname = "shared"\nversion = "0.1.0"\ndependencies = []\n',
+    );
+    await writeFile('lib/shared/__init__.py', 'class Config: pass\n');
+
+    await writeFile(
+      'app/pyproject.toml',
+      '[project]\nname = "myapp"\nversion = "0.1.0"\ndependencies = [\n  "shared",\n]\n',
+    );
+    await writeFile('app/myapp/a.py', 'from shared import Config\n');
+    await writeFile('app/myapp/b.py', 'from shared import Config\n');
+
+    const repos = { lib: 'shared', app: 'myapp' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractPythonWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+  });
+
+  it('handles aliased imports (from pkg import Foo as Bar)', async () => {
+    await writeFile(
+      'lib/pyproject.toml',
+      '[project]\nname = "models"\nversion = "0.1.0"\ndependencies = []\n',
+    );
+    await writeFile('lib/models/__init__.py', 'class Entity: pass\n');
+
+    await writeFile(
+      'app/pyproject.toml',
+      '[project]\nname = "myapp"\nversion = "0.1.0"\ndependencies = [\n  "models",\n]\n',
+    );
+    await writeFile(
+      'app/myapp/main.py',
+      'from models import Entity as BaseEntity\n',
+    );
+
+    const repos = { lib: 'models', app: 'myapp' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractPythonWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Entity');
+  });
+
+  it('reads optional-dependencies from pyproject.toml', async () => {
+    await writeFile(
+      'lib/pyproject.toml',
+      '[project]\nname = "extras"\nversion = "0.1.0"\ndependencies = []\n',
+    );
+    await writeFile('lib/extras/__init__.py', 'class Plugin: pass\n');
+
+    await writeFile(
+      'app/pyproject.toml',
+      '[project]\nname = "myapp"\nversion = "0.1.0"\ndependencies = []\n\n[project.optional-dependencies]\ndev = [\n  "extras>=0.1",\n]\n',
+    );
+    await writeFile('app/myapp/main.py', 'from extras import Plugin\n');
+
+    const repos = { lib: 'extras', app: 'myapp' };
+    const repoPaths = new Map([
+      ['lib', path.join(tmpDir, 'lib')],
+      ['app', path.join(tmpDir, 'app')],
+    ]);
+
+    const result = await extractPythonWorkspaceLinks(repos, repoPaths);
+
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].contract).toBe('Plugin');
+  });
+});

--- a/gitnexus/test/unit/group/python-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/python-workspace-extractor.test.ts
@@ -32,10 +32,7 @@ describe('PythonWorkspaceExtractor', () => {
       'api/pyproject.toml',
       '[project]\nname = "api-server"\nversion = "0.1.0"\ndependencies = [\n  "shared-models>=0.1.0",\n]\n',
     );
-    await writeFile(
-      'api/api_server/main.py',
-      'from shared_models import Schema\n',
-    );
+    await writeFile('api/api_server/main.py', 'from shared_models import Schema\n');
 
     const repos = { models: 'shared-models', api: 'api-server' };
     const repoPaths = new Map([
@@ -203,10 +200,7 @@ describe('PythonWorkspaceExtractor', () => {
       'app/pyproject.toml',
       '[project]\nname = "myapp"\nversion = "0.1.0"\ndependencies = [\n  "models",\n]\n',
     );
-    await writeFile(
-      'app/myapp/main.py',
-      'from models import Entity as BaseEntity\n',
-    );
+    await writeFile('app/myapp/main.py', 'from models import Entity as BaseEntity\n');
 
     const repos = { lib: 'models', app: 'myapp' };
     const repoPaths = new Map([

--- a/gitnexus/test/unit/group/python-workspace-extractor.test.ts
+++ b/gitnexus/test/unit/group/python-workspace-extractor.test.ts
@@ -50,7 +50,7 @@ describe('PythonWorkspaceExtractor', () => {
       from: 'models',
       to: 'api',
       type: 'custom',
-      contract: 'Schema',
+      contract: 'shared-models::Schema',
       role: 'provider',
     });
   });
@@ -77,7 +77,7 @@ describe('PythonWorkspaceExtractor', () => {
     const result = await extractPythonWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Engine');
+    expect(result.links[0].contract).toBe('mycore::Engine');
   });
 
   it('handles hyphenated package names (normalized to underscore in imports)', async () => {
@@ -102,7 +102,7 @@ describe('PythonWorkspaceExtractor', () => {
     const result = await extractPythonWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Helper');
+    expect(result.links[0].contract).toBe('my-utils::Helper');
   });
 
   it('handles submodule imports (from pkg.sub import Class)', async () => {
@@ -127,7 +127,7 @@ describe('PythonWorkspaceExtractor', () => {
     const result = await extractPythonWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Record');
+    expect(result.links[0].contract).toBe('datalib::Record');
   });
 
   it('ignores snake_case imports (functions, not types)', async () => {
@@ -152,7 +152,7 @@ describe('PythonWorkspaceExtractor', () => {
     const result = await extractPythonWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Config');
+    expect(result.links[0].contract).toBe('utils::Config');
   });
 
   it('skips repos without Python manifest', async () => {
@@ -217,7 +217,7 @@ describe('PythonWorkspaceExtractor', () => {
     const result = await extractPythonWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Entity');
+    expect(result.links[0].contract).toBe('models::Entity');
   });
 
   it('reads optional-dependencies from pyproject.toml', async () => {
@@ -242,6 +242,6 @@ describe('PythonWorkspaceExtractor', () => {
     const result = await extractPythonWorkspaceLinks(repos, repoPaths);
 
     expect(result.links).toHaveLength(1);
-    expect(result.links[0].contract).toBe('Plugin');
+    expect(result.links[0].contract).toBe('extras::Plugin');
   });
 });

--- a/gitnexus/test/unit/group/sync.test.ts
+++ b/gitnexus/test/unit/group/sync.test.ts
@@ -25,6 +25,7 @@ describe('syncGroup', () => {
       topics: false,
       shared_libs: false,
       embedding_fallback: false,
+      workspace_deps: false,
     },
     matching: { bm25_threshold: 0.7, embedding_threshold: 0.65, max_candidates_per_step: 3 },
   });
@@ -523,7 +524,7 @@ describe('syncGroup', () => {
       });
 
       const manifestLinks = result.crossLinks.filter((cl) => cl.matchType === 'manifest');
-      expect(manifestLinks.length).toBeGreaterThanOrEqual(2);
+      expect(manifestLinks).toHaveLength(2);
 
       const contractIds = manifestLinks.map((cl) => cl.contractId);
       expect(contractIds).toContain('http::GET::/api/parse');
@@ -571,7 +572,7 @@ describe('syncGroup', () => {
       });
 
       const manifestLinks = result.crossLinks.filter((cl) => cl.matchType === 'manifest');
-      expect(manifestLinks.length).toBeGreaterThanOrEqual(1);
+      expect(manifestLinks).toHaveLength(1);
       const nodeLink = manifestLinks.find(
         (cl) => cl.contractId === 'custom::@myorg/shared::Config',
       );

--- a/gitnexus/test/unit/group/sync.test.ts
+++ b/gitnexus/test/unit/group/sync.test.ts
@@ -420,7 +420,7 @@ describe('syncGroup', () => {
       expect(manifestLinks[0].to.repo).toBe('parser/mathlex');
     });
 
-    it('workspace_deps: false skips Rust workspace extraction', async () => {
+    it('workspace_deps: false skips workspace extraction entirely', async () => {
       tmpDir = path.join(os.tmpdir(), `gitnexus-sync-ws-off-${Date.now()}`);
       fs.mkdirSync(tmpDir, { recursive: true });
 
@@ -528,6 +528,54 @@ describe('syncGroup', () => {
       const contractIds = manifestLinks.map((cl) => cl.contractId);
       expect(contractIds).toContain('http::GET::/api/parse');
       expect(contractIds).toContain('custom::mathlex::Expression');
+    });
+
+    it('discovers Node workspace links through syncGroup orchestrator', async () => {
+      tmpDir = path.join(os.tmpdir(), `gitnexus-sync-ws-node-${Date.now()}`);
+      fs.mkdirSync(tmpDir, { recursive: true });
+
+      writeFileSync('shared/package.json', '{"name": "@myorg/shared", "version": "1.0.0"}');
+      writeFileSync('shared/src/index.ts', 'export class Config {}\n');
+
+      writeFileSync(
+        'app/package.json',
+        '{"name": "@myorg/app", "version": "1.0.0", "dependencies": {"@myorg/shared": "workspace:*"}}',
+      );
+      writeFileSync('app/src/index.ts', "import { Config } from '@myorg/shared';\n");
+
+      const mockEntries: RegistryEntry[] = [
+        {
+          name: 'shared',
+          path: path.join(tmpDir, 'shared'),
+          storagePath: path.join(tmpDir, 'shared', '.gitnexus'),
+          indexedAt: '',
+          lastCommit: '',
+        },
+        {
+          name: 'app',
+          path: path.join(tmpDir, 'app'),
+          storagePath: path.join(tmpDir, 'app', '.gitnexus'),
+          indexedAt: '',
+          lastCommit: '',
+        },
+      ];
+
+      const repoManager = await import('../../../src/storage/repo-manager.js');
+      vi.spyOn(repoManager, 'readRegistry').mockResolvedValue(mockEntries);
+
+      const config = makeWsConfig({ 'pkg/shared': 'shared', 'pkg/app': 'app' }, true);
+
+      const result = await syncGroup(config, {
+        extractorOverride: async () => [],
+        skipWrite: true,
+      });
+
+      const manifestLinks = result.crossLinks.filter((cl) => cl.matchType === 'manifest');
+      expect(manifestLinks.length).toBeGreaterThanOrEqual(1);
+      const nodeLink = manifestLinks.find(
+        (cl) => cl.contractId === 'custom::@myorg/shared::Config',
+      );
+      expect(nodeLink).toBeDefined();
     });
   });
 });

--- a/gitnexus/test/unit/group/sync.test.ts
+++ b/gitnexus/test/unit/group/sync.test.ts
@@ -313,8 +313,7 @@ describe('syncGroup', () => {
   });
 
   it('writes registry to groupDir when skipWrite is false', async () => {
-    const tmpDir = path.join(os.tmpdir(), `gitnexus-sync-write-${Date.now()}`);
-    fs.mkdirSync(tmpDir, { recursive: true });
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-sync-write-'));
 
     try {
       const config = makeConfig({});
@@ -372,8 +371,7 @@ describe('syncGroup', () => {
     });
 
     it('workspace_deps: true discovers Rust crate links through syncGroup', async () => {
-      tmpDir = path.join(os.tmpdir(), `gitnexus-sync-ws-${Date.now()}`);
-      fs.mkdirSync(tmpDir, { recursive: true });
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-sync-ws-'));
 
       writeFileSync(
         'crate-a/Cargo.toml',
@@ -422,8 +420,7 @@ describe('syncGroup', () => {
     });
 
     it('workspace_deps: false skips workspace extraction entirely', async () => {
-      tmpDir = path.join(os.tmpdir(), `gitnexus-sync-ws-off-${Date.now()}`);
-      fs.mkdirSync(tmpDir, { recursive: true });
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-sync-ws-off-'));
 
       writeFileSync(
         'crate-a/Cargo.toml',
@@ -455,8 +452,7 @@ describe('syncGroup', () => {
     });
 
     it('discovered workspace links merge with explicit manifest links', async () => {
-      tmpDir = path.join(os.tmpdir(), `gitnexus-sync-ws-merge-${Date.now()}`);
-      fs.mkdirSync(tmpDir, { recursive: true });
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-sync-ws-merge-'));
 
       writeFileSync(
         'crate-a/Cargo.toml',
@@ -532,8 +528,7 @@ describe('syncGroup', () => {
     });
 
     it('discovers Node workspace links through syncGroup orchestrator', async () => {
-      tmpDir = path.join(os.tmpdir(), `gitnexus-sync-ws-node-${Date.now()}`);
-      fs.mkdirSync(tmpDir, { recursive: true });
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-sync-ws-node-'));
 
       writeFileSync('shared/package.json', '{"name": "@myorg/shared", "version": "1.0.0"}');
       writeFileSync('shared/src/index.ts', 'export class Config {}\n');


### PR DESCRIPTION
## Summary

- Add workspace dependency extractors for 5 ecosystems, completing cross-language workspace contract discovery alongside the existing Rust extractor (#1256)
- **Node/TS**: reads `package.json` dependencies, scans ES/CJS imports for PascalCase exports (scoped packages, subpaths, aliases)
- **Python**: reads `pyproject.toml`/`setup.py`, scans `from <pkg> import <Class>` (PEP 503 normalization, optional-dependencies)
- **Go**: reads `go.mod` require/replace, scans `pkg.TypeName` usage in source
- **Java/Kotlin**: reads Maven `pom.xml`/Gradle build files, scans `import` statements against derived base packages
- **Elixir**: reads `mix.exs` deps, scans `alias`/direct module references (umbrella, git, path deps, grouped aliases)
- Extract workspace orchestrator (`workspace-extractor.ts`) from sync.ts for clean extension point
- All extractors use shared `IgnoreService` (not hardcoded ignore lists), qualify contracts with provider name to prevent collisions, and warn on duplicate project names

## Dependencies

- ~~#1256 (Rust workspace extractor + `workspace_deps` flag + sync wiring)~~ — merged
- ~~#1254 (custom resolveSymbol)~~ — merged

Branch is rebased onto current `main` with both dependencies merged.

## Config

`workspace_deps` defaults to `false` — users opt in via `detect: { workspace_deps: true }` in `group.yaml`. This avoids silently adding 6-ecosystem scans to existing groups on upgrade.

## Known V1 limitations

- **Go**: aliased imports (`import cfg "..."`) produce false negatives — basename used as qualifier, not the alias
- **Java**: `deriveBasePackage` is heuristic — may miss non-standard Maven naming conventions
- **Python**: PEP 503 normalization incomplete (missing lowercase + `.` handling)
- **Node**: `devDependencies` included in scan — may produce non-production links
- **Elixir**: contract naming uses full module name (`MyApp.Config`) rather than `appName::Module` format

## Test plan

- [x] 42 new unit tests across 5 extractors (9+9+8+8+8), all passing
- [x] 11 Rust extractor tests still passing
- [x] TypeScript compiles with no errors
- [x] Full group test suite (382 tests) passes
- [x] Each extractor correctly skips repos without matching manifest
- [x] Contract names are qualified (e.g. `@myorg/shared::Config`, `mathlex::Expression`)
- [x] Qualified contracts resolve to real graph symbols (prefix stripped before query)
- [x] Duplicate project names produce warning and skip