### PR TITLE
fix(docker): symlink `gitnexus` binary onto $PATH in runtime image (#1549)

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -58,6 +58,15 @@ COPY --from=builder --chown=node:node /app/gitnexus/package.json ./gitnexus/pack
 COPY --from=builder --chown=node:node /app/gitnexus/scripts/install-duckdb-extension.mjs ./gitnexus/scripts/install-duckdb-extension.mjs
 COPY --from=builder --chown=node:node /app/gitnexus/vendor ./gitnexus/vendor
 
+# Expose the `gitnexus` binary on PATH so the documented Docker workflow
+# (`docker compose exec gitnexus-server gitnexus index /workspace/<repo>`)
+# works without users having to invoke `node /app/gitnexus/dist/cli/index.js`.
+# `npm prune --omit=dev` in the builder stage strips `node_modules/.bin/`
+# entries, so the `gitnexus` bin declared in package.json (`dist/cli/index.js`,
+# which already carries `#!/usr/bin/env node` and 755 perms) is otherwise
+# unreachable from $PATH.
+RUN ln -s /app/gitnexus/dist/cli/index.js /usr/local/bin/gitnexus
+
 USER node
 
 # The web UI defaults to http://localhost:4747 - keep that contract.


### PR DESCRIPTION
## Summary

Fixes one of the two bugs reported in #1549: the documented Docker workflow command

```
docker compose exec gitnexus-server gitnexus index /workspace/my-repo
```

currently fails with `exec: "gitnexus": executable file not found in $PATH`. This PR adds a single symlink in the runtime stage of `Dockerfile.cli` so the command works as written.

## Mechanism

`gitnexus/package.json` declares `"bin": { "gitnexus": "dist/cli/index.js" }`. In a normal `npm install` that exposes `node_modules/.bin/gitnexus` and (if installed globally) `/usr/local/bin/gitnexus`. But the builder stage runs `npm prune --omit=dev --prefix gitnexus` (Dockerfile.cli line 37), which strips `node_modules/.bin/` entries, and nothing in the runtime stage re-adds the `gitnexus` name to `$PATH`. The container's own `CMD` works because the Dockerfile invokes Node directly:

```dockerfile
CMD ["node", "gitnexus/dist/cli/index.js", "serve", ...]
```

…but anyone following the README has no way to know that without reading the Dockerfile.

`dist/cli/index.js` already carries `#!/usr/bin/env node` and 755 perms, so a single symlink into `/usr/local/bin` is the minimal fix.

## Test plan

```bash
docker build -f Dockerfile.cli -t gitnexus:local-pr-test .

# Symlink + version (was: "executable file not found in $PATH")
docker run --rm gitnexus:local-pr-test which gitnexus
# → /usr/local/bin/gitnexus
docker run --rm gitnexus:local-pr-test gitnexus --version
# → 1.6.4
docker run --rm gitnexus:local-pr-test gitnexus --help | head -2
# → Usage: gitnexus [options] [command]

# CMD path unchanged
docker run --rm -d --name t gitnexus:local-pr-test
sleep 4
docker exec t curl -s localhost:4747/api/health
# → {"status":"ok"}
```

Both verified locally.

## Notes

- Strictly additive: no behaviour changes for the `CMD ["node", "gitnexus/...", "serve", ...]` boot path. Only adds a name on `$PATH`.
- Sibling PR #1550 fixes the *second* bug from #1549 (`ensureGitNexusIgnored` failing on the documented `:ro` workspace mount). Together they make the README's literal `docker compose exec gitnexus-server gitnexus index /workspace/my-repo` command work end-to-end.

Refs #1549.
