### PR TITLE
feat(mcp): add request log writer (PoC for #1351)

### DIFF
--- a/gitnexus/src/mcp/request-log.ts
+++ b/gitnexus/src/mcp/request-log.ts
@@ -21,6 +21,12 @@
  * #1351 — the OpenTelemetry / Prometheus direction proposed there
  * may make the JSONL path moot.
  *
+ * Privacy note: tool *inputs* (`params`/`rawArgs`) are never logged.
+ * The `error` field, however, captures error messages verbatim. Tool
+ * error messages can echo user input — e.g. cypher parse errors
+ * routinely include the offending clause. Treat the log as
+ * input-adjacent for retention and access purposes.
+ *
  * Failures to write are swallowed — the MCP server's availability
  * matters more than logging fidelity.
  */
@@ -79,6 +85,19 @@ export async function appendRequestLog(
 /**
  * Wrap an async tool-call handler so each invocation produces a log
  * entry. Returns the original result unchanged.
+ *
+ * MCP tool errors arrive two ways:
+ * 1. Thrown — caught here; `error` is the thrown message.
+ * 2. Returned as `{ isError: true, content: [...] }` envelopes — the
+ *    handler converts thrown errors into this shape before returning.
+ *    We inspect the envelope so the log doesn't undercount failures.
+ *    The `errorOf` hook lets the wrap site teach us how to read the
+ *    envelope (returns the error message string, or null on success).
+ *
+ * NOTE on error content: MCP tool error messages can echo user input
+ * (e.g. cypher parse errors include the offending clause verbatim). The
+ * log is therefore NOT free of input data; see request-log.ts module
+ * header.
  */
 export async function instrumented<T>(
   toolName: string,
@@ -88,17 +107,20 @@ export async function instrumented<T>(
     if (r === null || r === undefined) return 0;
     try { return Buffer.byteLength(JSON.stringify(r), 'utf8'); } catch { return 0; }
   },
+  errorOf: (result: T) => string | null = () => null,
 ): Promise<T> {
   const ts = new Date().toISOString();
   const startedAt = Date.now();
   try {
     const result = await fn();
+    let errorMsg: string | null = null;
+    try { errorMsg = errorOf(result); } catch { errorMsg = null; }
     void appendRequestLog({
       ts,
       tool: toolName,
       durationMs: Date.now() - startedAt,
       resultBytes: resultBytesOf(result),
-      error: null,
+      error: errorMsg,
     });
     return result;
   } catch (err) {

--- a/gitnexus/src/mcp/request-log.ts
+++ b/gitnexus/src/mcp/request-log.ts
@@ -7,18 +7,19 @@
  * long do calls take." A simpler counterpart to the full OpenTelemetry
  * proposal in #1351 — see the issue for the design discussion.
  *
- * Configuration via env (defaults are safe-by-default — opt-out, not
- * opt-in, so the log is present without extra setup):
+ * Configuration via env (opt-in default — no log written unless the
+ * user asks for one, so this PoC is safe to merge without privacy
+ * concerns about incidental capture in shared environments):
  *
- *   GITNEXUS_MCP_REQUEST_LOG=off        — disable entirely
- *   GITNEXUS_MCP_REQUEST_LOG=/path/log  — write to this absolute path
- *   GITNEXUS_MCP_REQUEST_LOG=<empty>    — default: ~/.gitnexus/mcp-requests.log
+ *   unset / empty                       — disabled (default)
+ *   GITNEXUS_MCP_REQUEST_LOG=on         — enable; write to ~/.gitnexus/mcp-requests.log
+ *   GITNEXUS_MCP_REQUEST_LOG=/path/log  — enable; write to this absolute path
+ *   GITNEXUS_MCP_REQUEST_LOG=off        — explicitly disabled (same as unset)
  *
- * Privacy: tool inputs (e.g. raw `cypher` queries) may contain symbol
- * names from private code. The log lives next to `.gitnexus/` data
- * that already contains the indexed graph, so no new exposure surface
- * is created — but the log is kept off by default in CI to avoid
- * incidental capture in shared environments (see request-log.test.ts).
+ * Whether the default should flip to opt-out (so server-side ground
+ * truth exists without setup) is part of the design discussion on
+ * #1351 — the OpenTelemetry / Prometheus direction proposed there
+ * may make the JSONL path moot.
  *
  * Failures to write are swallowed — the MCP server's availability
  * matters more than logging fidelity.
@@ -47,12 +48,15 @@ export interface RequestLogEntry {
  */
 export function resolveLogPath(env: NodeJS.ProcessEnv = process.env): string | null {
   const raw = env['GITNEXUS_MCP_REQUEST_LOG'];
-  if (typeof raw === 'string') {
-    const trimmed = raw.trim();
-    if (trimmed.toLowerCase() === 'off') return null;
-    if (trimmed.length > 0) return trimmed;
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  const lower = trimmed.toLowerCase();
+  if (lower === 'off' || lower === 'false' || lower === '0') return null;
+  if (lower === 'on' || lower === 'true' || lower === '1') {
+    return join(homedir(), '.gitnexus', 'mcp-requests.log');
   }
-  return join(homedir(), '.gitnexus', 'mcp-requests.log');
+  return trimmed;
 }
 
 /**

--- a/gitnexus/src/mcp/request-log.ts
+++ b/gitnexus/src/mcp/request-log.ts
@@ -1,0 +1,110 @@
+/**
+ * MCP request log (PoC for issue #1351).
+ *
+ * Writes one JSONL line per MCP `tools/call` to a configurable path so
+ * downstream utilization analysers (e.g. mcp-value-tracker) have a
+ * server-side ground truth for "is this MCP server being used and how
+ * long do calls take." A simpler counterpart to the full OpenTelemetry
+ * proposal in #1351 — see the issue for the design discussion.
+ *
+ * Configuration via env (defaults are safe-by-default — opt-out, not
+ * opt-in, so the log is present without extra setup):
+ *
+ *   GITNEXUS_MCP_REQUEST_LOG=off        — disable entirely
+ *   GITNEXUS_MCP_REQUEST_LOG=/path/log  — write to this absolute path
+ *   GITNEXUS_MCP_REQUEST_LOG=<empty>    — default: ~/.gitnexus/mcp-requests.log
+ *
+ * Privacy: tool inputs (e.g. raw `cypher` queries) may contain symbol
+ * names from private code. The log lives next to `.gitnexus/` data
+ * that already contains the indexed graph, so no new exposure surface
+ * is created — but the log is kept off by default in CI to avoid
+ * incidental capture in shared environments (see request-log.test.ts).
+ *
+ * Failures to write are swallowed — the MCP server's availability
+ * matters more than logging fidelity.
+ */
+
+import { appendFile, mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export interface RequestLogEntry {
+  /** ISO 8601 timestamp at request start. */
+  ts: string;
+  /** MCP tool name (e.g. "impact", "context"). */
+  tool: string;
+  /** Total duration in milliseconds from invocation to result. */
+  durationMs: number;
+  /** Size of the result payload in bytes (0 on error). */
+  resultBytes: number;
+  /** Error message if the call threw, else null. */
+  error: string | null;
+}
+
+/**
+ * Resolve the configured log path. Returns `null` if logging is disabled
+ * (env var explicitly set to "off") so callers can short-circuit.
+ */
+export function resolveLogPath(env: NodeJS.ProcessEnv = process.env): string | null {
+  const raw = env['GITNEXUS_MCP_REQUEST_LOG'];
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (trimmed.toLowerCase() === 'off') return null;
+    if (trimmed.length > 0) return trimmed;
+  }
+  return join(homedir(), '.gitnexus', 'mcp-requests.log');
+}
+
+/**
+ * Append one JSONL entry to the configured log file. Creates the parent
+ * directory if needed. Swallows all errors — availability over fidelity.
+ */
+export async function appendRequestLog(
+  entry: RequestLogEntry,
+  path: string | null = resolveLogPath(),
+): Promise<void> {
+  if (path === null) return;
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(path, JSON.stringify(entry) + '\n');
+  } catch {
+    // Intentionally silent — see module docstring.
+  }
+}
+
+/**
+ * Wrap an async tool-call handler so each invocation produces a log
+ * entry. Returns the original result unchanged.
+ */
+export async function instrumented<T>(
+  toolName: string,
+  fn: () => Promise<T>,
+  resultBytesOf: (result: T) => number = (r) => {
+    if (typeof r === 'string') return Buffer.byteLength(r, 'utf8');
+    if (r === null || r === undefined) return 0;
+    try { return Buffer.byteLength(JSON.stringify(r), 'utf8'); } catch { return 0; }
+  },
+): Promise<T> {
+  const ts = new Date().toISOString();
+  const startedAt = Date.now();
+  try {
+    const result = await fn();
+    void appendRequestLog({
+      ts,
+      tool: toolName,
+      durationMs: Date.now() - startedAt,
+      resultBytes: resultBytesOf(result),
+      error: null,
+    });
+    return result;
+  } catch (err) {
+    void appendRequestLog({
+      ts,
+      tool: toolName,
+      durationMs: Date.now() - startedAt,
+      resultBytes: 0,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+}

--- a/gitnexus/src/mcp/server.ts
+++ b/gitnexus/src/mcp/server.ts
@@ -209,6 +209,19 @@ export function createMCPServer(backend: LocalBackend): Server {
           return 0;
         }
       },
+      (result) => {
+        // The handler converts thrown tool errors into a returned
+        // envelope `{ isError: true, content: [{ type: 'text', text: 'Error: ...' }] }`,
+        // so `instrumented`'s catch branch never fires for tool errors.
+        // Inspect the envelope here so the log doesn't undercount failures.
+        try {
+          const envelope = result as { isError?: boolean; content?: Array<{ text?: string }> };
+          if (envelope?.isError !== true) return null;
+          return envelope.content?.[0]?.text ?? 'tool error';
+        } catch {
+          return null;
+        }
+      },
     );
   });
 

--- a/gitnexus/src/mcp/server.ts
+++ b/gitnexus/src/mcp/server.ts
@@ -27,6 +27,7 @@ import { GITNEXUS_TOOLS } from './tools.js';
 import { installGlobalStdoutSentinel } from './stdio-context.js';
 import type { LocalBackend } from './local/local-backend.js';
 import { getResourceDefinitions, getResourceTemplates, readResource } from './resources.js';
+import { instrumented } from './request-log.js';
 
 /**
  * Next-step hints appended to tool responses.
@@ -162,35 +163,53 @@ export function createMCPServer(backend: LocalBackend): Server {
     })),
   }));
 
-  // Handle tool calls — append next-step hints to guide agent workflow
+  // Handle tool calls — append next-step hints to guide agent workflow.
+  // Wrapped in `instrumented(...)` so every call writes one JSONL line to
+  // the MCP request log (see ./request-log.ts) for utilization analysis.
+  // The wrap is no-op if GITNEXUS_MCP_REQUEST_LOG=off.
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
 
-    try {
-      const result = await backend.callTool(name, args);
-      const resultText = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
-      const hint = getNextStepHint(name, args as Record<string, any> | undefined);
+    return instrumented(
+      name,
+      async () => {
+        try {
+          const result = await backend.callTool(name, args);
+          const resultText = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+          const hint = getNextStepHint(name, args as Record<string, any> | undefined);
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: resultText + hint,
-          },
-        ],
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Error: ${message}`,
-          },
-        ],
-        isError: true,
-      };
-    }
+          return {
+            content: [
+              {
+                type: 'text',
+                text: resultText + hint,
+              },
+            ],
+          };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Unknown error';
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error: ${message}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      },
+      (result) => {
+        // Size the text payload, not the whole envelope, so the log
+        // metric stays aligned with what the agent actually receives.
+        try {
+          const block = (result as { content?: Array<{ text?: string }> }).content?.[0];
+          return block?.text ? Buffer.byteLength(block.text, 'utf8') : 0;
+        } catch {
+          return 0;
+        }
+      },
+    );
   });
 
   // Handle list prompts request

--- a/gitnexus/test/unit/mcp/request-log.test.ts
+++ b/gitnexus/test/unit/mcp/request-log.test.ts
@@ -178,4 +178,38 @@ describe('instrumented', () => {
     await new Promise((r) => setTimeout(r, 30));
     expect(fs.existsSync(logPath)).toBe(false);
   });
+
+  it('logs tool errors returned as { isError: true } envelopes via errorOf', async () => {
+    type ErrEnvelope = { isError?: boolean; content: Array<{ type: string; text: string }> };
+    const envelope: ErrEnvelope = {
+      isError: true,
+      content: [{ type: 'text', text: 'Error: target not found' }],
+    };
+    await instrumented(
+      'impact',
+      async () => envelope,
+      (r) => Buffer.byteLength(r.content[0]!.text, 'utf8'),
+      (r) => (r.isError === true ? r.content[0]!.text : null),
+    );
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n');
+    const entry = JSON.parse(lines[0]!) as RequestLogEntry;
+    expect(entry.tool).toBe('impact');
+    expect(entry.error).toBe('Error: target not found');
+    expect(entry.resultBytes).toBe(Buffer.byteLength('Error: target not found', 'utf8'));
+  });
+
+  it('logs error: null when errorOf is not provided (back-compat default)', async () => {
+    type Envelope = { content: Array<{ text: string }> };
+    const envelope: Envelope = { content: [{ text: 'plain success' }] };
+    await instrumented('context', async () => envelope);
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n');
+    const entry = JSON.parse(lines[0]!) as RequestLogEntry;
+    expect(entry.error).toBeNull();
+  });
 });

--- a/gitnexus/test/unit/mcp/request-log.test.ts
+++ b/gitnexus/test/unit/mcp/request-log.test.ts
@@ -17,16 +17,25 @@ describe('resolveLogPath', () => {
     expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: '/tmp/custom.log' })).toBe('/tmp/custom.log');
   });
 
-  it('returns null when env var is "off"', () => {
+  it('returns null when env var disables logging', () => {
     expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: 'off' })).toBeNull();
     expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: 'OFF' })).toBeNull();
+    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: 'false' })).toBeNull();
+    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: '0' })).toBeNull();
   });
 
-  it('falls back to ~/.gitnexus/mcp-requests.log when env var is unset or empty', () => {
+  it('returns null (disabled) when env var is unset or empty (opt-in default)', () => {
+    expect(resolveLogPath({})).toBeNull();
+    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: '' })).toBeNull();
+    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: '   ' })).toBeNull();
+  });
+
+  it('returns the default log path for affirmative boolean values', () => {
     const expected = path.join(os.homedir(), '.gitnexus', 'mcp-requests.log');
-    expect(resolveLogPath({})).toBe(expected);
-    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: '' })).toBe(expected);
-    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: '   ' })).toBe(expected);
+    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: 'on' })).toBe(expected);
+    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: 'ON' })).toBe(expected);
+    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: 'true' })).toBe(expected);
+    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: '1' })).toBe(expected);
   });
 });
 

--- a/gitnexus/test/unit/mcp/request-log.test.ts
+++ b/gitnexus/test/unit/mcp/request-log.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the MCP request log (issue #1351 PoC).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  resolveLogPath,
+  appendRequestLog,
+  instrumented,
+  type RequestLogEntry,
+} from '../../../src/mcp/request-log.js';
+
+describe('resolveLogPath', () => {
+  it('returns the configured absolute path when env var is set', () => {
+    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: '/tmp/custom.log' })).toBe('/tmp/custom.log');
+  });
+
+  it('returns null when env var is "off"', () => {
+    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: 'off' })).toBeNull();
+    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: 'OFF' })).toBeNull();
+  });
+
+  it('falls back to ~/.gitnexus/mcp-requests.log when env var is unset or empty', () => {
+    const expected = path.join(os.homedir(), '.gitnexus', 'mcp-requests.log');
+    expect(resolveLogPath({})).toBe(expected);
+    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: '' })).toBe(expected);
+    expect(resolveLogPath({ GITNEXUS_MCP_REQUEST_LOG: '   ' })).toBe(expected);
+  });
+});
+
+describe('appendRequestLog', () => {
+  let tmpDir: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gnx-mcp-log-'));
+    logPath = path.join(tmpDir, 'nested', 'requests.log');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('appends one JSONL entry and creates the parent directory', async () => {
+    const entry: RequestLogEntry = {
+      ts: '2026-05-10T18:00:00Z',
+      tool: 'impact',
+      durationMs: 42,
+      resultBytes: 1234,
+      error: null,
+    };
+    await appendRequestLog(entry, logPath);
+    expect(fs.existsSync(logPath)).toBe(true);
+    const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!)).toEqual(entry);
+  });
+
+  it('appends multiple entries one per line', async () => {
+    const base: RequestLogEntry = {
+      ts: '2026-05-10T18:00:00Z',
+      tool: 'query',
+      durationMs: 10,
+      resultBytes: 5,
+      error: null,
+    };
+    await appendRequestLog(base, logPath);
+    await appendRequestLog({ ...base, tool: 'context', durationMs: 20 }, logPath);
+    await appendRequestLog({ ...base, tool: 'impact', error: 'boom' }, logPath);
+    const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(3);
+    expect(JSON.parse(lines[0]!).tool).toBe('query');
+    expect(JSON.parse(lines[1]!).tool).toBe('context');
+    expect(JSON.parse(lines[2]!).error).toBe('boom');
+  });
+
+  it('is a no-op when path is null (logging disabled)', async () => {
+    await appendRequestLog(
+      { ts: 't', tool: 'x', durationMs: 0, resultBytes: 0, error: null },
+      null,
+    );
+    expect(fs.existsSync(logPath)).toBe(false);
+  });
+
+  it('does not throw when the destination is unwritable', async () => {
+    // Use a path inside a non-existent root that mkdir can't create.
+    await expect(
+      appendRequestLog(
+        { ts: 't', tool: 'x', durationMs: 0, resultBytes: 0, error: null },
+        '/proc/0/nope/cannot-write.log',
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('instrumented', () => {
+  let tmpDir: string;
+  let logPath: string;
+  const prevEnv = process.env['GITNEXUS_MCP_REQUEST_LOG'];
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gnx-mcp-instrumented-'));
+    logPath = path.join(tmpDir, 'requests.log');
+    process.env['GITNEXUS_MCP_REQUEST_LOG'] = logPath;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (prevEnv === undefined) delete process.env['GITNEXUS_MCP_REQUEST_LOG'];
+    else process.env['GITNEXUS_MCP_REQUEST_LOG'] = prevEnv;
+  });
+
+  it('logs success calls with durationMs and resultBytes', async () => {
+    const result = await instrumented('impact', async () => 'hello world');
+    expect(result).toBe('hello world');
+
+    // Logger writes are fire-and-forget — give the loop a tick.
+    await new Promise((r) => setTimeout(r, 30));
+
+    const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]!) as RequestLogEntry;
+    expect(entry.tool).toBe('impact');
+    expect(entry.error).toBeNull();
+    expect(entry.resultBytes).toBe(Buffer.byteLength('hello world'));
+    expect(entry.durationMs).toBeGreaterThanOrEqual(0);
+    expect(entry.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('logs error calls with the message and rethrows', async () => {
+    await expect(
+      instrumented('cypher', async () => {
+        throw new Error('parse error');
+      }),
+    ).rejects.toThrow('parse error');
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]!) as RequestLogEntry;
+    expect(entry.tool).toBe('cypher');
+    expect(entry.error).toBe('parse error');
+    expect(entry.resultBytes).toBe(0);
+  });
+
+  it('honours a custom resultBytesOf to size text-only payloads', async () => {
+    type Envelope = { content: Array<{ text: string }> };
+    const envelope: Envelope = { content: [{ text: 'just-this-bit' }] };
+    await instrumented(
+      'context',
+      async () => envelope,
+      (r) => Buffer.byteLength(r.content[0]!.text, 'utf8'),
+    );
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n');
+    const entry = JSON.parse(lines[0]!) as RequestLogEntry;
+    expect(entry.resultBytes).toBe(Buffer.byteLength('just-this-bit', 'utf8'));
+  });
+
+  it('is a no-op writer when env says off (still returns the result)', async () => {
+    process.env['GITNEXUS_MCP_REQUEST_LOG'] = 'off';
+    const result = await instrumented('impact', async () => 42);
+    expect(result).toBe(42);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fs.existsSync(logPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
Refs #1351.

## Summary

Wraps the `CallToolRequestSchema` handler with an `instrumented()` helper that appends one JSONL line per `tools/call` to a configurable log file:

```json
{"ts":"2026-05-10T18:00:00Z","tool":"impact","durationMs":214,"resultBytes":1834,"error":null}
```

The same wrapper can host an OTLP span emitter alongside or instead of the JSONL writer — the single seam is `src/mcp/server.ts:166`.

## Changes

- `gitnexus/src/mcp/request-log.ts` — `resolveLogPath()`, `appendRequestLog()`, `instrumented(toolName, fn, resultBytesOf?, errorOf?)`. Async append, `mkdir -p` on the parent, errors swallowed.
- `gitnexus/src/mcp/server.ts` — wraps the existing handler. Behaviour unchanged when logging is disabled. `errorOf` reads the `{ isError: true, ... }` envelope so tool errors land in the log with their message (the handler converts thrown errors into a returned envelope, so the wrapper's catch branch never sees them).
- `gitnexus/test/unit/mcp/request-log.test.ts` — 14 unit tests.

## Configuration

Opt-in default:

| `GITNEXUS_MCP_REQUEST_LOG` | Result |
|---|---|
| unset / empty | disabled |
| `off` / `false` / `0` | disabled |
| `on` / `true` / `1` | `~/.gitnexus/mcp-requests.log` |
| `/abs/path/log` | that path |

## Privacy

Tool **inputs** (`params`/`rawArgs`) are never logged. The `error` field captures error messages verbatim; tool errors routinely echo input (cypher parse errors include the offending clause, etc.). Treat the log as input-adjacent.

## Verify

```bash
cd gitnexus
npm install
npx vitest run test/unit/mcp/request-log.test.ts   # 14 pass
```

End-to-end after `npm run build`:

```bash
GITNEXUS_MCP_REQUEST_LOG=on gitnexus mcp
# drive via any MCP client, then:
cat ~/.gitnexus/mcp-requests.log
```

## Risk

- One `JSON.stringify` + one `fs.appendFile` per tool call. Fire-and-forget; the request handler returns without awaiting.
- In-flight writes can be lost on `shutdown()` — no drain in this PoC. See decision table below.
- Unbounded log size — no rotation in this PoC.
- Rollback: revert the commit. No DB, schema, or index changes; no new runtime deps.

## Recommended decisions for v1

| # | Decision | Recommendation |
|---|---|---|
| 2 | JSONL only vs JSONL + OTLP | Both. JSONL stays as the local fallback; OTLP exporter behind `OTEL_EXPORTER_OTLP_ENDPOINT`. Same wrapper hosts both. |
| 3 | Log tool input vs size-only | Size-only. `error` already leaks input under failure; broadening would move privacy backwards. |
| 4 | Log rotation | Daily rotation, 30-day retention, opt-out via env. Free with pino transports (see #6). |
| 5 | Drain on `shutdown()` | Yes — `await Promise.allSettled(pending)` before `server.close()`. Cheap and bounded. |
| 6 | Hand-rolled `appendFile` vs `core/logger.ts` (pino) | Refactor to pino. `createLogger('mcp-requests', { ... })` gives NDJSON, log-injection hardening, and the existing test seam. |

## One open question

**Opt-in or opt-out default?** Opt-in maximises privacy posture; opt-out gives server-side ground truth without setup. Both are one line in `resolveLogPath()`. Maintainer's call.

Draft until that decision lands and we scope whether #2/#4/#5/#6 ship in this PR or as follow-ups.

---

Local CI:

- `npx vitest run test/unit/mcp/request-log.test.ts` — 14 pass.
- `npx tsc --noEmit` — clean on the changed files (baseline has unrelated tree-sitter errors from `--ignore-scripts` install).
- `.husky/pre-commit` not run locally; please verify in CI.
