### PR TITLE
feat(cli): add system onnxruntime-node binding override

### DIFF
--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -192,6 +192,15 @@ gitnexus analyze . --embeddings
 
 Works with Infinity, vLLM, TEI, llama.cpp, Ollama, LM Studio, or OpenAI. When unset, local embeddings are used unchanged.
 
+## System ONNX Runtime Binding (Advanced)
+
+If your environment provides a system-built onnxruntime-node binding (for example, Nix),
+you can direct GitNexus to use it instead of the package's bundled binary:
+
+```bash
+export GITNEXUS_ORT_BINDING_PATH=/absolute/path/to/onnxruntime_binding.node
+```
+
 ## Multi-Repo Support
 
 GitNexus supports indexing multiple repositories. Each `gitnexus analyze` registers the repo in a global registry (`~/.gitnexus/registry.json`). The MCP server serves all indexed repos automatically.

--- a/gitnexus/src/core/embeddings/embedder.ts
+++ b/gitnexus/src/core/embeddings/embedder.ts
@@ -28,6 +28,7 @@ import { DEFAULT_EMBEDDING_CONFIG, type EmbeddingConfig, type ModelProgress } fr
 import { isHttpMode, getHttpDimensions, httpEmbed } from './http-client.js';
 import { resolveEmbeddingConfig } from './config.js';
 import { applyHfEnvOverrides, isHfDownloadFailure, withHfDownloadRetry } from './hf-env.js';
+import { applyOnnxruntimeNodeBindingOverride } from './onnxruntime-node-loader.js';
 import { logger } from '../logger.js';
 
 /**
@@ -164,6 +165,7 @@ export const initEmbedder = async (
     try {
       // Configure transformers.js environment
       env.allowLocalModels = false;
+      applyOnnxruntimeNodeBindingOverride();
       // Bridge user-controlled env vars to transformers.js: HF_HOME →
       // env.cacheDir, HF_ENDPOINT → env.remoteHost (#1205). Centralised in
       // applyHfEnvOverrides so the MCP embedder entry point behaves

--- a/gitnexus/src/core/embeddings/onnxruntime-node-loader.ts
+++ b/gitnexus/src/core/embeddings/onnxruntime-node-loader.ts
@@ -1,0 +1,53 @@
+import Module from 'module';
+import { existsSync } from 'fs';
+import { isAbsolute } from 'path';
+
+const OVERRIDE_ENV = 'GITNEXUS_ORT_BINDING_PATH';
+
+/**
+ * Redirect onnxruntime-node to a system-provided binding binary.
+ *
+ * onnxruntime-node always requires a native .node file from its own package.
+ * We patch Node's module resolver so that specific request is redirected to
+ * the path provided by GITNEXUS_ORT_BINDING_PATH.
+ */
+export const applyOnnxruntimeNodeBindingOverride = (): void => {
+  const overridePath = process.env[OVERRIDE_ENV];
+  if (!overridePath) return;
+
+  if (!isAbsolute(overridePath)) {
+    throw new Error(`${OVERRIDE_ENV} must be an absolute path, got "${overridePath}"`);
+  }
+
+  if (!existsSync(overridePath)) {
+    throw new Error(`${OVERRIDE_ENV} points to a missing file: "${overridePath}"`);
+  }
+
+  const moduleAny = Module as typeof Module & {
+    _gitnexusOrtBindingOverrideApplied?: boolean;
+    _resolveFilename?: (
+      request: string,
+      parent: NodeModule | null,
+      isMain: boolean,
+      options?: unknown
+    ) => string;
+  };
+
+  if (moduleAny._gitnexusOrtBindingOverrideApplied) return;
+  moduleAny._gitnexusOrtBindingOverrideApplied = true;
+
+  const originalResolve = moduleAny._resolveFilename?.bind(Module);
+  if (!originalResolve) return;
+
+  moduleAny._resolveFilename = function (
+    request: string,
+    parent: NodeModule | null,
+    isMain: boolean,
+    options?: unknown
+  ): string {
+    if (typeof request === 'string' && request.endsWith('onnxruntime_binding.node')) {
+      return overridePath;
+    }
+    return originalResolve(request, parent, isMain, options);
+  };
+};

--- a/gitnexus/src/mcp/core/embedder.ts
+++ b/gitnexus/src/mcp/core/embedder.ts
@@ -17,6 +17,7 @@ import {
   isHfDownloadFailure,
   withHfDownloadRetry,
 } from '../../core/embeddings/hf-env.js';
+import { applyOnnxruntimeNodeBindingOverride } from '../../core/embeddings/onnxruntime-node-loader.js';
 import { silenceStdout, restoreStdout, realStderrWrite } from '../../core/lbug/pool-adapter.js';
 
 import { logger } from '../../core/logger.js';
@@ -49,6 +50,7 @@ export const initEmbedder = async (): Promise<FeatureExtractionPipeline> => {
   initPromise = (async () => {
     try {
       env.allowLocalModels = false;
+      applyOnnxruntimeNodeBindingOverride();
       // Bridge user-controlled env vars to transformers.js: HF_HOME →
       // env.cacheDir, HF_ENDPOINT → env.remoteHost (#1205). Centralised in
       // applyHfEnvOverrides so this MCP entry point behaves identically to


### PR DESCRIPTION
## Summary

Adds the **system ONNX Runtime binding override** support discussed in PR #589, updated for current `main` by keeping only the still-relevant pieces. This allows GitNexus to use a system-provided `onnxruntime_binding.node` via `GITNEXUS_ORT_BINDING_PATH`, and wires it into both embedder entry points.

## Motivation / context

This is a follow-up to the closed PR: https://github.com/abhigyanpatwari/GitNexus/pull/589  
Maintainer requested a fresh PR if still relevant. Since upstream already added the HF cache-dir work, this PR only carries forward the ONNX binding override part that remains missing.

## Areas touched

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- Add loader that redirects `onnxruntime_binding.node` to a user-specified absolute path.
- Wire override into both core embedder initialization paths:
- `gitnexus/src/core/embeddings/embedder.ts`
- `gitnexus/src/mcp/core/embedder.ts`
- Document usage in `gitnexus/README.md` under “System ONNX Runtime Binding (Advanced)”.

**Explicitly out of scope / not done here**

- Re-adding cache-dir configuration work from old PR #589 (already covered upstream).
- Any changes to embedding model behavior or selection logic.
- Any fix for LadybugDB/native test environment issues.

## Implementation notes

- Uses a guarded one-time patch of Node module resolution to reroute requests ending with `onnxruntime_binding.node`.
- Validates that `GITNEXUS_ORT_BINDING_PATH` is absolute and exists before applying override.
- Behavior remains unchanged unless the env var is set.

## Testing & verification

- [x] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [x] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(if web changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

### Commands run

```bash
# containerized run used for parity (node:20-trixie)
podman run --rm --platform=linux/amd64 \
  -v "$PWD":/app \
  -w /app/gitnexus \
  node:20-trixie bash -lc \
  "apt-get update -qq && apt-get install -y -qq python3 make g++ build-essential pkg-config git && npm ci && npx tsc --noEmit && npm test"
```

```bash
# targeted regression check on branch after fixture cleanup
podman run --rm --platform=linux/amd64 \
  -v "$PWD":/app \
  -w /app/gitnexus \
  node:20-trixie bash -lc \
  "apt-get update -qq && apt-get install -y -qq python3 make g++ build-essential pkg-config git && npm ci --ignore-scripts && npx vitest run test/integration/pipeline-graph-golden.test.ts"
```

### Notes on results

- `npx tsc --noEmit`: passed.
- Full `npm test` run in container reports existing unrelated failures in this environment.
- `pipeline-graph-golden` was initially failing due fixture pollution (`AGENTS.md`, `CLAUDE.md`, `.gitignore`) and now passes after cleaning fixture files.
- `mcp/server-startup` failure reproduces on `upstream/main` in this environment too (native `@ladybugdb/core` load issue), indicating it is not introduced by this PR.

## Risk & rollout

- Low risk, opt-in behavior only.
- No migrations required.
- Default runtime behavior unchanged when `GITNEXUS_ORT_BINDING_PATH` is unset.

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed