### PR TITLE
fix: prefer installed CLI for stale index guidance

### DIFF
--- a/gitnexus-claude-plugin/hooks/gitnexus-hook.js
+++ b/gitnexus-claude-plugin/hooks/gitnexus-hook.js
@@ -296,11 +296,12 @@ function handlePostToolUse(input) {
   // If HEAD matches last indexed commit, no reindex needed
   if (currentHead && currentHead === lastCommit) return;
 
-  const analyzeCmd = `npx gitnexus analyze${hadEmbeddings ? ' --embeddings' : ''}`;
+  const analyzeCmd = `gitnexus analyze${hadEmbeddings ? ' --embeddings' : ''}`;
+  const npxAnalyzeCmd = `npx gitnexus analyze${hadEmbeddings ? ' --embeddings' : ''}`;
   sendHookResponse(
     'PostToolUse',
     `GitNexus index is stale (last indexed: ${lastCommit ? lastCommit.slice(0, 7) : 'never'}). ` +
-      `Run \`${analyzeCmd}\` to update the knowledge graph.`,
+      `Run \`${analyzeCmd}\` to update the knowledge graph, or \`${npxAnalyzeCmd}\` if the CLI is not installed.`,
   );
 }
 

--- a/gitnexus-claude-plugin/skills/gitnexus-cli/SKILL.md
+++ b/gitnexus-claude-plugin/skills/gitnexus-cli/SKILL.md
@@ -5,14 +5,14 @@ description: "Use when the user needs to run GitNexus CLI commands like analyze/
 
 # GitNexus CLI Commands
 
-All commands work via `npx` — no global install required.
+Use the installed `gitnexus` CLI when available. Prefix commands with `npx gitnexus` if the CLI is not installed globally.
 
 ## Commands
 
 ### analyze — Build or refresh the index
 
 ```bash
-npx gitnexus analyze
+gitnexus analyze
 ```
 
 Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.

--- a/gitnexus-claude-plugin/skills/gitnexus-debugging/SKILL.md
+++ b/gitnexus-claude-plugin/skills/gitnexus-debugging/SKILL.md
@@ -22,7 +22,7 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `gitnexus analyze` in terminal (`npx gitnexus analyze` if the CLI is not installed).
 
 ## Checklist
 

--- a/gitnexus-claude-plugin/skills/gitnexus-exploring/SKILL.md
+++ b/gitnexus-claude-plugin/skills/gitnexus-exploring/SKILL.md
@@ -23,7 +23,7 @@ description: "Use when the user asks how code works, wants to understand archite
 5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
 ```
 
-> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If step 2 says "Index is stale" → run `gitnexus analyze` in terminal (`npx gitnexus analyze` if the CLI is not installed).
 
 ## Checklist
 

--- a/gitnexus-claude-plugin/skills/gitnexus-guide/SKILL.md
+++ b/gitnexus-claude-plugin/skills/gitnexus-guide/SKILL.md
@@ -15,7 +15,7 @@ For any task involving code understanding, debugging, impact analysis, or refact
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+> If step 1 warns the index is stale, run `gitnexus analyze` in the terminal first (`npx gitnexus analyze` if the CLI is not installed).
 
 ## Skills
 

--- a/gitnexus-claude-plugin/skills/gitnexus-impact-analysis/SKILL.md
+++ b/gitnexus-claude-plugin/skills/gitnexus-impact-analysis/SKILL.md
@@ -23,7 +23,7 @@ description: "Use when the user wants to know what will break if they change som
 4. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `gitnexus analyze` in terminal (`npx gitnexus analyze` if the CLI is not installed).
 
 ## Checklist
 

--- a/gitnexus-claude-plugin/skills/gitnexus-pr-review/SKILL.md
+++ b/gitnexus-claude-plugin/skills/gitnexus-pr-review/SKILL.md
@@ -26,7 +26,7 @@ description: "Use when the user wants to review a pull request, understand what 
 6. Summarize findings with risk assessment
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal before reviewing.
+> If "Index is stale" → run `gitnexus analyze` in terminal before reviewing (`npx gitnexus analyze` if the CLI is not installed).
 
 ## Checklist
 

--- a/gitnexus-claude-plugin/skills/gitnexus-refactoring/SKILL.md
+++ b/gitnexus-claude-plugin/skills/gitnexus-refactoring/SKILL.md
@@ -22,7 +22,7 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 4. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `gitnexus analyze` in terminal (`npx gitnexus analyze` if the CLI is not installed).
 
 ## Checklists
 

--- a/gitnexus/hooks/claude/gitnexus-hook.cjs
+++ b/gitnexus/hooks/claude/gitnexus-hook.cjs
@@ -298,11 +298,12 @@ function handlePostToolUse(input) {
   // If HEAD matches last indexed commit, no reindex needed
   if (currentHead && currentHead === lastCommit) return;
 
-  const analyzeCmd = `npx gitnexus analyze${hadEmbeddings ? ' --embeddings' : ''}`;
+  const analyzeCmd = `gitnexus analyze${hadEmbeddings ? ' --embeddings' : ''}`;
+  const npxAnalyzeCmd = `npx gitnexus analyze${hadEmbeddings ? ' --embeddings' : ''}`;
   sendHookResponse(
     'PostToolUse',
     `GitNexus index is stale (last indexed: ${lastCommit ? lastCommit.slice(0, 7) : 'never'}). ` +
-      `Run \`${analyzeCmd}\` to update the knowledge graph.`,
+      `Run \`${analyzeCmd}\` to update the knowledge graph, or \`${npxAnalyzeCmd}\` if the CLI is not installed.`,
   );
 }
 

--- a/gitnexus/skills/gitnexus-cli.md
+++ b/gitnexus/skills/gitnexus-cli.md
@@ -5,14 +5,14 @@ description: "Use when the user needs to run GitNexus CLI commands like analyze/
 
 # GitNexus CLI Commands
 
-All commands work via `npx` — no global install required.
+Commands below use the installed `gitnexus` CLI. If the CLI is not installed, use the equivalent `npx gitnexus ...` invocation.
 
 ## Commands
 
 ### analyze — Build or refresh the index
 
 ```bash
-npx gitnexus analyze
+gitnexus analyze
 ```
 
 Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
@@ -28,7 +28,7 @@ Run from the project root. This parses all source files, builds the knowledge gr
 ### status — Check index freshness
 
 ```bash
-npx gitnexus status
+gitnexus status
 ```
 
 Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
@@ -36,7 +36,7 @@ Shows whether the current repo has a GitNexus index, when it was last updated, a
 ### clean — Delete the index
 
 ```bash
-npx gitnexus clean
+gitnexus clean
 ```
 
 Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
@@ -49,7 +49,7 @@ Deletes the `.gitnexus/` directory and unregisters the repo from the global regi
 ### wiki — Generate documentation from the graph
 
 ```bash
-npx gitnexus wiki
+gitnexus wiki
 ```
 
 Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
@@ -66,7 +66,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 ### list — Show all indexed repos
 
 ```bash
-npx gitnexus list
+gitnexus list
 ```
 
 Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.

--- a/gitnexus/skills/gitnexus-debugging.md
+++ b/gitnexus/skills/gitnexus-debugging.md
@@ -22,7 +22,7 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `gitnexus analyze` in terminal (or `npx gitnexus analyze` if the CLI is not installed).
 
 ## Checklist
 

--- a/gitnexus/skills/gitnexus-exploring.md
+++ b/gitnexus/skills/gitnexus-exploring.md
@@ -23,7 +23,7 @@ description: "Use when the user asks how code works, wants to understand archite
 5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
 ```
 
-> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If step 2 says "Index is stale" → run `gitnexus analyze` in terminal (or `npx gitnexus analyze` if the CLI is not installed).
 
 ## Checklist
 

--- a/gitnexus/skills/gitnexus-guide.md
+++ b/gitnexus/skills/gitnexus-guide.md
@@ -15,7 +15,7 @@ For any task involving code understanding, debugging, impact analysis, or refact
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+> If step 1 warns the index is stale, run `gitnexus analyze` in the terminal first (or `npx gitnexus analyze` if the CLI is not installed).
 
 ## Skills
 

--- a/gitnexus/skills/gitnexus-impact-analysis.md
+++ b/gitnexus/skills/gitnexus-impact-analysis.md
@@ -23,7 +23,7 @@ description: "Use when the user wants to know what will break if they change som
 4. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `gitnexus analyze` in terminal (or `npx gitnexus analyze` if the CLI is not installed).
 
 ## Checklist
 

--- a/gitnexus/skills/gitnexus-pr-review.md
+++ b/gitnexus/skills/gitnexus-pr-review.md
@@ -26,7 +26,7 @@ description: "Use when the user wants to review a pull request, understand what 
 6. Summarize findings with risk assessment
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal before reviewing.
+> If "Index is stale" → run `gitnexus analyze` in terminal before reviewing (or `npx gitnexus analyze` if the CLI is not installed).
 
 ## Checklist
 

--- a/gitnexus/skills/gitnexus-refactoring.md
+++ b/gitnexus/skills/gitnexus-refactoring.md
@@ -22,7 +22,7 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 4. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `gitnexus analyze` in terminal (or `npx gitnexus analyze` if the CLI is not installed).
 
 ## Checklists
 

--- a/gitnexus/src/cli/ai-context.ts
+++ b/gitnexus/src/cli/ai-context.ts
@@ -119,7 +119,7 @@ function generateGitNexusContent(
 
 This project is indexed by GitNexus as **${projectName}**${noStats ? '' : ` (${stats.nodes || 0} symbols, ${stats.edges || 0} relationships, ${stats.processes || 0} execution flows)`}. Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> If any GitNexus tool warns the index is stale, run \`npx gitnexus analyze\` in terminal first.
+> If any GitNexus tool warns the index is stale, run \`gitnexus analyze\` in terminal first (or \`npx gitnexus analyze\` if the CLI is not installed).
 
 ## Always Do
 

--- a/gitnexus/src/mcp/resources.ts
+++ b/gitnexus/src/mcp/resources.ts
@@ -340,7 +340,9 @@ async function getContextResource(backend: LocalBackend, repoName?: string): Pro
   lines.push('  - cypher: Raw graph queries');
   lines.push('  - list_repos: Discover all indexed repositories');
   lines.push('');
-  lines.push('re_index: Run `npx gitnexus analyze` in terminal if data is stale');
+  lines.push(
+    're_index: Run `gitnexus analyze` in terminal if data is stale (or `npx gitnexus analyze` if the CLI is not installed)',
+  );
   lines.push('');
   lines.push('resources_available:');
   lines.push('  - gitnexus://repos: All indexed repositories');
@@ -581,7 +583,7 @@ async function getSetupResource(backend: LocalBackend): Promise<string> {
   const repos = await backend.listRepos();
 
   if (repos.length === 0) {
-    return '# GitNexus\n\nNo repositories indexed. Run: `npx gitnexus analyze` in a repository.';
+    return '# GitNexus\n\nNo repositories indexed. Run: `gitnexus analyze` in a repository (or `npx gitnexus analyze` if the CLI is not installed).';
   }
 
   const sections: string[] = [];

--- a/gitnexus/test/integration/hooks-e2e.test.ts
+++ b/gitnexus/test/integration/hooks-e2e.test.ts
@@ -77,7 +77,10 @@ describe.each(HOOKS)('hooks e2e ($name)', ({ name, path: hookPath }) => {
       const output = parseHookOutput(result.stdout);
       expect(output).not.toBeNull();
       expect(output!.additionalContext).toContain('stale');
-      expect(output!.additionalContext).toContain('npx gitnexus analyze');
+      expect(output!.additionalContext).toContain('Run `gitnexus analyze`');
+      expect(output!.additionalContext).toContain(
+        '`npx gitnexus analyze` if the CLI is not installed',
+      );
     });
 
     it('stays silent when meta.json lastCommit matches HEAD', () => {

--- a/gitnexus/test/unit/ai-context.test.ts
+++ b/gitnexus/test/unit/ai-context.test.ts
@@ -57,6 +57,8 @@ describe('generateAIContextFiles', () => {
     const content = await fs.readFile(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
 
     expect(content).toContain('If any GitNexus tool warns the index is stale');
+    expect(content).toContain('run `gitnexus analyze`');
+    expect(content).toContain('`npx gitnexus analyze` if the CLI is not installed');
     expect(content).toContain('## Always Do');
     expect(content).toContain('## Never Do');
     expect(content).toContain('## Resources');

--- a/gitnexus/test/unit/resources.test.ts
+++ b/gitnexus/test/unit/resources.test.ts
@@ -188,6 +188,7 @@ describe('readResource', () => {
     const backend = createMockBackend({ repos: [] });
     const result = await readResource('gitnexus://repos', backend);
     expect(result).toContain('No repositories indexed');
+    expect(result).toContain('Run: gitnexus analyze');
   });
 
   it('routes gitnexus://setup to setup resource', async () => {
@@ -211,6 +212,8 @@ describe('readResource', () => {
     const backend = createMockBackend({ repos: [] });
     const result = await readResource('gitnexus://setup', backend);
     expect(result).toContain('No repositories indexed');
+    expect(result).toContain('Run: `gitnexus analyze`');
+    expect(result).toContain('`npx gitnexus analyze` if the CLI is not installed');
   });
 
   it('routes group contracts resource through backend', async () => {


### PR DESCRIPTION
## Summary
- Prefer `gitnexus analyze` in stale-index recovery guidance for hooks, generated AI context, MCP resources, and GitNexus skills.
- Preserve `npx gitnexus analyze` as the documented fallback when the CLI is not installed.
- Mirror the stale-guidance update in the Claude plugin package so e2e hook coverage stays consistent.

## Verification
- `npm test -- test/integration/hooks-e2e.test.ts test/unit/ai-context.test.ts test/unit/resources.test.ts` (85 passed)
- `npm run build`
- LSP diagnostics: `src/cli/ai-context.ts`, `src/mcp/resources.ts`
- `node --check hooks/gitnexus-hook.js` in `gitnexus-claude-plugin`