### PR TITLE
fix(setup): correct OpenCode skills install path in status message

### DIFF
--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -604,7 +604,7 @@ async function installOpenCodeSkills(result: SetupResult): Promise<void> {
     const installed = await installSkillsTo(skillsDir);
     if (installed.length > 0) {
       result.configured.push(
-        `OpenCode skills (${installed.length} skills → ~/.config/opencode/skill/)`,
+        `OpenCode skills (${installed.length} skills → ~/.config/opencode/skills/)`,
       );
     }
   } catch (err: any) {

--- a/gitnexus/test/integration/setup-skills.test.ts
+++ b/gitnexus/test/integration/setup-skills.test.ts
@@ -52,6 +52,21 @@ describe('setupCommand skills integration', () => {
     await fs.rm(tempHome, { recursive: true, force: true });
   });
 
+  it('reports the OpenCode skills install path with the plural skills directory', async () => {
+    await fs.mkdir(path.join(tempHome, '.config', 'opencode'), { recursive: true });
+    await setupCommand();
+
+    const installedSkill = await fs.readFile(
+      path.join(tempHome, '.config', 'opencode', 'skills', 'gitnexus-cli', 'SKILL.md'),
+      'utf-8',
+    );
+
+    expect(installedSkill).toContain('GitNexus CLI Commands');
+    await expect(
+      fs.access(path.join(tempHome, '.config', 'opencode', 'skill', 'gitnexus-cli', 'SKILL.md')),
+    ).rejects.toThrow();
+  });
+
   it('installs packaged, flat-file, and directory skills into cursor skills directory', async () => {
     await setupCommand();
 


### PR DESCRIPTION
Closes #1381

## Summary

- The `installOpenCodeSkills` status message reported `~/.config/opencode/skill/` (missing trailing `s`) while the actual install target was already `~/.config/opencode/skills/`. Fixed the log string to match the real path.

## Checklist

- [x] `npx tsc --noEmit` clean
- [x] `prettier --check` clean
- [x] Pre-commit hook (lint-staged + typecheck) passes
- [x] No secrets or credentials