### PR TITLE
fix(git): suppress stderr leak in getCurrentCommit and getGitRoot (#1172)

### DIFF
--- a/gitnexus/src/storage/git.ts
+++ b/gitnexus/src/storage/git.ts
@@ -15,7 +15,17 @@ export const isGitRepo = (repoPath: string): boolean => {
 
 export const getCurrentCommit = (repoPath: string): string => {
   try {
-    return execSync('git rev-parse HEAD', { cwd: repoPath }).toString().trim();
+    return execSync('git rev-parse HEAD', {
+      cwd: repoPath,
+      // Suppress stderr — without an explicit stdio option, Node's execSync
+      // forwards the child's stderr to the parent process (documented behaviour).
+      // When repoPath is not inside a git worktree, git prints
+      // "fatal: not a git repository" to stderr, which leaks to the user's
+      // terminal even though the error is caught here (#1172).
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
   } catch {
     return '';
   }
@@ -86,7 +96,13 @@ export const getRemoteUrl = (repoPath: string): string | undefined => {
  */
 export const getGitRoot = (fromPath: string): string | null => {
   try {
-    const raw = execSync('git rev-parse --show-toplevel', { cwd: fromPath }).toString().trim();
+    const raw = execSync('git rev-parse --show-toplevel', {
+      cwd: fromPath,
+      // Suppress stderr — see getCurrentCommit comment and #1172.
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
     // On Windows, git returns /d/Projects/Foo — path.resolve normalizes to D:\Projects\Foo
     return path.resolve(raw);
   } catch {

--- a/gitnexus/src/storage/git.ts
+++ b/gitnexus/src/storage/git.ts
@@ -17,7 +17,7 @@ export const getCurrentCommit = (repoPath: string): string => {
   try {
     return execSync('git rev-parse HEAD', {
       cwd: repoPath,
-      // Suppress stderr — without an explicit stdio option, Node's execSync
+      // Suppress stderr -- without an explicit stdio option, Node's execSync
       // forwards the child's stderr to the parent process (documented behaviour).
       // When repoPath is not inside a git worktree, git prints
       // "fatal: not a git repository" to stderr, which leaks to the user's
@@ -98,7 +98,7 @@ export const getGitRoot = (fromPath: string): string | null => {
   try {
     const raw = execSync('git rev-parse --show-toplevel', {
       cwd: fromPath,
-      // Suppress stderr — see getCurrentCommit comment and #1172.
+      // Suppress stderr -- see getCurrentCommit comment and #1172.
       stdio: ['ignore', 'pipe', 'ignore'],
     })
       .toString()

--- a/gitnexus/test/unit/git-utils.test.ts
+++ b/gitnexus/test/unit/git-utils.test.ts
@@ -131,6 +131,21 @@ describe('getGitRoot', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  // Regression: #1172 -- mirrors the getCurrentCommit stderr test above.
+  it('does not leak git stderr to process.stderr (#1172)', async () => {
+    const { getGitRoot } = await import('../../src/storage/git.js');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-test-'));
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      getGitRoot(tmpDir);
+      const stderrOutput = spy.mock.calls.map((c) => String(c[0])).join('');
+      expect(stderrOutput).not.toContain('fatal');
+    } finally {
+      spy.mockRestore();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ─── getRemoteUrl ─────────────────────────────────────────────────────────

--- a/gitnexus/test/unit/git-utils.test.ts
+++ b/gitnexus/test/unit/git-utils.test.ts
@@ -4,7 +4,7 @@
  * Tests isGitRepo, getCurrentCommit, getGitRoot, and the newly added
  * hasGitDir helper introduced for issue #384 (indexing non-git folders).
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import path from 'path';
 import os from 'os';
 import fs from 'fs';
@@ -94,6 +94,26 @@ describe('getCurrentCommit', () => {
     try {
       expect(getCurrentCommit(tmpDir)).toBe('');
     } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // Regression: #1172 — without explicit stdio on execSync, Node forwards
+  // the child's stderr to the parent process, printing "fatal: not a git
+  // repository" to the user's terminal even though the error is caught.
+  it('does not leak git stderr to process.stderr (#1172)', async () => {
+    const { getCurrentCommit } = await import('../../src/storage/git.js');
+    // git-init a dir without commits so `git rev-parse HEAD` fails with a
+    // "fatal:" message — the exact class of error that leaked before the fix.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-test-'));
+    execSync('git init -q', { cwd: tmpDir, stdio: 'ignore' });
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      expect(getCurrentCommit(tmpDir)).toBe('');
+      const stderrOutput = spy.mock.calls.map((c) => String(c[0])).join('');
+      expect(stderrOutput).not.toContain('fatal');
+    } finally {
+      spy.mockRestore();
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary

- **Root cause**: Node's `execSync` forwards child stderr to the parent process when the `stdio` option is not explicitly set (documented Node.js behaviour). `getCurrentCommit` and `getGitRoot` caught the resulting error but never suppressed the stderr output, so `git rev-parse` failures printed `fatal: not a git repository` to the user's terminal.
- **Fix**: Add `stdio: ['ignore', 'pipe', 'ignore']` to both functions, matching the pattern already used by `getRemoteUrl`, `getRemoteOriginUrl`, and `getCanonicalRepoRoot` in the same file.
- **Regression test**: New test that `git init`-s a directory without commits (forces `git rev-parse HEAD` to fail), then asserts `process.stderr.write` is never called with a `fatal` message.

Closes #1172

## Test plan

- [x] `npx vitest run test/unit/git-utils.test.ts` — 15/18 pass (3 pre-existing failures unrelated to this change)
- [x] New `does not leak git stderr to process.stderr (#1172)` test passes
- [x] `tsc --noEmit` — no new type errors
- [x] `prettier --check` — clean