### PR TITLE
chore(quality): exclude test/fixtures from CodeQL, ESLint, and Prettier

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,6 +60,10 @@ jobs:
               - 'gitnexus/vendor/**'
               - 'gitnexus/src/core/parsing/**/parser.c'
               - 'gitnexus/src/core/parsing/**/parser.js'
+              # Test fixtures are intentionally synthetic inputs (broken/unused
+              # code, malformed samples) used to exercise the analyzer. CodeQL
+              # findings here are noise, not real bugs.
+              - '**/test/fixtures/**'
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ dist/
 coverage/
 gitnexus/vendor/
 gitnexus/test/fixtures/
+gitnexus-web/test/fixtures/
 gitnexus-web/playwright-report/
 gitnexus-web/test-results/
 *.d.ts

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ export default [
       'gitnexus/vendor/**',
       'gitnexus-web/src/vendor/**',
       'gitnexus/test/fixtures/**',
+      'gitnexus-web/test/fixtures/**',
       'gitnexus-web/playwright-report/**',
       'gitnexus-web/test-results/**',
       '**/*.d.ts',


### PR DESCRIPTION
## Summary

Test fixtures are intentionally synthetic inputs (broken/unused code, malformed samples, deliberate edge cases) that exist to exercise the analyzer. Quality-tool findings on them are noise, not real bugs — and right now they're drowning out actionable signal in the GitHub Security tab (~75% of the 471 open CodeQL alerts originate in `test/fixtures/` and other test code).

This PR excludes `test/fixtures/**` from CodeQL, ESLint, and Prettier. Real test files (`*.test.ts`) remain in scope so genuine issues like `js/file-system-race` and `js/insecure-temporary-file` in test code still surface.

## Changes

- **`.github/workflows/codeql.yml`** — add `**/test/fixtures/**` to `paths-ignore` in the CodeQL config block.
- **`eslint.config.mjs`** — add `gitnexus-web/test/fixtures/**` to the global ignores block (the `gitnexus/` counterpart was already ignored; this closes the gap).
- **`.prettierignore`** — add `gitnexus-web/test/fixtures/` (same gap as ESLint).

`tsconfig.test.json` is intentionally left alone — fixtures are consumed as text inputs by tests, not built into the TS graph except for the two opt-outs that already exist.

## Expected impact

- Significant drop in CodeQL alerts on next scan (the `typescript-reexport-type/src/app.ts` `js/call-to-non-callable` errors and similar will disappear — they're fixtures designed to be broken).
- Cleaner `gitnexus-web/test/fixtures/` output from local `npm run lint` and pre-commit Prettier runs.

## Test plan

- [ ] CI runs CodeQL against this PR; confirm fewer fixture-origin alerts than baseline.
- [ ] `npm run lint` does not traverse `gitnexus-web/test/fixtures/`.
- [ ] `npx prettier --check .` does not flag files under either fixtures directory.