### PR TITLE
fix(test): widen rate-limit test window to prevent flake on Windows CI

### DIFF
--- a/gitnexus/test/unit/rate-limit.test.ts
+++ b/gitnexus/test/unit/rate-limit.test.ts
@@ -11,10 +11,10 @@
  *      per call, has the right signature, exposes the right error shape.
  *   2. Integration tests — mount the same factory on a tiny isolated express
  *      app that does fs.readFile (the exact CodeQL sink class) and prove the
- *      429 fires after the configured limit. Tight windowMs (100ms) + small
- *      sleep (200ms) keeps the suite fast and resistant to CI scheduling
- *      jitter; each test uses a fresh limiter so counter state never carries
- *      between tests.
+ *      429 fires after the configured limit. windowMs (2 000 ms) is generous
+ *      enough that 4 sequential requests fit inside one window even on slow
+ *      Windows CI runners; each test uses a fresh limiter so counter state
+ *      never carries between tests.
  */
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import express, { type Express } from 'express';
@@ -41,9 +41,9 @@ afterAll(async () => {
 });
 
 // Build a fresh app + server per test so counter state never carries between
-// tests. Tight windowMs keeps the limiter responsive; the 200ms reset sleep
-// in window-rollover tests gives 2x margin even on slow CI.
-const buildApp = (limit: number, windowMs = 100): Express => {
+// tests. windowMs = 2 000 ms gives ample headroom for Windows CI where
+// sequential loopback HTTP requests can take 50–80 ms each.
+const buildApp = (limit: number, windowMs = 2000): Express => {
   const app = express();
   app.set('trust proxy', 'loopback, linklocal, uniquelocal');
   app.get('/test/file', createRouteLimiter({ windowMs, limit }), async (_req, res) => {
@@ -145,8 +145,8 @@ describe('createRouteLimiter — integration with a real route', () => {
     for (let i = 1; i <= 3; i++) await fetch(`${baseUrl}/test/file`);
     const tripped = await fetch(`${baseUrl}/test/file`);
     expect(tripped.status).toBe(429);
-    // Wait for the window to roll over (100ms window + 200ms margin).
-    await new Promise((r) => setTimeout(r, 200));
+    // Wait for the window to roll over (2 000 ms window + 200 ms margin).
+    await new Promise((r) => setTimeout(r, 2200));
     const reset = await fetch(`${baseUrl}/test/file`);
     expect(reset.status).toBe(200);
   });


### PR DESCRIPTION
## Summary

- `windowMs` in the rate-limit integration test widened from **100 ms → 2 000 ms**
- Window-reset sleep bumped from **200 ms → 2 200 ms** accordingly
- Single file changed: `test/unit/rate-limit.test.ts` (comments + two values)

## Root cause

express-rate-limit's `MemoryStore.increment()` lazily resets the per-client counter when `resetTime <= now`. With `windowMs=100` and 4 sequential loopback HTTP requests that each take ~50–80 ms on Windows CI (TCP overhead + `fs.readFile` on temp file), the total sequence spans ~235 ms. The 100 ms window expires mid-sequence, the counter resets to 0, and the 4th request gets 200 instead of 429.

**Reproduced locally** by adding 40 ms artificial delay per request — identical failure on macOS, confirming this is purely a timing issue.

### Why Windows only

On Linux/macOS, loopback HTTP + `fs.readFile` completes in ~5–15 ms per request. 4 requests take ~20–60 ms total — well within a 100 ms window. On Windows CI, per-request latency is 3–5× higher due to the TCP stack, I/O subsystem, and scheduler differences.

### Why this surfaced on PR #1324

PR #1324 adds a worker-pool integration test that spawns real `Worker` threads with deliberate stall behavior. On a shared Windows CI runner, this adds enough CPU contention to push per-request latency in the rate-limit test past the 100 ms threshold. The fragility was always present — the additional load was the trigger.

## Test plan

- [x] All 15 rate-limit tests pass locally (macOS, Node 20)
- [x] Typecheck clean
- [x] Prettier clean
- [ ] Windows CI passes (the entire purpose of this PR)