### PR TITLE
fix(server): rate-limit /api/analyze and /api/embed endpoints (#1328)

### DIFF
--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -1348,7 +1348,7 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
   // ── Analyze API ──────────────────────────────────────────────────────
 
   // POST /api/analyze — start a new analysis job
-  app.post('/api/analyze', async (req, res) => {
+  app.post('/api/analyze', createRouteLimiter({ limit: 10 }), async (req, res) => {
     try {
       const { url: repoUrl, path: repoLocalPath, force, embeddings, dropEmbeddings } = req.body;
 
@@ -1615,7 +1615,7 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
   const embedJobManager = new JobManager();
 
   // POST /api/embed — trigger server-side embedding generation
-  app.post('/api/embed', async (req, res) => {
+  app.post('/api/embed', createRouteLimiter({ limit: 20 }), async (req, res) => {
     try {
       const entry = await resolveRepo(requestedRepo(req));
       if (!entry) {

--- a/gitnexus/test/unit/rate-limit.test.ts
+++ b/gitnexus/test/unit/rate-limit.test.ts
@@ -230,6 +230,14 @@ describe('production routes — rate-limit middleware wiring', () => {
     expect(apiSource).toMatch(/app\.delete\('\/api\/repo',\s*createRouteLimiter\(/);
   });
 
+  it('POST /api/analyze is wired with createRouteLimiter', () => {
+    expect(apiSource).toMatch(/app\.post\('\/api\/analyze',\s*createRouteLimiter\(/);
+  });
+
+  it('POST /api/embed is wired with createRouteLimiter', () => {
+    expect(apiSource).toMatch(/app\.post\('\/api\/embed',\s*createRouteLimiter\(/);
+  });
+
   it('SPA fallback is wired with createRouteLimiter', () => {
     expect(apiSource).toMatch(/app\.get\(SPA_FALLBACK_REGEX,\s*createRouteLimiter\(/);
   });


### PR DESCRIPTION
## Summary

- Applies `createRouteLimiter()` to `POST /api/analyze` (10 rpm/IP) and `POST /api/embed` (20 rpm/IP) — the two heaviest FS-touching endpoints that were out of scope for U4 (#1327) because CodeQL did not flag them directly.
- Limits match issue #1328's recommendation: 10 rpm for analyze (clone + full-tree walk), 20 rpm for embed (ONNX inference per file).
- Adds 2 structural wiring tests in `rate-limit.test.ts` matching the existing pattern.

## Changes

| File | Change |
|---|---|
| `gitnexus/src/server/api.ts` | Insert `createRouteLimiter({ limit: 10 })` on POST /api/analyze, `createRouteLimiter({ limit: 20 })` on POST /api/embed |
| `gitnexus/test/unit/rate-limit.test.ts` | 2 structural wiring assertions (regex against api.ts source) |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run test/unit/rate-limit.test.ts` — 15/15 pass (was 13)
- [x] `npx prettier --check` on changed files — clean
- [x] Pre-commit hooks (eslint + prettier + typecheck) — passed
- [x] Full `vitest run --project default` — only pre-existing dev-env failures (home dir `.git` causes tmpdir-based tests to see a parent git repo); all pass on CI

Closes #1328