### PR TITLE
fix(test): widen worker pool retry timeout to prevent CI flake (#1323)

### DIFF
--- a/gitnexus/test/integration/worker-pool.test.ts
+++ b/gitnexus/test/integration/worker-pool.test.ts
@@ -300,7 +300,7 @@ describe('worker pool integration', () => {
 
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     pool = createWorkerPool(pathToFileURL(workerPath) as URL, 1, {
-      subBatchIdleTimeoutMs: 150,
+      subBatchIdleTimeoutMs: 500,
       maxTimeoutRetries: 1,
       timeoutBackoffFactor: 4,
     });
@@ -308,7 +308,7 @@ describe('worker pool integration', () => {
     try {
       const results = await pool.dispatch<any, any>([{ path: 'retry.ts', content: '' }]);
       expect(results).toEqual([{ fileCount: 1, recovered: true }]);
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Retrying with 0.6s timeout'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Retrying with 2s timeout'));
     } finally {
       warnSpy.mockRestore();
       fs.rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- The `replaces a timed-out worker and retries with a longer timeout` test used a 150 ms idle timeout (`subBatchIdleTimeoutMs: 150`), leaving almost no headroom when CI runners are under load.
- Widens the timeout to 500 ms; with the existing `timeoutBackoffFactor: 4`, the retry fires at 2 000 ms instead of 600 ms, giving the worker time to respond before the assertion window closes.
- Updates the matching assertion from `'Retrying with 0.6s timeout'` to `'Retrying with 2s timeout'`.

## Test plan
- [x] `npx vitest run test/integration/worker-pool.test.ts` — all 22 tests pass
- [x] No other test uses the same 150 ms value in a way that would be affected

Closes #1323