### PR TITLE
feat(Select mcp server): Add selection in mcp server command

### DIFF
--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -157,7 +157,8 @@ gitnexus analyze --skip-agents-md  # Preserve custom AGENTS.md/CLAUDE.md gitnexu
 gitnexus analyze --verbose       # Log skipped files when parsers are unavailable
 gitnexus analyze --max-file-size 1024  # Skip files larger than N KB (default: 512, cap: 32768)
 gitnexus analyze --worker-timeout 60  # Increase worker idle timeout for slow parses
-gitnexus mcp                     # Start MCP server (stdio) — serves all indexed repos
+gitnexus mcp                     # Start MCP server (stdio) — all indexed repos (default)
+gitnexus mcp --repos a,b         # Same, but only registry names a and b (also GITNEXUS_MCP_REPOS)
 gitnexus serve                   # Start local HTTP server (multi-repo) for web UI
 gitnexus index                   # Register an existing .gitnexus/ folder into the global registry
 gitnexus list                    # List all indexed repositories

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -91,7 +91,11 @@ program
 
 program
   .command('mcp')
-  .description('Start MCP server (stdio) — serves all indexed repos')
+  .description('Start MCP server (stdio) — serves indexed repos (optional subset via --repos)')
+  .option(
+    '--repos <names>',
+    'Comma-separated registry repo names to expose (default: all). Env: GITNEXUS_MCP_REPOS; CLI overrides env.',
+  )
   .action(createLazyAction(() => import('./mcp.js'), 'mcpCommand'));
 
 program

--- a/gitnexus/src/cli/mcp.ts
+++ b/gitnexus/src/cli/mcp.ts
@@ -2,14 +2,50 @@
  * MCP Command
  *
  * Starts the MCP server in standalone mode.
- * Loads all indexed repos from the global registry.
+ * Loads indexed repos from the global registry (optional subset via --repos).
  * No longer depends on cwd — works from any directory.
  */
 
 import { startMCPServer } from '../mcp/server.js';
-import { LocalBackend } from '../mcp/local/local-backend.js';
+import { LocalBackend, type LocalBackendOptions } from '../mcp/local/local-backend.js';
+import { listRegisteredRepos } from '../storage/repo-manager.js';
 
-export const mcpCommand = async () => {
+function parseMcpRepoAllowlistTokens(cliRepos: string | undefined): string {
+  const fromCli = cliRepos?.trim();
+  const fromEnv = process.env.GITNEXUS_MCP_REPOS?.trim();
+  return fromCli || fromEnv || '';
+}
+
+async function buildMcpBackendOptions(cliRepos?: string): Promise<LocalBackendOptions | undefined> {
+  const rawList = parseMcpRepoAllowlistTokens(cliRepos);
+  if (!rawList) return undefined;
+
+  const tokens = rawList.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+  const entries = await listRegisteredRepos({ validate: true });
+  const registered = new Set(entries.map((e) => e.name.toLowerCase()));
+  const unknown = tokens.filter((t) => !registered.has(t.toLowerCase()));
+  if (unknown.length > 0) {
+    console.error(
+      `GitNexus: Unknown repo name(s) in --repos / GITNEXUS_MCP_REPOS: ${unknown.join(', ')}`,
+    );
+    const label = entries.map((e) => e.name).join(', ');
+    console.error(label ? `Registered repos: ${label}` : 'No repos registered yet.');
+    process.exit(1);
+  }
+
+  const seen = new Set<string>();
+  const matchedDisplay: string[] = [];
+  for (const t of tokens) {
+    const low = t.toLowerCase();
+    if (seen.has(low)) continue;
+    seen.add(low);
+    const entry = entries.find((e) => e.name.toLowerCase() === low);
+    if (entry) matchedDisplay.push(entry.name);
+  }
+  return { mcpRepoAllowlist: matchedDisplay };
+}
+
+export const mcpCommand = async (options?: { repos?: string }) => {
   // Prevent unhandled errors from crashing the MCP server process.
   // LadybugDB lock conflicts and transient errors should degrade gracefully.
   process.on('uncaughtException', (err) => {
@@ -22,10 +58,13 @@ export const mcpCommand = async () => {
     console.error(`GitNexus MCP: unhandled rejection — ${msg}`);
   });
 
+  const restricted = Boolean(parseMcpRepoAllowlistTokens(options?.repos));
+  const backendOpts = await buildMcpBackendOptions(options?.repos);
+
   // Initialize multi-repo backend from registry.
   // The server starts even with 0 repos — tools call refreshRepos() lazily,
   // so repos indexed after the server starts are discovered automatically.
-  const backend = new LocalBackend();
+  const backend = new LocalBackend(backendOpts);
   await backend.init();
 
   const repos = await backend.listRepos();
@@ -33,12 +72,15 @@ export const mcpCommand = async () => {
     console.error(
       'GitNexus: No indexed repos yet. Run `gitnexus analyze` in a git repo — the server will pick it up automatically.',
     );
+  } else if (restricted) {
+    console.error(
+      `GitNexus: MCP server restricted to ${repos.length} repo(s): ${repos.map((r) => r.name).join(', ')}`,
+    );
   } else {
     console.error(
       `GitNexus: MCP server starting with ${repos.length} repo(s): ${repos.map((r) => r.name).join(', ')}`,
     );
   }
 
-  // Start MCP server (serves all repos, discovers new ones lazily)
   await startMCPServer(backend);
 };

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -55,6 +55,9 @@ function resolveGitnexusBin(): string | null {
  *
  * Falls back to npx when the binary isn't on PATH — e.g. first-time
  * users who ran `npx gitnexus analyze` but haven't done `npm i -g`.
+ *
+ * To expose only some registered repos over MCP, use `gitnexus mcp --repos name1,name2`
+ * or set env `GITNEXUS_MCP_REPOS=name1,name2` (e.g. in the editor MCP server `env` block).
  */
 function getMcpEntry() {
   const bin = resolveGitnexusBin();

--- a/gitnexus/src/core/group/cross-impact.ts
+++ b/gitnexus/src/core/group/cross-impact.ts
@@ -69,6 +69,12 @@ type BridgeNeighborRow = {
   contractType: string;
 };
 
+function neighborRegistryAllowed(port: GroupToolPort, registryName: string): boolean {
+  const al = port.mcpRepoAllowlist;
+  if (!al || al.size === 0) return true;
+  return al.has(registryName.trim().toLowerCase());
+}
+
 export interface RunGroupImpactDeps {
   port: GroupToolPort;
   gitnexusDir: string;
@@ -334,6 +340,16 @@ export async function runGroupImpact(
     return { error: e instanceof Error ? e.message : String(e) };
   }
 
+  const baseReg = config.repos[repoPath];
+  const al = deps.port.mcpRepoAllowlist;
+  if (al && al.size > 0) {
+    if (!baseReg || !al.has(baseReg.trim().toLowerCase())) {
+      return {
+        error: `Group repo path "${repoPath}" is not exposed by this MCP server (repo allowlist).`,
+      };
+    }
+  }
+
   const resolved = await resolveGroupRepo(deps.port, config, repoPath);
   if ('error' in resolved) return { error: resolved.error };
 
@@ -483,6 +499,7 @@ export async function runGroupImpact(
 
       const regName = config.repos[n.neighborRepo];
       if (!regName) continue;
+      if (!neighborRegistryAllowed(deps.port, regName)) continue;
 
       let neighborHandle: GroupRepoHandle;
       try {

--- a/gitnexus/src/core/group/resolve-at-member.ts
+++ b/gitnexus/src/core/group/resolve-at-member.ts
@@ -5,9 +5,18 @@
 import { loadGroupConfig } from './config-parser.js';
 import { getDefaultGitnexusDir, getGroupDir } from './storage.js';
 
+function memberRegistryNameAllowed(
+  registryName: string,
+  mcpRepoAllowlist: ReadonlySet<string> | null | undefined,
+): boolean {
+  if (mcpRepoAllowlist == null || mcpRepoAllowlist.size === 0) return true;
+  return mcpRepoAllowlist.has(registryName.trim().toLowerCase());
+}
+
 export async function resolveAtGroupMemberRepoPath(
   groupName: string,
   explicitMemberPath: string | undefined,
+  mcpRepoAllowlist?: ReadonlySet<string> | null,
 ): Promise<{ ok: true; repoPath: string } | { ok: false; error: string }> {
   const trimmed = groupName.trim();
   if (!trimmed) return { ok: false, error: 'Group name is empty.' };
@@ -25,9 +34,28 @@ export async function resolveAtGroupMemberRepoPath(
           error: `Unknown member path "${explicitMemberPath}" in group "${trimmed}". Known paths: ${keys.join(', ')}`,
         };
       }
+      const reg = config.repos[explicitMemberPath];
+      if (!memberRegistryNameAllowed(reg, mcpRepoAllowlist)) {
+        return {
+          ok: false,
+          error: `Group member "${explicitMemberPath}" is not exposed by this MCP server (repo allowlist).`,
+        };
+      }
       return { ok: true, repoPath: explicitMemberPath };
     }
-    return { ok: true, repoPath: keys[0]! };
+    if (mcpRepoAllowlist == null || mcpRepoAllowlist.size === 0) {
+      return { ok: true, repoPath: keys[0]! };
+    }
+    for (const k of keys) {
+      const reg = config.repos[k];
+      if (reg && memberRegistryNameAllowed(reg, mcpRepoAllowlist)) {
+        return { ok: true, repoPath: k };
+      }
+    }
+    return {
+      ok: false,
+      error: `No members of group "${trimmed}" are exposed by this MCP server (repo allowlist).`,
+    };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }

--- a/gitnexus/src/core/group/service.ts
+++ b/gitnexus/src/core/group/service.ts
@@ -32,6 +32,11 @@ export interface GroupRepoHandle {
 }
 
 export interface GroupToolPort {
+  /**
+   * When set (`gitnexus mcp --repos` / `GITNEXUS_MCP_REPOS`), group tools only
+   * include registry names in this set (lowercase). Omitted = unrestricted.
+   */
+  mcpRepoAllowlist?: ReadonlySet<string> | null;
   resolveRepo(repoParam?: string): Promise<GroupRepoHandle>;
   impact(
     repo: GroupRepoHandle,
@@ -211,6 +216,30 @@ async function loadContractRegistryResilient(
   return { ok: true, registry, skippedCorrupt };
 }
 
+function mcpAllowlist(port: GroupToolPort): ReadonlySet<string> | null {
+  const al = port.mcpRepoAllowlist;
+  if (!al || al.size === 0) return null;
+  return al;
+}
+
+function filterReposByMcpAllowlist(
+  repos: Record<string, string>,
+  allowlist: ReadonlySet<string> | null,
+): Record<string, string> {
+  if (!allowlist) return repos;
+  return Object.fromEntries(
+    Object.entries(repos).filter(([, reg]) => allowlist.has(reg.trim().toLowerCase())),
+  );
+}
+
+function filterGroupMemberEntries(
+  entries: [string, string][],
+  allowlist: ReadonlySet<string> | null,
+): [string, string][] {
+  if (!allowlist) return entries;
+  return entries.filter(([, reg]) => allowlist.has(reg.trim().toLowerCase()));
+}
+
 export class GroupService {
   constructor(private readonly port: GroupToolPort) {}
 
@@ -232,12 +261,18 @@ export class GroupService {
     return {
       name: config.name,
       description: config.description,
-      repos: config.repos,
+      repos: filterReposByMcpAllowlist(config.repos, mcpAllowlist(this.port)),
       links: config.links,
     };
   }
 
   async groupSync(params: Record<string, unknown>): Promise<unknown> {
+    if (mcpAllowlist(this.port)) {
+      return {
+        error:
+          'group_sync is disabled when the MCP server runs with a repo allowlist (--repos / GITNEXUS_MCP_REPOS).',
+      };
+    }
     const name = String(params.name ?? '').trim();
     if (!name) return { error: 'name is required' };
     const groupDir = getGroupDir(getDefaultGitnexusDir(), name);
@@ -288,7 +323,25 @@ export class GroupService {
       );
       contracts = contracts.filter((c) => !matchedIds.has(`${c.repo}::${c.contractId}`));
     }
-    const out: Record<string, unknown> = { contracts, crossLinks: registry.crossLinks };
+
+    let crossLinksOut = registry.crossLinks;
+    const al = mcpAllowlist(this.port);
+    if (al) {
+      let groupCfg: GroupConfig;
+      try {
+        groupCfg = await loadGroupConfig(groupDir);
+      } catch {
+        return { error: `Cannot load group.yaml for "${name}" while applying repo allowlist.` };
+      }
+      const pathOk = (repoPath: string) => {
+        const reg = groupCfg.repos[repoPath];
+        return Boolean(reg && al.has(reg.trim().toLowerCase()));
+      };
+      contracts = contracts.filter((c) => pathOk(c.repo));
+      crossLinksOut = crossLinksOut.filter((l) => pathOk(l.from.repo) && pathOk(l.to.repo));
+    }
+
+    const out: Record<string, unknown> = { contracts, crossLinks: crossLinksOut };
     if (skippedCorrupt > 0) out.skippedCorrupt = skippedCorrupt;
     return out;
   }
@@ -344,9 +397,19 @@ export class GroupService {
       };
     }
 
-    const memberEntries = Object.entries(config.repos).filter(([repoPath]) =>
+    let memberEntries = Object.entries(config.repos).filter(([repoPath]) =>
       repoInSubgroup(repoPath, subgroup, subgroupExact),
     );
+    memberEntries = filterGroupMemberEntries(memberEntries, mcpAllowlist(this.port));
+    if (memberEntries.length === 0) {
+      return {
+        group: name,
+        target: target || uid,
+        service: servicePrefix,
+        error: 'No group members in scope for this MCP server (repo allowlist).',
+        results: [],
+      };
+    }
 
     const results: GroupContextResult['results'] = await Promise.all(
       memberEntries.map(async ([repoPath, registryName]) => {
@@ -412,9 +475,13 @@ export class GroupService {
       throw err;
     }
 
-    const memberEntries = Object.entries(config.repos).filter(([repoPath]) =>
+    let memberEntries = Object.entries(config.repos).filter(([repoPath]) =>
       repoInSubgroup(repoPath, subgroup, subgroupExact),
     );
+    memberEntries = filterGroupMemberEntries(memberEntries, mcpAllowlist(this.port));
+    if (memberEntries.length === 0) {
+      return { error: 'No group members in scope for this MCP server (repo allowlist).' };
+    }
 
     const perRepo = await Promise.all(
       memberEntries.map(async ([repoPath, registryName]) => {
@@ -469,6 +536,7 @@ export class GroupService {
       throw err;
     }
     const registry = await readContractRegistry(groupDir);
+    const al = mcpAllowlist(this.port);
 
     const repoStatuses: Record<
       string,
@@ -481,6 +549,9 @@ export class GroupService {
     > = {};
 
     for (const [repoPath, registryName] of Object.entries(config.repos)) {
+      if (al && !al.has(registryName.trim().toLowerCase())) {
+        continue;
+      }
       try {
         const repoObj = await this.port.resolveRepo(registryName);
         const metaPath = path.join(repoObj.storagePath, 'meta.json');
@@ -506,10 +577,19 @@ export class GroupService {
       }
     }
 
+    const rawMissing = registry?.missingRepos || [];
+    const missingRepos =
+      al != null
+        ? rawMissing.filter((repoPath) => {
+            const reg = config.repos[repoPath];
+            return Boolean(reg && al.has(reg.trim().toLowerCase()));
+          })
+        : rawMissing;
+
     return {
       group: name,
       lastSync: registry?.generatedAt || null,
-      missingRepos: registry?.missingRepos || [],
+      missingRepos,
       repos: repoStatuses,
     };
   }

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -211,7 +211,18 @@ interface RepoHandle {
   stats?: RegistryEntry['stats'];
 }
 
+/** Options for {@link LocalBackend} (MCP subset mode, tests, etc.). */
+export type LocalBackendOptions = {
+  /**
+   * Only these registry repo names (see `gitnexus list`) are loaded. Names are
+   * matched case-insensitively. Omit or pass empty for full registry (default).
+   */
+  mcpRepoAllowlist?: string[];
+};
+
 export class LocalBackend {
+  private readonly mcpRepoAllowlist: ReadonlySet<string> | null;
+
   private repos: Map<string, RepoHandle> = new Map();
   private contextCache: Map<string, CodebaseContext> = new Map();
   private initializedRepos: Set<string> = new Set();
@@ -234,12 +245,26 @@ export class LocalBackend {
    */
   private warnedVectorUnsupported = false;
 
+  constructor(opts?: LocalBackendOptions) {
+    const raw = opts?.mcpRepoAllowlist?.map((s) => s.trim()).filter((s) => s.length > 0) ?? [];
+    this.mcpRepoAllowlist = raw.length > 0 ? new Set(raw.map((n) => n.toLowerCase())) : null;
+  }
+
+  /**
+   * True when this backend was constructed with a non-empty MCP repo allowlist
+   * (`gitnexus mcp --repos` / `GITNEXUS_MCP_REPOS`). Used for MCP resource metadata.
+   */
+  isMcpRepoAllowlistActive(): boolean {
+    return this.mcpRepoAllowlist != null && this.mcpRepoAllowlist.size > 0;
+  }
+
   /**
    * Cross-repo group tools (CLI). Shares logic with MCP `group_*` handlers.
    */
   getGroupService(): GroupService {
     if (!this.groupToolSvc) {
       const port: GroupToolPort = {
+        mcpRepoAllowlist: this.mcpRepoAllowlist,
         resolveRepo: (p) => this.resolveRepo(p),
         impact: (r, p) => this.impact(r as RepoHandle, p),
         query: (r, p) => this.query(r as RepoHandle, p),
@@ -273,7 +298,11 @@ export class LocalBackend {
    * LadybugDB connections for removed repos are NOT closed (they idle-timeout naturally).
    */
   private async refreshRepos(): Promise<void> {
-    const entries = await listRegisteredRepos({ validate: true });
+    const entriesAll = await listRegisteredRepos({ validate: true });
+    const entries =
+      this.mcpRepoAllowlist == null
+        ? entriesAll
+        : entriesAll.filter((e) => this.mcpRepoAllowlist!.has(e.name.trim().toLowerCase()));
     const freshIds = new Set<string>();
 
     for (const entry of entries) {
@@ -3092,7 +3121,11 @@ export class LocalBackend {
     const groupName = (slash === -1 ? raw : raw.slice(0, slash)).trim();
     const memberRest = slash === -1 ? undefined : raw.slice(slash + 1).trim() || undefined;
 
-    const resolved = await resolveAtGroupMemberRepoPath(groupName, memberRest);
+    const resolved = await resolveAtGroupMemberRepoPath(
+      groupName,
+      memberRest,
+      this.mcpRepoAllowlist,
+    );
     if (resolved.ok === false) return { error: resolved.error };
 
     const svc = this.getGroupService();

--- a/gitnexus/src/mcp/resources.ts
+++ b/gitnexus/src/mcp/resources.ts
@@ -100,6 +100,130 @@ export function getResourceTemplates(): ResourceTemplate[] {
   ];
 }
 
+/** Path tail after `gitnexus://repo/<name>/` for MCP catalog rows (subset mode). */
+const MCP_REPO_RESOURCE_SLICES: Array<{
+  tail: string;
+  catalogTitle: string;
+  description: string;
+  mimeType: string;
+}> = [
+  {
+    tail: 'context',
+    catalogTitle: 'Repo overview',
+    description: 'Codebase stats, staleness check, and available tools',
+    mimeType: 'text/yaml',
+  },
+  {
+    tail: 'clusters',
+    catalogTitle: 'Repo modules',
+    description: 'All functional areas (Leiden clusters)',
+    mimeType: 'text/yaml',
+  },
+  {
+    tail: 'processes',
+    catalogTitle: 'Repo processes',
+    description: 'All execution flows',
+    mimeType: 'text/yaml',
+  },
+  {
+    tail: 'schema',
+    catalogTitle: 'Graph schema',
+    description: 'Node/edge schema for Cypher queries',
+    mimeType: 'text/yaml',
+  },
+];
+
+function repoPathSegmentForUri(repoName: string): string {
+  return encodeURIComponent(repoName);
+}
+
+export function concreteRepoResourceUri(repoName: string, tail: string): string {
+  return `gitnexus://repo/${repoPathSegmentForUri(repoName)}/${tail}`;
+}
+
+function mapStaticResourceDefinitionsForRestrictMode(
+  restricted: boolean,
+): ResourceDefinition[] {
+  return getResourceDefinitions().map((r) => {
+    if (restricted && r.uri === 'gitnexus://repos') {
+      return {
+        ...r,
+        name: 'MCP-visible repositories',
+        description:
+          'Repos this MCP server exposes (subset when started with --repos or GITNEXUS_MCP_REPOS). Not the full global registry.',
+      };
+    }
+    if (restricted && r.uri === 'gitnexus://setup') {
+      return {
+        ...r,
+        name: 'GitNexus setup (MCP subset)',
+        description:
+          'Onboarding-style content for repos visible to this MCP process only (same allowlist as list_repos).',
+      };
+    }
+    return r;
+  });
+}
+
+/**
+ * Resources returned by MCP `resources/list` — matches {@link LocalBackend.listRepos}
+ * when repo allowlist is active (concrete per-repo URIs, no misleading `{name}` catalog).
+ */
+export async function buildMcpListResourcesPayload(
+  backend: LocalBackend,
+): Promise<ResourceDefinition[]> {
+  const restricted = backend.isMcpRepoAllowlistActive();
+  const staticPart = mapStaticResourceDefinitionsForRestrictMode(restricted);
+  if (!restricted) {
+    return staticPart;
+  }
+
+  const repos = await backend.listRepos();
+  const extra: ResourceDefinition[] = [];
+  for (const repo of repos) {
+    const rname = repo.name;
+    for (const slice of MCP_REPO_RESOURCE_SLICES) {
+      extra.push({
+        uri: concreteRepoResourceUri(rname, slice.tail),
+        name: `${slice.catalogTitle} (${rname})`,
+        description: `${slice.description} — MCP allowlist view.`,
+        mimeType: slice.mimeType,
+      });
+    }
+  }
+  return [...staticPart, ...extra];
+}
+
+/**
+ * Resource templates for MCP `resources/templates/list`.
+ * When allowlist is active, repo-scoped `{name}` templates are replaced by concrete
+ * URIs per visible repo so the catalog matches `list_repos` and `gitnexus://repos`.
+ */
+export async function buildMcpResourceTemplatesPayload(
+  backend: LocalBackend,
+): Promise<ResourceTemplate[]> {
+  const all = getResourceTemplates();
+  if (!backend.isMcpRepoAllowlistActive()) {
+    return all;
+  }
+
+  const repos = await backend.listRepos();
+  const groupTemplates = all.filter((t) => t.uriTemplate.startsWith('gitnexus://group/'));
+  const concrete: ResourceTemplate[] = [];
+  for (const repo of repos) {
+    for (const slice of MCP_REPO_RESOURCE_SLICES) {
+      const uri = concreteRepoResourceUri(repo.name, slice.tail);
+      concrete.push({
+        uriTemplate: uri,
+        name: `${slice.catalogTitle} (${repo.name})`,
+        description: `${slice.description} — MCP allowlist.`,
+        mimeType: slice.mimeType,
+      });
+    }
+  }
+  return [...groupTemplates, ...concrete];
+}
+
 /** Query parameters for `gitnexus://group/{name}/contracts` */
 export type GroupContractsResourceFilter = {
   type?: string;
@@ -273,10 +397,20 @@ async function getReposResource(backend: LocalBackend): Promise<string> {
   const repos = await backend.listRepos();
 
   if (repos.length === 0) {
-    return 'repos: []\n# No repositories indexed. Run: gitnexus analyze';
+    const emptyHint = backend.isMcpRepoAllowlistActive()
+      ? '\n# MCP allowlist active: none of the allowed names matched the registry (or registry is empty).'
+      : '';
+    return `repos: []\n# No repositories indexed. Run: gitnexus analyze${emptyHint}`;
   }
 
-  const lines: string[] = ['repos:'];
+  const lines: string[] = [];
+  if (backend.isMcpRepoAllowlistActive()) {
+    lines.push(
+      '# MCP subset: only repos allowed for this server (--repos / GITNEXUS_MCP_REPOS), not the full registry.',
+    );
+    lines.push('');
+  }
+  lines.push('repos:');
   for (const repo of repos) {
     lines.push(`  - name: "${repo.name}"`);
     lines.push(`    path: "${repo.path}"`);

--- a/gitnexus/src/mcp/server.ts
+++ b/gitnexus/src/mcp/server.ts
@@ -26,7 +26,11 @@ import {
 import { GITNEXUS_TOOLS } from './tools.js';
 import { realStdoutWrite } from './core/lbug-adapter.js';
 import type { LocalBackend } from './local/local-backend.js';
-import { getResourceDefinitions, getResourceTemplates, readResource } from './resources.js';
+import {
+  buildMcpListResourcesPayload,
+  buildMcpResourceTemplatesPayload,
+  readResource,
+} from './resources.js';
 
 /**
  * Next-step hints appended to tool responses.
@@ -37,14 +41,34 @@ import { getResourceDefinitions, getResourceTemplates, readResource } from './re
  * Design: Each hint is a short, actionable instruction (not a suggestion).
  * The hint references the specific tool/resource to use next.
  */
-function getNextStepHint(toolName: string, args: Record<string, any> | undefined): string {
+async function getNextStepHint(
+  backend: LocalBackend,
+  toolName: string,
+  args: Record<string, any> | undefined,
+): Promise<string> {
   const repo = args?.repo;
   const repoParam = repo ? `, repo: "${repo}"` : '';
   const repoPath = repo || '{name}';
 
   switch (toolName) {
-    case 'list_repos':
+    case 'list_repos': {
+      if (backend.isMcpRepoAllowlistActive()) {
+        const repos = await backend.listRepos();
+        if (repos.length === 0) {
+          return `\n\n---\n**Next:** No repos in this MCP allowlist; fix --repos / GITNEXUS_MCP_REPOS or run \`gitnexus analyze\`.`;
+        }
+        if (repos.length === 1) {
+          const n = repos[0].name;
+          const enc = encodeURIComponent(n);
+          return `\n\n---\n**Next:** READ gitnexus://repo/${enc}/context for an overview and staleness check.`;
+        }
+        const examples = repos
+          .map((r) => `gitnexus://repo/${encodeURIComponent(r.name)}/context`)
+          .join(', ');
+        return `\n\n---\n**Next:** READ one of these (same repos as list_repos): ${examples}`;
+      }
       return `\n\n---\n**Next:** READ gitnexus://repo/{name}/context for any repo above to get its overview and check staleness.`;
+    }
 
     case 'query':
       return `\n\n---\n**Next:** To understand a specific symbol in depth, use context({name: "<symbol_name>"${repoParam}}) to see categorized refs and process participation.`;
@@ -100,7 +124,7 @@ export function createMCPServer(backend: LocalBackend): Server {
 
   // Handle list resources request
   server.setRequestHandler(ListResourcesRequestSchema, async () => {
-    const resources = getResourceDefinitions();
+    const resources = await buildMcpListResourcesPayload(backend);
     return {
       resources: resources.map((r) => ({
         uri: r.uri,
@@ -113,7 +137,7 @@ export function createMCPServer(backend: LocalBackend): Server {
 
   // Handle list resource templates request (for dynamic resources)
   server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
-    const templates = getResourceTemplates();
+    const templates = await buildMcpResourceTemplatesPayload(backend);
     return {
       resourceTemplates: templates.map((t) => ({
         uriTemplate: t.uriTemplate,
@@ -169,7 +193,7 @@ export function createMCPServer(backend: LocalBackend): Server {
     try {
       const result = await backend.callTool(name, args);
       const resultText = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
-      const hint = getNextStepHint(name, args as Record<string, any> | undefined);
+      const hint = await getNextStepHint(backend, name, args as Record<string, any> | undefined);
 
       return {
         content: [

--- a/gitnexus/src/mcp/tools.ts
+++ b/gitnexus/src/mcp/tools.ts
@@ -54,9 +54,10 @@ const DESTRUCTIVE_TOOL_ANNOTATIONS: ToolAnnotations = {
 export const GITNEXUS_TOOLS: ToolDefinition[] = [
   {
     name: 'list_repos',
-    description: `List all indexed repositories available to GitNexus.
+    description: `List indexed repositories available to this MCP server.
 
 Returns each repo's name, path, indexed date, last commit, and stats.
+If the server was started with \`gitnexus mcp --repos\` (or GITNEXUS_MCP_REPOS), this list is only that subset — not every repo in the global registry.
 
 WHEN TO USE: First step when multiple repos are indexed, or to discover available repos.
 AFTER THIS: READ gitnexus://repo/{name}/context for the repo you want to work with.

--- a/gitnexus/test/unit/mcp/mcp-repo-allowlist.test.ts
+++ b/gitnexus/test/unit/mcp/mcp-repo-allowlist.test.ts
@@ -1,0 +1,126 @@
+/**
+ * MCP repo allowlist: LocalBackend registry view, GroupService, resolveAtGroupMemberRepoPath.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import type { RegistryEntry } from '../../../src/storage/repo-manager.js';
+
+vi.mock('../../../src/storage/repo-manager.js', () => ({
+  listRegisteredRepos: vi.fn(),
+  cleanupOldKuzuFiles: vi.fn().mockResolvedValue({ found: false, needsReindex: false }),
+}));
+
+import { listRegisteredRepos } from '../../../src/storage/repo-manager.js';
+import { LocalBackend } from '../../../src/mcp/local/local-backend.js';
+import { GroupService, type GroupToolPort } from '../../../src/core/group/service.js';
+import { resolveAtGroupMemberRepoPath } from '../../../src/core/group/resolve-at-member.js';
+
+function makePort(overrides: Partial<GroupToolPort> = {}): GroupToolPort {
+  return {
+    resolveRepo: vi.fn(async (name?: string) => ({
+      id: (name || 'test').toLowerCase(),
+      name: name || 'test',
+      repoPath: '/tmp/repo',
+      storagePath: '/tmp/repo/.gitnexus',
+    })),
+    impact: vi.fn(async () => ({ symbols: [] })),
+    query: vi.fn(async () => ({ processes: [] })),
+    impactByUid: vi.fn(async () => null),
+    context: vi.fn(async () => ({ status: 'not_found' })),
+    ...overrides,
+  };
+}
+
+describe('MCP repo allowlist', () => {
+  beforeEach(() => {
+    vi.mocked(listRegisteredRepos).mockReset();
+  });
+
+  it('LocalBackend filters registry entries to mcpRepoAllowlist', async () => {
+    const entries: RegistryEntry[] = [
+      {
+        name: 'Alpha',
+        path: '/x/a',
+        storagePath: '/x/a/.gitnexus',
+        indexedAt: '1',
+        lastCommit: 'deadbeef1',
+      },
+      {
+        name: 'Beta',
+        path: '/x/b',
+        storagePath: '/x/b/.gitnexus',
+        indexedAt: '1',
+        lastCommit: 'deadbeef2',
+      },
+    ];
+    vi.mocked(listRegisteredRepos).mockResolvedValue(entries);
+
+    const backend = new LocalBackend({ mcpRepoAllowlist: ['alpha'] });
+    expect(backend.isMcpRepoAllowlistActive()).toBe(true);
+    expect(new LocalBackend().isMcpRepoAllowlistActive()).toBe(false);
+    await backend.init();
+    const listed = await backend.listRepos();
+    expect(listed).toHaveLength(1);
+    expect(listed[0].name).toBe('Alpha');
+
+    await expect(backend.resolveRepo('Beta')).rejects.toThrow(/not found/i);
+    const a = await backend.resolveRepo('Alpha');
+    expect(a.name).toBe('Alpha');
+  });
+
+  it('group_sync is disabled when port has mcpRepoAllowlist', async () => {
+    const port = makePort({ mcpRepoAllowlist: new Set(['any']) });
+    const svc = new GroupService(port);
+    const out = await svc.groupSync({ name: 'g' });
+    expect(out).toMatchObject({
+      error: expect.stringMatching(/group_sync is disabled/i),
+    });
+  });
+});
+
+describe('resolveAtGroupMemberRepoPath with MCP allowlist', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-mcp-al-'));
+    const groupDir = path.join(tmpDir, 'groups', 'g1');
+    fs.mkdirSync(groupDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(groupDir, 'group.yaml'),
+      `version: 1
+name: g1
+repos:
+  zeta/backend: test-backend
+  app/frontend: test-frontend
+`,
+    );
+    vi.stubEnv('GITNEXUS_HOME', tmpDir);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('picks first sorted member whose registry name is allowed', async () => {
+    const al = new Set(['test-frontend']);
+    const r = await resolveAtGroupMemberRepoPath('g1', undefined, al);
+    expect(r).toEqual({ ok: true, repoPath: 'app/frontend' });
+  });
+
+  it('skips lexicographically earlier members when their registry name is not allowed', async () => {
+    const al = new Set(['test-backend']);
+    const r = await resolveAtGroupMemberRepoPath('g1', undefined, al);
+    expect(r).toEqual({ ok: true, repoPath: 'zeta/backend' });
+  });
+
+  it('rejects explicit member when registry name not in allowlist', async () => {
+    const al = new Set(['test-frontend']);
+    const r = await resolveAtGroupMemberRepoPath('g1', 'zeta/backend', al);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/not exposed/i);
+  });
+});

--- a/gitnexus/test/unit/resources.test.ts
+++ b/gitnexus/test/unit/resources.test.ts
@@ -10,6 +10,9 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import {
+  buildMcpListResourcesPayload,
+  buildMcpResourceTemplatesPayload,
+  concreteRepoResourceUri,
   getResourceDefinitions,
   getResourceTemplates,
   parseResourceUri,
@@ -20,6 +23,9 @@ import {
 
 function createMockBackend(overrides: Partial<Record<string, any>> = {}): any {
   return {
+    isMcpRepoAllowlistActive: vi
+      .fn()
+      .mockReturnValue(overrides.allowlistActive ?? false),
     listRepos: vi.fn().mockResolvedValue(overrides.repos ?? []),
     resolveRepo: vi.fn().mockResolvedValue(
       overrides.resolvedRepo ?? {
@@ -76,6 +82,43 @@ describe('getResourceDefinitions', () => {
       expect(def.description).toBeTruthy();
       expect(def.mimeType).toBeTruthy();
     }
+  });
+});
+
+describe('buildMcpListResourcesPayload / buildMcpResourceTemplatesPayload', () => {
+  it('unrestricted: static resources only, full template catalog', async () => {
+    const backend = createMockBackend({
+      allowlistActive: false,
+      repos: [{ name: 'A', path: '/a', indexedAt: '1', lastCommit: 'c' }],
+    });
+    const list = await buildMcpListResourcesPayload(backend);
+    expect(list).toHaveLength(2);
+    expect(list.some((r) => r.uri === 'gitnexus://repos')).toBe(true);
+    const tmpl = await buildMcpResourceTemplatesPayload(backend);
+    expect(tmpl.some((t) => t.uriTemplate.includes('{name}'))).toBe(true);
+    expect(tmpl).toHaveLength(8);
+  });
+
+  it('restricted: adds concrete per-repo URIs and renames static repos entry', async () => {
+    const backend = createMockBackend({
+      allowlistActive: true,
+      repos: [
+        { name: 'OnlyRepo', path: '/x', indexedAt: '1', lastCommit: 'abc' },
+      ],
+    });
+    const list = await buildMcpListResourcesPayload(backend);
+    expect(list.find((r) => r.uri === 'gitnexus://repos')?.name).toBe('MCP-visible repositories');
+    const ctx = list.find((r) => r.uri === concreteRepoResourceUri('OnlyRepo', 'context'));
+    expect(ctx).toBeDefined();
+    expect(list.filter((r) => r.uri.startsWith('gitnexus://repo/')).length).toBe(4);
+
+    const tmpl = await buildMcpResourceTemplatesPayload(backend);
+    expect(tmpl.some((t) => t.uriTemplate.startsWith('gitnexus://repo/{name}'))).toBe(false);
+    expect(tmpl.some((t) => t.uriTemplate === concreteRepoResourceUri('OnlyRepo', 'context'))).toBe(
+      true,
+    );
+    expect(tmpl.filter((t) => t.uriTemplate.startsWith('gitnexus://group/')).length).toBe(2);
+    expect(tmpl.length).toBe(6);
   });
 });
 


### PR DESCRIPTION
## Summary

Add options in command mcp to select which one to run and do not run all the repos in the mcp

## Motivation / context

In this issue full description is written https://github.com/abhigyanpatwari/GitNexus/issues/1203

## Areas touched

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- mcp tools
- mcp resources

**Explicitly out of scope / not done here**

- <!-- bullets — prevents reviewers assuming missing work is an oversight -->

## Implementation notes

<!-- Optional: design choices, tradeoffs, follow-ups -->

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [ ] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [ ] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(if web changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

## Risk & rollout

<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->

## Checklist

- [ ] PR body meets repo minimum length (workflow may label short descriptions)
- [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [ ] No secrets, tokens, or machine-specific paths committed
