### PR TITLE
ci(release): use fine-grained PAT for rc tag push

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -123,7 +123,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      contents: write # push rc tag + marker
+      # The default GITHUB_TOKEN cannot be granted `workflows: write`, so
+      # tag pushes that reach a commit which modified `.github/workflows/**`
+      # are rejected with: "refusing to allow a GitHub App to create or
+      # update workflow ... without `workflows` permission". We pass a
+      # fine-grained PAT (RELEASE_PUSH_TOKEN, scoped to this repo with
+      # Contents: write + Workflows: write) to `actions/checkout` so that
+      # the subsequent `git push --atomic` of the v-tag and rc marker
+      # carries the PAT's identity. Job-level GITHUB_TOKEN keeps its
+      # scoped permissions for everything else (npm provenance, etc.).
+      contents: write # push rc tag + marker (via PAT)
       id-token: write # npm provenance
     outputs:
       vtag: ${{ steps.reltag.outputs.vtag }}
@@ -132,6 +141,11 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          # Use the PAT so `origin` is preauthed for `git push`. Without
+          # this the default GITHUB_TOKEN is wired into the remote, and a
+          # workflows-touching tag push is rejected — see the permissions
+          # block above.
+          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
## Summary

- Pass a fine-grained PAT (`RELEASE_PUSH_TOKEN`) to `actions/checkout` in the `release-candidate.yml` publish job so the subsequent `git push --atomic` of the rc v-tag and marker tag carries an identity that holds `workflows: write`.
- Default `GITHUB_TOKEN` cannot be granted `workflows: write`, which is why the most recent rc publish hit `! [remote rejected] v1.6.4-rc.82 (refusing to allow a GitHub App to create or update workflow .github/workflows/trivy.yml without workflows permission)` — GitHub's rule fires whenever a tag's reachable commit chain includes a workflow-file change.
- Job-level `GITHUB_TOKEN` permissions are unchanged; the PAT only swaps in for the `git push` step via the checkout token wiring.

## One-time setup before merging

1. Create a **fine-grained PAT** scoped to this repo:
   - Repository access → Only select repositories → `GitNexus`
   - Repository permissions: **Contents: write**, **Workflows: write**, **Metadata: read** (auto). All others: No access.
   - Pick an expiration you'll remember to rotate (90d–1y).
2. Add as a repo secret named **`RELEASE_PUSH_TOKEN`** under Settings → Secrets and variables → Actions.
3. Add a calendar reminder a week before the PAT's expiry — when it expires, the rc workflow fails the same visible way it failed today.

## Test plan

- [x] Create the fine-grained PAT and add `RELEASE_PUSH_TOKEN` secret.
- [x] Merge this PR.
- [ ] Re-run the failed `Release Candidate` workflow via `Actions → Release Candidate → Run workflow` (with `force=true` if the marker for the failing HEAD is still in place; otherwise wait for the next merge to `main`).
- [ ] Verify the `v1.6.4-rc.N` tag, npm publish, and GitHub prerelease all complete.
- [ ] Confirm the rc Docker images build.

## Considered alternatives

- **GitHub App** with `Contents: write` + `Workflows: write`, minted via `actions/create-github-app-token`. Better long-term (org-owned, rotatable, bot identity, short-lived tokens) but heavier setup. Migration is mechanical if we want to switch later.
- **Skip pushing tags** from the workflow. Doesn't work — tags are also the dedup mechanism (`rc/<HEAD_SHA>` marker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)