### PR TITLE
fix(server): flush WAL after /api/embed so search sees new embeddings (#1149)

### DIFF
--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -1702,6 +1702,16 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
               undefined, // context
               existingEmbeddings,
             );
+
+            // Flush WAL so subsequent /api/search requests see the new
+            // embeddings immediately (#1149). In the CLI path closeLbug()
+            // handles this during process exit, but the server keeps the
+            // connection open for other routes -- a CHECKPOINT is enough.
+            try {
+              await executeQuery('CHECKPOINT');
+            } catch {
+              /* best-effort -- older LadybugDB may not support it */
+            }
           });
 
           clearTimeout(embedTimeout);


### PR DESCRIPTION
## Summary
- After `/api/embed` completes, the embedding rows remain in the WAL because the server keeps the DB connection open for other routes.
- Subsequent `/api/search` requests return zero semantic results until an unrelated operation forces a WAL replay.
- Adds an explicit `CHECKPOINT` inside the `withLbugDb` callback after the embedding pipeline finishes, matching the pattern already documented in `closeLbug()`.

## Root cause
The CLI path (`analyze --embeddings`) flushes the WAL via `closeLbug()` during `process.exit()`. The server path (`/api/embed`) uses a shared singleton connection that stays open -- `withLbugDb` only releases the session lock, it never checkpoints or closes. The `closeLbug()` comment is explicit: "This is especially critical after embedding writes, which generate large amounts of WAL data."

## Test plan
- [x] `npx tsc --noEmit` -- clean
- [x] `npx vitest run test/unit/rate-limit.test.ts` -- 16/16 pass (source-grep confirms api.ts structure)
- [x] Prettier clean
- [ ] Manual: `POST /api/embed` -> poll completion -> `POST /api/search` returns semantic results (reviewer verification)

Closes #1149