### PR TITLE
chore(deps): bump @ladybugdb/core to ^0.16.1

### DIFF
--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -11,7 +11,7 @@
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^4.1.0",
-        "@ladybugdb/core": "^0.16.0",
+        "@ladybugdb/core": "^0.16.1",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@scarf/scarf": "^1.4.0",
         "cli-progress": "^3.12.0",
@@ -1159,9 +1159,9 @@
       }
     },
     "node_modules/@ladybugdb/core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core/-/core-0.16.0.tgz",
-      "integrity": "sha512-t/t4MPZmBMocFBzG5G3E3iHPwuIiXYEuLeW0CTOloGofkKQ7gHt3JlLzyDn2a+AHNQjr1YqlsodKKYQFhsFZXw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core/-/core-0.16.1.tgz",
+      "integrity": "sha512-qwuEcR8CVMKb6tNDaHtq7Ux8hT/XbPC0db+vwutX6JxNAejyx7YomHKPSy9XAKURhYK8mezZe3UN8rf+xpHOjQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1169,17 +1169,17 @@
         "node-addon-api": "^6.0.0"
       },
       "optionalDependencies": {
-        "@ladybugdb/core-darwin-arm64": "0.16.0",
-        "@ladybugdb/core-darwin-x64": "0.16.0",
-        "@ladybugdb/core-linux-arm64": "0.16.0",
-        "@ladybugdb/core-linux-x64": "0.16.0",
-        "@ladybugdb/core-win32-x64": "0.16.0"
+        "@ladybugdb/core-darwin-arm64": "0.16.1",
+        "@ladybugdb/core-darwin-x64": "0.16.1",
+        "@ladybugdb/core-linux-arm64": "0.16.1",
+        "@ladybugdb/core-linux-x64": "0.16.1",
+        "@ladybugdb/core-win32-x64": "0.16.1"
       }
     },
     "node_modules/@ladybugdb/core-darwin-arm64": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-arm64/-/core-darwin-arm64-0.16.0.tgz",
-      "integrity": "sha512-2IpiUbd6Lb50KRUkURk+PIgDRKume63uI4KYZNpjxNDwdHRXdadZTBZn74+DgK7IhpTyiPbtKddiXHKtSV2CWg==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-arm64/-/core-darwin-arm64-0.16.1.tgz",
+      "integrity": "sha512-Nl+Cf70rD+HaC9IBHv+oeUwqX9plghXD7PN9tyMzMohRVPvcGEbqWPB6YcdJa8rR7qRqCCbmaNMDen5wg4rY2w==",
       "cpu": [
         "arm64"
       ],
@@ -1189,10 +1189,23 @@
         "darwin"
       ]
     },
+    "node_modules/@ladybugdb/core-darwin-x64": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-x64/-/core-darwin-x64-0.16.1.tgz",
+      "integrity": "sha512-4eAjfimAAQRSmDfUUkGrl9OhefxcW1ziA9tl0eljBlGoUseE7dL02+RSqjGohYMcQ+lzuHAq1QWb0XRlMA8YTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/@ladybugdb/core-linux-arm64": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-arm64/-/core-linux-arm64-0.16.0.tgz",
-      "integrity": "sha512-l+lV7BXfnA0w1voApKblBaGE+bKQqSlOG+30HkSYOAW7POYv+OoydgY/BGwabBUTvcnhVyrNApvBsPF8G3Nm3g==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-arm64/-/core-linux-arm64-0.16.1.tgz",
+      "integrity": "sha512-zkctksev+hsPFrNxHHdq4lYK5OWdLhWfRdQzjzkgDyaHayHU6yCL2fgD6uPGQ8TRQ6/2DxMErb4p3FzGW85Ubw==",
       "cpu": [
         "arm64"
       ],
@@ -1203,9 +1216,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-linux-x64": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-x64/-/core-linux-x64-0.16.0.tgz",
-      "integrity": "sha512-XOL2H0y51e57dIFIHO8LHtN8Ner2qEyti6zAkxKr+w8LkvczHeVX910doz2de8+xvxDYJyzrcj2xWqDTxcK/Jg==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-x64/-/core-linux-x64-0.16.1.tgz",
+      "integrity": "sha512-5rAb9T5vif8WKhHwhobosu2/aiOwJkWb/ViybvUc5GFKunKl8VI6RmZQVeufT9zUzRktUwrxBrxblCxsnamXJw==",
       "cpu": [
         "x64"
       ],
@@ -1216,9 +1229,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-win32-x64": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-win32-x64/-/core-win32-x64-0.16.0.tgz",
-      "integrity": "sha512-MyKiELqPgzx9gVHmwxzptnToAcDtCN7dTP5Y4IPMYhc2QpNbZKCihmvdXjbOmdIOfIHW4fBp4vrzT8fVbdAMZw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-win32-x64/-/core-win32-x64-0.16.1.tgz",
+      "integrity": "sha512-ShOUTrIuZKQ63J95tcRJxKf1cvg8yi2FSYx9kMTSercc1FdQZPV+zxUN0myMq3MTWOl7xDxsVMmdp/t80O29UQ==",
       "cpu": [
         "x64"
       ],

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^4.1.0",
-    "@ladybugdb/core": "^0.16.0",
+    "@ladybugdb/core": "^0.16.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@scarf/scarf": "^1.4.0",
     "cli-progress": "^3.12.0",


### PR DESCRIPTION
## Summary

Bumps `@ladybugdb/core` (and platform packages) from 0.16.0 to **0.16.1** per [LadybugDB/ladybug releases](https://github.com/LadybugDB/ladybug/releases) - patch fixes (e.g. ANY graph dynamic property scans, wasm Windows paths, darwin-x64 npm publish). No GitNexus source changes; `lbug-config.ts` already pins 0.16.0 `Database` constructor semantics.

## Definition of Done (this PR)

- [x] Scope: `gitnexus/package.json` + `gitnexus/package-lock.json` only
- [x] `cd gitnexus && npx tsc --noEmit`
- [x] `cd gitnexus && npm test` (7737 passed, 11 skipped)
- [x] `CHANGELOG.md` not edited (release-owned)
- [x] No contract / MCP / HTTP / ingestion changes

## Validation

| Command | Result |
|---------|--------|
| `npx tsc --noEmit` | pass |
| `npm test` | pass |

## Rollback

Revert this commit or set `@ladybugdb/core` back to `^0.16.0` and regenerate lockfile.
