### PR TITLE
[codex] Make HTTP embedding batch size configurable

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -151,6 +151,7 @@ export interface AnalyzeOptions {
   embeddingThreads?: string;
   embeddingBatchSize?: string;
   embeddingSubBatchSize?: string;
+  embeddingHttpBatchSize?: string;
   embeddingDevice?: string;
 }
 
@@ -250,6 +251,11 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
       '--embedding-sub-batch-size',
       'GITNEXUS_EMBEDDING_SUB_BATCH_SIZE',
       options?.embeddingSubBatchSize,
+    ) ||
+    !setPositiveEnv(
+      '--embedding-http-batch-size',
+      'GITNEXUS_EMBEDDING_HTTP_BATCH_SIZE',
+      options?.embeddingHttpBatchSize,
     )
   ) {
     return;

--- a/gitnexus/src/cli/doctor.ts
+++ b/gitnexus/src/cli/doctor.ts
@@ -1,6 +1,6 @@
 import { getRuntimeCapabilities, getRuntimeFingerprint } from '../core/platform/capabilities.js';
 import { resolveEmbeddingConfig } from '../core/embeddings/config.js';
-import { isHttpMode } from '../core/embeddings/http-client.js';
+import { getHttpBatchSize, isHttpMode } from '../core/embeddings/http-client.js';
 
 export const doctorCommand = async () => {
   const fingerprint = getRuntimeFingerprint();
@@ -29,4 +29,6 @@ export const doctorCommand = async () => {
   console.log(`  Threads:   ${embeddingConfig.threads}`);
   console.log(`  Batch:     ${embeddingConfig.batchSize} nodes`);
   console.log(`  Sub-batch: ${embeddingConfig.subBatchSize} chunks`);
+  if (isHttpMode())
+    console.log(`  HTTP batch:${String(getHttpBatchSize()).padStart(6)} chunks/request`);
 };

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -73,6 +73,7 @@ program
   .option('--embedding-threads <n>', 'Limit local ONNX embedding CPU threads')
   .option('--embedding-batch-size <n>', 'Number of nodes per embedding batch')
   .option('--embedding-sub-batch-size <n>', 'Number of chunks per embedding model call')
+  .option('--embedding-http-batch-size <n>', 'Number of chunks per HTTP embedding request')
   .option('--embedding-device <device>', 'Embedding device: auto, cpu, dml, cuda, or wasm')
   .addHelpText(
     'after',
@@ -82,6 +83,7 @@ program
       '  GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS=N  Worker idle timeout in milliseconds. Default 30000.\n' +
       '  GITNEXUS_WORKER_SUB_BATCH_MAX_BYTES=N  Worker job byte budget. Default 8388608.\n' +
       '  GITNEXUS_EMBEDDING_THREADS=N  Limit local ONNX CPU threads for --embeddings.\n' +
+      '  GITNEXUS_EMBEDDING_HTTP_BATCH_SIZE=N  Max chunks per HTTP embedding request. Default 64.\n' +
       '  GITNEXUS_SEMANTIC_EXACT_SCAN_LIMIT=N  Max embedding chunks for exact-scan fallback. Default 10000.\n' +
       '\nTip: `.gitnexusignore` supports `.gitignore`-style negation. Add e.g.\n' +
       '     `!__tests__/` to index a directory that is auto-filtered by default (#771).',

--- a/gitnexus/src/core/embeddings/http-client.ts
+++ b/gitnexus/src/core/embeddings/http-client.ts
@@ -16,9 +16,21 @@ import { CircuitOpenError, ResilientFetchExhaustedError, resilientFetch } from '
 const HTTP_TIMEOUT_MS = 30_000;
 const HTTP_MAX_RETRIES = 2;
 const HTTP_RETRY_BACKOFF_MS = 1_000;
-const HTTP_BATCH_SIZE = 64;
+const DEFAULT_HTTP_BATCH_SIZE = 64;
 const DEFAULT_DIMS = 384;
 const HTTP_BREAKER_KEY = 'embeddings-http';
+
+const parsePositiveInt = (name: string, value: string | undefined, fallback: number): number => {
+  if (value === undefined) return fallback;
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${name} must be a positive integer, got "${value}"`);
+  }
+  const parsed = parseInt(value, 10);
+  if (parsed <= 0) {
+    throw new Error(`${name} must be a positive integer, got "${value}"`);
+  }
+  return parsed;
+};
 
 interface HttpConfig {
   baseUrl: string;
@@ -68,6 +80,16 @@ export const isHttpMode = (): boolean => readConfig() !== null;
  * if HTTP mode is not active or no explicit dimensions are set.
  */
 export const getHttpDimensions = (): number | undefined => readConfig()?.dimensions;
+
+/**
+ * Return the max number of chunks sent in a single HTTP embedding request.
+ */
+export const getHttpBatchSize = (): number =>
+  parsePositiveInt(
+    'GITNEXUS_EMBEDDING_HTTP_BATCH_SIZE',
+    process.env.GITNEXUS_EMBEDDING_HTTP_BATCH_SIZE,
+    DEFAULT_HTTP_BATCH_SIZE,
+  );
 
 /**
  * Return a safe representation of a URL for error messages.
@@ -183,10 +205,11 @@ export const httpEmbed = async (texts: string[]): Promise<Float32Array[]> => {
 
   const url = `${config.baseUrl}/embeddings`;
   const allVectors: Float32Array[] = [];
+  const httpBatchSize = getHttpBatchSize();
 
-  for (let i = 0; i < texts.length; i += HTTP_BATCH_SIZE) {
-    const batch = texts.slice(i, i + HTTP_BATCH_SIZE);
-    const batchIndex = Math.floor(i / HTTP_BATCH_SIZE);
+  for (let i = 0; i < texts.length; i += httpBatchSize) {
+    const batch = texts.slice(i, i + httpBatchSize);
+    const batchIndex = Math.floor(i / httpBatchSize);
     const items = await httpEmbedBatch(
       url,
       batch,

--- a/gitnexus/test/unit/http-embedder.test.ts
+++ b/gitnexus/test/unit/http-embedder.test.ts
@@ -6,6 +6,7 @@ const ENV_KEYS = [
   'GITNEXUS_EMBEDDING_MODEL',
   'GITNEXUS_EMBEDDING_API_KEY',
   'GITNEXUS_EMBEDDING_DIMS',
+  'GITNEXUS_EMBEDDING_HTTP_BATCH_SIZE',
 ] as const;
 
 /** 384d mock vector matching the default schema dimensions. */
@@ -256,6 +257,50 @@ describe('HTTP embedding backend', () => {
 
       expect(fetch).toHaveBeenCalledTimes(2);
       expect(results).toHaveLength(70);
+    });
+
+    it('uses GITNEXUS_EMBEDDING_HTTP_BATCH_SIZE for HTTP request splitting', async () => {
+      process.env.GITNEXUS_EMBEDDING_URL = 'http://test:8080/v1';
+      process.env.GITNEXUS_EMBEDDING_MODEL = 'test-model';
+      process.env.GITNEXUS_EMBEDDING_HTTP_BATCH_SIZE = '100';
+
+      const makeResp = (n: number) => ({
+        ok: true,
+        json: async () => ({ data: Array.from({ length: n }, () => ({ embedding: mockVec })) }),
+      });
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValueOnce(makeResp(100)).mockResolvedValueOnce(makeResp(30)),
+      );
+
+      const { embedBatch } = await import('../../src/core/embeddings/embedder.js');
+      const results = await embedBatch(Array.from({ length: 130 }, (_, i) => `text ${i}`));
+
+      const requestSizes = (fetch as any).mock.calls.map(([, options]: any[]) => {
+        const body = JSON.parse(options.body);
+        return body.input.length;
+      });
+      expect(requestSizes).toEqual([100, 30]);
+      expect(results).toHaveLength(130);
+    });
+
+    it('rejects non-numeric GITNEXUS_EMBEDDING_HTTP_BATCH_SIZE values', async () => {
+      process.env.GITNEXUS_EMBEDDING_URL = 'http://test:8080/v1';
+      process.env.GITNEXUS_EMBEDDING_MODEL = 'test-model';
+      process.env.GITNEXUS_EMBEDDING_HTTP_BATCH_SIZE = '64abc';
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ data: [{ embedding: mockVec }] }),
+        }),
+      );
+
+      const { embedBatch } = await import('../../src/core/embeddings/embedder.js');
+      await expect(embedBatch(['text'])).rejects.toThrow(
+        'GITNEXUS_EMBEDDING_HTTP_BATCH_SIZE must be a positive integer',
+      );
     });
 
     it('forwards dimensions in every batch when splitting large inputs', async () => {


### PR DESCRIPTION
## Summary

- Add `GITNEXUS_EMBEDDING_HTTP_BATCH_SIZE` to configure how many chunks are sent in each HTTP embedding request.
- Add `--embedding-http-batch-size <n>` and show the active HTTP request batch size in `gitnexus doctor` when HTTP mode is enabled.
- Keep the existing default of 64 chunks per HTTP request and add unit coverage for custom and invalid values.

## Why

HTTP embedding backends vary widely in optimal request size. The current hard-coded split of 64 chunks is conservative, but it can underuse higher-throughput local or remote OpenAI-compatible embedding servers. Making this value configurable lets users tune throughput without patching source code, while preserving the existing default behavior.

## Validation

- `npm test -- test/unit/http-embedder.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- `npx prettier --check gitnexus/src/core/embeddings/http-client.ts gitnexus/src/cli/analyze.ts gitnexus/src/cli/index.ts gitnexus/src/cli/doctor.ts gitnexus/test/unit/http-embedder.test.ts`
- `git diff --check`
- `gitnexus detect-changes --scope staged` reported medium risk, limited to the expected analyze and HTTP embedding flows.

## Secret Review

- Staged diff contains only source and unit-test files for this change.
- Scanned added lines for common credential patterns, host-specific values, and personal paths; no real secrets or personal configuration were found.