### PR TITLE
fix(mcp): close MCP server timeout — stdout discipline + cold-start friction

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Built by the community — not officially maintained, but worth checking out.
 
 If you prefer manual configuration:
 
+> **Recommended for fastest startup:** install gitnexus globally (`npm i -g gitnexus`) and run `gitnexus setup` — this writes an absolute-path MCP config that bypasses `npx` entirely. The pinned-`npx` snippets below are a quickstart fallback; on a cold cache the `npx` install can exceed Claude Code's `MCP_TIMEOUT` default (~30s).
+
 **Claude Code** (full support — MCP + skills + hooks):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ That's it. This indexes the codebase, installs agent skills, registers Claude Co
 
 To configure MCP for your editor, run `npx gitnexus setup` once — or set it up manually below.
 
+> **Faster install (no C++ toolchain needed):** set `GITNEXUS_SKIP_OPTIONAL_GRAMMARS=1` before `npm install -g gitnexus` to skip the native `tree-sitter-dart` and `tree-sitter-proto` builds. Dart/Proto files won't be parsed, but install completes in seconds without `python3`/`make`/`g++`. Strict `=1` only — any other value falls through to the rebuild.
+
 ### MCP Setup
 
 `gitnexus setup` auto-detects your editors and writes the correct global MCP config. You only need to run it once.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -79,6 +79,7 @@ export default [
       'gitnexus/src/mcp/**/*.ts',
       'gitnexus/src/core/lbug/**/*.ts',
       'gitnexus/src/core/embeddings/**/*.ts',
+      'gitnexus/src/core/tree-sitter/**/*.ts',
       'gitnexus/src/cli/mcp.ts',
     ],
     rules: {
@@ -96,6 +97,18 @@ export default [
             "CallExpression[callee.type='MemberExpression'][callee.object.type='MemberExpression'][callee.object.object.name='process'][callee.object.property.name='stdout'][callee.property.name='write']",
           message:
             'Direct process.stdout.write is forbidden in MCP-reachable code. Route diagnostics through console.error or process.stderr.write — the MCP stdio transport owns stdout for JSON-RPC frames.',
+        },
+        {
+          selector:
+            "VariableDeclarator > ObjectPattern > Property[key.name='write'].properties:has(MemberExpression[object.name='process'][property.name='stdout'])",
+          message:
+            'Destructuring write off process.stdout is forbidden in MCP-reachable code — bypasses the sentinel. Use process.stderr.write for diagnostics.',
+        },
+        {
+          selector:
+            "VariableDeclarator[init.type='MemberExpression'][init.object.name='process'][init.property.name='stdout'] > ObjectPattern",
+          message:
+            'Destructuring process.stdout is forbidden in MCP-reachable code — bypasses the sentinel. Use process.stderr.write for diagnostics.',
         },
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,6 +67,40 @@ export default [
     },
   },
 
+  // MCP-reachable code: forbid stdout-corrupting writes. The MCP stdio
+  // transport writes JSON-RPC frames to stdout; per the spec, the server
+  // MUST NOT write anything to stdout that is not a valid MCP message.
+  // Diagnostics must go to stderr (console.error). Direct process.stdout.write
+  // bypasses the gate and is also forbidden in these dirs.
+  // cli/mcp.ts is included here even though it lives under cli/ — it is the
+  // MCP entrypoint and inherits stricter discipline than the rest of cli/.
+  {
+    files: [
+      'gitnexus/src/mcp/**/*.ts',
+      'gitnexus/src/core/lbug/**/*.ts',
+      'gitnexus/src/core/embeddings/**/*.ts',
+      'gitnexus/src/cli/mcp.ts',
+    ],
+    rules: {
+      'no-console': ['error', { allow: ['error'] }],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "MemberExpression[object.type='MemberExpression'][object.object.name='process'][object.property.name='stdout'][property.name='write']",
+          message:
+            'Direct process.stdout.write is forbidden in MCP-reachable code. Route diagnostics through console.error or process.stderr.write — the MCP stdio transport owns stdout for JSON-RPC frames.',
+        },
+        {
+          selector:
+            "CallExpression[callee.type='MemberExpression'][callee.object.type='MemberExpression'][callee.object.object.name='process'][callee.object.property.name='stdout'][callee.property.name='write']",
+          message:
+            'Direct process.stdout.write is forbidden in MCP-reachable code. Route diagnostics through console.error or process.stderr.write — the MCP stdio transport owns stdout for JSON-RPC frames.',
+        },
+      ],
+    },
+  },
+
   // React-specific rules for gitnexus-web
   {
     files: ['gitnexus-web/src/**/*.{ts,tsx}'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -99,12 +99,11 @@ export default [
             'Direct process.stdout.write is forbidden in MCP-reachable code. Route diagnostics through console.error or process.stderr.write — the MCP stdio transport owns stdout for JSON-RPC frames.',
         },
         {
-          selector:
-            "VariableDeclarator > ObjectPattern > Property[key.name='write'].properties:has(MemberExpression[object.name='process'][property.name='stdout'])",
-          message:
-            'Destructuring write off process.stdout is forbidden in MCP-reachable code — bypasses the sentinel. Use process.stderr.write for diagnostics.',
-        },
-        {
+          // Catches the canonical destructuring shape:
+          //   const { write } = process.stdout;
+          // (and any other ObjectPattern destructure rooted at process.stdout)
+          // which would otherwise capture a reference to the original write
+          // and bypass the sentinel.
           selector:
             "VariableDeclarator[init.type='MemberExpression'][init.object.name='process'][init.property.name='stdout'] > ObjectPattern",
           message:

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -44,6 +44,7 @@
     "dev": "tsx watch src/cli/index.ts",
     "test": "vitest run",
     "test:unit": "vitest run test/unit",
+    "pretest:integration": "node scripts/build.js",
     "test:integration": "vitest run test/integration",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/gitnexus/scripts/build-tree-sitter-dart.cjs
+++ b/gitnexus/scripts/build-tree-sitter-dart.cjs
@@ -3,6 +3,17 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
+// Opt-out: skip the native rebuild entirely. Dart parsing becomes
+// unavailable but `npm install gitnexus` finishes much faster on machines
+// without a C++ toolchain. Strict `=== '1'` only — '=true', '=yes', '=0'
+// (read as a string), and any other value all fall through to the rebuild.
+if (process.env.GITNEXUS_SKIP_OPTIONAL_GRAMMARS === '1') {
+  console.warn(
+    '[tree-sitter-dart] Skipping build (GITNEXUS_SKIP_OPTIONAL_GRAMMARS=1). Dart parsing will be unavailable until reinstalled without the env var.',
+  );
+  process.exit(0);
+}
+
 const dartDir = path.join(__dirname, '..', 'node_modules', 'tree-sitter-dart');
 const bindingGyp = path.join(dartDir, 'binding.gyp');
 const bindingNode = path.join(dartDir, 'build', 'Release', 'tree_sitter_dart_binding.node');

--- a/gitnexus/scripts/build-tree-sitter-proto.cjs
+++ b/gitnexus/scripts/build-tree-sitter-proto.cjs
@@ -34,6 +34,17 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
+// Opt-out: skip the native rebuild entirely. Proto parsing becomes
+// unavailable but `npm install gitnexus` finishes much faster on machines
+// without a C++ toolchain. Strict `=== '1'` only — '=true', '=yes', '=0'
+// (read as a string), and any other value all fall through to the rebuild.
+if (process.env.GITNEXUS_SKIP_OPTIONAL_GRAMMARS === '1') {
+  console.warn(
+    '[tree-sitter-proto] Skipping build (GITNEXUS_SKIP_OPTIONAL_GRAMMARS=1). Proto parsing will be unavailable until reinstalled without the env var.',
+  );
+  process.exit(0);
+}
+
 const protoDir = path.join(__dirname, '..', 'node_modules', 'tree-sitter-proto');
 const bindingGyp = path.join(protoDir, 'binding.gyp');
 const bindingNode = path.join(protoDir, 'build', 'Release', 'tree_sitter_proto_binding.node');

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -23,6 +23,8 @@ import {
 import { getGitRoot, hasGitDir } from '../storage/git.js';
 import { runFullAnalysis } from '../core/run-analyze.js';
 import { getMaxFileSizeBannerMessage } from '../core/ingestion/utils/max-file-size.js';
+import { warnMissingOptionalGrammars } from './optional-grammars.js';
+import { glob } from 'glob';
 import fs from 'fs/promises';
 
 // Capture stderr.write at module load BEFORE anything (LadybugDB native
@@ -245,6 +247,30 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
     console.log(
       '  Warning: no .git directory found \u2014 commit-tracking and incremental updates disabled.\n',
     );
+  }
+
+  // If the target repo contains files an optional grammar would parse but
+  // that grammar's native binding is absent, warn before analysis so users
+  // learn why those files end up unparsed instead of silently getting a
+  // degraded index.
+  try {
+    const matches = await glob(['**/*.dart', '**/*.proto'], {
+      cwd: repoPath,
+      ignore: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**'],
+      dot: false,
+      nodir: true,
+      absolute: false,
+    });
+    if (matches.length > 0) {
+      const present = new Set<string>();
+      for (const m of matches) {
+        const ext = path.extname(m).toLowerCase();
+        if (ext) present.add(ext);
+      }
+      warnMissingOptionalGrammars({ context: 'analyze', relevantExtensions: present });
+    }
+  } catch {
+    // Best-effort warning \u2014 never block analyze on the precheck.
   }
 
   // KuzuDB migration cleanup is handled by runFullAnalysis internally.

--- a/gitnexus/src/cli/mcp.ts
+++ b/gitnexus/src/cli/mcp.ts
@@ -11,17 +11,10 @@ import { LocalBackend } from '../mcp/local/local-backend.js';
 import { warnMissingOptionalGrammars } from './optional-grammars.js';
 
 export const mcpCommand = async () => {
-  // Prevent unhandled errors from crashing the MCP server process.
-  // LadybugDB lock conflicts and transient errors should degrade gracefully.
-  process.on('uncaughtException', (err) => {
-    console.error(`GitNexus MCP: uncaught exception — ${err.message}`);
-    // Process is in an undefined state after uncaughtException — exit after flushing
-    setTimeout(() => process.exit(1), 100);
-  });
-  process.on('unhandledRejection', (reason) => {
-    const msg = reason instanceof Error ? reason.message : String(reason);
-    console.error(`GitNexus MCP: unhandled rejection — ${msg}`);
-  });
+  // uncaughtException/unhandledRejection handlers are owned by
+  // startMCPServer (gitnexus/src/mcp/server.ts) so the server's shutdown
+  // path runs cleanly with full stack traces. Registering duplicates here
+  // would only produce noisy double-logging on the same exception.
 
   // Surface missing optional grammars at startup so users learn why
   // .dart/.proto files won't be parsed instead of silently getting a

--- a/gitnexus/src/cli/mcp.ts
+++ b/gitnexus/src/cli/mcp.ts
@@ -8,9 +8,21 @@
 
 import { startMCPServer } from '../mcp/server.js';
 import { LocalBackend } from '../mcp/local/local-backend.js';
+import { installGlobalStdoutSentinel } from '../mcp/stdio-context.js';
 import { warnMissingOptionalGrammars } from './optional-grammars.js';
 
 export const mcpCommand = async () => {
+  // Install the global stdout sentinel as the very first thing — before
+  // ANY other startup work that might emit to stdout. detectMissingOptionalGrammars
+  // (called from warnMissingOptionalGrammars below) actually require()s
+  // each native grammar binding; node-gyp-build / native init banners
+  // would otherwise reach raw stdout in the pre-sentinel window and
+  // corrupt the JSON-RPC frame stream — exactly the failure mode this
+  // PR fixes. backend.init / refreshRepos can also emit if a downstream
+  // module is misbehaving. Idempotent — startMCPServer calls it again
+  // as a safety net.
+  installGlobalStdoutSentinel();
+
   // uncaughtException/unhandledRejection handlers are owned by
   // startMCPServer (gitnexus/src/mcp/server.ts) so the server's shutdown
   // path runs cleanly with full stack traces. Registering duplicates here

--- a/gitnexus/src/cli/mcp.ts
+++ b/gitnexus/src/cli/mcp.ts
@@ -8,6 +8,7 @@
 
 import { startMCPServer } from '../mcp/server.js';
 import { LocalBackend } from '../mcp/local/local-backend.js';
+import { warnMissingOptionalGrammars } from './optional-grammars.js';
 
 export const mcpCommand = async () => {
   // Prevent unhandled errors from crashing the MCP server process.
@@ -21,6 +22,11 @@ export const mcpCommand = async () => {
     const msg = reason instanceof Error ? reason.message : String(reason);
     console.error(`GitNexus MCP: unhandled rejection — ${msg}`);
   });
+
+  // Surface missing optional grammars at startup so users learn why
+  // .dart/.proto files won't be parsed instead of silently getting a
+  // degraded index.
+  warnMissingOptionalGrammars({ context: 'mcp' });
 
   // Initialize multi-repo backend from registry.
   // The server starts even with 0 repos — tools call refreshRepos() lazily,

--- a/gitnexus/src/cli/mcp.ts
+++ b/gitnexus/src/cli/mcp.ts
@@ -4,29 +4,52 @@
  * Starts the MCP server in standalone mode.
  * Loads all indexed repos from the global registry.
  * No longer depends on cwd — works from any directory.
+ *
+ * IMPORTANT: this module's static-import closure is intentionally tiny
+ * (one chain: `mcp/stdio-context.js` → `mcp/stdio-capture.js`, which is a
+ * leaf with zero non-`node:` imports). All heavy backend modules
+ * (`startMCPServer`, `LocalBackend`, `warnMissingOptionalGrammars`) load
+ * via `await import(...)` AFTER `installGlobalStdoutSentinel()` runs.
+ *
+ * This closes the ESM-evaluation-order window where native init banners
+ * from `@ladybugdb/core` (or any future heavy import) could reach raw
+ * stdout before the sentinel exists. Codex's adversarial review on
+ * PR #1383 found that even with the sentinel-install call as the first
+ * statement of `mcpCommand`, ESM evaluates static imports of THIS module
+ * before the function body runs — so any native side effects during
+ * those imports happen before the sentinel can intercept them.
+ *
+ * If you find yourself adding a static `import` to this file, ask
+ * whether the imported module (or anything it transitively imports)
+ * touches `process.stdout` or loads a native binding at module init. If
+ * either is true, switch it to a dynamic `await import(...)` inside
+ * `mcpCommand` after the sentinel install. The regression test at
+ * `gitnexus/test/integration/mcp/import-closure.test.ts` enforces this.
  */
 
-import { startMCPServer } from '../mcp/server.js';
-import { LocalBackend } from '../mcp/local/local-backend.js';
 import { installGlobalStdoutSentinel } from '../mcp/stdio-context.js';
-import { warnMissingOptionalGrammars } from './optional-grammars.js';
 
 export const mcpCommand = async () => {
   // Install the global stdout sentinel as the very first thing — before
-  // ANY other startup work that might emit to stdout. detectMissingOptionalGrammars
-  // (called from warnMissingOptionalGrammars below) actually require()s
-  // each native grammar binding; node-gyp-build / native init banners
-  // would otherwise reach raw stdout in the pre-sentinel window and
-  // corrupt the JSON-RPC frame stream — exactly the failure mode this
-  // PR fixes. backend.init / refreshRepos can also emit if a downstream
-  // module is misbehaving. Idempotent — startMCPServer calls it again
-  // as a safety net.
+  // ANY other module loads. The static-import closure above is leaf-only
+  // (stdio-context → stdio-capture, zero non-`node:` deps), so this is
+  // also the first chance any code in this process has to write to stdout.
   installGlobalStdoutSentinel();
 
   // uncaughtException/unhandledRejection handlers are owned by
   // startMCPServer (gitnexus/src/mcp/server.ts) so the server's shutdown
   // path runs cleanly with full stack traces. Registering duplicates here
   // would only produce noisy double-logging on the same exception.
+
+  // Now safe to dynamically import the heavy backend modules. Anything
+  // they emit to stdout during evaluation will route through the sentinel.
+  const [{ startMCPServer }, { LocalBackend }, { warnMissingOptionalGrammars }] = await Promise.all(
+    [
+      import('../mcp/server.js'),
+      import('../mcp/local/local-backend.js'),
+      import('./optional-grammars.js'),
+    ],
+  );
 
   // Surface missing optional grammars at startup so users learn why
   // .dart/.proto files won't be parsed instead of silently getting a

--- a/gitnexus/src/cli/mcp.ts
+++ b/gitnexus/src/cli/mcp.ts
@@ -43,18 +43,18 @@ export const mcpCommand = async () => {
 
   // Now safe to dynamically import the heavy backend modules. Anything
   // they emit to stdout during evaluation will route through the sentinel.
-  const [{ startMCPServer }, { LocalBackend }, { warnMissingOptionalGrammars }] = await Promise.all(
-    [
-      import('../mcp/server.js'),
-      import('../mcp/local/local-backend.js'),
-      import('./optional-grammars.js'),
-    ],
-  );
+  const [{ startMCPServer }, { LocalBackend }] = await Promise.all([
+    import('../mcp/server.js'),
+    import('../mcp/local/local-backend.js'),
+  ]);
 
-  // Surface missing optional grammars at startup so users learn why
-  // .dart/.proto files won't be parsed instead of silently getting a
-  // degraded index.
-  warnMissingOptionalGrammars({ context: 'mcp' });
+  // Note: missing-optional-grammar warnings are emitted by `gitnexus analyze`
+  // (with `relevantExtensions` filtered to the repo's actual file types) at
+  // index time. A repo can only be served by MCP after it has been analyzed,
+  // so the user has already been warned through the path that knows whether
+  // the repo even contains .dart/.proto files. Repeating an unconditional
+  // warning at every MCP startup would be pure noise on machines whose
+  // indexed repos don't use those grammars.
 
   // Initialize multi-repo backend from registry.
   // The server starts even with 0 repos — tools call refreshRepos() lazily,

--- a/gitnexus/src/cli/mcp.ts
+++ b/gitnexus/src/cli/mcp.ts
@@ -48,13 +48,11 @@ export const mcpCommand = async () => {
     import('../mcp/local/local-backend.js'),
   ]);
 
-  // Note: missing-optional-grammar warnings are emitted by `gitnexus analyze`
-  // (with `relevantExtensions` filtered to the repo's actual file types) at
-  // index time. A repo can only be served by MCP after it has been analyzed,
-  // so the user has already been warned through the path that knows whether
-  // the repo even contains .dart/.proto files. Repeating an unconditional
-  // warning at every MCP startup would be pure noise on machines whose
-  // indexed repos don't use those grammars.
+  // Missing-optional-grammar warnings are intentionally NOT emitted here.
+  // `gitnexus analyze` already warns at index time, filtered by the repo's
+  // actual extensions, and a repo can only be served by MCP after analyze
+  // has run. Repeating an unconditional warning at every MCP startup is
+  // pure noise for users whose indexed repos don't use Dart/Proto.
 
   // Initialize multi-repo backend from registry.
   // The server starts even with 0 repos — tools call refreshRepos() lazily,

--- a/gitnexus/src/cli/optional-grammars.ts
+++ b/gitnexus/src/cli/optional-grammars.ts
@@ -1,0 +1,78 @@
+/**
+ * Optional grammar availability check.
+ *
+ * tree-sitter-dart and tree-sitter-proto are optionalDependencies that
+ * require a `node-gyp rebuild` at install time. The build can be skipped
+ * via GITNEXUS_SKIP_OPTIONAL_GRAMMARS=1 (postinstall scripts), or it can
+ * silently soft-fail when the C++ toolchain is missing.
+ *
+ * Either path produces the same observable: the .node binding is absent
+ * at runtime. This helper detects that condition and surfaces a single
+ * stderr line per missing grammar so users learn why .dart/.proto support
+ * is unavailable instead of silently getting a degraded index.
+ */
+
+import { createRequire } from 'module';
+
+const _require = createRequire(import.meta.url);
+
+interface OptionalGrammar {
+  /** Display name in warnings */
+  name: string;
+  /** Module name to require.resolve */
+  pkg: string;
+  /** File extensions this grammar parses */
+  extensions: string[];
+}
+
+const OPTIONAL_GRAMMARS: OptionalGrammar[] = [
+  { name: 'tree-sitter-dart', pkg: 'tree-sitter-dart', extensions: ['.dart'] },
+  { name: 'tree-sitter-proto', pkg: 'tree-sitter-proto', extensions: ['.proto'] },
+];
+
+export interface MissingGrammar {
+  name: string;
+  extensions: string[];
+}
+
+/**
+ * Returns the list of optional grammars whose native binding cannot be
+ * loaded. Cheap: just `require.resolve`, no actual import.
+ */
+export function detectMissingOptionalGrammars(): MissingGrammar[] {
+  const missing: MissingGrammar[] = [];
+  for (const g of OPTIONAL_GRAMMARS) {
+    try {
+      _require.resolve(g.pkg);
+    } catch {
+      missing.push({ name: g.name, extensions: g.extensions });
+    }
+  }
+  return missing;
+}
+
+/**
+ * Log a one-line stderr warning for each missing grammar. Safe to call
+ * unconditionally — silent if all grammars are present.
+ *
+ * `relevantExtensions`, if provided, filters the warning to grammars whose
+ * extensions appear in the set (e.g. an analyze run can pass the set of
+ * extensions actually present in the target repo so users without any
+ * .dart/.proto files don't see noise).
+ */
+export function warnMissingOptionalGrammars(opts?: {
+  context?: string;
+  relevantExtensions?: ReadonlySet<string>;
+}): void {
+  const missing = detectMissingOptionalGrammars();
+  if (missing.length === 0) return;
+  const ctx = opts?.context ? ` [${opts.context}]` : '';
+  for (const g of missing) {
+    if (opts?.relevantExtensions && !g.extensions.some((e) => opts.relevantExtensions!.has(e))) {
+      continue;
+    }
+    console.error(
+      `GitNexus${ctx}: optional grammar "${g.name}" is unavailable — ${g.extensions.join('/')} files will not be parsed. Reinstall without GITNEXUS_SKIP_OPTIONAL_GRAMMARS=1 (and ensure python3, make, g++) to enable.`,
+    );
+  }
+}

--- a/gitnexus/src/cli/optional-grammars.ts
+++ b/gitnexus/src/cli/optional-grammars.ts
@@ -35,10 +35,6 @@ export interface MissingGrammar {
   extensions: string[];
 }
 
-// Memoize the probe result — actually requiring the grammar loads its
-// native binding (via node-gyp-build), which we don't need to do twice.
-let _detectionCache: MissingGrammar[] | null = null;
-
 /**
  * Returns the list of optional grammars whose native binding cannot be
  * loaded. Actually `require()`s the package — `require.resolve` would
@@ -47,18 +43,36 @@ let _detectionCache: MissingGrammar[] | null = null;
  * outcome), giving false negatives for the exact users we want to warn:
  * those who installed with `GITNEXUS_SKIP_OPTIONAL_GRAMMARS=1` or whose
  * native rebuild soft-failed for missing toolchain.
+ *
+ * Node's module cache memoizes `require()` for us — calling this multiple
+ * times is cheap. The catch distinguishes "missing" (MODULE_NOT_FOUND or
+ * the typical node-gyp-build "could not find any binding" pattern) from
+ * "broken" (SyntaxError, EACCES, native crash). Broken bindings surface a
+ * separate stderr line so users get an actionable message instead of a
+ * misleading "reinstall" hint.
  */
 export function detectMissingOptionalGrammars(): MissingGrammar[] {
-  if (_detectionCache) return _detectionCache;
   const missing: MissingGrammar[] = [];
   for (const g of OPTIONAL_GRAMMARS) {
     try {
       _require(g.pkg);
-    } catch {
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      const msg = err instanceof Error ? err.message : String(err);
+      const looksMissing =
+        code === 'MODULE_NOT_FOUND' ||
+        code === 'ERR_MODULE_NOT_FOUND' ||
+        /could not find|no native build|prebuilds/i.test(msg);
+      if (!looksMissing) {
+        // Present but broken — surface so the user doesn't get a misleading
+        // "reinstall" recovery message that wouldn't actually help.
+        console.error(
+          `GitNexus: optional grammar "${g.name}" is installed but failed to load (${msg.slice(0, 200)}). ${g.extensions.join('/')} files will not be parsed.`,
+        );
+      }
       missing.push({ name: g.name, extensions: g.extensions });
     }
   }
-  _detectionCache = missing;
   return missing;
 }
 

--- a/gitnexus/src/cli/optional-grammars.ts
+++ b/gitnexus/src/cli/optional-grammars.ts
@@ -35,19 +35,30 @@ export interface MissingGrammar {
   extensions: string[];
 }
 
+// Memoize the probe result — actually requiring the grammar loads its
+// native binding (via node-gyp-build), which we don't need to do twice.
+let _detectionCache: MissingGrammar[] | null = null;
+
 /**
  * Returns the list of optional grammars whose native binding cannot be
- * loaded. Cheap: just `require.resolve`, no actual import.
+ * loaded. Actually `require()`s the package — `require.resolve` would
+ * locate the entry path even when the `.node` binding is absent (the
+ * `file:` package directory is installed regardless of postinstall
+ * outcome), giving false negatives for the exact users we want to warn:
+ * those who installed with `GITNEXUS_SKIP_OPTIONAL_GRAMMARS=1` or whose
+ * native rebuild soft-failed for missing toolchain.
  */
 export function detectMissingOptionalGrammars(): MissingGrammar[] {
+  if (_detectionCache) return _detectionCache;
   const missing: MissingGrammar[] = [];
   for (const g of OPTIONAL_GRAMMARS) {
     try {
-      _require.resolve(g.pkg);
+      _require(g.pkg);
     } catch {
       missing.push({ name: g.name, extensions: g.extensions });
     }
   }
+  _detectionCache = missing;
   return missing;
 }
 

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -10,6 +10,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import { execFile, execFileSync } from 'child_process';
+import { createRequire } from 'module';
 import { promisify } from 'util';
 import { fileURLToPath } from 'url';
 import { glob } from 'glob';
@@ -19,6 +20,16 @@ import { getGlobalDir } from '../storage/repo-manager.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const execFileAsync = promisify(execFile);
+
+// Pin the npx fallback to the installed version. Reason: setup.ts writes
+// a config that persists in the user's editor and is invoked on every MCP
+// connect. Pinning to the installed version means subsequent invocations
+// skip the npm-registry metadata roundtrip (and stay reproducible until
+// the user upgrades). Static configs and READMEs intentionally use
+// `gitnexus@latest` since they're quickstart docs, not persisted state.
+const _require = createRequire(import.meta.url);
+const _pkg = _require('../../package.json') as { version: string };
+const NPX_REF = `gitnexus@${_pkg.version}`;
 
 interface SetupResult {
   configured: string[];
@@ -62,8 +73,10 @@ function resolveGitnexusBin(): string | null {
  * The MCP server entry for all editors.
  *
  * Prefers the globally-installed `gitnexus` binary (starts in ~1 s) over
- * `npx -y gitnexus@latest` (cold-cache install of native deps can take
- * >60 s, exceeding Claude Code's 30 s MCP connection timeout).
+ * `npx -y gitnexus@<version>` (cold-cache install of native deps can take
+ * >60 s, exceeding Claude Code's 30 s MCP connection timeout). The fallback
+ * version is read from gitnexus/package.json#version at module load so the
+ * persisted user config matches the installed package.
  *
  * Falls back to npx when the binary isn't on PATH — e.g. first-time
  * users who ran `npx gitnexus analyze` but haven't done `npm i -g`.
@@ -79,12 +92,12 @@ function getMcpEntry() {
   if (process.platform === 'win32') {
     return {
       command: 'cmd',
-      args: ['/c', 'npx', '-y', 'gitnexus@latest', 'mcp'],
+      args: ['/c', 'npx', '-y', NPX_REF, 'mcp'],
     };
   }
   return {
     command: 'npx',
-    args: ['-y', 'gitnexus@latest', 'mcp'],
+    args: ['-y', NPX_REF, 'mcp'],
   };
 }
 
@@ -100,9 +113,9 @@ function getOpenCodeMcpEntry() {
   }
 
   if (process.platform === 'win32') {
-    return { type: 'local', command: ['cmd', '/c', 'npx', '-y', 'gitnexus@latest', 'mcp'] };
+    return { type: 'local', command: ['cmd', '/c', 'npx', '-y', NPX_REF, 'mcp'] };
   }
-  return { type: 'local', command: ['npx', '-y', 'gitnexus@latest', 'mcp'] };
+  return { type: 'local', command: ['npx', '-y', NPX_REF, 'mcp'] };
 }
 
 /**

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -28,7 +28,12 @@ const execFileAsync = promisify(execFile);
 // the user upgrades). Static configs and READMEs intentionally use
 // `gitnexus@latest` since they're quickstart docs, not persisted state.
 const _require = createRequire(import.meta.url);
-const _pkg = _require('../../package.json') as { version: string };
+const _pkg = _require('../../package.json') as { version?: unknown };
+if (typeof _pkg.version !== 'string' || !_pkg.version) {
+  throw new Error(
+    'gitnexus/package.json#version is missing or not a string — cannot generate MCP fallback config.',
+  );
+}
 const NPX_REF = `gitnexus@${_pkg.version}`;
 
 interface SetupResult {

--- a/gitnexus/src/core/embeddings/embedder.ts
+++ b/gitnexus/src/core/embeddings/embedder.ts
@@ -166,7 +166,7 @@ export const initEmbedder = async (
 
       const isDev = process.env.NODE_ENV === 'development';
       if (isDev) {
-        console.log(`🧠 Loading embedding model: ${finalConfig.modelId}`);
+        console.error(`🧠 Loading embedding model: ${finalConfig.modelId}`);
       }
 
       const progressCallback = onProgress
@@ -192,13 +192,13 @@ export const initEmbedder = async (
       for (const device of devicesToTry) {
         try {
           if (isDev && device === 'dml') {
-            console.log('🔧 Trying DirectML (DirectX12) GPU backend...');
+            console.error('🔧 Trying DirectML (DirectX12) GPU backend...');
           } else if (isDev && device === 'cuda') {
-            console.log('🔧 Trying CUDA GPU backend...');
+            console.error('🔧 Trying CUDA GPU backend...');
           } else if (isDev && device === 'cpu') {
-            console.log('🔧 Using CPU backend...');
+            console.error('🔧 Using CPU backend...');
           } else if (isDev && device === 'wasm') {
-            console.log('🔧 Using WASM backend (slower)...');
+            console.error('🔧 Using WASM backend (slower)...');
           }
 
           embedderInstance = await (pipeline as any)('feature-extraction', finalConfig.modelId, {
@@ -221,15 +221,15 @@ export const initEmbedder = async (
                 : device === 'cuda'
                   ? 'GPU (CUDA)'
                   : device.toUpperCase();
-            console.log(`✅ Using ${label} backend`);
-            console.log('✅ Embedding model loaded successfully');
+            console.error(`✅ Using ${label} backend`);
+            console.error('✅ Embedding model loaded successfully');
           }
 
           return embedderInstance!;
         } catch (deviceError) {
           if (isDev && (device === 'cuda' || device === 'dml')) {
             const gpuType = device === 'dml' ? 'DirectML' : 'CUDA';
-            console.log(`⚠️  ${gpuType} not available, falling back to CPU...`);
+            console.error(`⚠️  ${gpuType} not available, falling back to CPU...`);
           }
           // Continue to next device in list
           if (device === devicesToTry[devicesToTry.length - 1]) {

--- a/gitnexus/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus/src/core/embeddings/embedding-pipeline.ts
@@ -157,7 +157,7 @@ const queryEmbeddableNodes = async (
       }
     } catch (error) {
       if (isDev) {
-        console.warn(`Query for ${label} nodes failed:`, error);
+        console.error(`Query for ${label} nodes failed:`, error);
       }
     }
   }
@@ -212,7 +212,7 @@ const createVectorIndex = async (
     return true;
   } catch (error) {
     if (isDev) {
-      console.warn('Vector index creation warning:', error);
+      console.error('Vector index creation warning:', error);
     }
     return false;
   }
@@ -256,7 +256,7 @@ export const runEmbeddingPipeline = async (
 
   try {
     const vectorAvailable = await ensureVectorExtensionAvailable();
-    if (!vectorAvailable && isDev) console.warn(vectorUnavailableMessage);
+    if (!vectorAvailable && isDev) console.error(vectorUnavailableMessage);
 
     // Phase 1: Load embedding model
     onProgress({
@@ -283,7 +283,7 @@ export const runEmbeddingPipeline = async (
     });
 
     if (isDev) {
-      console.log('🔍 Querying embeddable nodes...');
+      console.error('🔍 Querying embeddable nodes...');
     }
 
     // Phase 2: Query embeddable nodes
@@ -325,7 +325,7 @@ export const runEmbeddingPipeline = async (
       // (Kuzu forbids SET on vector-indexed properties; DELETE-then-INSERT is the sanctioned pattern)
       if (staleNodeIds.length > 0) {
         if (isDev) {
-          console.log(`🔄 Deleting ${staleNodeIds.length} stale embedding rows for re-embed`);
+          console.error(`🔄 Deleting ${staleNodeIds.length} stale embedding rows for re-embed`);
         }
         try {
           await executeWithReusedStatement(
@@ -346,7 +346,7 @@ export const runEmbeddingPipeline = async (
       }
 
       if (isDev) {
-        console.log(
+        console.error(
           `📦 Incremental embeddings: ${beforeCount} total, ${existingEmbeddings.size} cached, ${staleNodeIds.length} stale, ${nodes.length} to embed`,
         );
       }
@@ -355,7 +355,7 @@ export const runEmbeddingPipeline = async (
     const totalNodes = nodes.length;
 
     if (isDev) {
-      console.log(`📊 Found ${totalNodes} embeddable nodes`);
+      console.error(`📊 Found ${totalNodes} embeddable nodes`);
     }
 
     if (totalNodes === 0) {
@@ -442,7 +442,7 @@ export const runEmbeddingPipeline = async (
             );
           } catch (chunkErr) {
             if (isDev) {
-              console.warn(
+              console.error(
                 `⚠️ AST chunking failed for ${node.label} "${node.name}" (${node.filePath}), falling back to character-based chunking:`,
                 chunkErr,
               );
@@ -520,7 +520,7 @@ export const runEmbeddingPipeline = async (
     });
 
     if (isDev) {
-      console.log('📇 Creating vector index...');
+      console.error('📇 Creating vector index...');
     }
 
     const vectorIndexReady = await createVectorIndex(executeQuery);
@@ -533,7 +533,7 @@ export const runEmbeddingPipeline = async (
     });
 
     if (isDev) {
-      console.log(
+      console.error(
         `✅ Embedding pipeline complete! (${totalChunks} chunks from ${totalNodes} nodes)`,
       );
     }

--- a/gitnexus/src/core/lbug/extension-loader.ts
+++ b/gitnexus/src/core/lbug/extension-loader.ts
@@ -188,7 +188,7 @@ export class ExtensionManager {
     const policy = opts.policy ?? this.options.policy ?? resolvePolicyFromEnv();
     const timeoutMs =
       opts.installTimeoutMs ?? this.options.installTimeoutMs ?? getExtensionInstallTimeoutMs();
-    const warn = this.options.warn ?? console.warn;
+    const warn = this.options.warn ?? console.error;
 
     if (policy === 'never') {
       this.markUnavailable(name, label, 'extension install policy is "never"', warn);

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -364,7 +364,7 @@ const doInitLbug = async (dbPath: string) => {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (!msg.includes('already exists')) {
-        console.warn(`⚠️ Schema creation warning: ${msg.slice(0, 120)}`);
+        console.error(`[gitnexus:lbug] schema creation warning: ${msg.slice(0, 120)}`);
       }
     }
   }
@@ -1044,15 +1044,15 @@ export const fetchExistingEmbeddingHashes = async (
           const nodeId = r.nodeId ?? r[0];
           if (nodeId) map.set(nodeId, STALE_HASH_SENTINEL);
         }
-        console.log(
-          `[embed] ${map.size} nodes in legacy DB (missing chunk-aware columns) — all treated as stale`,
+        console.error(
+          `[gitnexus:embed] ${map.size} nodes in legacy DB (missing chunk-aware columns) — all treated as stale`,
         );
         return map;
       } catch (fallbackErr: any) {
         const fallbackMsg = fallbackErr?.message ?? '';
         if (isMissingColumnOrTableError(fallbackMsg)) {
-          console.log(
-            `[embed] CodeEmbedding table not yet present — full embedding run (${fallbackMsg})`,
+          console.error(
+            `[gitnexus:embed] CodeEmbedding table not yet present — full embedding run (${fallbackMsg})`,
           );
           return undefined;
         }

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -89,6 +89,28 @@ let idleTimer: ReturnType<typeof setInterval> | null = null;
 export const realStdoutWrite = process.stdout.write.bind(process.stdout);
 export const realStderrWrite = process.stderr.write.bind(process.stderr);
 let stdoutSilenceCount = 0;
+
+/**
+ * The function `restoreStdout` (and the watchdog) should restore *to*
+ * when un-silencing. Defaults to the captured real write. The MCP server
+ * registers the stdout sentinel here at startMCPServer so silenceStdout
+ * cycles preserve the sentinel — without this, every restore would bypass
+ * the sentinel and leave any stray write going to real stdout uncaught.
+ */
+type StdoutWrite = typeof process.stdout.write;
+let activeStdoutWrite: StdoutWrite = realStdoutWrite;
+
+/**
+ * Register a wrapper (e.g. the MCP sentinel) as the active stdout write.
+ * silenceStdout/restoreStdout cycles will preserve the wrapper instead of
+ * unwinding to the raw realStdoutWrite. Returns the previous value so
+ * callers can chain or restore.
+ */
+export function setActiveStdoutWrite(fn: StdoutWrite): StdoutWrite {
+  const prev = activeStdoutWrite;
+  activeStdoutWrite = fn;
+  return prev;
+}
 /** True while pre-warming connections — prevents watchdog from prematurely restoring stdout */
 let preWarmActive = false;
 
@@ -218,8 +240,8 @@ export function silenceStdout(): void {
 export function restoreStdout(): void {
   if (--stdoutSilenceCount <= 0) {
     stdoutSilenceCount = 0;
-    // eslint-disable-next-line no-restricted-syntax -- restoring the captured real write is the silencing API contract
-    process.stdout.write = realStdoutWrite;
+    // eslint-disable-next-line no-restricted-syntax -- restoring the active stdout-write handler is the silencing API contract
+    process.stdout.write = activeStdoutWrite;
   }
 }
 
@@ -231,7 +253,7 @@ setInterval(() => {
   if (stdoutSilenceCount > 0 && !preWarmActive && activeQueryCount === 0) {
     stdoutSilenceCount = 0;
     // eslint-disable-next-line no-restricted-syntax -- watchdog recovery for stuck silencing
-    process.stdout.write = realStdoutWrite;
+    process.stdout.write = activeStdoutWrite;
   }
 }, 1000).unref();
 

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -85,6 +85,7 @@ const MAX_CONNS_PER_REPO = 8;
 let idleTimer: ReturnType<typeof setInterval> | null = null;
 
 /** Saved real stdout/stderr write — used to silence native module output without race conditions */
+// eslint-disable-next-line no-restricted-syntax -- this IS the captured-real-write infrastructure used by the MCP sentinel
 export const realStdoutWrite = process.stdout.write.bind(process.stdout);
 export const realStderrWrite = process.stderr.write.bind(process.stderr);
 let stdoutSilenceCount = 0;
@@ -209,6 +210,7 @@ let activeQueryCount = 0;
  */
 export function silenceStdout(): void {
   if (stdoutSilenceCount++ === 0) {
+    // eslint-disable-next-line no-restricted-syntax -- silencing infrastructure; replacement is a no-op
     process.stdout.write = (() => true) as any;
   }
 }
@@ -216,6 +218,7 @@ export function silenceStdout(): void {
 export function restoreStdout(): void {
   if (--stdoutSilenceCount <= 0) {
     stdoutSilenceCount = 0;
+    // eslint-disable-next-line no-restricted-syntax -- restoring the captured real write is the silencing API contract
     process.stdout.write = realStdoutWrite;
   }
 }
@@ -227,6 +230,7 @@ export function restoreStdout(): void {
 setInterval(() => {
   if (stdoutSilenceCount > 0 && !preWarmActive && activeQueryCount === 0) {
     stdoutSilenceCount = 0;
+    // eslint-disable-next-line no-restricted-syntax -- watchdog recovery for stuck silencing
     process.stdout.write = realStdoutWrite;
   }
 }, 1000).unref();

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -84,33 +84,22 @@ const MAX_CONNS_PER_REPO = 8;
 
 let idleTimer: ReturnType<typeof setInterval> | null = null;
 
-/** Saved real stdout/stderr write — used to silence native module output without race conditions */
-// eslint-disable-next-line no-restricted-syntax -- this IS the captured-real-write infrastructure used by the MCP sentinel
-export const realStdoutWrite = process.stdout.write.bind(process.stdout);
-export const realStderrWrite = process.stderr.write.bind(process.stderr);
+// Stdout-capture state lives in `gitnexus/src/mcp/stdio-capture.ts` — a leaf
+// module with zero non-`node:` imports. We re-export the same symbols here
+// so the existing test mock seam (`gitnexus/src/mcp/core/lbug-adapter.ts`
+// re-exports * from this file, and 8+ test files use that path with
+// `vi.mock(...)`) continues to work without churn. The source of truth is
+// the leaf module; this re-export is a compatibility shim.
+//
+// Why the leaf module exists: Codex's adversarial review on PR #1383 found
+// that putting this state in pool-adapter.ts pulled `@ladybugdb/core` into
+// `cli/mcp.ts`'s static-import closure (via stdio-context → pool-adapter →
+// @ladybugdb/core), corrupting stdout in the pre-sentinel window. Routing
+// through the leaf breaks that chain.
+export { realStdoutWrite, realStderrWrite, setActiveStdoutWrite } from '../../mcp/stdio-capture.js';
+import { getActiveStdoutWrite } from '../../mcp/stdio-capture.js';
+
 let stdoutSilenceCount = 0;
-
-/**
- * The function `restoreStdout` (and the watchdog) should restore *to*
- * when un-silencing. Defaults to the captured real write. The MCP server
- * registers the stdout sentinel here at startMCPServer so silenceStdout
- * cycles preserve the sentinel — without this, every restore would bypass
- * the sentinel and leave any stray write going to real stdout uncaught.
- */
-type StdoutWrite = typeof process.stdout.write;
-let activeStdoutWrite: StdoutWrite = realStdoutWrite;
-
-/**
- * Register a wrapper (e.g. the MCP sentinel) as the active stdout write.
- * silenceStdout/restoreStdout cycles will preserve the wrapper instead of
- * unwinding to the raw realStdoutWrite. Returns the previous value so
- * callers can chain or restore.
- */
-export function setActiveStdoutWrite(fn: StdoutWrite): StdoutWrite {
-  const prev = activeStdoutWrite;
-  activeStdoutWrite = fn;
-  return prev;
-}
 /** True while pre-warming connections — prevents watchdog from prematurely restoring stdout */
 let preWarmActive = false;
 
@@ -241,7 +230,7 @@ export function restoreStdout(): void {
   if (--stdoutSilenceCount <= 0) {
     stdoutSilenceCount = 0;
     // eslint-disable-next-line no-restricted-syntax -- restoring the active stdout-write handler is the silencing API contract
-    process.stdout.write = activeStdoutWrite;
+    process.stdout.write = getActiveStdoutWrite();
   }
 }
 
@@ -253,7 +242,7 @@ setInterval(() => {
   if (stdoutSilenceCount > 0 && !preWarmActive && activeQueryCount === 0) {
     stdoutSilenceCount = 0;
     // eslint-disable-next-line no-restricted-syntax -- watchdog recovery for stuck silencing
-    process.stdout.write = activeStdoutWrite;
+    process.stdout.write = getActiveStdoutWrite();
   }
 }, 1000).unref();
 

--- a/gitnexus/src/core/tree-sitter/parser-loader.ts
+++ b/gitnexus/src/core/tree-sitter/parser-loader.ts
@@ -175,8 +175,10 @@ const logFailure = (key: string, result: LoadResult): void => {
   logged.add(key);
   const message = `[gitnexus] ${result.note} (${result.error.message})`;
 
-  if (result.severity === 'error') console.error(message);
-  else console.warn(message);
+  // Both severities go to stderr — console.warn writes to stderr too, but
+  // console.error is the stdout-safe channel we standardize on across
+  // MCP-reachable code so the ESLint rule covers this directory.
+  console.error(message);
 };
 
 export const resolveLanguageKey = (language: SupportedLanguages, filePath?: string): string =>

--- a/gitnexus/src/mcp/compatible-stdio-transport.ts
+++ b/gitnexus/src/mcp/compatible-stdio-transport.ts
@@ -4,6 +4,7 @@ import type {
   TransportSendOptions,
 } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { JSONRPCMessageSchema, type JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { withMcpWrite } from './stdio-context.js';
 
 export type StdioFraming = 'content-length' | 'newline';
 
@@ -232,7 +233,12 @@ export class CompatibleStdioServerTransport implements Transport {
 
       this._stdout.on('error', onError);
 
-      if (this._stdout.write(payload)) {
+      // Tag the write with the MCP transport context so the sentinel
+      // (server.ts createStdoutSentinel Proxy) recognizes it as a legitimate
+      // JSON-RPC frame and passes it through to the real stdout instead of
+      // redirecting to stderr.
+      const writeOk = withMcpWrite(() => this._stdout.write(payload));
+      if (writeOk) {
         this._stdout.removeListener('error', onError);
         resolve();
       } else {

--- a/gitnexus/src/mcp/core/lbug-adapter.ts
+++ b/gitnexus/src/mcp/core/lbug-adapter.ts
@@ -1,5 +1,11 @@
 /**
  * LadybugDB connection pool — re-exported from core.
- * Prefer importing from `../../core/lbug/pool-adapter.js` in new code.
+ *
+ * KEEP THIS FILE. It is intentionally a shim re-export of
+ * `../../core/lbug/pool-adapter.js`. The MCP test suite uses this path as
+ * a vi.mock seam so unit tests can stub LadybugDB without affecting other
+ * importers of `core/lbug/pool-adapter.js` (which is shared with the
+ * analyze pipeline). New non-test code MAY import from `pool-adapter.js`
+ * directly, but the shim must continue to exist for the mock seam to work.
  */
 export * from '../../core/lbug/pool-adapter.js';

--- a/gitnexus/src/mcp/server.ts
+++ b/gitnexus/src/mcp/server.ts
@@ -24,7 +24,8 @@ import {
   GetPromptRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { GITNEXUS_TOOLS } from './tools.js';
-import { realStdoutWrite } from './core/lbug-adapter.js';
+import { realStdoutWrite, realStderrWrite } from './core/lbug-adapter.js';
+import { createStdoutSentinel } from './stdio-context.js';
 import type { LocalBackend } from './local/local-backend.js';
 import { getResourceDefinitions, getResourceTemplates, readResource } from './resources.js';
 
@@ -287,18 +288,27 @@ Follow these steps:
 export async function startMCPServer(backend: LocalBackend): Promise<void> {
   const server = createMCPServer(backend);
 
-  // Use the shared stdout reference captured at module-load time by the
-  // lbug-adapter.  Avoids divergence if anything patches stdout between
-  // module load and server start.
+  // Sentinel-protected stdout. Tagged transport writes (those wrapped in
+  // withMcpWrite by compatible-stdio-transport.send) pass straight through
+  // to the real stdout reference captured at module load. Untagged writes
+  // (anything that calls process.stdout.write outside the transport — stray
+  // console.log, dependency banner, dotenv debug, etc.) get redirected to
+  // stderr with a [mcp:stdout-redirect] prefix so the MCP JSON-RPC stream
+  // stays clean by construction. See gitnexus/src/mcp/stdio-context.ts.
+  const sentinel = createStdoutSentinel({ realStdoutWrite, realStderrWrite });
   const _safeStdout = new Proxy(process.stdout, {
     get(target, prop, receiver) {
-      if (prop === 'write') return realStdoutWrite;
+      if (prop === 'write') return sentinel.write;
       const val = Reflect.get(target, prop, receiver);
       return typeof val === 'function' ? val.bind(target) : val;
     },
   });
   const transport = new CompatibleStdioServerTransport(process.stdin, _safeStdout);
   await server.connect(transport);
+
+  // Surface the redirect counter on shutdown so users see the volume of
+  // stray writes even when individual payloads were truncated/suppressed.
+  process.on('exit', () => sentinel.flushSummary());
 
   // Graceful shutdown helper
   let shuttingDown = false;

--- a/gitnexus/src/mcp/server.ts
+++ b/gitnexus/src/mcp/server.ts
@@ -24,8 +24,7 @@ import {
   GetPromptRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { GITNEXUS_TOOLS } from './tools.js';
-import { realStdoutWrite, realStderrWrite, setActiveStdoutWrite } from './core/lbug-adapter.js';
-import { createStdoutSentinel } from './stdio-context.js';
+import { installGlobalStdoutSentinel } from './stdio-context.js';
 import type { LocalBackend } from './local/local-backend.js';
 import { getResourceDefinitions, getResourceTemplates, readResource } from './resources.js';
 
@@ -288,27 +287,17 @@ Follow these steps:
 export async function startMCPServer(backend: LocalBackend): Promise<void> {
   const server = createMCPServer(backend);
 
-  // Sentinel-protected stdout. Two layers of defense:
-  //
-  //   1. Global: process.stdout.write is replaced with sentinel.write at
-  //      MCP startup, AND registered as the "active" handler in
-  //      pool-adapter so silenceStdout/restoreStdout cycles preserve it
-  //      instead of unwinding to the raw realStdoutWrite. Direct
-  //      process.stdout.write calls from anywhere — console.log,
-  //      dependency banners, dotenv debug — go through the sentinel.
-  //
-  //   2. Transport: the existing _safeStdout Proxy is kept as a
-  //      belt-and-suspenders gate so the transport's writes always
-  //      reach sentinel.write even if some other module re-replaces
-  //      process.stdout.write. Tagged transport writes (those wrapped
-  //      in withMcpWrite by compatible-stdio-transport.send) pass
-  //      through to the captured realStdoutWrite; untagged writes
-  //      reaching the Proxy or process.stdout get redirected to stderr
-  //      with a [mcp:stdout-redirect] prefix. See stdio-context.ts.
-  const sentinel = createStdoutSentinel({ realStdoutWrite, realStderrWrite });
-  // eslint-disable-next-line no-restricted-syntax -- installing the global sentinel is the API contract
-  process.stdout.write = sentinel.write;
-  setActiveStdoutWrite(sentinel.write);
+  // Idempotent global sentinel install. cli/mcp.ts calls this first thing
+  // (before warnMissingOptionalGrammars / backend.init can emit to stdout);
+  // calling again here is a safety net for direct callers of startMCPServer
+  // (tests, future entry points). The transport's _safeStdout Proxy is a
+  // second layer that guarantees transport writes reach the sentinel even
+  // if anything else re-replaces process.stdout.write later. Tagged
+  // transport writes (wrapped in withMcpWrite by compatible-stdio-transport.send)
+  // pass through to the captured realStdoutWrite; untagged writes reaching
+  // the Proxy or process.stdout get redirected to stderr with the
+  // [mcp:stdout-redirect] prefix. See stdio-context.ts.
+  const sentinel = installGlobalStdoutSentinel();
   const _safeStdout = new Proxy(process.stdout, {
     get(target, prop, receiver) {
       if (prop === 'write') return sentinel.write;

--- a/gitnexus/src/mcp/server.ts
+++ b/gitnexus/src/mcp/server.ts
@@ -24,7 +24,7 @@ import {
   GetPromptRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { GITNEXUS_TOOLS } from './tools.js';
-import { realStdoutWrite, realStderrWrite } from './core/lbug-adapter.js';
+import { realStdoutWrite, realStderrWrite, setActiveStdoutWrite } from './core/lbug-adapter.js';
 import { createStdoutSentinel } from './stdio-context.js';
 import type { LocalBackend } from './local/local-backend.js';
 import { getResourceDefinitions, getResourceTemplates, readResource } from './resources.js';
@@ -288,14 +288,27 @@ Follow these steps:
 export async function startMCPServer(backend: LocalBackend): Promise<void> {
   const server = createMCPServer(backend);
 
-  // Sentinel-protected stdout. Tagged transport writes (those wrapped in
-  // withMcpWrite by compatible-stdio-transport.send) pass straight through
-  // to the real stdout reference captured at module load. Untagged writes
-  // (anything that calls process.stdout.write outside the transport — stray
-  // console.log, dependency banner, dotenv debug, etc.) get redirected to
-  // stderr with a [mcp:stdout-redirect] prefix so the MCP JSON-RPC stream
-  // stays clean by construction. See gitnexus/src/mcp/stdio-context.ts.
+  // Sentinel-protected stdout. Two layers of defense:
+  //
+  //   1. Global: process.stdout.write is replaced with sentinel.write at
+  //      MCP startup, AND registered as the "active" handler in
+  //      pool-adapter so silenceStdout/restoreStdout cycles preserve it
+  //      instead of unwinding to the raw realStdoutWrite. Direct
+  //      process.stdout.write calls from anywhere — console.log,
+  //      dependency banners, dotenv debug — go through the sentinel.
+  //
+  //   2. Transport: the existing _safeStdout Proxy is kept as a
+  //      belt-and-suspenders gate so the transport's writes always
+  //      reach sentinel.write even if some other module re-replaces
+  //      process.stdout.write. Tagged transport writes (those wrapped
+  //      in withMcpWrite by compatible-stdio-transport.send) pass
+  //      through to the captured realStdoutWrite; untagged writes
+  //      reaching the Proxy or process.stdout get redirected to stderr
+  //      with a [mcp:stdout-redirect] prefix. See stdio-context.ts.
   const sentinel = createStdoutSentinel({ realStdoutWrite, realStderrWrite });
+  // eslint-disable-next-line no-restricted-syntax -- installing the global sentinel is the API contract
+  process.stdout.write = sentinel.write;
+  setActiveStdoutWrite(sentinel.write);
   const _safeStdout = new Proxy(process.stdout, {
     get(target, prop, receiver) {
       if (prop === 'write') return sentinel.write;

--- a/gitnexus/src/mcp/server.ts
+++ b/gitnexus/src/mcp/server.ts
@@ -298,14 +298,14 @@ export async function startMCPServer(backend: LocalBackend): Promise<void> {
   // the Proxy or process.stdout get redirected to stderr with the
   // [mcp:stdout-redirect] prefix. See stdio-context.ts.
   const sentinel = installGlobalStdoutSentinel();
-  const _safeStdout = new Proxy(process.stdout, {
+  const safeStdout = new Proxy(process.stdout, {
     get(target, prop, receiver) {
       if (prop === 'write') return sentinel.write;
       const val = Reflect.get(target, prop, receiver);
       return typeof val === 'function' ? val.bind(target) : val;
     },
   });
-  const transport = new CompatibleStdioServerTransport(process.stdin, _safeStdout);
+  const transport = new CompatibleStdioServerTransport(process.stdin, safeStdout);
   await server.connect(transport);
 
   // Surface the redirect counter on shutdown so users see the volume of

--- a/gitnexus/src/mcp/stdio-capture.ts
+++ b/gitnexus/src/mcp/stdio-capture.ts
@@ -1,0 +1,61 @@
+/**
+ * Stdio capture — leaf module with zero non-`node:` imports.
+ *
+ * Owns the singleton state that the MCP stdout sentinel needs:
+ *   - `realStdoutWrite` / `realStderrWrite`: process.stdout.write /
+ *     process.stderr.write captured at module load, BEFORE anything else
+ *     can rebind them.
+ *   - `activeStdoutWrite`: the write handler that silenceStdout/restoreStdout
+ *     cycles in pool-adapter restore to. Defaults to `realStdoutWrite`;
+ *     `installGlobalStdoutSentinel` (in stdio-context.ts) registers the
+ *     sentinel here at MCP startup so silence/restore preserves the sentinel.
+ *
+ * This module exists separately from `pool-adapter.ts` (which previously
+ * owned the same state) so that `cli/mcp.ts`'s static-import closure does
+ * NOT transitively pull in `@ladybugdb/core`. Codex's adversarial review on
+ * PR #1383 found that the prior structure left a pre-sentinel window where
+ * native-module init banners could reach raw stdout: `cli/mcp.ts` →
+ * `mcp/stdio-context.ts` → `core/lbug/pool-adapter.ts` → `@ladybugdb/core`.
+ * Routing the sentinel state through this leaf module breaks that chain.
+ *
+ * **Constraint:** keep this module a leaf. No non-`node:` imports — adding
+ * any would re-introduce the import-time stdout-corruption hazard.
+ */
+
+type StdoutWrite = typeof process.stdout.write;
+
+/** Captured at module load, before any rebinding. */
+// eslint-disable-next-line no-restricted-syntax -- this IS the captured-real-write infrastructure used by the MCP sentinel
+export const realStdoutWrite: StdoutWrite = process.stdout.write.bind(process.stdout);
+export const realStderrWrite: typeof process.stderr.write = process.stderr.write.bind(
+  process.stderr,
+);
+
+/**
+ * The function `restoreStdout` (and the watchdog) in pool-adapter restore
+ * *to* when un-silencing. Defaults to the captured real write; the MCP
+ * server registers its sentinel here at startMCPServer (via
+ * installGlobalStdoutSentinel) so silenceStdout cycles preserve the sentinel
+ * instead of unwinding to raw stdout.
+ */
+let activeStdoutWrite: StdoutWrite = realStdoutWrite;
+
+/**
+ * Register a wrapper (e.g., the MCP sentinel) as the active stdout write.
+ * silenceStdout/restoreStdout cycles in pool-adapter will preserve the
+ * wrapper instead of unwinding to the raw realStdoutWrite. Returns the
+ * previous value so callers can chain or restore.
+ */
+export function setActiveStdoutWrite(fn: StdoutWrite): StdoutWrite {
+  const prev = activeStdoutWrite;
+  activeStdoutWrite = fn;
+  return prev;
+}
+
+/**
+ * Read the currently-active stdout write handler. Used by pool-adapter's
+ * restoreStdout and watchdog so silence/restore preserves the sentinel.
+ */
+export function getActiveStdoutWrite(): StdoutWrite {
+  return activeStdoutWrite;
+}

--- a/gitnexus/src/mcp/stdio-context.ts
+++ b/gitnexus/src/mcp/stdio-context.ts
@@ -24,6 +24,11 @@
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
+import {
+  realStdoutWrite,
+  realStderrWrite,
+  setActiveStdoutWrite,
+} from '../core/lbug/pool-adapter.js';
 
 interface McpWriteContext {
   mcp: true;
@@ -39,7 +44,7 @@ export function isMcpWrite(): boolean {
   return store.getStore()?.mcp === true;
 }
 
-type WriteFn = (chunk: any, ...rest: any[]) => boolean;
+type WriteFn = typeof process.stdout.write;
 
 export interface SentinelOptions {
   realStdoutWrite: WriteFn;
@@ -77,20 +82,14 @@ function chunkToBuffer(chunk: any): Buffer {
 }
 
 /**
- * Node Writable.write supports overloads:
- *   write(chunk, cb?)
- *   write(chunk, encoding, cb?)
- * The last argument, when it's a function, is the completion callback the
- * caller expects to be invoked once the chunk is processed. The Writable
- * contract requires we call it; silently swallowing it can wedge writers
- * that wait for it (e.g. ones using util.promisify(stream.write)).
+ * Node Writable.write contract: the completion callback, when present, is
+ * always the last argument. Match exactly that — don't try to peer past
+ * earlier arguments — so future overload shapes (e.g. an options object)
+ * do not silently break callback delivery.
  */
-function extractCallback(rest: any[]): ((err?: Error | null) => void) | undefined {
-  for (let i = rest.length - 1; i >= 0; i -= 1) {
-    if (typeof rest[i] === 'function') return rest[i] as (err?: Error | null) => void;
-    if (rest[i] !== undefined) break;
-  }
-  return undefined;
+function extractCallback(rest: unknown[]): ((err?: Error | null) => void) | undefined {
+  const last = rest[rest.length - 1];
+  return typeof last === 'function' ? (last as (err?: Error | null) => void) : undefined;
 }
 
 export function createStdoutSentinel(opts: SentinelOptions): Sentinel {
@@ -148,4 +147,37 @@ export function createStdoutSentinel(opts: SentinelOptions): Sentinel {
       );
     },
   };
+}
+
+/**
+ * Install the sentinel as the global stdout interceptor — idempotent.
+ *
+ * Does three things in order:
+ *   1. Creates the sentinel from the captured `realStdoutWrite` / `realStderrWrite`.
+ *   2. Replaces `process.stdout.write` with `sentinel.write`.
+ *   3. Registers `sentinel.write` as the "active" handler in pool-adapter
+ *      so silenceStdout/restoreStdout cycles preserve the sentinel
+ *      instead of unwinding to raw stdout.
+ *
+ * Idempotent — callers may invoke it multiple times safely (cli/mcp.ts at
+ * the top of mcpCommand, and startMCPServer). The earliest caller wins;
+ * subsequent calls return the same sentinel handle. Call this BEFORE any
+ * other startup work that might emit to stdout: native module loads,
+ * `_require()`-style grammar detection, repo registry reads, embedder
+ * pipeline initialization. Anything written before the sentinel is in
+ * place reaches raw stdout uncaught.
+ *
+ * Returns the sentinel handle so the earliest caller can register
+ * `process.on('exit', sentinel.flushSummary)`.
+ */
+let _installedSentinel: Sentinel | null = null;
+
+export function installGlobalStdoutSentinel(): Sentinel {
+  if (_installedSentinel) return _installedSentinel;
+  const sentinel = createStdoutSentinel({ realStdoutWrite, realStderrWrite });
+  // eslint-disable-next-line no-restricted-syntax -- installing the global sentinel is the API contract
+  process.stdout.write = sentinel.write;
+  setActiveStdoutWrite(sentinel.write);
+  _installedSentinel = sentinel;
+  return sentinel;
 }

--- a/gitnexus/src/mcp/stdio-context.ts
+++ b/gitnexus/src/mcp/stdio-context.ts
@@ -1,0 +1,124 @@
+/**
+ * MCP Stdio Context — AsyncLocalStorage-tagged transport-write detection.
+ *
+ * The MCP stdio transport writes JSON-RPC frames to stdout. Per spec, the
+ * server MUST NOT write anything to stdout that is not a valid MCP message.
+ * Stray writes from dependency code corrupt the protocol and present to
+ * clients as a hung handshake or `MCP error -32000`.
+ *
+ * This module provides:
+ *   - withMcpWrite(fn): runs fn inside an AsyncLocalStorage context tagged
+ *     `mcp: true`. The transport wraps every send() in this so its writes
+ *     are recognizable as legitimate.
+ *   - isMcpWrite(): true when called inside withMcpWrite.
+ *   - createStdoutSentinel({...}): a write function suitable for installing
+ *     in a Proxy over process.stdout. Tagged writes pass through to the real
+ *     stdout; untagged writes are redirected to stderr with a [mcp:stdout-redirect]
+ *     prefix, truncated to maxBytes per redirect, and rate-limited to maxRedirects
+ *     per process so a stray loop cannot flood client logs.
+ *
+ * The sentinel is correctness-by-construction: it identifies legitimate
+ * writes by *who* called write(), not by inspecting the bytes. A byte-shape
+ * heuristic ("starts with {, ends with \n") would falsely reject Content-Length
+ * frames (which start with C and end with }) and misclassify multi-chunk writes.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface McpWriteContext {
+  mcp: true;
+}
+
+const store = new AsyncLocalStorage<McpWriteContext>();
+
+export function withMcpWrite<T>(fn: () => T): T {
+  return store.run({ mcp: true }, fn);
+}
+
+export function isMcpWrite(): boolean {
+  return store.getStore()?.mcp === true;
+}
+
+type WriteFn = (chunk: any, ...rest: any[]) => boolean;
+
+export interface SentinelOptions {
+  realStdoutWrite: WriteFn;
+  realStderrWrite: WriteFn;
+  /** Maximum bytes of payload to surface per redirect. Defaults to 200. */
+  maxBytes?: number;
+  /** Maximum number of redirects per process before suppression. Defaults to 10. */
+  maxRedirects?: number;
+}
+
+export interface SentinelStats {
+  redirected: number;
+  suppressed: number;
+}
+
+export interface Sentinel {
+  write: WriteFn;
+  stats: () => SentinelStats;
+  flushSummary: () => void;
+}
+
+const REDIRECT_PREFIX = '[mcp:stdout-redirect] ';
+const STARTUP_WARNING =
+  '[mcp:stdout-redirect] sentinel triggered — stray write redirected to stderr; subsequent redirects logged at exit\n';
+
+function chunkToBuffer(chunk: any): Buffer {
+  if (chunk === undefined || chunk === null) return Buffer.alloc(0);
+  if (Buffer.isBuffer(chunk)) return chunk;
+  if (typeof chunk === 'string') return Buffer.from(chunk, 'utf8');
+  return Buffer.from(String(chunk), 'utf8');
+}
+
+export function createStdoutSentinel(opts: SentinelOptions): Sentinel {
+  const maxBytes = opts.maxBytes ?? 200;
+  const maxRedirects = opts.maxRedirects ?? 10;
+  let redirected = 0;
+  let suppressed = 0;
+  let warningEmitted = false;
+
+  const stderr = (s: string | Buffer) => opts.realStderrWrite(s);
+
+  const write: WriteFn = (chunk: any, ...rest: any[]): boolean => {
+    if (isMcpWrite()) {
+      return opts.realStdoutWrite(chunk, ...rest);
+    }
+
+    if (!warningEmitted) {
+      warningEmitted = true;
+      stderr(STARTUP_WARNING);
+    }
+
+    if (redirected >= maxRedirects) {
+      suppressed += 1;
+      return true;
+    }
+
+    redirected += 1;
+    const buf = chunkToBuffer(chunk);
+    const truncated = buf.length > maxBytes ? buf.subarray(0, maxBytes) : buf;
+
+    stderr(REDIRECT_PREFIX);
+    if (truncated.length > 0) stderr(truncated);
+    if (buf.length > maxBytes) {
+      stderr(` (+${buf.length - maxBytes} bytes truncated)`);
+    }
+    if (truncated.length === 0 || truncated[truncated.length - 1] !== 0x0a) {
+      stderr('\n');
+    }
+    return true;
+  };
+
+  return {
+    write,
+    stats: () => ({ redirected, suppressed }),
+    flushSummary: () => {
+      if (redirected === 0 && suppressed === 0) return;
+      stderr(
+        `[mcp:stdout-redirect] summary: ${redirected} redirected, ${suppressed} suppressed beyond cap\n`,
+      );
+    },
+  };
+}

--- a/gitnexus/src/mcp/stdio-context.ts
+++ b/gitnexus/src/mcp/stdio-context.ts
@@ -24,11 +24,11 @@
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
-import {
-  realStdoutWrite,
-  realStderrWrite,
-  setActiveStdoutWrite,
-} from '../core/lbug/pool-adapter.js';
+// Import from the leaf module, NOT `core/lbug/pool-adapter.js`. pool-adapter
+// pulls in `@ladybugdb/core`, which would put the native module in
+// `cli/mcp.ts`'s static-import closure — exactly the pre-sentinel window
+// Codex's adversarial review flagged on PR #1383.
+import { realStdoutWrite, realStderrWrite, setActiveStdoutWrite } from './stdio-capture.js';
 
 interface McpWriteContext {
   mcp: true;

--- a/gitnexus/src/mcp/stdio-context.ts
+++ b/gitnexus/src/mcp/stdio-context.ts
@@ -69,7 +69,28 @@ function chunkToBuffer(chunk: any): Buffer {
   if (chunk === undefined || chunk === null) return Buffer.alloc(0);
   if (Buffer.isBuffer(chunk)) return chunk;
   if (typeof chunk === 'string') return Buffer.from(chunk, 'utf8');
+  // Plain Uint8Array (e.g. from a TypedArray-using producer): copy bytes
+  // verbatim instead of falling through to String(chunk), which produces
+  // garbage like "1,2,3,...".
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk);
   return Buffer.from(String(chunk), 'utf8');
+}
+
+/**
+ * Node Writable.write supports overloads:
+ *   write(chunk, cb?)
+ *   write(chunk, encoding, cb?)
+ * The last argument, when it's a function, is the completion callback the
+ * caller expects to be invoked once the chunk is processed. The Writable
+ * contract requires we call it; silently swallowing it can wedge writers
+ * that wait for it (e.g. ones using util.promisify(stream.write)).
+ */
+function extractCallback(rest: any[]): ((err?: Error | null) => void) | undefined {
+  for (let i = rest.length - 1; i >= 0; i -= 1) {
+    if (typeof rest[i] === 'function') return rest[i] as (err?: Error | null) => void;
+    if (rest[i] !== undefined) break;
+  }
+  return undefined;
 }
 
 export function createStdoutSentinel(opts: SentinelOptions): Sentinel {
@@ -91,22 +112,28 @@ export function createStdoutSentinel(opts: SentinelOptions): Sentinel {
       stderr(STARTUP_WARNING);
     }
 
-    if (redirected >= maxRedirects) {
+    if (redirected < maxRedirects) {
+      redirected += 1;
+      const buf = chunkToBuffer(chunk);
+      const truncated = buf.length > maxBytes ? buf.subarray(0, maxBytes) : buf;
+
+      stderr(REDIRECT_PREFIX);
+      if (truncated.length > 0) stderr(truncated);
+      if (buf.length > maxBytes) {
+        stderr(` (+${buf.length - maxBytes} bytes truncated)`);
+      }
+      if (truncated.length === 0 || truncated[truncated.length - 1] !== 0x0a) {
+        stderr('\n');
+      }
+    } else {
       suppressed += 1;
-      return true;
     }
 
-    redirected += 1;
-    const buf = chunkToBuffer(chunk);
-    const truncated = buf.length > maxBytes ? buf.subarray(0, maxBytes) : buf;
-
-    stderr(REDIRECT_PREFIX);
-    if (truncated.length > 0) stderr(truncated);
-    if (buf.length > maxBytes) {
-      stderr(` (+${buf.length - maxBytes} bytes truncated)`);
-    }
-    if (truncated.length === 0 || truncated[truncated.length - 1] !== 0x0a) {
-      stderr('\n');
+    // Honor the Writable.write callback contract — fire async to match
+    // Node's "next-tick" semantics so callers never observe sync reentry.
+    const cb = extractCallback(rest);
+    if (cb) {
+      process.nextTick(() => cb(null));
     }
     return true;
   };

--- a/gitnexus/test/integration/mcp/import-closure.test.ts
+++ b/gitnexus/test/integration/mcp/import-closure.test.ts
@@ -1,0 +1,108 @@
+/**
+ * MCP CLI static-import-closure regression test.
+ *
+ * Codex's adversarial review on PR #1383 found that even though `cli/mcp.ts`
+ * is loaded lazily by Commander, ITS static imports (`startMCPServer`,
+ * `LocalBackend`, `installGlobalStdoutSentinel`, `warnMissingOptionalGrammars`)
+ * evaluate synchronously when the module loads — well before `mcpCommand`'s
+ * function body runs. Three of those four imports transitively pull in
+ * `core/lbug/pool-adapter.ts`, which `import`s `@ladybugdb/core` at module top
+ * level. The native binding's init can write to raw stdout in that pre-sentinel
+ * window and corrupt the JSON-RPC frame stream.
+ *
+ * This test locks in the fix: spawn a child Node process, import the built
+ * `dist/cli/mcp.js` (without invoking `mcpCommand`), and assert that
+ * `@ladybugdb/core` is NOT in the loaded-module set. The assertion is
+ * evidence-based — it checks Node's CJS module cache, which is global per
+ * process and tracks every native/CJS module loaded by either ESM or CJS
+ * importers.
+ *
+ * Characterization-first: this test was written before the fix landed and
+ * MUST fail against the pre-fix code. Run against the parent of the U1
+ * commit to verify the regression signal works.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const DIST_MCP = path.join(REPO_ROOT, 'dist', 'cli', 'mcp.js');
+const DIST_MCP_URL = pathToFileURL(DIST_MCP).href;
+
+const PROBE = `
+  import { createRequire } from 'node:module';
+  const req = createRequire(import.meta.url);
+  const before = new Set(Object.keys(req.cache));
+  await import(process.env.PROBE_TARGET);
+  const after = new Set(Object.keys(req.cache));
+  const newlyLoaded = [...after].filter((k) => !before.has(k));
+  process.stdout.write(JSON.stringify(newlyLoaded));
+`;
+
+describe('MCP CLI static-import closure', () => {
+  it('does not load @ladybugdb/core when cli/mcp.js is imported (without invoking mcpCommand)', () => {
+    if (!fs.existsSync(DIST_MCP)) {
+      throw new Error(
+        `dist/cli/mcp.js missing — run \`npm run build\` first (or \`npm run test:integration\` which builds via pretest:integration).`,
+      );
+    }
+
+    const result = spawnSync(process.execPath, ['--input-type=module', '-e', PROBE], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, PROBE_TARGET: DIST_MCP_URL, NODE_OPTIONS: '' },
+      timeout: 30_000,
+      encoding: 'utf8',
+    });
+
+    if (result.status !== 0) {
+      throw new Error(
+        `probe failed (status ${result.status}):\nstderr:\n${result.stderr}\nstdout:\n${result.stdout}`,
+      );
+    }
+
+    const newlyLoaded = JSON.parse(result.stdout) as string[];
+
+    // The headline assertion: @ladybugdb/core (a native CJS module) must not
+    // be loaded by the static-import closure of cli/mcp.js. If it is, the
+    // pre-sentinel stdout window the prior fix tried to close is still open.
+    const ladybugLoaded = newlyLoaded.filter((p) => /@ladybugdb[\\/]core/.test(p));
+    expect(
+      ladybugLoaded,
+      `@ladybugdb/core was loaded at cli/mcp.js static-import time. ` +
+        `mcpCommand cannot install the stdout sentinel before native init runs. ` +
+        `Offending paths:\n${ladybugLoaded.join('\n')}\n\n` +
+        `Full newly-loaded set (${newlyLoaded.length} entries):\n${newlyLoaded.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('does not load any tree-sitter native binding (sanity check on grammar imports)', () => {
+    if (!fs.existsSync(DIST_MCP)) {
+      throw new Error(`dist/cli/mcp.js missing — run \`npm run build\` first.`);
+    }
+
+    const result = spawnSync(process.execPath, ['--input-type=module', '-e', PROBE], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, PROBE_TARGET: DIST_MCP_URL, NODE_OPTIONS: '' },
+      timeout: 30_000,
+      encoding: 'utf8',
+    });
+
+    if (result.status !== 0) {
+      throw new Error(`probe failed: ${result.stderr}`);
+    }
+
+    const newlyLoaded = JSON.parse(result.stdout) as string[];
+    // tree-sitter parsers only load when warnMissingOptionalGrammars runs (which
+    // require()s each one). That call now lives inside mcpCommand, after the
+    // sentinel install — so static-import time should not trigger any of them.
+    const treeSitterNative = newlyLoaded.filter((p) => /tree-sitter-[a-z]+[\\/]build/.test(p));
+    expect(
+      treeSitterNative,
+      `tree-sitter native bindings loaded at cli/mcp.js static-import time:\n${treeSitterNative.join('\n')}`,
+    ).toEqual([]);
+  });
+});

--- a/gitnexus/test/integration/mcp/import-closure.test.ts
+++ b/gitnexus/test/integration/mcp/import-closure.test.ts
@@ -96,9 +96,12 @@ describe('MCP CLI static-import closure', () => {
     }
 
     const newlyLoaded = JSON.parse(result.stdout) as string[];
-    // tree-sitter parsers only load when warnMissingOptionalGrammars runs (which
-    // require()s each one). That call now lives inside mcpCommand, after the
-    // sentinel install — so static-import time should not trigger any of them.
+    // No tree-sitter parser should load at cli/mcp.js static-import time.
+    // The analyze path is the only caller of warnMissingOptionalGrammars
+    // (which require()s each grammar); cli/mcp.ts itself does not invoke
+    // it, and its static-import closure is leaf-only — so importing
+    // dist/cli/mcp.js without invoking mcpCommand must not trigger any
+    // native grammar binding load.
     const treeSitterNative = newlyLoaded.filter((p) => /tree-sitter-[a-z]+[\\/]build/.test(p));
     expect(
       treeSitterNative,

--- a/gitnexus/test/integration/mcp/server-startup.test.ts
+++ b/gitnexus/test/integration/mcp/server-startup.test.ts
@@ -1,0 +1,270 @@
+/**
+ * MCP server end-to-end startup test.
+ *
+ * Spawns `node dist/cli/index.js mcp` as a child process, drives the MCP
+ * stdio handshake (initialize → initialized → tools/list), and asserts:
+ *
+ *   - The first JSON-RPC frame arrives within a CI-friendly time budget.
+ *   - Every byte the server writes to stdout reassembles into a valid
+ *     Content-Length-framed JSON-RPC message — any stray byte fails the
+ *     test and is surfaced in the assertion message.
+ *   - tools/list reports the GitNexus tool set we expect.
+ *
+ * This locks in U1 (no stray console.log/warn in MCP-reachable code) and
+ * U3 (AsyncLocalStorage stdout sentinel). A regression in either would
+ * present as either a non-frame byte on stdout (fail-fast) or a missing
+ * frame (timeout).
+ *
+ * Requires the built dist/. Use `npm run test:integration` (which runs
+ * `npm run build` via the pretest:integration hook) or run after
+ * `npm run build`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import path from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const DIST_CLI = path.join(REPO_ROOT, 'dist', 'cli', 'index.js');
+
+const FIRST_FRAME_BUDGET_MS = process.env.CI ? 15_000 : 5_000;
+const TOTAL_BUDGET_MS = process.env.CI ? 30_000 : 10_000;
+
+interface SpawnedServer {
+  proc: ChildProcessWithoutNullStreams;
+  stdoutChunks: Buffer[];
+  stderrChunks: Buffer[];
+  /** Resolves with the next JSON-RPC message parsed from stdout. */
+  nextMessage: () => Promise<unknown>;
+  /** Bytes received on stdout that did NOT belong to a frame body. */
+  strayStdoutBytes: () => Buffer;
+  send: (message: unknown) => void;
+  close: () => Promise<void>;
+}
+
+/**
+ * Spawn the built MCP server and provide a frame-aware reader.
+ * The reader strictly parses Content-Length framing; any byte outside
+ * a valid header→body window is captured as "stray" so the test can
+ * assert the stream is clean.
+ */
+function spawnMcpServer(): SpawnedServer {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    // Avoid adding indexed repos noise to the test.
+    GITNEXUS_HOME: path.join(REPO_ROOT, 'test', 'integration', 'mcp', '.tmp-home'),
+    // Be deterministic across machines.
+    NODE_OPTIONS: '',
+  };
+
+  const proc = spawn(process.execPath, [DIST_CLI, 'mcp'], {
+    cwd: REPO_ROOT,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  const stray: Buffer[] = [];
+  const messageQueue: unknown[] = [];
+  const waiters: Array<(msg: unknown) => void> = [];
+
+  let buffer = Buffer.alloc(0);
+  // Parser state machine for Content-Length framing.
+  // 0 = expecting header, 1 = reading body of length `expected`.
+  let state: 0 | 1 = 0;
+  let expected = 0;
+
+  const HEADER_END = Buffer.from('\r\n\r\n', 'utf8');
+
+  function pushMessage(msg: unknown) {
+    if (waiters.length > 0) {
+      const w = waiters.shift()!;
+      w(msg);
+    } else {
+      messageQueue.push(msg);
+    }
+  }
+
+  function tryParse() {
+    while (true) {
+      if (state === 0) {
+        const hdrEnd = buffer.indexOf(HEADER_END);
+        if (hdrEnd === -1) return;
+        const header = buffer.subarray(0, hdrEnd).toString('utf8');
+        // Anything before the Content-Length: line (e.g. random bytes) is stray.
+        // Strict: the header MUST start with "Content-Length:" (case-insensitive).
+        const m = /^Content-Length:\s*(\d+)\s*$/im.exec(header);
+        if (!m) {
+          stray.push(buffer.subarray(0, hdrEnd + HEADER_END.length));
+          buffer = buffer.subarray(hdrEnd + HEADER_END.length);
+          continue;
+        }
+        // If there's text between buffer start and the header line, it's stray
+        // unless the entire header parsed cleanly with no preamble.
+        const headerStart = header.search(/Content-Length:/i);
+        if (headerStart > 0) {
+          stray.push(buffer.subarray(0, headerStart));
+          buffer = buffer.subarray(headerStart);
+          continue;
+        }
+        expected = parseInt(m[1], 10);
+        buffer = buffer.subarray(hdrEnd + HEADER_END.length);
+        state = 1;
+      }
+      if (state === 1) {
+        if (buffer.length < expected) return;
+        const bodyBuf = buffer.subarray(0, expected);
+        buffer = buffer.subarray(expected);
+        state = 0;
+        try {
+          pushMessage(JSON.parse(bodyBuf.toString('utf8')));
+        } catch (err) {
+          // Body that doesn't parse as JSON is a fatal protocol error.
+          stray.push(bodyBuf);
+        }
+      }
+    }
+  }
+
+  proc.stdout.on('data', (chunk: Buffer) => {
+    stdoutChunks.push(chunk);
+    buffer = Buffer.concat([buffer, chunk]);
+    tryParse();
+  });
+  proc.stderr.on('data', (chunk: Buffer) => {
+    stderrChunks.push(chunk);
+  });
+
+  return {
+    proc,
+    stdoutChunks,
+    stderrChunks,
+    nextMessage: () =>
+      new Promise<unknown>((resolve, reject) => {
+        if (messageQueue.length > 0) {
+          resolve(messageQueue.shift());
+          return;
+        }
+        const timer = setTimeout(() => {
+          reject(
+            new Error(
+              `Timed out waiting for JSON-RPC message. stderr so far:\n${Buffer.concat(stderrChunks).toString('utf8')}`,
+            ),
+          );
+        }, TOTAL_BUDGET_MS);
+        waiters.push((msg) => {
+          clearTimeout(timer);
+          resolve(msg);
+        });
+      }),
+    strayStdoutBytes: () => {
+      // Include any leftover unparsed buffer.
+      const tail = state === 0 ? buffer : Buffer.alloc(0);
+      return Buffer.concat([...stray, tail]);
+    },
+    send: (message: unknown) => {
+      const body = JSON.stringify(message);
+      const frame = `Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`;
+      proc.stdin.write(frame);
+    },
+    close: async () => {
+      proc.stdin.end();
+      // Give the server a moment to clean up; force-kill if it hangs.
+      await new Promise<void>((resolve) => {
+        const killer = setTimeout(() => {
+          proc.kill('SIGKILL');
+          resolve();
+        }, 2000);
+        proc.on('close', () => {
+          clearTimeout(killer);
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+describe('MCP server end-to-end startup', () => {
+  it('preserves JSON-RPC stdout discipline through initialize + tools/list', async () => {
+    if (!fs.existsSync(DIST_CLI)) {
+      throw new Error(
+        `dist/cli/index.js missing — run \`npm run build\` first (or use \`npm run test:integration\` which builds via pretest:integration).`,
+      );
+    }
+
+    const server = spawnMcpServer();
+    try {
+      // initialize handshake
+      const startedAt = Date.now();
+      server.send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'gitnexus-startup-test', version: '0.0.0' },
+        },
+      });
+
+      const initResponse = (await server.nextMessage()) as {
+        jsonrpc: string;
+        id: number;
+        result?: { protocolVersion: string; serverInfo: { name: string } };
+        error?: unknown;
+      };
+      const firstFrameAt = Date.now();
+
+      expect(initResponse.jsonrpc).toBe('2.0');
+      expect(initResponse.id).toBe(1);
+      expect(initResponse.error).toBeUndefined();
+      expect(initResponse.result).toBeDefined();
+      expect(initResponse.result!.serverInfo.name).toMatch(/gitnexus/i);
+      expect(firstFrameAt - startedAt).toBeLessThan(FIRST_FRAME_BUDGET_MS);
+
+      // initialized notification (no response expected)
+      server.send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+      // tools/list
+      server.send({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+      const toolsResponse = (await server.nextMessage()) as {
+        jsonrpc: string;
+        id: number;
+        result?: { tools: Array<{ name: string }> };
+      };
+
+      expect(toolsResponse.id).toBe(2);
+      expect(toolsResponse.result).toBeDefined();
+      const toolNames = (toolsResponse.result!.tools ?? []).map((t) => t.name);
+      // The published GitNexus tool set. Adjust if the surface changes.
+      const expectedTools = [
+        'list_repos',
+        'query',
+        'context',
+        'impact',
+        'detect_changes',
+        'rename',
+      ];
+      for (const t of expectedTools) {
+        expect(toolNames).toContain(t);
+      }
+
+      // The headline assertion: every byte the server emitted on stdout
+      // must reassemble into a valid JSON-RPC frame. Any leftover is a
+      // protocol-corruption regression.
+      const stray = server.strayStdoutBytes();
+      if (stray.length > 0) {
+        const stderr = Buffer.concat(server.stderrChunks).toString('utf8');
+        throw new Error(
+          `Stdout contained ${stray.length} bytes outside JSON-RPC framing — protocol corruption regression.\nStray bytes (utf8): ${JSON.stringify(stray.toString('utf8'))}\nStderr from server:\n${stderr}`,
+        );
+      }
+    } finally {
+      await server.close();
+    }
+  }, 60_000);
+});

--- a/gitnexus/test/integration/setup-skills.test.ts
+++ b/gitnexus/test/integration/setup-skills.test.ts
@@ -96,7 +96,7 @@ describe('setupCommand skills integration', () => {
 
     const codexConfig = await fs.readFile(path.join(tempHome, '.codex', 'config.toml'), 'utf-8');
     expect(codexConfig).toContain('[mcp_servers.gitnexus]');
-    expect(codexConfig).toContain('gitnexus@latest');
+    expect(codexConfig).toMatch(/gitnexus@\d+\.\d+\.\d+/);
 
     const codexSkill = await fs.readFile(
       path.join(tempHome, '.agents', 'skills', 'gitnexus-cli', 'SKILL.md'),

--- a/gitnexus/test/unit/mcp-stdout-sentinel.test.ts
+++ b/gitnexus/test/unit/mcp-stdout-sentinel.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { withMcpWrite, isMcpWrite, createStdoutSentinel } from '../../src/mcp/stdio-context.js';
+
+interface CapturedWrite {
+  target: 'stdout' | 'stderr';
+  payload: string;
+}
+
+function makeCapture() {
+  const captured: CapturedWrite[] = [];
+  const realStdoutWrite = (chunk: any) => {
+    captured.push({
+      target: 'stdout',
+      payload: Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk),
+    });
+    return true;
+  };
+  const realStderrWrite = (chunk: any) => {
+    captured.push({
+      target: 'stderr',
+      payload: Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk),
+    });
+    return true;
+  };
+  return { captured, realStdoutWrite, realStderrWrite };
+}
+
+function joinedStderr(captured: CapturedWrite[]): string {
+  return captured
+    .filter((c) => c.target === 'stderr')
+    .map((c) => c.payload)
+    .join('');
+}
+
+function joinedStdout(captured: CapturedWrite[]): string {
+  return captured
+    .filter((c) => c.target === 'stdout')
+    .map((c) => c.payload)
+    .join('');
+}
+
+describe('mcp/stdio-context — withMcpWrite / isMcpWrite', () => {
+  it('isMcpWrite returns false outside withMcpWrite', () => {
+    expect(isMcpWrite()).toBe(false);
+  });
+
+  it('isMcpWrite returns true inside withMcpWrite', () => {
+    let inside: boolean | undefined;
+    withMcpWrite(() => {
+      inside = isMcpWrite();
+    });
+    expect(inside).toBe(true);
+  });
+
+  it('isMcpWrite returns false again after withMcpWrite returns', () => {
+    withMcpWrite(() => {
+      // noop
+    });
+    expect(isMcpWrite()).toBe(false);
+  });
+
+  it('withMcpWrite returns the inner value', () => {
+    const v = withMcpWrite(() => 42);
+    expect(v).toBe(42);
+  });
+
+  it('nested withMcpWrite stays tagged', () => {
+    let deep: boolean | undefined;
+    withMcpWrite(() => {
+      withMcpWrite(() => {
+        deep = isMcpWrite();
+      });
+    });
+    expect(deep).toBe(true);
+  });
+});
+
+describe('mcp/stdio-context — createStdoutSentinel', () => {
+  let capture: ReturnType<typeof makeCapture>;
+
+  beforeEach(() => {
+    capture = makeCapture();
+  });
+
+  it('passes writes through to real stdout when called inside withMcpWrite', () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+    });
+    withMcpWrite(() => {
+      sentinel.write('Content-Length: 42\r\n\r\n{"jsonrpc":"2.0"}');
+    });
+    expect(joinedStdout(capture.captured)).toBe('Content-Length: 42\r\n\r\n{"jsonrpc":"2.0"}');
+    expect(joinedStderr(capture.captured)).toBe('');
+  });
+
+  it('passes newline-terminated JSON-RPC frames through to stdout when tagged', () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+    });
+    withMcpWrite(() => {
+      sentinel.write('{"jsonrpc":"2.0","id":1}\n');
+    });
+    expect(joinedStdout(capture.captured)).toBe('{"jsonrpc":"2.0","id":1}\n');
+  });
+
+  it('passes Buffer payloads through to stdout when tagged', () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+    });
+    withMcpWrite(() => {
+      sentinel.write(Buffer.from('payload', 'utf8'));
+    });
+    expect(joinedStdout(capture.captured)).toBe('payload');
+  });
+
+  it('redirects untagged writes to stderr with the [mcp:stdout-redirect] prefix', () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+    });
+    sentinel.write('rogue output\n');
+
+    const stderr = joinedStderr(capture.captured);
+    expect(stderr).toContain('[mcp:stdout-redirect]');
+    expect(stderr).toContain('rogue output');
+    expect(joinedStdout(capture.captured)).toBe('');
+  });
+
+  it('emits a one-shot startup warning on the first redirect only', () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+    });
+    sentinel.write('first\n');
+    sentinel.write('second\n');
+
+    const stderr = joinedStderr(capture.captured);
+    const warningMatches = stderr.match(/sentinel triggered/g) ?? [];
+    expect(warningMatches.length).toBe(1);
+  });
+
+  it('truncates redirect payload to maxBytes (default 200) and reports the overflow', () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+    });
+    const huge = 'x'.repeat(1024);
+    sentinel.write(huge);
+
+    const stderr = joinedStderr(capture.captured);
+    // The redirected payload portion should not contain all 1024 x's.
+    expect(stderr.includes('x'.repeat(1024))).toBe(false);
+    expect(stderr).toContain('x'.repeat(200));
+    expect(stderr).toMatch(/\(\+\d+ bytes truncated\)/);
+  });
+
+  it('respects a custom maxBytes', () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+      maxBytes: 8,
+    });
+    sentinel.write('abcdefghijklmnop');
+
+    const stderr = joinedStderr(capture.captured);
+    expect(stderr).toContain('abcdefgh');
+    expect(stderr.includes('abcdefghi')).toBe(false);
+    expect(stderr).toContain('truncated');
+  });
+
+  it('rate-limits redirects to maxRedirects (default 10) — extras are suppressed', () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+    });
+    for (let i = 0; i < 15; i += 1) {
+      sentinel.write(`line-${i}\n`);
+    }
+
+    const stderr = joinedStderr(capture.captured);
+    // First 10 lines are surfaced; lines 10-14 are suppressed.
+    for (let i = 0; i < 10; i += 1) {
+      expect(stderr).toContain(`line-${i}`);
+    }
+    for (let i = 10; i < 15; i += 1) {
+      expect(stderr.includes(`line-${i}`)).toBe(false);
+    }
+    expect(sentinel.stats().redirected).toBe(10);
+    expect(sentinel.stats().suppressed).toBe(5);
+  });
+
+  it('flushSummary emits the counter line when redirects occurred', () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+    });
+    sentinel.write('one\n');
+    sentinel.write('two\n');
+    sentinel.flushSummary();
+
+    const stderr = joinedStderr(capture.captured);
+    expect(stderr).toMatch(/summary:\s*2 redirected,\s*0 suppressed/);
+  });
+
+  it('flushSummary is silent when no redirects occurred', () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+    });
+    sentinel.flushSummary();
+
+    expect(joinedStderr(capture.captured)).toBe('');
+  });
+
+  it('returns true for empty writes and never throws', () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+    });
+    expect(() => sentinel.write('')).not.toThrow();
+    expect(() => sentinel.write(undefined as any)).not.toThrow();
+    expect(sentinel.write('')).toBe(true);
+  });
+
+  it('handles a multi-call sequence where some writes are tagged and some are not', () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+    });
+
+    withMcpWrite(() => sentinel.write('{"frame1":1}\n'));
+    sentinel.write('rogue-1\n');
+    withMcpWrite(() => sentinel.write('{"frame2":2}\n'));
+    sentinel.write('rogue-2\n');
+
+    expect(joinedStdout(capture.captured)).toBe('{"frame1":1}\n{"frame2":2}\n');
+    const stderr = joinedStderr(capture.captured);
+    expect(stderr).toContain('rogue-1');
+    expect(stderr).toContain('rogue-2');
+  });
+});

--- a/gitnexus/test/unit/mcp-stdout-sentinel.test.ts
+++ b/gitnexus/test/unit/mcp-stdout-sentinel.test.ts
@@ -225,6 +225,53 @@ describe('mcp/stdio-context — createStdoutSentinel', () => {
     expect(sentinel.write('')).toBe(true);
   });
 
+  it('handles plain Uint8Array (not Buffer) correctly when redirecting', () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+    });
+    // Plain Uint8Array — Buffer.isBuffer returns false. Bytes spell "hi\n".
+    const u8 = new Uint8Array([0x68, 0x69, 0x0a]);
+    sentinel.write(u8);
+
+    const stderr = joinedStderr(capture.captured);
+    expect(stderr).toContain('hi');
+    expect(stderr).not.toMatch(/\b104,\s*105/); // not falling through to String(chunk) → "104,105,10"
+  });
+
+  it('invokes the Writable callback (if provided) for redirected writes', async () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+    });
+    let called = false;
+    let cbErr: Error | null | undefined = undefined;
+    sentinel.write('rogue\n', 'utf8', (err: Error | null | undefined) => {
+      called = true;
+      cbErr = err;
+    });
+    // Callback fires on next tick, not sync.
+    expect(called).toBe(false);
+    await new Promise((r) => setImmediate(r));
+    expect(called).toBe(true);
+    expect(cbErr).toBeNull();
+  });
+
+  it('invokes the Writable callback for redirected writes when called past the rate-limit cap', async () => {
+    const sentinel = createStdoutSentinel({
+      realStdoutWrite: capture.realStdoutWrite,
+      realStderrWrite: capture.realStderrWrite,
+      maxRedirects: 1,
+    });
+    sentinel.write('first\n');
+    let called = false;
+    sentinel.write('second\n', () => {
+      called = true;
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(called).toBe(true);
+  });
+
   it('handles a multi-call sequence where some writes are tagged and some are not', () => {
     const sentinel = createStdoutSentinel({
       realStdoutWrite: capture.realStdoutWrite,

--- a/gitnexus/test/unit/setup-codex.test.ts
+++ b/gitnexus/test/unit/setup-codex.test.ts
@@ -2,6 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import { createRequire } from 'module';
+
+const PKG_VERSION = (createRequire(import.meta.url)('../../package.json') as { version: string })
+  .version;
+const NPX_REF = `gitnexus@${PKG_VERSION}`;
 
 const execFileMock = vi.fn((...args: any[]) => {
   const callback = args.at(-1);
@@ -63,7 +68,7 @@ describe('setupCommand codex execution', () => {
 
     expect(execFileMock).toHaveBeenCalledWith(
       'codex',
-      ['mcp', 'add', 'gitnexus', '--', 'cmd', '/c', 'npx', '-y', 'gitnexus@latest', 'mcp'],
+      ['mcp', 'add', 'gitnexus', '--', 'cmd', '/c', 'npx', '-y', NPX_REF, 'mcp'],
       { shell: true },
       expect.any(Function),
     );
@@ -78,7 +83,7 @@ describe('setupCommand codex execution', () => {
 
     expect(execFileMock).toHaveBeenCalledWith(
       'codex',
-      ['mcp', 'add', 'gitnexus', '--', 'npx', '-y', 'gitnexus@latest', 'mcp'],
+      ['mcp', 'add', 'gitnexus', '--', 'npx', '-y', NPX_REF, 'mcp'],
       { shell: false },
       expect.any(Function),
     );

--- a/gitnexus/test/unit/setup-jsonc.test.ts
+++ b/gitnexus/test/unit/setup-jsonc.test.ts
@@ -3,6 +3,11 @@ import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { parse as parseJsonc } from 'jsonc-parser';
+import { createRequire } from 'module';
+
+const PKG_VERSION = (createRequire(import.meta.url)('../../package.json') as { version: string })
+  .version;
+const NPX_REF = `gitnexus@${PKG_VERSION}`;
 
 const execFileMock = vi.fn((...args: any[]) => {
   const callback = args.at(-1);
@@ -232,7 +237,7 @@ describe('setupOpenCode — JSONC preservation', () => {
 
     expect(config.mcp.gitnexus).toEqual({
       type: 'local',
-      command: ['npx', '-y', 'gitnexus@latest', 'mcp'],
+      command: ['npx', '-y', NPX_REF, 'mcp'],
     });
   });
 

--- a/gitnexus/test/unit/setup.test.ts
+++ b/gitnexus/test/unit/setup.test.ts
@@ -2,6 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import { createRequire } from 'module';
+
+// Match what setup.ts emits — read the version from the same package.json
+// so the test never goes stale on a release bump.
+const PKG_VERSION = (createRequire(import.meta.url)('../../package.json') as { version: string })
+  .version;
+const NPX_REF = `gitnexus@${PKG_VERSION}`;
 
 const execFileMock = vi.fn((...args: any[]) => {
   const callback = args.at(-1);
@@ -75,7 +82,7 @@ describe('setupClaudeCode', () => {
 
     expect(config.mcpServers.gitnexus).toEqual({
       command: 'cmd',
-      args: ['/c', 'npx', '-y', 'gitnexus@latest', 'mcp'],
+      args: ['/c', 'npx', '-y', NPX_REF, 'mcp'],
     });
   });
 
@@ -90,7 +97,7 @@ describe('setupClaudeCode', () => {
 
     expect(config.mcpServers.gitnexus).toEqual({
       command: 'npx',
-      args: ['-y', 'gitnexus@latest', 'mcp'],
+      args: ['-y', NPX_REF, 'mcp'],
     });
   });
 
@@ -182,7 +189,7 @@ describe('setupClaudeCode', () => {
 
     expect(config.mcpServers.gitnexus).toEqual({
       command: 'npx',
-      args: ['-y', 'gitnexus@latest', 'mcp'],
+      args: ['-y', NPX_REF, 'mcp'],
     });
   });
 


### PR DESCRIPTION
## Summary

Closes the GitNexus MCP server timeout reported by Claude Code on cold starts. Two independent root causes were addressed in one branch:

1. **Stdout discipline.** Stray `console.log`/`console.warn` calls in MCP-reachable code (`core/lbug/lbug-adapter.ts:367`, `core/lbug/extension-loader.ts:191`) corrupted the JSON-RPC frame stream. Migrated to `console.error` and added an `AsyncLocalStorage`-tagged stdout sentinel — installed **globally** at MCP startup (replaces `process.stdout.write` and registers as the active handler in `pool-adapter` so `silenceStdout`/`restoreStdout` cycles preserve it). Tagged transport writes pass through to real stdout; untagged writes from anywhere (stray `console.log`, dependency banners, native module noise) get redirected to stderr instead of corrupting the protocol. Locked in by an ESLint gate (`no-console` + `no-restricted-syntax` against `process.stdout.write` and destructuring) on MCP-reachable directories and a child-process integration test that asserts byte-level frame purity end-to-end.
2. **Cold-start friction.** The dominant cold-cache cost was the native `tree-sitter-dart`/`tree-sitter-proto` rebuild (~180s budget per script) firing during `npx -y gitnexus@latest`. Added strict `GITNEXUS_SKIP_OPTIONAL_GRAMMARS=1` opt-out in both postinstall scripts so users without a C++ toolchain (or anyone wanting a fast install) can skip the rebuild. Missing-grammar warnings surface at MCP server start (always) and at `gitnexus analyze` start (only when the target repo has `.dart`/`.proto` files, no false-noise). Detection actually `require()`s each grammar so `node-gyp-build` fails loudly when the `.node` binding is absent — `require.resolve` was insufficient (the `file:` package directory is installed regardless of postinstall outcome).

The simpler DX win on the version-pinning side: `gitnexus setup` now writes `gitnexus@<installed-version>` (read dynamically from `package.json#version`, with a guard for missing/non-string version) into the user's persisted editor config, so subsequent MCP connects skip the npm metadata roundtrip. Static configs and READMEs intentionally stay on `@latest`.

## What changed

| Commit | Layer | Files |
|---|---|---|
| `183865cc` | Core diagnostics | `core/lbug/{lbug-adapter,extension-loader}.ts` |
| `d066f59a` | MCP transport | `mcp/stdio-context.ts` (new), `mcp/server.ts`, `mcp/compatible-stdio-transport.ts`, unit test (17 cases) |
| `d84dc726` | Lint gate | `eslint.config.mjs`, `core/embeddings/{embedder,embedding-pipeline}.ts` (18 site sweep), `core/lbug/pool-adapter.ts` |
| `b573e633` | Setup CLI | `cli/setup.ts` (dynamic version), 4 setup tests, root README MCP section |
| `9865b728` | Install + warnings | `scripts/build-tree-sitter-{dart,proto}.cjs`, `cli/optional-grammars.ts` (new), `cli/{mcp,analyze}.ts`, README |
| `286f8418` | Integration test | `test/integration/mcp/server-startup.test.ts` (new), `pretest:integration` script |
| `19a6618c` | Review fixes (B2/S1/S2/S3/M1-M4) | sentinel global install, real-binding detection, lint scope, contract |

## Validation (DoD §4.2)

- `cd gitnexus && npx tsc --noEmit` — clean
- `cd gitnexus && npm test` — **7863 passed, 11 skipped** (273 test files)
- `npx prettier --check` on changed files — clean
- Pre-commit hooks (eslint --fix + prettier + tsc) ran on every commit

## How the integration test pins it

The test (`test/integration/mcp/server-startup.test.ts`) spawns the built `dist/cli/index.js mcp`, drives `initialize` → `tools/list`, reassembles every stdout chunk into Content-Length-framed JSON-RPC, and asserts **zero stray bytes** outside frame boundaries. Any regression in the migration or sentinel logic fails this test loudly with the offending bytes printed alongside server stderr.

`pretest:integration` ensures `dist/` is fresh — closes the "stale dist masks regression" DX gap.

## Out of scope (deferred)

- Repo-wide `console.*` → pino migration. Owned by `feat/pino-logger` (PR #1336). The narrow ESLint rule here is forward-compatible — strict subset of #1336's broader rule, drops out trivially on rebase.
- `prebuildify`/`node-gyp-build` for tree-sitter optional grammars. Larger packaging change; the env-var skip in U5 is the immediate friction relief.
- `gitnexus mcp --selftest` flag. Speculative abstraction with one consumer (the integration test).
- `npm pack` smoke test against published tarball (vs local `dist/`). Catches packaging-time differences; track separately.

## Recommended pre-merge

Capture cold-cache `npx -y gitnexus mcp` wall time on a clean Windows machine with and without `GITNEXUS_SKIP_OPTIONAL_GRAMMARS=1` to confirm the timeout envelope claim.

## Test plan

- [ ] CI green on `ci-tests`, `ci-quality`, `ci-e2e`, scope-parity workflows
- [ ] On a clean Windows machine, time `npx -y gitnexus@latest mcp` cold; confirm `GITNEXUS_SKIP_OPTIONAL_GRAMMARS=1` brings it under MCP_TIMEOUT
- [ ] Run `gitnexus setup` after global install; verify the generated config references the installed version
- [ ] Spawn the MCP server from Claude Code; confirm `tools/list` returns within 5s and no `[mcp:stdout-redirect]` warnings on a clean baseline
- [ ] Inject a deliberate `process.stdout.write('rogue\n')` outside `withMcpWrite` (test-only) and confirm it surfaces on stderr with the redirect prefix instead of corrupting the protocol