### PR TITLE
fix(docker): include DuckDB extension installer script in runtime image

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -55,6 +55,7 @@ RUN mkdir -p /data/gitnexus && chown -R node:node /data
 COPY --from=builder --chown=node:node /app/gitnexus/dist ./gitnexus/dist
 COPY --from=builder --chown=node:node /app/gitnexus/node_modules ./gitnexus/node_modules
 COPY --from=builder --chown=node:node /app/gitnexus/package.json ./gitnexus/package.json
+COPY --from=builder --chown=node:node /app/gitnexus/scripts/install-duckdb-extension.mjs ./gitnexus/scripts/install-duckdb-extension.mjs
 COPY --from=builder --chown=node:node /app/gitnexus/vendor ./gitnexus/vendor
 
 USER node


### PR DESCRIPTION
Title: fix(docker): include DuckDB extension installer script in runtime image

What
- Include `gitnexus/scripts/install-duckdb-extension.mjs` in Docker runtime image.

Why
- Runtime code in `gitnexus/src/core/lbug/extension-loader.ts` executes this script when trying to install optional DuckDB extensions (FTS path).
- Current runtime image omits `scripts`, causing:
  `Cannot find module '/app/gitnexus/scripts/install-duckdb-extension.mjs'`

Patch
```diff
diff --git a/Dockerfile.cli b/Dockerfile.cli
@@
 COPY --from=builder --chown=node:node /app/gitnexus/dist ./gitnexus/dist
 COPY --from=builder --chown=node:node /app/gitnexus/node_modules ./gitnexus/node_modules
 COPY --from=builder --chown=node:node /app/gitnexus/package.json ./gitnexus/package.json
 COPY --from=builder --chown=node:node /app/gitnexus/vendor ./gitnexus/vendor
+COPY --from=builder --chown=node:node /app/gitnexus/scripts/install-duckdb-extension.mjs ./gitnexus/scripts/install-duckdb-extension.mjs
```

Validation
- Build runtime image from this branch.
- Run:
  `node gitnexus/dist/cli/index.js analyze /repo`
- Confirm no `MODULE_NOT_FOUND` for `install-duckdb-extension.mjs`.

Notes
- This keeps image change minimal while preserving current extension-loader behavior.
