### PR TITLE
feat(embeddings) Support macOS accelerated device fallback

### DIFF
--- a/gitnexus/src/core/embeddings/config.ts
+++ b/gitnexus/src/core/embeddings/config.ts
@@ -14,6 +14,8 @@ const parseDevice = (value: string | undefined): EmbeddingConfig['device'] | und
   if (value === undefined) return undefined;
   if (
     value === 'auto' ||
+    value === 'webgpu' ||
+    value === 'coreml' ||
     value === 'dml' ||
     value === 'cuda' ||
     value === 'cpu' ||
@@ -21,7 +23,9 @@ const parseDevice = (value: string | undefined): EmbeddingConfig['device'] | und
   ) {
     return value;
   }
-  throw new Error(`embedding device must be one of auto, dml, cuda, cpu, wasm; got "${value}"`);
+  throw new Error(
+    `embedding device must be one of auto, webgpu, coreml, dml, cuda, cpu, wasm; got "${value}"`,
+  );
 };
 
 export const resolveEmbeddingConfig = (

--- a/gitnexus/src/core/embeddings/devices.ts
+++ b/gitnexus/src/core/embeddings/devices.ts
@@ -1,0 +1,93 @@
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { createRequire } from 'module';
+import { dirname, join } from 'path';
+import type { EmbeddingDevice } from './types.js';
+
+export type ConcreteEmbeddingDevice = Exclude<EmbeddingDevice, 'auto'>;
+
+/**
+ * Check whether the onnxruntime-node package that @huggingface/transformers
+ * will actually load at runtime ships the CUDA execution provider.
+ */
+function hasOrtCudaProvider(): boolean {
+  try {
+    const require = createRequire(import.meta.url);
+    const transformersDir = dirname(require.resolve('@huggingface/transformers/package.json'));
+    const ortRequire = createRequire(join(transformersDir, 'package.json'));
+    const ortPath = dirname(ortRequire.resolve('onnxruntime-node/package.json'));
+    const arch = process.arch;
+    return existsSync(
+      join(ortPath, 'bin', 'napi-v6', 'linux', arch, 'libonnxruntime_providers_cuda.so'),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check whether CUDA libraries are actually available on this system.
+ */
+export function isCudaAvailable(): boolean {
+  if (!hasOrtCudaProvider()) return false;
+
+  try {
+    const out = execFileSync('ldconfig', ['-p'], { timeout: 3000, encoding: 'utf-8' });
+    if (out.includes('libcublasLt.so.12')) return true;
+  } catch {
+    // ldconfig is not available on every platform/container.
+  }
+
+  for (const envVar of ['CUDA_PATH', 'LD_LIBRARY_PATH']) {
+    const val = process.env[envVar];
+    if (!val) continue;
+    for (const dir of val.split(':').filter(Boolean)) {
+      if (
+        existsSync(join(dir, 'lib64', 'libcublasLt.so.12')) ||
+        existsSync(join(dir, 'lib', 'libcublasLt.so.12')) ||
+        existsSync(join(dir, 'libcublasLt.so.12'))
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+export function getAutoDeviceCandidates(
+  platform: NodeJS.Platform = process.platform,
+  cudaAvailable?: boolean,
+): ConcreteEmbeddingDevice[] {
+  if (platform === 'darwin') return ['webgpu', 'coreml', 'cpu'];
+  if (platform === 'win32') return ['dml', 'cpu'];
+  if (platform === 'linux' && (cudaAvailable ?? isCudaAvailable())) return ['cuda', 'cpu'];
+  return ['cpu'];
+}
+
+export function isAcceleratedDevice(device: ConcreteEmbeddingDevice): boolean {
+  return device !== 'cpu' && device !== 'wasm';
+}
+
+export function getDeviceCandidates(device: EmbeddingDevice): ConcreteEmbeddingDevice[] {
+  if (device === 'auto') return getAutoDeviceCandidates();
+
+  return isAcceleratedDevice(device) ? [device, 'cpu'] : [device];
+}
+
+export function formatDeviceLabel(device: ConcreteEmbeddingDevice): string {
+  switch (device) {
+    case 'webgpu':
+      return 'GPU (WebGPU/Metal)';
+    case 'coreml':
+      return 'GPU/ANE (CoreML)';
+    case 'dml':
+      return 'GPU (DirectML/DirectX12)';
+    case 'cuda':
+      return 'GPU (CUDA)';
+    case 'wasm':
+      return 'WASM';
+    case 'cpu':
+      return 'CPU';
+  }
+}

--- a/gitnexus/src/core/embeddings/embedder.ts
+++ b/gitnexus/src/core/embeddings/embedder.ts
@@ -15,92 +15,27 @@ if (!process.env.ORT_LOG_LEVEL) {
 }
 
 import { pipeline, env, type FeatureExtractionPipeline } from '@huggingface/transformers';
-import { existsSync } from 'fs';
-import { execFileSync } from 'child_process';
-import { join, dirname } from 'path';
-import { createRequire } from 'module';
-import { DEFAULT_EMBEDDING_CONFIG, type EmbeddingConfig, type ModelProgress } from './types.js';
+import {
+  DEFAULT_EMBEDDING_CONFIG,
+  type EmbeddingConfig,
+  type EmbeddingDevice,
+  type ModelProgress,
+} from './types.js';
 import { isHttpMode, getHttpDimensions, httpEmbed } from './http-client.js';
 import { resolveEmbeddingConfig } from './config.js';
 import { applyHfEnvOverrides } from './hf-env.js';
-
-/**
- * Check whether the onnxruntime-node package that @huggingface/transformers
- * will actually load at runtime ships the CUDA execution provider.
- *
- * Critical: we resolve from transformers' own module scope, NOT from ours.
- * npm may install two copies — a top-level 1.24.x (our dep) and a nested
- * 1.21.0 (transformers' pinned dep). The guard must inspect whichever copy
- * transformers.js will dlopen, otherwise the check is meaningless.
- */
-function hasOrtCudaProvider(): boolean {
-  try {
-    const require = createRequire(import.meta.url);
-    // Resolve from @huggingface/transformers' scope so we find the same
-    // onnxruntime-node binary that transformers.js will use at runtime
-    const transformersDir = dirname(require.resolve('@huggingface/transformers/package.json'));
-    const ortRequire = createRequire(join(transformersDir, 'package.json'));
-    const ortPath = dirname(ortRequire.resolve('onnxruntime-node/package.json'));
-    // ORT 1.24.x only ships CUDA binaries for linux/x64 (downloaded from NuGet
-    // at postinstall). arm64 will correctly return false here until ORT adds support.
-    const arch = process.arch;
-    return existsSync(
-      join(ortPath, 'bin', 'napi-v6', 'linux', arch, 'libonnxruntime_providers_cuda.so'),
-    );
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Check whether CUDA libraries are actually available on this system.
- * ONNX Runtime's native layer crashes (uncatchable) if we attempt CUDA
- * without the required shared libraries, so we probe first.
- *
- * Checks both:
- * 1. That system CUDA libraries (libcublasLt) are present
- * 2. That onnxruntime-node ships the CUDA execution provider binary
- *
- * Both conditions must be true — system CUDA libs alone are not enough
- * if onnxruntime-node is a CPU-only build (versions < 1.24.0).
- */
-function isCudaAvailable(): boolean {
-  // First, verify onnxruntime-node has the CUDA provider binary.
-  // Without this, requesting CUDA causes an uncatchable native crash.
-  if (!hasOrtCudaProvider()) return false;
-
-  // Primary: query the dynamic linker cache — covers all architectures,
-  // distro layouts, and custom install paths registered with ldconfig
-  try {
-    const out = execFileSync('ldconfig', ['-p'], { timeout: 3000, encoding: 'utf-8' });
-    if (out.includes('libcublasLt.so.12')) return true;
-  } catch {
-    // ldconfig not available (e.g. non-standard container)
-  }
-
-  // Fallback: check CUDA_PATH and LD_LIBRARY_PATH for environments where
-  // ldconfig doesn't know about the CUDA install (conda, manual /opt/cuda, etc.)
-  for (const envVar of ['CUDA_PATH', 'LD_LIBRARY_PATH']) {
-    const val = process.env[envVar];
-    if (!val) continue;
-    for (const dir of val.split(':').filter(Boolean)) {
-      if (
-        existsSync(join(dir, 'lib64', 'libcublasLt.so.12')) ||
-        existsSync(join(dir, 'lib', 'libcublasLt.so.12')) ||
-        existsSync(join(dir, 'libcublasLt.so.12'))
-      )
-        return true;
-    }
-  }
-
-  return false;
-}
+import {
+  formatDeviceLabel,
+  getDeviceCandidates,
+  isAcceleratedDevice,
+  type ConcreteEmbeddingDevice,
+} from './devices.js';
 
 // Module-level state for singleton pattern
 let embedderInstance: FeatureExtractionPipeline | null = null;
 let isInitializing = false;
 let initPromise: Promise<FeatureExtractionPipeline> | null = null;
-let currentDevice: 'dml' | 'cuda' | 'cpu' | 'wasm' | null = null;
+let currentDevice: ConcreteEmbeddingDevice | null = null;
 
 /**
  * Progress callback type for model loading
@@ -110,7 +45,7 @@ export type ModelProgressCallback = (progress: ModelProgress) => void;
 /**
  * Get the current device being used for inference
  */
-export const getCurrentDevice = (): 'dml' | 'cuda' | 'cpu' | 'wasm' | null => currentDevice;
+export const getCurrentDevice = (): ConcreteEmbeddingDevice | null => currentDevice;
 
 /**
  * Initialize the embedding model
@@ -124,7 +59,7 @@ export const getCurrentDevice = (): 'dml' | 'cuda' | 'cpu' | 'wasm' | null => cu
 export const initEmbedder = async (
   onProgress?: ModelProgressCallback,
   config: Partial<EmbeddingConfig> = {},
-  forceDevice?: 'dml' | 'cuda' | 'cpu' | 'wasm',
+  forceDevice?: ConcreteEmbeddingDevice,
 ): Promise<FeatureExtractionPipeline> => {
   if (isHttpMode()) {
     throw new Error(
@@ -146,13 +81,7 @@ export const initEmbedder = async (
   isInitializing = true;
 
   const finalConfig = resolveEmbeddingConfig(config);
-  // CUDA is probe-gated because ONNX Runtime can crash in native code when
-  // provider libraries are missing. DirectML stays opt-in for the same reason.
-  // Probe for CUDA first — ONNX Runtime crashes (uncatchable native error)
-  // if we attempt CUDA without the required shared libraries
-  const gpuDevice = isCudaAvailable() ? 'cuda' : 'cpu';
-  const requestedDevice =
-    forceDevice || (finalConfig.device === 'auto' ? gpuDevice : finalConfig.device);
+  const requestedDevice: EmbeddingDevice = forceDevice || finalConfig.device;
 
   initPromise = (async () => {
     try {
@@ -182,23 +111,13 @@ export const initEmbedder = async (
           }
         : undefined;
 
-      // Try GPU first if auto, fall back to CPU
-      // Windows: dml (DirectML/DirectX12), Linux: cuda
-      const devicesToTry: Array<'dml' | 'cuda' | 'cpu' | 'wasm'> =
-        requestedDevice === 'dml' || requestedDevice === 'cuda'
-          ? [requestedDevice, 'cpu']
-          : [requestedDevice as 'cpu' | 'wasm'];
+      const devicesToTry = getDeviceCandidates(requestedDevice);
 
       for (const device of devicesToTry) {
         try {
-          if (isDev && device === 'dml') {
-            console.log('🔧 Trying DirectML (DirectX12) GPU backend...');
-          } else if (isDev && device === 'cuda') {
-            console.log('🔧 Trying CUDA GPU backend...');
-          } else if (isDev && device === 'cpu') {
-            console.log('🔧 Using CPU backend...');
-          } else if (isDev && device === 'wasm') {
-            console.log('🔧 Using WASM backend (slower)...');
+          if (isDev) {
+            const action = isAcceleratedDevice(device) ? 'Trying' : 'Using';
+            console.log(`🔧 ${action} ${formatDeviceLabel(device)} backend...`);
           }
 
           embedderInstance = await (pipeline as any)('feature-extraction', finalConfig.modelId, {
@@ -215,21 +134,14 @@ export const initEmbedder = async (
           currentDevice = device;
 
           if (isDev) {
-            const label =
-              device === 'dml'
-                ? 'GPU (DirectML/DirectX12)'
-                : device === 'cuda'
-                  ? 'GPU (CUDA)'
-                  : device.toUpperCase();
-            console.log(`✅ Using ${label} backend`);
+            console.log(`✅ Using ${formatDeviceLabel(device)} backend`);
             console.log('✅ Embedding model loaded successfully');
           }
 
           return embedderInstance!;
         } catch (deviceError) {
-          if (isDev && (device === 'cuda' || device === 'dml')) {
-            const gpuType = device === 'dml' ? 'DirectML' : 'CUDA';
-            console.log(`⚠️  ${gpuType} not available, falling back to CPU...`);
+          if (isDev && isAcceleratedDevice(device)) {
+            console.log(`⚠️  ${formatDeviceLabel(device)} not available, trying next backend...`);
           }
           // Continue to next device in list
           if (device === devicesToTry[devicesToTry.length - 1]) {

--- a/gitnexus/src/core/embeddings/types.ts
+++ b/gitnexus/src/core/embeddings/types.ts
@@ -213,8 +213,8 @@ export interface EmbeddingConfig {
   threads: number;
   /** Embedding vector dimensions */
   dimensions: number;
-  /** Device to use for inference: 'auto' tries GPU first (DirectML on Windows, CUDA on Linux), falls back to CPU */
-  device: 'auto' | 'dml' | 'cuda' | 'cpu' | 'wasm';
+  /** Device to use for inference: 'auto' tries GPU first, falls back to CPU */
+  device: EmbeddingDevice;
   /** Maximum characters of code snippet to include */
   maxSnippetLength: number;
   /** Maximum code chunk size in characters (for chunking long code) */
@@ -224,6 +224,8 @@ export interface EmbeddingConfig {
   /** Maximum description length in characters */
   maxDescriptionLength: number;
 }
+
+export type EmbeddingDevice = 'auto' | 'webgpu' | 'coreml' | 'dml' | 'cuda' | 'cpu' | 'wasm';
 
 /**
  * Default embedding configuration

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -398,32 +398,41 @@ export async function runFullAnalysis(
         getInferredRepoName(repoPath) ??
         path.basename(resolveRepoIdentityRoot(repoPath));
       const serverName = await readServerMapping(projectName);
-      const embeddingResult = await runEmbeddingPipeline(
-        executeQuery,
-        executeWithReusedStatement,
-        (p) => {
-          const scaled = 90 + Math.round((p.percent / 100) * 8);
-          const label =
-            p.phase === 'loading-model'
-              ? httpMode
-                ? 'Connecting to embedding endpoint...'
-                : 'Loading embedding model...'
-              : `Embedding ${p.nodesProcessed || 0}/${p.totalNodes || '?'}`;
-          progress('embeddings', scaled, label);
-        },
-        {},
-        cachedEmbeddingNodeIds.size > 0 ? cachedEmbeddingNodeIds : undefined,
-        { repoName: projectName, serverName },
-        existingEmbeddings,
-      );
-      if (embeddingResult.semanticMode === 'exact-scan') {
-        semanticMode = 'exact-scan';
-        log(
-          'Semantic embeddings were generated without a VECTOR index; ' +
-            'queries will use exact-scan fallback within the configured limit.',
+      try {
+        const embeddingResult = await runEmbeddingPipeline(
+          executeQuery,
+          executeWithReusedStatement,
+          (p) => {
+            const scaled = 90 + Math.round((p.percent / 100) * 8);
+            const label =
+              p.phase === 'loading-model'
+                ? httpMode
+                  ? 'Connecting to embedding endpoint...'
+                  : 'Loading embedding model...'
+                : `Embedding ${p.nodesProcessed || 0}/${p.totalNodes || '?'}`;
+            progress('embeddings', scaled, label);
+          },
+          {},
+          cachedEmbeddingNodeIds.size > 0 ? cachedEmbeddingNodeIds : undefined,
+          { repoName: projectName, serverName },
+          existingEmbeddings,
         );
-      } else {
-        semanticMode = 'vector-index';
+        if (embeddingResult.semanticMode === 'exact-scan') {
+          semanticMode = 'exact-scan';
+          log(
+            'Semantic embeddings were generated without a VECTOR index; ' +
+              'queries will use exact-scan fallback within the configured limit.',
+          );
+        } else {
+          semanticMode = 'vector-index';
+        }
+      } finally {
+        if (!httpMode) {
+          const { getCurrentDevice, disposeEmbedder } = await import('./embeddings/embedder.js');
+          if (getCurrentDevice() === 'webgpu') {
+            await disposeEmbedder();
+          }
+        }
       }
     }
 

--- a/gitnexus/src/mcp/core/embedder.ts
+++ b/gitnexus/src/mcp/core/embedder.ts
@@ -13,6 +13,11 @@ import {
 } from '../../core/embeddings/http-client.js';
 import { resolveEmbeddingConfig } from '../../core/embeddings/config.js';
 import { applyHfEnvOverrides } from '../../core/embeddings/hf-env.js';
+import {
+  formatDeviceLabel,
+  getDeviceCandidates,
+  type ConcreteEmbeddingDevice,
+} from '../../core/embeddings/devices.js';
 import { silenceStdout, restoreStdout, realStderrWrite } from '../../core/lbug/pool-adapter.js';
 
 // Model config
@@ -53,10 +58,7 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
 
       console.error('GitNexus: Loading embedding model (first search may take a moment)...');
 
-      const devicesToTry: Array<'dml' | 'cuda' | 'cpu'> =
-        embeddingConfig.device === 'dml' || embeddingConfig.device === 'cuda'
-          ? [embeddingConfig.device, 'cpu']
-          : ['cpu'];
+      const devicesToTry: ConcreteEmbeddingDevice[] = getDeviceCandidates(embeddingConfig.device);
 
       for (const device of devicesToTry) {
         try {
@@ -82,7 +84,7 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
             restoreStdout();
             process.stderr.write = realStderrWrite;
           }
-          console.error(`GitNexus: Embedding model loaded (${device})`);
+          console.error(`GitNexus: Embedding model loaded (${formatDeviceLabel(device)})`);
           return embedderInstance!;
         } catch {
           if (device === 'cpu') throw new Error('Failed to load embedding model');

--- a/gitnexus/test/unit/embedding-config.test.ts
+++ b/gitnexus/test/unit/embedding-config.test.ts
@@ -22,6 +22,14 @@ describe('resolveEmbeddingConfig', () => {
     expect(config.device).toBe('cpu');
   });
 
+  it('accepts macOS accelerated devices from env', () => {
+    process.env.GITNEXUS_EMBEDDING_DEVICE = 'webgpu';
+    expect(resolveEmbeddingConfig().device).toBe('webgpu');
+
+    process.env.GITNEXUS_EMBEDDING_DEVICE = 'coreml';
+    expect(resolveEmbeddingConfig().device).toBe('coreml');
+  });
+
   it('rejects invalid numeric env values', () => {
     process.env.GITNEXUS_EMBEDDING_THREADS = '0';
 

--- a/gitnexus/test/unit/embedding-devices.test.ts
+++ b/gitnexus/test/unit/embedding-devices.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getAutoDeviceCandidates, getDeviceCandidates } from '../../src/core/embeddings/devices.js';
+
+describe('embedding device selection', () => {
+  it('prefers WebGPU and CoreML before CPU on macOS', () => {
+    expect(getAutoDeviceCandidates('darwin')).toEqual(['webgpu', 'coreml', 'cpu']);
+  });
+
+  it('prefers DirectML before CPU on Windows', () => {
+    expect(getAutoDeviceCandidates('win32')).toEqual(['dml', 'cpu']);
+  });
+
+  it('uses CUDA before CPU on Linux when CUDA is available', () => {
+    expect(getAutoDeviceCandidates('linux', true)).toEqual(['cuda', 'cpu']);
+  });
+
+  it('uses CPU on Linux when CUDA is unavailable', () => {
+    expect(getAutoDeviceCandidates('linux', false)).toEqual(['cpu']);
+  });
+
+  it('falls back from explicit accelerated devices to CPU', () => {
+    expect(getDeviceCandidates('webgpu')).toEqual(['webgpu', 'cpu']);
+    expect(getDeviceCandidates('coreml')).toEqual(['coreml', 'cpu']);
+  });
+
+  it('does not add fallback for explicit CPU or WASM', () => {
+    expect(getDeviceCandidates('cpu')).toEqual(['cpu']);
+    expect(getDeviceCandidates('wasm')).toEqual(['wasm']);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared embedding device selection with macOS WebGPU/CoreML candidates before CPU fallback
- reuse device selection in CLI and MCP embedders so local embedding behavior stays aligned
- dispose the WebGPU embedder after analysis to avoid macOS exit-time ONNX Runtime logger teardown errors
- add unit coverage for macOS device config and fallback ordering

## Validation
- npm test -- test/unit/embedding-config.test.ts test/unit/embedding-devices.test.ts
- npx tsc --noEmit
- pre-commit hook: eslint --fix, prettier --write, gitnexus typecheck
- GitNexus impact/detect_changes: LOW risk, no affected processes

## Note
- Full npm test was also run locally. It failed only on existing Swift optional parser availability in this environment: tree-sitter-swift native module could not be loaded, causing test/unit/language-skip.test.ts and test/unit/parser-loader.test.ts Swift assertions to fail. The embedding-related tests above passed.