### PR TITLE
fix(setup): use OpenCode skills directory

### DIFF
--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -604,7 +604,7 @@ async function installOpenCodeSkills(result: SetupResult): Promise<void> {
     const installed = await installSkillsTo(skillsDir);
     if (installed.length > 0) {
       result.configured.push(
-        `OpenCode skills (${installed.length} skills → ~/.config/opencode/skill/)`,
+        `OpenCode skills (${installed.length} skills → ~/.config/opencode/skills/)`,
       );
     }
   } catch (err: any) {

--- a/gitnexus/test/integration/setup-skills.test.ts
+++ b/gitnexus/test/integration/setup-skills.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
@@ -50,6 +50,21 @@ describe('setupCommand skills integration', () => {
     process.env.USERPROFILE = originalUserProfile;
     process.env.PATH = originalPath;
     await fs.rm(tempHome, { recursive: true, force: true });
+  });
+
+  it('reports the OpenCode skills install path with the plural skills directory', async () => {
+    await fs.mkdir(path.join(tempHome, '.config', 'opencode'), { recursive: true });
+    await setupCommand();
+
+    const installedSkill = await fs.readFile(
+      path.join(tempHome, '.config', 'opencode', 'skills', 'gitnexus-cli', 'SKILL.md'),
+      'utf-8',
+    );
+
+    expect(installedSkill).toContain('GitNexus CLI Commands');
+    await expect(
+      fs.access(path.join(tempHome, '.config', 'opencode', 'skill', 'gitnexus-cli', 'SKILL.md')),
+    ).rejects.toThrow();
   });
 
   it('installs packaged, flat-file, and directory skills into cursor skills directory', async () => {


### PR DESCRIPTION
## Summary
- fix the OpenCode skills install message to use the documented `~/.config/opencode/skills/` path
- add an integration test that verifies setup installs GitNexus skills into the plural `skills` directory

## Testing
- `cd gitnexus && npm test -- --run test/integration/setup-skills.test.ts test/unit/setup-jsonc.test.ts`

## Issue
- fixes #1381
