### PR TITLE
ci(claude): fix /review PR comments blocked by Bash approval in Actions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -158,6 +158,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: '*'
           show_full_output: true
+          # Review posts use Bash (`gh`, etc.); default mode asks for approval — impossible in CI.
+          claude_args: '--dangerously-skip-permissions'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review https://github.com/${{ github.repository }}/pull/${{ steps.pr.outputs.number }} --comment'


### PR DESCRIPTION
## Problem

The \/review\ path runs the code-review plugin in GitHub Actions. Bash commands such as \gh pr comment\ and \gh api\ were returning **\This command requires approval\\**, which cannot be satisfied in CI, so the workflow finished green but **posted no PR comment**.

Example: workflow run 25720169951 (logs show repeated approval errors; MCP inline-comment tool is not available in this environment, so the plugin falls back to shell).

## Change

Add \claude_args: '--dangerously-skip-permissions'\ **only** to the **Run Claude Code Review** step so headless CI can execute the shell commands the plugin uses to publish feedback.

This is scoped to the review job only; the default interactive approval behavior remains for the non-review \@claude\ step unless we decide to align later.

## Security note

This relaxes Claude Code permission prompts for that step. It is appropriate for trusted automation where the runner already holds \GITHUB_TOKEN\ with \pull-requests: write\ and the checkout is pinned to the PR head SHA for forks.