### PR TITLE
feat:(wiki) added --timeout and --retries flags for large module pages to mitigate timeout aborts

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,12 @@ gitnexus wiki --base-url https://api.anthropic.com/v1
 
 # Force full regeneration
 gitnexus wiki --force
+
+
+# Increase the timeout or retries for large codebase or slow LLM providers
+gitnexus wiki --timeout <seconds> # Per-attempt LLM request timeout in seconds (default: 60) 
+gitnexus wiki --retries <n>      # Max LLM retry attempts per request (default: 3)
+
 ```
 
 The wiki generator reads the indexed graph structure, groups files into modules via LLM, generates per-module documentation pages, and creates an overview page — all with cross-references to the knowledge graph.

--- a/gitnexus-claude-plugin/skills/gitnexus-cli/SKILL.md
+++ b/gitnexus-claude-plugin/skills/gitnexus-cli/SKILL.md
@@ -62,6 +62,8 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 | `--api-key <key>` | LLM API key |
 | `--concurrency <n>` | Parallel LLM calls (default: 3) |
 | `--gist` | Publish wiki as a public GitHub Gist |
+| `--timeout <seconds>` | Per-attempt LLM request timeout in seconds (default: 60) |
+| `--retries <n>` | Max LLM retry attempts per request (default: 3) |
 
 ### list — Show all indexed repos
 

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -161,6 +161,8 @@ program
   )
   .option('--no-reasoning-model', 'Disable reasoning model mode (overrides saved config)')
   .option('--concurrency <n>', 'Parallel LLM calls (default: 3)', '3')
+  .option('--timeout <seconds>', 'Per-attempt LLM request timeout in seconds (default: 60)')
+  .option('--retries <n>', 'Max LLM retry attempts per request (default: 3)')
   .option('--gist', 'Publish wiki as a public GitHub Gist after generation')
   .option('-v, --verbose', 'Enable verbose output (show LLM commands and responses)')
   .option('--review', 'Stop after grouping to review module structure before generating pages')

--- a/gitnexus/src/cli/wiki.ts
+++ b/gitnexus/src/cli/wiki.ts
@@ -33,6 +33,8 @@ export interface WikiCommandOptions {
   provider?: LLMProvider;
   verbose?: boolean;
   review?: boolean;
+  timeout?: string;
+  retries?: string;
 }
 
 /**
@@ -345,6 +347,16 @@ export const wikiCommand = async (inputPath?: string, options?: WikiCommandOptio
         llmConfig = { ...llmConfig, apiKey: key, baseUrl, model, provider };
       }
     }
+  }
+
+  // ── Apply per-run overrides not saved to config ────────────────────
+  if (options?.timeout) {
+    const secs = parseInt(options.timeout, 10);
+    if (!isNaN(secs) && secs > 0) llmConfig.requestTimeoutMs = secs * 1000;
+  }
+  if (options?.retries) {
+    const n = parseInt(options.retries, 10);
+    if (!isNaN(n) && n > 0) llmConfig.maxAttempts = n;
   }
 
   // ── Setup progress bar with elapsed timer ──────────────────────────

--- a/gitnexus/src/core/wiki/llm-client.ts
+++ b/gitnexus/src/core/wiki/llm-client.ts
@@ -23,6 +23,10 @@ export interface LLMConfig {
   apiVersion?: string;
   /** When true, strips sampling params and uses max_completion_tokens instead of max_tokens */
   isReasoningModel?: boolean;
+  /** Per-attempt fetch timeout in ms (default: 60_000). */
+  requestTimeoutMs?: number;
+  /** Max fetch attempts before giving up (default: 3). */
+  maxAttempts?: number;
 }
 
 export interface LLMResponse {
@@ -237,12 +241,12 @@ export async function callLLM(
         // indefinitely on a frozen TCP connection — the per-call
         // signal is the only timeout `resilientFetch` honors;
         // `capDelayMs` only bounds the *backoff* between attempts.
-        // 60s matches typical LLM completion budgets.
-        signal: AbortSignal.timeout(60_000),
+        // Default 60s; raise via --timeout for slow models or large pages.
+        signal: AbortSignal.timeout(config.requestTimeoutMs ?? 60_000),
       },
       {
         breakerKey: `wiki-llm-${new URL(url).host}`,
-        retry: { maxAttempts: 3, baseDelayMs: 2_000, capDelayMs: 30_000 },
+        retry: { maxAttempts: config.maxAttempts ?? 3, baseDelayMs: 2_000, capDelayMs: 30_000 },
       },
     );
   } catch (err) {


### PR DESCRIPTION
## Summary
Add --timeout <seconds> and --retries <n> flags to gitnexus wiki so users can override the default 60s per-attempt LLM request timeout and 3-attempt retry cap when generating large module pages.  

<!-- One or two sentences: what does this PR change? -->

## Motivation / context
Related to Issue: #1537
Large module pages with heavy source code cause the LLM fetch to exceed the hardcoded AbortSignal.timeout(60_000) in llm-client.ts, which throws a DOMException [TimeoutError]: The operation was aborted due to timeout. classified as   
 terminal-network by resilientFetch, meaning no retries happen. Users had no way to work around this without patching the source.

Related to #1537
<!-- Why is this change needed? Link issues, ADRs, or prior discussion. -->


## Areas touched

<!-- Check all that apply -->

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- --timeout <seconds> flag: sets per-attempt fetch timeout in seconds
- --retries <n> flag: sets max retry attempts                                                                                                                                                                                              
- Both are per-run only — not saved to ~/.gitnexus/config.json
<!-- bullets -->

**Explicitly out of scope / not done here**
- Rolling/idle timeout on the SSE stream (would fix the root cause more precisely but is a larger change)                                                                                                                                  
- Cursor CLI path (unchanged) 
<!-- bullets — prevents reviewers assuming missing work is an oversight -->

## Implementation notes
requestTimeoutMs and maxAttempts added as optional fields on LLMConfig. Defaults remain 60_000ms and 3 respectively, so existing behavior is unchanged. Flags are applied after resolveLLMConfig and before the generator runs.
<!-- Optional: design choices, tradeoffs, follow-ups -->

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [ ] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [x] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(if web changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

## Risk & rollout
No breaking changes. All new fields are optional with existing defaults.
<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed
