### PR TITLE
ci: add fork-safe PR autofix pipeline

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -95,31 +95,33 @@ jobs:
 
           # Validate PR number is a positive integer (artifact comes from
           # untrusted fork code, so treat contents defensively).
-          PR_NUM=$(cat "$DIR/pr_number" | tr -d '[:space:]')
+          PR_NUM=$(tr -d '[:space:]' < "$DIR/pr_number")
           if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "::error::Invalid PR number in artifact: '$PR_NUM'"
             exit 0
           fi
 
-          echo "skip=false"              >> "$GITHUB_OUTPUT"
-          echo "pr_number=$PR_NUM"       >> "$GITHUB_OUTPUT"
           # Validate job-result strings against known GitHub Actions values.
           # Artifact contents come from the PR workflow (potentially untrusted
           # fork code), so we whitelist to prevent newline injection into
           # GITHUB_OUTPUT.
           validate_result() {
             local val
-            val=$(cat "$1" | tr -d '[:space:]')
+            val=$(tr -d '[:space:]' < "$1")
             case "$val" in
               success|failure|cancelled|skipped) echo "$val" ;;
               *) echo "unknown" ;;
             esac
           }
 
-          echo "quality=$(validate_result "$DIR/quality_result")"        >> "$GITHUB_OUTPUT"
-          echo "tests=$(validate_result "$DIR/tests_result")"            >> "$GITHUB_OUTPUT"
-          echo "e2e=$(validate_result "$DIR/e2e_result")"                >> "$GITHUB_OUTPUT"
+          {
+            echo "skip=false"
+            echo "pr_number=$PR_NUM"
+            echo "quality=$(validate_result "$DIR/quality_result")"
+            echo "tests=$(validate_result "$DIR/tests_result")"
+            echo "e2e=$(validate_result "$DIR/e2e_result")"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout (for vitest config)
         if: steps.meta.outputs.skip != 'true'
@@ -279,14 +281,17 @@ jobs:
             fi
           }
 
-          read CLI_T CLI_P CLI_F CLI_S CLI_SU CLI_D <<< "$(sum_results "$RESULTS_FILE")"
-          read WEB_T WEB_P WEB_F WEB_S WEB_SU WEB_D <<< "$(sum_results "$WEB_RESULTS_FILE")"
+          # `_` placeholder for the suite-count column — positional
+          # readability for sum_results' 6-field output, but the value
+          # isn't surfaced in the report (suites are tracked per-test
+          # framework, not as a top-line metric).
+          read -r CLI_T CLI_P CLI_F CLI_S _ CLI_D <<< "$(sum_results "$RESULTS_FILE")"
+          read -r WEB_T WEB_P WEB_F WEB_S _ WEB_D <<< "$(sum_results "$WEB_RESULTS_FILE")"
 
           TOTAL=$((CLI_T + WEB_T))
           PASSED=$((CLI_P + WEB_P))
           FAILED=$((CLI_F + WEB_F))
           SKIPPED=$((CLI_S + WEB_S))
-          SUITES=$((CLI_SU + WEB_SU))
           DURATION=$((CLI_D > WEB_D ? CLI_D : WEB_D))
 
           # ── Status helpers ──

--- a/.github/workflows/pr-autofix-publish.yml
+++ b/.github/workflows/pr-autofix-publish.yml
@@ -1,0 +1,261 @@
+name: PR Autofix (publish)
+
+# TRUSTED HALF of the autofix pipeline.
+#
+# Triggered by `pr-autofix.yml` completing on a PR (including fork PRs).
+# Downloads the diff artifact produced by the untrusted job and posts
+# inline review-comment suggestions to the PR using `reviewdog`. This
+# job NEVER checks out fork code — it only consumes the diff (data) and
+# calls the GitHub API. That isolation is what makes it safe to run
+# under `pull-requests: write` on fork-triggered events.
+#
+# Also posts (or edits) a single sticky summary comment so contributors
+# and AI agents have one stable, machine-readable signal that says
+# whether autofix had anything to suggest. Look for the heading
+# "## :sparkles: PR Autofix" in the PR's top-level comments.
+#
+# Reviewdog reporter: `github-pr-review` reads $REVIEWDOG_GITHUB_API_TOKEN
+# and posts via the GraphQL/REST PR-review API. It does not need a
+# checkout because the diff itself encodes file paths + line numbers.
+
+on:
+  workflow_run:
+    workflows: ['PR Autofix']
+    types: [completed]
+
+concurrency:
+  # Key on PR identity, NOT workflow_run.id — workflow_run.id is per-run
+  # unique, which would defeat serialization and let two parallel
+  # publishes both POST a sticky summary comment. CONTRIBUTING.md
+  # § GitHub Actions — Concurrency Convention names this anti-pattern
+  # explicitly. For fork PRs, `pull_requests[]` is empty in the
+  # workflow_run payload, so we fall back to head-repo + head-branch.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number || format('{0}/{1}', github.event.workflow_run.head_repository.full_name, github.event.workflow_run.head_branch) }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  publish:
+    name: publish-autofix
+    if: >-
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+      # Required by actions/download-artifact to fetch artifacts produced
+      # by a different workflow run.
+      actions: read
+    steps:
+      # Pinned to v8.0.1. Verify SHA via:
+      #   gh api repos/actions/download-artifact/git/refs/tags/v8.0.1
+      - name: Download autofix artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: autofix
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: autofix-in
+
+      - name: Read and validate metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f autofix-in/metadata.json
+          jq . autofix-in/metadata.json
+
+          # The artifact comes from the untrusted half running fork code.
+          # Every field is allowlist-validated before it can flow into
+          # $GITHUB_OUTPUT. A newline in head_ref would otherwise let a
+          # malicious branch name inject a second `pr_number=N` line and
+          # redirect this job's reviewdog suggestions / sticky summary
+          # comment onto a victim PR under github-actions[bot] with
+          # pull-requests: write.
+          assert_field() {
+            local key="$1" pattern="$2" value
+            value=$(jq -r ".${key} // empty" autofix-in/metadata.json)
+            if [ -z "$value" ] || ! [[ "$value" =~ $pattern ]]; then
+              echo "::error::metadata.${key} failed allowlist (got: $(printf '%q' "$value"))"
+              exit 1
+            fi
+            printf '%s' "$value"
+          }
+
+          SCHEMA=$(assert_field    schema         '^gitnexus\.pr-autofix/v[0-9]+$')
+          PR_NUMBER=$(assert_field pr_number      '^[0-9]+$')
+          HEAD_SHA=$(assert_field  head_sha       '^[0-9a-f]{40}$')
+          HEAD_REF=$(assert_field  head_ref       '^[A-Za-z0-9._/-]+$')
+          HEAD_REPO=$(assert_field head_repo      '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$')
+          BASE_REPO=$(assert_field base_repo      '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$')
+          CHANGED=$(assert_field   changed_lines  '^[0-9]+$')
+
+          # Defence-in-depth: refuse to act if the artifact claims to
+          # belong to a different repo than the one that triggered us.
+          if [ "$BASE_REPO" != "${GITHUB_REPOSITORY}" ]; then
+            echo "::error::Artifact base_repo does not match \$GITHUB_REPOSITORY — refusing to publish."
+            exit 1
+          fi
+
+          {
+            echo "schema=${SCHEMA}"
+            echo "pr_number=${PR_NUMBER}"
+            echo "head_sha=${HEAD_SHA}"
+            echo "head_ref=${HEAD_REF}"
+            echo "head_repo=${HEAD_REPO}"
+            echo "base_repo=${BASE_REPO}"
+            echo "changed_lines=${CHANGED}"
+          } >> "$GITHUB_OUTPUT"
+
+      # Pinned to v1.5.0. Verify SHA via:
+      #   gh api repos/reviewdog/action-setup/git/refs/tags/v1.5.0
+      #   (annotated tag — resolve via .../git/tags/<sha> --jq .object)
+      - name: Install reviewdog
+        if: steps.meta.outputs.changed_lines != '0'
+        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1.5.0
+        with:
+          # Pin the binary, not just the action SHA — a bad reviewdog
+          # release otherwise breaks every PR with no rollback. Bump
+          # this knob deliberately when validating a new release.
+          reviewdog_version: v0.21.0
+
+      - name: Post inline suggestions
+        id: suggest
+        if: steps.meta.outputs.changed_lines != '0'
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_REPO_OWNER: ${{ github.repository_owner }}
+          CI_REPO_NAME: ${{ github.event.repository.name }}
+          CI_PULL_REQUEST: ${{ steps.meta.outputs.pr_number }}
+          CI_COMMIT: ${{ steps.meta.outputs.head_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          patch=autofix-in/autofix.patch
+          if [ ! -s "$patch" ]; then
+            echo "Empty patch — nothing to suggest."
+            echo "posted=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # GitHub's review-comment API returns 406 on diffs above ~3k
+          # changed lines. Bail out gracefully and let the summary
+          # comment carry the signal instead.
+          if [ "${{ steps.meta.outputs.changed_lines }}" -gt 3000 ]; then
+            echo "Diff too large (${{ steps.meta.outputs.changed_lines }} lines) — skipping inline suggestions."
+            echo "posted=skipped-too-large" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # `-f.diff.strip=1` matches `git diff` output (a/foo b/foo).
+          # `-filter-mode=added` only suggests on lines the PR added,
+          #   which avoids re-suggesting on already-resolved threads when
+          #   the contributor re-adds the autoformat label.
+          reviewdog \
+            -f=diff -f.diff.strip=1 \
+            -name="prettier+eslint" \
+            -reporter=github-pr-review \
+            -filter-mode=added \
+            -level=warning \
+            -fail-on-error=false < "$patch"
+
+          echo "posted=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert sticky summary comment
+        # Only post when ci-quality found something fixable (= the
+        # autofix patch is non-empty). When prettier/eslint are clean
+        # the patch is zero bytes and the sticky comment is pure noise,
+        # so we skip it. When the diff was too large for inline
+        # suggestions, the sticky is the only signal the contributor
+        # gets, so we still post in that case.
+        if: >-
+          always()
+          && steps.meta.outputs.pr_number != ''
+          && steps.meta.outputs.changed_lines != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ steps.meta.outputs.pr_number }}
+          CHANGED: ${{ steps.meta.outputs.changed_lines }}
+          HEAD_SHA: ${{ steps.meta.outputs.head_sha }}
+          SCHEMA: ${{ steps.meta.outputs.schema }}
+          POSTED: ${{ steps.suggest.outputs.posted }}
+          RUN_ID: ${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Stable heading + marker — agents grep for these exact strings.
+          marker="<!-- gitnexus:pr-autofix-summary -->"
+          heading="## :sparkles: PR Autofix"
+
+          if [ "${POSTED}" = "skipped-too-large" ]; then
+            ui_state="skipped-too-large"
+            prose="Diff is **${CHANGED}** lines — too large for inline suggestions (GitHub caps the review-comment API at ~3000). Run locally: \`npm run lint:fix && npm run format\`."
+          else
+            ui_state="suggestions-posted"
+            prose="Posted formatting / unused-import suggestions inline. Click **Apply suggestion** on each, or run locally: \`npm run lint:fix && npm run format\`."
+          fi
+
+          # Machine-readable JSON block — agents parse this instead of
+          # regexing English. Fenced code-block info string is
+          # `gitnexus-autofix` so agents can locate it without ambiguity.
+          json=$(jq -n -c \
+            --arg schema       "${SCHEMA}" \
+            --arg state        "${ui_state}" \
+            --argjson pr_number "${PR}" \
+            --argjson changed_lines "${CHANGED}" \
+            --arg head_sha     "${HEAD_SHA}" \
+            --arg run_id       "${RUN_ID}" \
+            '{schema:$schema, state:$state, pr_number:$pr_number, changed_lines:$changed_lines, head_sha:$head_sha, run_id:$run_id}')
+
+          # Multi-line quoted string instead of a column-0 heredoc — YAML's
+          # `run: |` block ends as soon as a content line dedents below the
+          # block's first-line indent, which would mis-parse the workflow.
+          body="${marker}
+          ${heading}
+
+          ${prose}
+
+          \`\`\`gitnexus-autofix
+          ${json}
+          \`\`\`"
+          # Strip the leading 10-space indent that the YAML block requires
+          # so the rendered comment body starts at column 0.
+          body="$(printf '%s\n' "$body" | sed 's/^          //')"
+
+          # Small retry wrapper for transient 5xx / rate-limit responses
+          # on the GitHub REST API. Three tries with linear backoff. We
+          # only retry GET (idempotent) and PATCH on a known comment id
+          # (idempotent). POST is NOT wrapped — retrying a comment-create
+          # would create duplicates if the first attempt actually landed.
+          gh_retry() {
+            local n=0 max=3
+            while true; do
+              if gh "$@"; then return 0; fi
+              n=$((n+1))
+              if [ "$n" -ge "$max" ]; then return 1; fi
+              sleep $((n * 2))
+            done
+          }
+
+          # Find existing bot comment by the marker and edit-in-place; else create.
+          # CRITICAL: filter by `.user.login == "github-actions[bot]"`. A regular
+          # user posting a comment containing the marker would otherwise be the
+          # `head -n1` match; PATCH on someone else's comment 403s, `set -e`
+          # aborts, and the bot is permanently DoS'd for that PR.
+          existing=$(gh_retry api "repos/${GH_REPO}/issues/${PR}/comments" \
+            --paginate --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${marker}\"))) | .id" \
+            | head -n1 || true)
+
+          if [ -n "${existing}" ]; then
+            gh_retry api -X PATCH "repos/${GH_REPO}/issues/comments/${existing}" \
+              -f body="${body}" >/dev/null
+            echo "Updated comment ${existing}."
+          else
+            gh api -X POST "repos/${GH_REPO}/issues/${PR}/comments" \
+              -f body="${body}" >/dev/null
+            echo "Created summary comment."
+          fi

--- a/.github/workflows/pr-autofix-publish.yml
+++ b/.github/workflows/pr-autofix-publish.yml
@@ -48,6 +48,11 @@ jobs:
       # Required by actions/download-artifact to fetch artifacts produced
       # by a different workflow run.
       actions: read
+      # Required to create the `gitnexus/autofix` Check Run that reports
+      # the outcome (clean / suggestions-posted / skipped-too-large) to
+      # the PR's Checks tab. Branch protection or agents can grep the
+      # conclusion + output title without parsing the sticky comment.
+      checks: write
     steps:
       # Pinned to v8.0.1. Verify SHA via:
       #   gh api repos/actions/download-artifact/git/refs/tags/v8.0.1
@@ -259,3 +264,47 @@ jobs:
               -f body="${body}" >/dev/null
             echo "Created summary comment."
           fi
+
+      - name: Emit gitnexus/autofix Check Run
+        # Stable check name `gitnexus/autofix` so PR-watching agents can
+        # `gh pr checks <pr>` and read the conclusion + title without
+        # parsing the sticky comment. Three outcomes:
+        #   clean              → conclusion: success
+        #   suggestions-posted → conclusion: neutral (review suggestions)
+        #   skipped-too-large  → conclusion: neutral (diff > 3000 lines)
+        # `neutral` does not block branch-protection required-checks but
+        # is visually distinct from a green pass.
+        if: always() && steps.meta.outputs.head_sha != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.meta.outputs.head_sha }}
+          CHANGED: ${{ steps.meta.outputs.changed_lines }}
+          POSTED: ${{ steps.suggest.outputs.posted }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${CHANGED}" = "0" ]; then
+            conclusion="success"
+            title="Formatting clean"
+            summary="Prettier and ESLint --fix produced no changes."
+          elif [ "${POSTED}" = "skipped-too-large" ]; then
+            conclusion="neutral"
+            title="Diff too large for inline suggestions (${CHANGED} lines)"
+            summary="GitHub caps the review-comment API at ~3000 lines. Run \`npm run lint:fix && npm run format\` locally."
+          else
+            conclusion="neutral"
+            title="Suggestions posted"
+            summary="Inline review-comment suggestions posted. Click **Apply suggestion** on each, or run \`npm run lint:fix && npm run format\` locally."
+          fi
+
+          gh api -X POST "repos/${GH_REPO}/check-runs" \
+            -f name="gitnexus/autofix" \
+            -f head_sha="${HEAD_SHA}" \
+            -f status="completed" \
+            -f conclusion="${conclusion}" \
+            -f "output[title]=${title}" \
+            -f "output[summary]=${summary}" \
+            >/dev/null
+          echo "Posted check-run gitnexus/autofix=${conclusion} (${title})"

--- a/.github/workflows/pr-autofix-publish.yml
+++ b/.github/workflows/pr-autofix-publish.yml
@@ -135,6 +135,10 @@ jobs:
           CI_REPO_NAME: ${{ github.event.repository.name }}
           CI_PULL_REQUEST: ${{ steps.meta.outputs.pr_number }}
           CI_COMMIT: ${{ steps.meta.outputs.head_sha }}
+          # Pull `changed_lines` through env so bash gets a real
+          # variable (and shellcheck SC2170 doesn't fire on `-gt` against
+          # a `${{ }}`-interpolated literal).
+          CHANGED_LINES: ${{ steps.meta.outputs.changed_lines }}
         shell: bash
         run: |
           set -euo pipefail
@@ -148,8 +152,8 @@ jobs:
           # GitHub's review-comment API returns 406 on diffs above ~3k
           # changed lines. Bail out gracefully and let the summary
           # comment carry the signal instead.
-          if [ "${{ steps.meta.outputs.changed_lines }}" -gt 3000 ]; then
-            echo "Diff too large (${{ steps.meta.outputs.changed_lines }} lines) — skipping inline suggestions."
+          if [ "$CHANGED_LINES" -gt 3000 ]; then
+            echo "Diff too large ($CHANGED_LINES lines) — skipping inline suggestions."
             echo "posted=skipped-too-large" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -1,0 +1,132 @@
+name: PR Autofix
+
+# UNTRUSTED HALF of the autofix pipeline.
+#
+# Runs `npm run lint:fix` + `npm run format` against the PR head
+# (including fork heads) and uploads the resulting diff as an artifact.
+# This job has NO privileged token and CANNOT post to the PR. The trusted
+# `pr-autofix-publish.yml` workflow downloads the artifact via
+# `workflow_run` and posts the inline review-comment suggestions.
+#
+# Why the split:
+#   ESLint loads plugins from fork-controlled `node_modules`, so running
+#   it in a job with `pull-requests: write` would let a malicious fork PR
+#   ship a poisoned eslint plugin and execute arbitrary code under that
+#   token. By keeping fork code execution in this job (token: read-only)
+#   and posting from a separate trusted job that never touches fork
+#   code, we get the inline-suggestion UX for fork PRs without the
+#   supply-chain hole. (See autofix.ci for the same pattern.)
+#
+# Removes unused imports via `eslint-plugin-unused-imports`, already in
+# devDependencies and wired into the `lint` config.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    # Skip lockfile / generated-file PRs entirely — `action-suggester`
+    # cannot post on diffs > ~3k lines (GitHub returns 406) and these
+    # paths produce massive diffs no human wants suggested back inline.
+    paths-ignore:
+      - '**/package-lock.json'
+      - '**/*.snap'
+      - '**/dist/**'
+      - '**/node_modules/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  # Don't cancel in-flight runs; the publish workflow may already be
+  # downloading the artifact and a cancelled untrusted run produces no
+  # signal at all (worse DX than waiting).
+  cancel-in-progress: false
+
+# This workflow runs untrusted fork code. Top-level deny-all and NO
+# job-level grants — the job can only read its own checkout.
+permissions: {}
+
+jobs:
+  autofix:
+    name: autofix
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # PR head commit (not the synthetic merge ref) — we need the
+          # exact tree the contributor pushed so suggestions line up.
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      # `--ignore-scripts` blocks pre/postinstall lifecycle hooks. ESLint
+      # plugins still load from node_modules (that is the actual escape
+      # hatch on a typical fork), but this job has no token to abuse —
+      # which is the whole point of the split.
+      - run: npm ci --ignore-scripts
+
+      - name: ESLint --fix (removes unused imports)
+        run: npm run lint:fix
+        # Lint errors that --fix can't auto-resolve must not block the
+        # diff artifact — partial fixes are still useful as suggestions.
+        continue-on-error: true
+
+      - name: Prettier --write
+        run: npm run format
+        continue-on-error: true
+
+      - name: Capture diff and metadata
+        id: capture
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p autofix-out
+
+          # Produce a unified diff of the working tree vs. the PR head.
+          # Empty diff => nothing to suggest; the publish job short-circuits.
+          git diff --no-color > autofix-out/autofix.patch
+
+          # NOTE: `changed_lines` is the line-count of the patch file,
+          # which includes hunk headers and context lines — NOT the
+          # added/removed source-line count. The 3000-line cap in
+          # pr-autofix-publish.yml is therefore conservative (fires
+          # before reviewdog hits GitHub's ~3k review-comment API
+          # ceiling). That bias is intentional.
+          changed_lines=$(wc -l < autofix-out/autofix.patch | tr -d ' ')
+          echo "changed_lines=${changed_lines}" >> "$GITHUB_OUTPUT"
+
+          # Carry PR identity over to the trusted job. workflow_run
+          # context is base-repo-only, so the publish job needs these
+          # to call the GitHub PR API on the right resource.
+          # CONTRACT: keep this schema in sync with pr-autofix-publish.yml's
+          # `assert_field` validators and the agent-facing JSON block in
+          # the sticky comment. Bump `schema` when changing field names.
+          jq -n \
+            --arg     schema      'gitnexus.pr-autofix/v1' \
+            --argjson pr_number   '${{ github.event.pull_request.number }}' \
+            --arg     head_sha    '${{ github.event.pull_request.head.sha }}' \
+            --arg     head_ref    '${{ github.event.pull_request.head.ref }}' \
+            --arg     head_repo   '${{ github.event.pull_request.head.repo.full_name }}' \
+            --arg     base_repo   '${{ github.repository }}' \
+            --argjson changed_lines "${changed_lines}" \
+            '{schema:$schema, pr_number:$pr_number, head_sha:$head_sha, head_ref:$head_ref, head_repo:$head_repo, base_repo:$base_repo, changed_lines:$changed_lines}' \
+            > autofix-out/metadata.json
+
+          echo "--- metadata ---"
+          cat autofix-out/metadata.json
+          echo "--- diff (head) ---"
+          head -c 2000 autofix-out/autofix.patch || true
+
+      # Pinned to v7.0.1. Verify SHA via:
+      #   gh api repos/actions/upload-artifact/git/refs/tags/v7.0.1
+      - name: Upload autofix artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: autofix
+          path: autofix-out/
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -81,6 +81,20 @@ jobs:
 
       - name: Capture diff and metadata
         id: capture
+        # Pass GitHub-context values via env: rather than `${{ }}`
+        # interpolated directly into the bash body. `head.ref` and
+        # `head.repo.full_name` are fork-controlled strings; expanding
+        # them into shell source is the canonical template-injection
+        # vector zizmor flags. Even though this job has `permissions: {}`,
+        # routing through env: makes it impossible for a future scope
+        # grant to turn into RCE. Inside bash, reference as `$HEAD_REF`
+        # etc. — the values are then plain strings, not code.
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         shell: bash
         run: |
           set -euo pipefail
@@ -106,12 +120,12 @@ jobs:
           # `assert_field` validators and the agent-facing JSON block in
           # the sticky comment. Bump `schema` when changing field names.
           jq -n \
-            --arg     schema      'gitnexus.pr-autofix/v1' \
-            --argjson pr_number   '${{ github.event.pull_request.number }}' \
-            --arg     head_sha    '${{ github.event.pull_request.head.sha }}' \
-            --arg     head_ref    '${{ github.event.pull_request.head.ref }}' \
-            --arg     head_repo   '${{ github.event.pull_request.head.repo.full_name }}' \
-            --arg     base_repo   '${{ github.repository }}' \
+            --arg     schema        'gitnexus.pr-autofix/v1' \
+            --argjson pr_number     "${PR_NUMBER}" \
+            --arg     head_sha      "${HEAD_SHA}" \
+            --arg     head_ref      "${HEAD_REF}" \
+            --arg     head_repo     "${HEAD_REPO}" \
+            --arg     base_repo     "${BASE_REPO}" \
             --argjson changed_lines "${changed_lines}" \
             '{schema:$schema, pr_number:$pr_number, head_sha:$head_sha, head_ref:$head_ref, head_repo:$head_repo, base_repo:$base_repo, changed_lines:$changed_lines}' \
             > autofix-out/metadata.json

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -294,9 +294,11 @@ jobs:
             fi
           fi
 
-          echo "base=$BASE"             >> "$GITHUB_OUTPUT"
-          echo "rc_n=$NEXT_N"           >> "$GITHUB_OUTPUT"
-          echo "rc_version=$RC_VERSION" >> "$GITHUB_OUTPUT"
+          {
+            echo "base=$BASE"
+            echo "rc_n=$NEXT_N"
+            echo "rc_version=$RC_VERSION"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Apply rc version in-CI
         shell: bash
@@ -354,9 +356,11 @@ jobs:
           # remote ref, the push fails and we stop before npm publish.
           git push --atomic origin "refs/tags/$VTAG" "refs/tags/$MARKER"
 
-          echo "vtag=$VTAG"     >> "$GITHUB_OUTPUT"
-          echo "marker=$MARKER" >> "$GITHUB_OUTPUT"
-          echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
+          {
+            echo "vtag=$VTAG"
+            echo "marker=$MARKER"
+            echo "release_sha=$RELEASE_SHA"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Publish to npm (rc dist-tag)
         run: npm publish --provenance --access public --tag rc

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,10 +1,13 @@
-name: Workflow Lint (zizmor)
+name: Workflow Lint
 
-# Lints .github/workflows/** for known GitHub Actions security misconfigurations:
-# unpinned Actions, dangerous ${{ ... }} interpolation in run: blocks,
-# missing per-job permissions:, etc.
+# Lints .github/workflows/** for both:
+#   - actionlint: YAML syntax, expression typing, shellcheck inside `run:`
+#     blocks, unknown contexts, deprecated runner labels.
+#   - zizmor: security misconfigurations — unpinned actions, dangerous
+#     `${{ }}` interpolation, missing per-job permissions, etc.
 #
-# Scoped to PRs that touch .github/** only — keeps off the typical PR critical path.
+# Scoped to PRs that touch .github/** only — keeps off the typical PR
+# critical path.
 
 on:
   pull_request:
@@ -17,6 +20,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Pinned to v2.1.2. Verify SHA via:
+      #   gh api repos/raven-actions/actionlint/git/refs/tags/v2.1.2
+      # The action wraps the upstream `rhysd/actionlint` binary and emits
+      # GitHub-annotation-formatted findings on PRs.
+      - name: Run actionlint
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+        with:
+          fail-on-error: true
+
   zizmor:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -14,6 +14,15 @@ rules:
       # no checkout of fork code occurs. Header comment in the file documents.
       - ci-report.yml
 
+      # workflow_run is the trusted half of the autofix pipeline. The
+      # untrusted half (pr-autofix.yml) runs fork code with permissions:{}
+      # and produces only a diff artifact (data, not executable code). The
+      # publish job consumes the artifact, allowlist-validates every field
+      # of metadata.json before exporting to $GITHUB_OUTPUT, never checks
+      # out fork code, and never executes anything fork-controlled. Header
+      # comment in the file documents the split.
+      - pr-autofix-publish.yml
+
       # pull_request_target needed by claude-code-action to access secrets
       # and post review comments on fork PRs. Mitigated by: PR checkouts pin
       # the fork's HEAD SHA (not the branch ref) to prevent TOCTOU races,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,24 @@ Every workflow under `.github/workflows/` MUST declare a top-level `concurrency:
 
 - When adding a new workflow, copy the concurrency block from an existing workflow of the same event shape.
 
+## CI automation contracts
+
+Two workflows produce machine-readable signals on every PR. Coding agents and humans alike can rely on the names and shapes below — change them with intent.
+
+### `gitnexus/autofix`
+
+`pr-autofix.yml` (untrusted) + `pr-autofix-publish.yml` (trusted) run `prettier --write` and `eslint --fix` against the PR head and surface the diff as inline review-comment suggestions. Three signals are emitted:
+
+| Surface | Where | Notes |
+|---|---|---|
+| Sticky PR comment | Top-level comment with the HTML marker `<!-- gitnexus:pr-autofix-summary -->` and heading `## :sparkles: PR Autofix`. Only posted when there is something to fix; clean PRs stay silent. | Edit-in-place via marker; one comment per PR. |
+| Fenced JSON block | Inside the sticky, fenced as `gitnexus-autofix`. Schema `gitnexus.pr-autofix/v1` with fields `state` (`suggestions-posted` \| `skipped-too-large`), `pr_number`, `head_sha`, `changed_lines`, `run_id`. | Parseable signal — preferred over regexing prose. |
+| Check Run | Stable name `gitnexus/autofix` on the PR head SHA. Conclusion: `success` (clean) or `neutral` (suggestions-posted / skipped-too-large). The output title disambiguates the two `neutral` cases. | Surfaced under PR Checks; readable via `gh pr checks <pr>`. |
+
+To detect outcome from an agent: `gh pr checks <pr> --json name,conclusion,output | jq '.[] | select(.name == "gitnexus/autofix")'`.
+
+Forks are supported. The untrusted half runs fork code with `permissions: {}` and ships the diff as an artifact; the trusted publish job consumes only the diff (data, not code) and posts the comment + check run.
+
 ## AI-assisted contributions
 
 If you use coding agents, follow project context files (e.g. `AGENTS.md`, `CLAUDE.md`) and avoid drive-by refactors unrelated to the issue. Prefer incremental, test-backed changes.


### PR DESCRIPTION
## Summary

Adds a two-workflow autofix pipeline that posts `prettier` + `eslint --fix` output as inline review-comment suggestions on PRs — including fork PRs — without ever running fork-controlled ESLint plugins under a privileged token.

| Workflow | Trigger | Token | Role |
|---|---|---|---|
| `pr-autofix.yml` | `pull_request` (incl. forks) | `permissions: {}` | Untrusted: runs `lint:fix` + `format`, uploads diff as artifact. No write capability. |
| `pr-autofix-publish.yml` | `workflow_run` | `pull-requests: write`, `actions: read` | Trusted: never touches fork code. Posts inline suggestions via `reviewdog` and one sticky summary comment when there's actually something to fix. |

## Why split into two halves

ESLint loads plugins from fork-controlled `node_modules`, so running it in a job with `pull-requests: write` would let a malicious fork PR ship a poisoned ESLint plugin and execute arbitrary code under that token. The untrusted half runs fork code with `permissions: {}` (no token to abuse) and the trusted half consumes only the diff artifact (data, not code) — same pattern as autofix.ci.

## Hardening applied (from multi-agent review)

- **Concurrency** keyed on PR number with fork fallback to head-repo+branch — `workflow_run.id` (per-run unique) is the anti-pattern called out by name in `CONTRIBUTING.md`.
- **Metadata allowlist**: every `metadata.json` field is regex-validated before being exported to `$GITHUB_OUTPUT`, closing the `head_ref` newline-injection vector that would otherwise let a fork redirect bot comments to a victim PR.
- **Sticky-comment author filter**: lookup matches `.user.login == "github-actions[bot]"` so a regular user posting a comment with the marker can't permanently DoS the upsert.
- **Reviewdog binary pinned** to `v0.21.0` (not `latest`) — bad release otherwise breaks every PR.
- **`gh` API retry** on transient 5xx for the idempotent calls (GET, PATCH).
- **Sticky only when actionable**: when `prettier`/`eslint` are clean, `npm run lint:fix && npm run format` produces an empty diff and no comment is posted. The sticky carries a fenced `gitnexus-autofix` JSON block under a stable HTML marker so agents can parse state without regex.
- **`paths-ignore`** on `package-lock.json` / snapshots / `dist/` / `node_modules/` to avoid reviewdog's 406-on-3k-lines failure mode.

## Required out-of-band repo settings

To replace the previously-considered `chinthakagodawita/autoupdate` (unmaintained since 2023):

- [ ] Enable **merge queue** on `main`.
- [ ] Branch protection: **Require branches to be up to date before merging**.
- [ ] Optionally: add a CI-automation note to `CONTRIBUTING.md` describing the sticky-comment marker and `gitnexus-autofix` JSON schema (follow-up).

## Test plan

`workflow_run` cannot run from a feature branch — first execution is post-merge. Manual validation:

- [ ] Open a small same-repo PR with a deliberate prettier/eslint violation; confirm reviewdog suggestions appear on the PR head and one sticky comment with the JSON block.
- [ ] Open a fork PR with the same violation; confirm same behaviour.
- [ ] Open a clean PR; confirm no sticky comment and no inline suggestions.
- [ ] Open a PR touching only `package-lock.json`; confirm the workflow doesn't fire.
- [ ] Verify `python3 .github/scripts/check-workflow-concurrency.py .github/workflows` passes (it does locally).

## Follow-ups (intentionally out of scope)

- `actionlint` workflow to catch YAML/expression typos in future PRs.
- Emit a `Check Run` so the `success`/`neutral` status itself reflects autofix outcome (currently agents must read the sticky's JSON block).
- Document the `<!-- gitnexus:pr-autofix-summary -->` marker + `gitnexus-autofix` schema in `CONTRIBUTING.md`.