### PR TITLE
fix(ci): make /review reliably post PR comments

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -160,4 +160,4 @@ jobs:
           show_full_output: true
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}'
+          prompt: '/code-review:code-review https://github.com/${{ github.repository }}/pull/${{ steps.pr.outputs.number }} --comment'


### PR DESCRIPTION
## Summary
- `.github/workflows/claude.yml` was passing an invalid PR ref (`owner/repo/pull/N`) to `/code-review:code-review`. `gh` interprets that string as a branch name, so the plugin's early `gh pr view` calls failed with `no pull requests found for branch "..."` and only later recovered via `gh pr diff <N> --repo ...`.
- More impactfully, the prompt omitted `--comment`. Per the [code-review plugin docs](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md), without `--comment` the review only displays in terminal output — `gh pr comment` is never invoked, which matches the observed symptom (green CI, long transcript, no comment on the PR).
- Switching to a full PR URL + `--comment` makes the plugin post during the session via its own `gh` tool calls. That also routes around upstream bugs [anthropics/claude-code-action#1061](https://github.com/anthropics/claude-code-action/issues/1061) (P1: `issue_comment` triggers silently drop the action's post-step comments) and [#1087](https://github.com/anthropics/claude-code-action/issues/1087) (plugin's final turn is `TodoWrite` → `result: ""` → nothing captured), where the documented workaround is precisely to have Claude call `gh pr comment` itself.

## Change
One line in `.github/workflows/claude.yml`:

```diff
- prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}'
+ prompt: '/code-review:code-review https://github.com/${{ github.repository }}/pull/${{ steps.pr.outputs.number }} --comment'
```

## Test plan
- [ ] Comment `/review` on an open PR after this merges and confirm a review comment appears on the PR thread.
- [ ] Check the action logs no longer show `no pull requests found for branch "..."` from `gh pr view`.
- [ ] Confirm no regression to the non-review `@claude` path (separate step, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)