### PR TITLE
feat(elixir): add tree-sitter language support

### DIFF
--- a/gitnexus-shared/src/language-detection.ts
+++ b/gitnexus-shared/src/language-detection.ts
@@ -43,6 +43,7 @@ const EXTENSION_MAP: Record<SupportedLanguages, readonly string[]> = {
   [SupportedLanguages.Dart]: ['.dart'],
   [SupportedLanguages.Vue]: ['.vue'],
   [SupportedLanguages.Cobol]: ['.cbl', '.cob', '.cpy', '.cobol'],
+  [SupportedLanguages.Elixir]: ['.ex', '.exs'],
 } satisfies Record<SupportedLanguages, readonly string[]>; // Ensure exhaustiveness
 
 /** Pre-built reverse lookup: extension → language (built once at module load). */
@@ -101,6 +102,7 @@ const SYNTAX_MAP: Record<SupportedLanguages, string> = {
   [SupportedLanguages.Dart]: 'dart',
   [SupportedLanguages.Vue]: 'typescript',
   [SupportedLanguages.Cobol]: 'cobol',
+  [SupportedLanguages.Elixir]: 'elixir',
 } satisfies Record<SupportedLanguages, string>; // Ensure exhaustiveness
 
 /** Non-code file extensions → Prism-compatible syntax identifiers */

--- a/gitnexus-shared/src/languages.ts
+++ b/gitnexus-shared/src/languages.ts
@@ -22,4 +22,5 @@ export enum SupportedLanguages {
   Vue = 'vue',
   /** Standalone regex processor — no tree-sitter, no LanguageProvider. */
   Cobol = 'cobol',
+  Elixir = 'elixir',
 }

--- a/gitnexus-shared/src/scope-resolution/language-classification.ts
+++ b/gitnexus-shared/src/scope-resolution/language-classification.ts
@@ -41,6 +41,7 @@ export const LanguageClassifications: Readonly<Record<SupportedLanguages, Langua
     [SupportedLanguages.Dart]: 'production',
     [SupportedLanguages.Vue]: 'experimental',
     [SupportedLanguages.Cobol]: 'experimental',
+    [SupportedLanguages.Elixir]: 'experimental',
   };
 
 /** Convenience predicate: is this language gating Ring 4 retirement? */

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -36,6 +36,7 @@
         "tree-sitter-c": "0.21.4",
         "tree-sitter-c-sharp": "0.23.1",
         "tree-sitter-cpp": "0.23.2",
+        "tree-sitter-elixir": "^0.3.5",
         "tree-sitter-go": "^0.23.0",
         "tree-sitter-java": "^0.23.5",
         "tree-sitter-javascript": "^0.23.0",
@@ -5295,6 +5296,26 @@
     "node_modules/tree-sitter-dart": {
       "resolved": "vendor/tree-sitter-dart",
       "link": true
+    },
+    "node_modules/tree-sitter-elixir": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-elixir/-/tree-sitter-elixir-0.3.5.tgz",
+      "integrity": "sha512-xozQMvYK0aSolcQZAx2d84Xe/YMWFuRPYFlLVxO01bM2GITh5jyiIp0TqPCQa8754UzRAI7A83hZmfiYub5TZQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      }
+    },
+    "node_modules/tree-sitter-elixir/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/tree-sitter-go": {
       "version": "0.23.4",

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -79,6 +79,7 @@
     "tree-sitter-c": "0.21.4",
     "tree-sitter-c-sharp": "0.23.1",
     "tree-sitter-cpp": "0.23.2",
+    "tree-sitter-elixir": "^0.3.5",
     "tree-sitter-go": "^0.23.0",
     "tree-sitter-java": "^0.23.5",
     "tree-sitter-javascript": "^0.23.0",

--- a/gitnexus/src/core/ingestion/call-processor.ts
+++ b/gitnexus/src/core/ingestion/call-processor.ts
@@ -504,7 +504,14 @@ const findEnclosingFunction = (
           if (resolved.candidates.length === 1) {
             return resolved.candidates[0].nodeId;
           }
-          const classInfo = findEnclosingClassInfo(current.previousSibling ?? current, filePath);
+          const sigNodeForClass = customResult.definitionNode ?? current.previousSibling ?? current;
+          const classInfo = findEnclosingClassInfo(
+            sigNodeForClass,
+            filePath,
+            provider.resolveEnclosingOwner,
+            provider.isClassContainerNode,
+            provider.extractEnclosingClassInfo,
+          );
           if (classInfo) {
             const classMatches = resolved.candidates.filter((c) => c.ownerId === classInfo.classId);
             if (classMatches.length === 1) return classMatches[0].nodeId;
@@ -518,16 +525,22 @@ const findEnclosingFunction = (
           }
         }
         let finalLabel = customResult.label;
+        const sigNode = customResult.definitionNode ?? current.previousSibling ?? current;
         if (provider.labelOverride) {
-          const override = provider.labelOverride(current.previousSibling!, finalLabel);
+          const override = provider.labelOverride(sigNode, finalLabel);
           if (override !== null) finalLabel = override;
         }
-        const classInfo2 = findEnclosingClassInfo(current.previousSibling ?? current, filePath);
+        const classInfo2 = findEnclosingClassInfo(
+          sigNode,
+          filePath,
+          provider.resolveEnclosingOwner,
+          provider.isClassContainerNode,
+          provider.extractEnclosingClassInfo,
+        );
         const qualifiedName = classInfo2
           ? `${classInfo2.className}.${customResult.funcName}`
           : customResult.funcName;
         // Include #<arity> and ~typeTag suffix to match definition-phase Method/Constructor IDs.
-        const sigNode = current.previousSibling ?? current;
         const language2 = getLanguageFromFilename(filePath);
         let arity2: number | undefined;
         let encTypeTag2 = '';

--- a/gitnexus/src/core/ingestion/class-extractors/configs/elixir.ts
+++ b/gitnexus/src/core/ingestion/class-extractors/configs/elixir.ts
@@ -1,0 +1,47 @@
+// gitnexus/src/core/ingestion/class-extractors/configs/elixir.ts
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { ClassExtractionConfig } from '../../class-types.js';
+import type { SyntaxNode } from '../../utils/ast-helpers.js';
+
+const ELIXIR_MODULE_KEYWORDS = new Set(['defmodule', 'defprotocol']);
+
+/** Return the `target` identifier text of a call node, or undefined. */
+function callKeyword(node: SyntaxNode): string | undefined {
+  const t = node.childForFieldName?.('target');
+  return t?.type === 'identifier' ? t.text : undefined;
+}
+
+/** Find the arguments node among named children. */
+function findArguments(node: SyntaxNode): SyntaxNode | null {
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const c = node.namedChild(i);
+    if (c?.type === 'arguments') return c;
+  }
+  return null;
+}
+
+export const elixirClassConfig: ClassExtractionConfig = {
+  language: SupportedLanguages.Elixir,
+
+  // defmodule / defprotocol are the class-like nodes (both are `call` nodes in tree-sitter)
+  typeDeclarationNodes: ['call'],
+
+  extractName(node) {
+    if (!ELIXIR_MODULE_KEYWORDS.has(callKeyword(node) ?? '')) return undefined;
+    const args = findArguments(node);
+    if (!args) return undefined;
+    for (let i = 0; i < args.namedChildCount; i++) {
+      const a = args.namedChild(i);
+      if (a?.type === 'alias') return a.text;
+    }
+    return undefined;
+  },
+
+  extractType(node) {
+    const kw = callKeyword(node);
+    if (kw === 'defprotocol') return 'Interface';
+    if (kw === 'defmodule') return 'Class';
+    return undefined;
+  },
+};

--- a/gitnexus/src/core/ingestion/export-detection.ts
+++ b/gitnexus/src/core/ingestion/export-detection.ts
@@ -246,3 +246,25 @@ export const rubyExportChecker: ExportChecker = (_node, _name) => true;
 
 /** Dart: public if no leading underscore (convention, same as Python). */
 export const dartExportChecker: ExportChecker = (_node, name) => !name.startsWith('_');
+
+const ELIXIR_PRIVATE_KEYWORDS = new Set(['defp', 'defmacrop', 'defguardp']);
+const ELIXIR_PUBLIC_KEYWORDS = new Set(['def', 'defmacro', 'defguard', 'defdelegate']);
+
+/**
+ * Elixir: def = public, defp = private. Walk up to the enclosing def/defp call
+ * to determine visibility. defmodule/defprotocol/defimpl are always public.
+ */
+export const elixirExportChecker: ExportChecker = (node, _name) => {
+  let current: SyntaxNode | null = node;
+  while (current) {
+    if (current.type === 'call') {
+      const target = current.childForFieldName?.('target');
+      if (target?.type === 'identifier') {
+        if (ELIXIR_PRIVATE_KEYWORDS.has(target.text)) return false;
+        if (ELIXIR_PUBLIC_KEYWORDS.has(target.text)) return true;
+      }
+    }
+    current = current.parent;
+  }
+  return true;
+};

--- a/gitnexus/src/core/ingestion/import-resolvers/configs/elixir.ts
+++ b/gitnexus/src/core/ingestion/import-resolvers/configs/elixir.ts
@@ -1,0 +1,73 @@
+/**
+ * Elixir import resolution config.
+ *
+ * Elixir modules are identified by atoms (capitalized names, e.g. MyApp.User).
+ * By convention, `MyApp.User` maps to `lib/my_app/user.ex` (or `.exs`).
+ * Each dotted segment is snake_cased independently.
+ *
+ * Handles: import, alias, use, require directives.
+ * External/hex dependencies (no slash in module path context) return empty.
+ */
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { ImportResolutionConfig, ImportResolverStrategy } from '../types.js';
+
+/**
+ * Convert a PascalCase module name segment to snake_case.
+ * HTTPClient → http_client, MyApp → my_app, XmlParser → xml_parser
+ */
+function toSnakeCase(segment: string): string {
+  return segment
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .replace(/([a-z\d])([A-Z])/g, '$1_$2')
+    .toLowerCase();
+}
+
+/**
+ * Convert a dotted Elixir module alias to a relative file path.
+ * MyApp.User → my_app/user
+ * Elixir.MyApp.User → elixir/my_app/user (Erlang-namespaced modules)
+ */
+function moduleToRelPath(moduleName: string): string {
+  return moduleName
+    .split('.')
+    .map(toSnakeCase)
+    .join('/');
+}
+
+const ELIXIR_EXTS = ['.ex', '.exs'];
+
+/** Elixir module alias → file path strategy. */
+const elixirModuleStrategy: ImportResolverStrategy = (rawImportPath, _filePath, ctx) => {
+  const moduleName = rawImportPath.trim();
+
+  // Must start with a capital letter (Elixir module alias convention)
+  if (!moduleName || !/^[A-Z]/.test(moduleName)) return null;
+
+  const relPath = moduleToRelPath(moduleName);
+
+  // Try common Elixir project roots: lib/, test/, apps/*/lib/, apps/*/test/
+  const prefixes = ['lib/', 'test/', ''];
+  const files: string[] = [];
+
+  for (const prefix of prefixes) {
+    for (const ext of ELIXIR_EXTS) {
+      const candidate = `${prefix}${relPath}${ext}`;
+      for (const fp of ctx.allFileList) {
+        if (fp === candidate || fp.endsWith(`/${candidate}`)) {
+          files.push(fp);
+          break;
+        }
+      }
+      if (files.length > 0) return { kind: 'files', files };
+    }
+  }
+
+  // No local file found — likely an external hex dependency
+  return { kind: 'files', files: [] };
+};
+
+export const elixirImportConfig: ImportResolutionConfig = {
+  language: SupportedLanguages.Elixir,
+  strategies: [elixirModuleStrategy],
+};

--- a/gitnexus/src/core/ingestion/language-provider.ts
+++ b/gitnexus/src/core/ingestion/language-provider.ts
@@ -208,7 +208,20 @@ interface LanguageProviderConfig {
    *  Default: undefined (standard parent walk only). */
   readonly enclosingFunctionFinder?: (
     ancestorNode: SyntaxNode,
-  ) => { funcName: string; label: NodeLabel } | null;
+  ) => { funcName: string; label: NodeLabel; definitionNode?: SyntaxNode } | null;
+
+  /** Additional provider-owned container predicate for languages whose class-like
+   *  constructs reuse generic AST node types. Example: Elixir `defmodule` is a
+   *  `call` node, but treating every `call` as a global container would break
+   *  Ruby/Python. Default: undefined (CLASS_CONTAINER_TYPES only). */
+  readonly isClassContainerNode?: (node: SyntaxNode) => boolean;
+
+  /** Provider-owned class info extraction for custom containers returned by
+   *  `isClassContainerNode`. Default: undefined (generic name/label extraction). */
+  readonly extractEnclosingClassInfo?: (
+    node: SyntaxNode,
+    filePath: string,
+  ) => { classId: string; className: string } | null;
 
   // ── Labels ────────────────────────────────────────────────────────
   /** Override the default node label for definition.function captures.

--- a/gitnexus/src/core/ingestion/languages/elixir.ts
+++ b/gitnexus/src/core/ingestion/languages/elixir.ts
@@ -1,0 +1,272 @@
+/**
+ * Elixir Language Provider
+ *
+ * Key Elixir traits:
+ *   - importSemantics: 'wildcard-leaf' (import/use bring all public functions into scope)
+ *   - mroStrategy: 'none' (functional language — no class inheritance)
+ *   - heritageDefaultEdge: 'IMPLEMENTS' (protocol/behaviour relationships)
+ *   - Modules defined with defmodule, functions with def/defp
+ *   - Module names are atoms: MyApp.User → lib/my_app/user.ex by convention
+ */
+
+import { SupportedLanguages, type NodeLabel } from 'gitnexus-shared';
+import type { AstFrameworkPatternConfig } from '../language-provider.js';
+import { defineLanguage } from '../language-provider.js';
+import { typeConfig as elixirTypeConfig } from '../type-extractors/elixir.js';
+import { elixirExportChecker } from '../export-detection.js';
+import { createImportResolver } from '../import-resolvers/resolver-factory.js';
+import { elixirImportConfig } from '../import-resolvers/configs/elixir.js';
+import { ELIXIR_QUERIES } from '../tree-sitter-queries.js';
+import { createMethodExtractor } from '../method-extractors/generic.js';
+import { elixirMethodConfig } from '../method-extractors/configs/elixir.js';
+import { createClassExtractor } from '../class-extractors/generic.js';
+import { elixirClassConfig } from '../class-extractors/configs/elixir.js';
+import { createHeritageExtractor } from '../heritage-extractors/generic.js';
+import type { CallExtractor, ExtractedCallSite } from '../call-types.js';
+import type { SyntaxNode } from '../utils/ast-helpers.js';
+import { countCallArguments } from '../utils/call-analysis.js';
+import { generateId } from '../../../lib/utils.js';
+
+const ELIXIR_DEF_KEYWORDS = new Set([
+  'def',
+  'defp',
+  'defmacro',
+  'defmacrop',
+  'defguard',
+  'defguardp',
+  'defdelegate',
+]);
+
+const ELIXIR_MODULE_KEYWORDS = new Set(['defmodule', 'defprotocol']);
+
+const ELIXIR_NON_CALL_KEYWORDS = new Set([
+  ...ELIXIR_DEF_KEYWORDS,
+  ...ELIXIR_MODULE_KEYWORDS,
+  'defimpl',
+  'defstruct',
+  'defoverridable',
+  'defexception',
+  'import',
+  'alias',
+  'use',
+  'require',
+  'case',
+  'cond',
+  'if',
+  'unless',
+  'for',
+  'with',
+  'receive',
+  'try',
+  'quote',
+  'fn',
+]);
+
+function callKeyword(node: SyntaxNode): string | undefined {
+  const target = node.childForFieldName?.('target');
+  return target?.type === 'identifier' ? target.text : undefined;
+}
+
+function findArguments(node: SyntaxNode): SyntaxNode | null {
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
+    if (child?.type === 'arguments') return child;
+  }
+  return null;
+}
+
+function firstAliasArgument(node: SyntaxNode): string | undefined {
+  const args = findArguments(node);
+  if (!args) return undefined;
+  for (let i = 0; i < args.namedChildCount; i++) {
+    const child = args.namedChild(i);
+    if (child?.type === 'alias') return child.text;
+  }
+  return undefined;
+}
+
+function extractFunctionNameFromDef(node: SyntaxNode): string | undefined {
+  if (!ELIXIR_DEF_KEYWORDS.has(callKeyword(node) ?? '')) return undefined;
+  const args = findArguments(node);
+  if (!args) return undefined;
+  for (let i = 0; i < args.namedChildCount; i++) {
+    const arg = args.namedChild(i);
+    if (!arg) continue;
+    if (arg.type === 'identifier') return arg.text;
+    if (arg.type === 'call') {
+      const target = arg.childForFieldName?.('target');
+      if (target?.type === 'identifier') return target.text;
+    }
+    if (arg.type === 'binary_operator') {
+      const left = arg.childForFieldName?.('left');
+      if (left?.type === 'call') {
+        const target = left.childForFieldName?.('target');
+        if (target?.type === 'identifier') return target.text;
+      }
+    }
+  }
+  return undefined;
+}
+
+function isInsideDefinitionHead(node: SyntaxNode): boolean {
+  let current = node.parent;
+  while (current) {
+    if (current.type === 'do_block') return false;
+    if (current.type === 'call' && ELIXIR_DEF_KEYWORDS.has(callKeyword(current) ?? '')) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+function isModuleAttributeCall(node: SyntaxNode): boolean {
+  return node.parent?.type === 'unary_operator' && node.parent.text.startsWith('@');
+}
+
+function remoteReceiver(callNode: SyntaxNode): string | undefined {
+  const target = callNode.childForFieldName?.('target');
+  if (target?.type !== 'dot') return undefined;
+  const left = target.childForFieldName?.('left');
+  return left?.type === 'alias' ? left.text : undefined;
+}
+
+const elixirCallExtractor: CallExtractor = {
+  language: SupportedLanguages.Elixir,
+
+  extract(callNode, callNameNode): ExtractedCallSite | null {
+    if (!callNameNode) return null;
+    if (isModuleAttributeCall(callNode) || isInsideDefinitionHead(callNode)) return null;
+
+    const calledName = callNameNode.text;
+    if (ELIXIR_NON_CALL_KEYWORDS.has(calledName)) return null;
+
+    const receiverName = remoteReceiver(callNode);
+    return {
+      calledName,
+      callForm: receiverName ? 'member' : 'free',
+      ...(receiverName ? { receiverName } : {}),
+      argCount: countCallArguments(callNode),
+    };
+  },
+};
+
+const elixirIsClassContainerNode = (node: SyntaxNode): boolean =>
+  node.type === 'call' && ELIXIR_MODULE_KEYWORDS.has(callKeyword(node) ?? '');
+
+const elixirExtractEnclosingClassInfo = (node: SyntaxNode, filePath: string) => {
+  if (!elixirIsClassContainerNode(node)) return null;
+  const className = firstAliasArgument(node);
+  if (!className) return null;
+  const label = callKeyword(node) === 'defprotocol' ? 'Interface' : 'Class';
+  return { classId: generateId(label, `${filePath}:${className}`), className };
+};
+
+const elixirEnclosingFunctionFinder = (
+  node: SyntaxNode,
+): { funcName: string; label: NodeLabel; definitionNode: SyntaxNode } | null => {
+  if (node.type !== 'call') return null;
+  const funcName = extractFunctionNameFromDef(node);
+  return funcName ? { funcName, label: 'Function', definitionNode: node } : null;
+};
+
+const elixirImportPathPreprocessor = (cleaned: string, importNode: SyntaxNode): string | null => {
+  const keyword = callKeyword(importNode);
+  return keyword === 'import' || keyword === 'use' || keyword === 'require' || keyword === 'alias'
+    ? cleaned
+    : null;
+};
+
+const BUILT_INS: ReadonlySet<string> = new Set([
+  // Kernel built-ins
+  'send', 'spawn', 'spawn_link', 'spawn_monitor', 'exit', 'throw', 'raise',
+  'reraise', 'apply', 'is_atom', 'is_binary', 'is_bitstring', 'is_boolean',
+  'is_float', 'is_function', 'is_integer', 'is_list', 'is_map', 'is_nil',
+  'is_number', 'is_pid', 'is_port', 'is_reference', 'is_struct', 'is_tuple',
+  'length', 'hd', 'tl', 'abs', 'ceil', 'floor', 'round', 'trunc', 'rem',
+  'div', 'max', 'min', 'elem', 'put_elem', 'tuple_size', 'map_size',
+  'byte_size', 'bit_size', 'binary_part', 'get_in', 'put_in', 'update_in',
+  'pop_in', 'get_and_update_in', 'struct', 'struct!',
+  // IO
+  'IO.puts', 'IO.inspect', 'IO.gets', 'IO.write', 'IO.read',
+  // Common pipeline functions
+  'then', 'tap', 'dbg',
+]);
+
+export const elixirProvider = defineLanguage({
+  id: SupportedLanguages.Elixir,
+  extensions: ['.ex', '.exs'],
+
+  entryPointPatterns: [
+    /^mount$/,
+    /^handle_event$/,
+    /^handle_info$/,
+    /^handle_call$/,
+    /^handle_cast$/,
+    /^handle_continue$/,
+    /^perform$/,
+    /^process$/,
+    /^call$/,
+    /^init$/,
+    /^start_link$/,
+    /^action$/,
+  ],
+
+  astFrameworkPatterns: [
+    {
+      framework: 'phoenix-liveview',
+      entryPointMultiplier: 3.0,
+      reason: 'liveview-handler',
+      patterns: ['Phoenix.LiveView', 'use Phoenix.LiveView', 'mount', 'handle_event'],
+    },
+    {
+      framework: 'phoenix-controller',
+      entryPointMultiplier: 2.5,
+      reason: 'phoenix-action',
+      patterns: ['use Phoenix.Controller', 'conn', 'params', 'Phoenix.Controller'],
+    },
+    {
+      framework: 'phoenix-channel',
+      entryPointMultiplier: 2.5,
+      reason: 'phoenix-channel',
+      patterns: ['use Phoenix.Channel', 'Phoenix.Channel', 'socket', 'join'],
+    },
+    {
+      framework: 'oban-worker',
+      entryPointMultiplier: 2.8,
+      reason: 'oban-job',
+      patterns: ['use Oban.Worker', 'Oban.Worker', 'perform'],
+    },
+    {
+      framework: 'genserver',
+      entryPointMultiplier: 2.0,
+      reason: 'genserver',
+      patterns: ['use GenServer', 'GenServer', 'handle_call', 'handle_cast', 'handle_info'],
+    },
+    {
+      framework: 'plug',
+      entryPointMultiplier: 2.0,
+      reason: 'plug-middleware',
+      patterns: ['use Plug.Router', 'Plug.Conn', 'plug'],
+    },
+  ] satisfies AstFrameworkPatternConfig[],
+
+  treeSitterQueries: ELIXIR_QUERIES,
+  typeConfig: elixirTypeConfig,
+  exportChecker: elixirExportChecker,
+  importResolver: createImportResolver(elixirImportConfig),
+  importPathPreprocessor: elixirImportPathPreprocessor,
+  importSemantics: 'wildcard-leaf',
+
+  callExtractor: elixirCallExtractor,
+  isClassContainerNode: elixirIsClassContainerNode,
+  extractEnclosingClassInfo: elixirExtractEnclosingClassInfo,
+  enclosingFunctionFinder: elixirEnclosingFunctionFinder,
+  methodExtractor: createMethodExtractor(elixirMethodConfig),
+  classExtractor: createClassExtractor(elixirClassConfig),
+  heritageExtractor: createHeritageExtractor(SupportedLanguages.Elixir),
+
+  heritageDefaultEdge: 'IMPLEMENTS',
+
+  builtInNames: BUILT_INS,
+});

--- a/gitnexus/src/core/ingestion/languages/index.ts
+++ b/gitnexus/src/core/ingestion/languages/index.ts
@@ -25,6 +25,7 @@ import { swiftProvider } from './swift.js';
 import { dartProvider } from './dart.js';
 import { vueProvider } from './vue.js';
 import { cobolProvider } from './cobol.js';
+import { elixirProvider } from './elixir.js';
 
 export const providers = {
   [SupportedLanguages.JavaScript]: javascriptProvider,
@@ -43,6 +44,7 @@ export const providers = {
   [SupportedLanguages.Dart]: dartProvider,
   [SupportedLanguages.Vue]: vueProvider,
   [SupportedLanguages.Cobol]: cobolProvider,
+  [SupportedLanguages.Elixir]: elixirProvider,
 } satisfies Record<SupportedLanguages, LanguageProvider>;
 
 /** Get provider by language enum (always succeeds for SupportedLanguages). */

--- a/gitnexus/src/core/ingestion/method-extractors/configs/elixir.ts
+++ b/gitnexus/src/core/ingestion/method-extractors/configs/elixir.ts
@@ -1,0 +1,152 @@
+// gitnexus/src/core/ingestion/method-extractors/configs/elixir.ts
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { MethodExtractionConfig, ParameterInfo, MethodVisibility } from '../../method-types.js';
+import type { SyntaxNode } from '../../utils/ast-helpers.js';
+
+const ELIXIR_DEF_KEYWORDS = new Set([
+  'def', 'defp', 'defmacro', 'defmacrop', 'defguard', 'defguardp', 'defdelegate',
+]);
+
+const ELIXIR_PRIVATE_KEYWORDS = new Set(['defp', 'defmacrop', 'defguardp']);
+
+/** Return the `target` identifier text of a call node, or undefined. */
+function callKeyword(node: SyntaxNode): string | undefined {
+  const t = node.childForFieldName?.('target');
+  return t?.type === 'identifier' ? t.text : undefined;
+}
+
+/** Find the arguments node among named children. */
+function findArguments(node: SyntaxNode): SyntaxNode | null {
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const c = node.namedChild(i);
+    if (c?.type === 'arguments') return c;
+  }
+  return null;
+}
+
+/**
+ * Extract the function name from a def/defp call node.
+ *
+ * AST shape: call(target: identifier("def"), arguments(call(target: identifier("name"), ...), ...))
+ * No-arg zero-clause: call(target: identifier("def"), arguments(identifier("name"), ...))
+ */
+function extractElixirName(node: SyntaxNode): string | undefined {
+  if (!ELIXIR_DEF_KEYWORDS.has(callKeyword(node) ?? '')) return undefined;
+  const args = findArguments(node);
+  if (!args) return undefined;
+  for (let i = 0; i < args.namedChildCount; i++) {
+    const arg = args.namedChild(i);
+    if (!arg) continue;
+    if (arg.type === 'call') {
+      const innerTarget = arg.childForFieldName?.('target');
+      if (innerTarget?.type === 'identifier') return innerTarget.text;
+    }
+    if (arg.type === 'identifier') return arg.text;
+    // binary_operator covers guard forms: def name(x) when is_integer(x)
+    if (arg.type === 'binary_operator') {
+      const left = arg.childForFieldName?.('left');
+      if (left?.type === 'call') {
+        const innerTarget = left.childForFieldName?.('target');
+        if (innerTarget?.type === 'identifier') return innerTarget.text;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extract parameters from the inner function-signature call inside a def node.
+ * Captures simple identifier parameters; skips pattern-match and default-value nodes.
+ */
+function extractElixirParameters(node: SyntaxNode): ParameterInfo[] {
+  const args = findArguments(node);
+  if (!args) return [];
+
+  // Find the inner call (the function signature)
+  let sigArgs: SyntaxNode | null = null;
+  for (let i = 0; i < args.namedChildCount; i++) {
+    const arg = args.namedChild(i);
+    if (arg?.type === 'call') {
+      sigArgs = findArguments(arg);
+      break;
+    }
+    // guard form: binary_operator left: call
+    if (arg?.type === 'binary_operator') {
+      const left = arg.childForFieldName?.('left');
+      if (left?.type === 'call') {
+        sigArgs = findArguments(left);
+        break;
+      }
+    }
+  }
+  if (!sigArgs) return [];
+
+  const params: ParameterInfo[] = [];
+  for (let i = 0; i < sigArgs.namedChildCount; i++) {
+    const p = sigArgs.namedChild(i);
+    if (!p) continue;
+    if (p.type === 'identifier') {
+      params.push({ name: p.text, type: null, isOptional: false, isVariadic: false });
+    } else if (p.type === 'binary_operator') {
+      // default value: `param \\ default` or `param // default`
+      const left = p.childForFieldName?.('left');
+      if (left?.type === 'identifier') {
+        params.push({ name: left.text, type: null, isOptional: true, isVariadic: false });
+      }
+    }
+    // Skip map/struct patterns, tuples, etc. — complex destructuring
+  }
+  return params;
+}
+
+function extractElixirVisibility(node: SyntaxNode): MethodVisibility {
+  return ELIXIR_PRIVATE_KEYWORDS.has(callKeyword(node) ?? '') ? 'private' : 'public';
+}
+
+/**
+ * Walk up from a def/defp call to find the enclosing defmodule's alias name.
+ * Returns undefined for top-level functions (no parent defmodule).
+ */
+function extractElixirOwnerName(node: SyntaxNode): string | undefined {
+  let cur = node.parent;
+  while (cur) {
+    if (cur.type === 'do_block') {
+      const parent = cur.parent;
+      if (parent?.type === 'call') {
+        const kw = callKeyword(parent);
+        if (kw === 'defmodule') {
+          const pArgs = findArguments(parent);
+          if (pArgs) {
+            for (let i = 0; i < pArgs.namedChildCount; i++) {
+              const a = pArgs.namedChild(i);
+              if (a?.type === 'alias') return a.text;
+            }
+          }
+        }
+      }
+    }
+    cur = cur.parent;
+  }
+  return undefined;
+}
+
+export const elixirMethodConfig: MethodExtractionConfig = {
+  language: SupportedLanguages.Elixir,
+
+  // defmodule calls are the class-like containers; def/defp calls are the methods
+  typeDeclarationNodes: ['call'],
+  methodNodeTypes: ['call'],
+  bodyNodeTypes: ['do_block'],
+  staticOwnerTypes: new Set(), // opt out — Elixir has no static concept
+
+  extractName: extractElixirName,
+  extractReturnType: () => undefined, // dynamic typing — no return type annotation in AST
+  extractParameters: extractElixirParameters,
+  extractVisibility: extractElixirVisibility,
+  extractOwnerName: extractElixirOwnerName,
+
+  isStatic: () => false,
+  isAbstract: () => false,
+  isFinal: () => false,
+};

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -257,10 +257,18 @@ const cachedFindEnclosingClassInfo = (
   node: SyntaxNode,
   filePath: string,
   resolveEnclosingOwner?: (node: SyntaxNode) => SyntaxNode | null,
+  isClassContainerNode?: (node: SyntaxNode) => boolean,
+  extractEnclosingClassInfo?: (node: SyntaxNode, filePath: string) => EnclosingClassInfo | null,
 ): EnclosingClassInfo | null => {
   const cached = classInfoCache.get(node);
   if (cached !== undefined) return cached;
-  const result = findEnclosingClassInfo(node, filePath, resolveEnclosingOwner);
+  const result = findEnclosingClassInfo(
+    node,
+    filePath,
+    resolveEnclosingOwner,
+    isClassContainerNode,
+    extractEnclosingClassInfo,
+  );
   classInfoCache.set(node, result);
   return result;
 };
@@ -523,6 +531,8 @@ const processParsingSequential = async (
             nameNode || definitionNodeForRange,
             file.path,
             provider.resolveEnclosingOwner,
+            provider.isClassContainerNode,
+            provider.extractEnclosingClassInfo,
           )
         : null;
       const enclosingClassId = enclosingClassInfo?.classId ?? null;

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -1504,6 +1504,96 @@ export const DART_QUERIES = `
       (type_identifier) @heritage.trait))) @heritage
 `;
 
+export const ELIXIR_QUERIES = `
+; ── Modules ──────────────────────────────────────────────────────────────────
+(call
+  target: (identifier) @_def (#eq? @_def "defmodule")
+  (arguments
+    (alias) @name)) @definition.class
+
+; ── Protocols ─────────────────────────────────────────────────────────────────
+(call
+  target: (identifier) @_def (#eq? @_def "defprotocol")
+  (arguments
+    (alias) @name)) @definition.interface
+
+; ── Public functions & macros ─────────────────────────────────────────────────
+(call
+  target: (identifier) @_def (#eq? @_def "def")
+  (arguments
+    (call
+      target: (identifier) @name))) @definition.function
+
+(call
+  target: (identifier) @_def (#eq? @_def "defmacro")
+  (arguments
+    (call
+      target: (identifier) @name))) @definition.function
+
+(call
+  target: (identifier) @_def (#eq? @_def "defguard")
+  (arguments
+    (call
+      target: (identifier) @name))) @definition.function
+
+(call
+  target: (identifier) @_def (#eq? @_def "defdelegate")
+  (arguments
+    (call
+      target: (identifier) @name))) @definition.function
+
+; ── Private functions & macros ────────────────────────────────────────────────
+(call
+  target: (identifier) @_def (#eq? @_def "defp")
+  (arguments
+    (call
+      target: (identifier) @name))) @definition.function
+
+(call
+  target: (identifier) @_def (#eq? @_def "defmacrop")
+  (arguments
+    (call
+      target: (identifier) @name))) @definition.function
+
+(call
+  target: (identifier) @_def (#eq? @_def "defguardp")
+  (arguments
+    (call
+      target: (identifier) @name))) @definition.function
+
+; ── Imports: import/use/require ───────────────────────────────────────────────
+(call
+  target: (identifier) @_kw (#eq? @_kw "import")
+  (arguments
+    (alias) @import.source)) @import
+
+(call
+  target: (identifier) @_kw (#eq? @_kw "use")
+  (arguments
+    (alias) @import.source)) @import
+
+(call
+  target: (identifier) @_kw (#eq? @_kw "require")
+  (arguments
+    (alias) @import.source)) @import
+
+; ── Aliases ───────────────────────────────────────────────────────────────────
+(call
+  target: (identifier) @_kw (#eq? @_kw "alias")
+  (arguments
+    (alias) @import.source)) @import
+
+; ── Remote calls: Module.function() ──────────────────────────────────────────
+(call
+  target: (dot
+    left: (alias) @call.receiver
+    right: (identifier) @call.name)) @call
+
+; ── Local calls: function() — provider filters definitions/control-flow ───────
+(call
+  target: (identifier) @call.name) @call
+`;
+
 import { SupportedLanguages } from 'gitnexus-shared';
 
 export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
@@ -1523,4 +1613,5 @@ export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.Dart]: DART_QUERIES,
   [SupportedLanguages.Vue]: TYPESCRIPT_QUERIES, // Vue <script> blocks are parsed as TypeScript
   [SupportedLanguages.Cobol]: '', // Standalone regex processor — no tree-sitter queries
+  [SupportedLanguages.Elixir]: ELIXIR_QUERIES,
 };

--- a/gitnexus/src/core/ingestion/type-env.ts
+++ b/gitnexus/src/core/ingestion/type-env.ts
@@ -151,7 +151,9 @@ const lookupInEnv = (
   varName: string,
   callNode: SyntaxNode,
   patternOverrides?: PatternOverrides,
-  enclosingFunctionFinder?: (n: SyntaxNode) => { funcName: string; label: NodeLabel } | null,
+  enclosingFunctionFinder?: (
+    n: SyntaxNode,
+  ) => { funcName: string; label: NodeLabel; definitionNode?: SyntaxNode } | null,
   extractFunctionNameHook?: (n: SyntaxNode) => { funcName: string | null; label: NodeLabel } | null,
 ): string | undefined => {
   // Self/this receiver: resolve to enclosing class name via AST walk
@@ -385,7 +387,9 @@ const extractParentClassFromNode = (classNode: SyntaxNode): string | undefined =
  *  signature instead of a child. */
 const findEnclosingScopeKey = (
   node: SyntaxNode,
-  enclosingFunctionFinder?: (n: SyntaxNode) => { funcName: string; label: NodeLabel } | null,
+  enclosingFunctionFinder?: (
+    n: SyntaxNode,
+  ) => { funcName: string; label: NodeLabel; definitionNode?: SyntaxNode } | null,
   extractFunctionNameHook?: (n: SyntaxNode) => { funcName: string | null; label: NodeLabel } | null,
 ): string | undefined => {
   let current = node.parent;
@@ -398,7 +402,7 @@ const findEnclosingScopeKey = (
     if (enclosingFunctionFinder) {
       const result = enclosingFunctionFinder(current);
       if (result) {
-        const sigNode = current.previousSibling;
+        const sigNode = result.definitionNode ?? current.previousSibling;
         const startIdx = sigNode?.startIndex ?? current.startIndex;
         return `${result.funcName}@${startIdx}`;
       }
@@ -802,7 +806,7 @@ export interface BuildTypeEnvOptions {
    *  where function_body is a sibling of the signature (e.g., Dart). */
   enclosingFunctionFinder?: (
     ancestorNode: SyntaxNode,
-  ) => { funcName: string; label: NodeLabel } | null;
+  ) => { funcName: string; label: NodeLabel; definitionNode?: SyntaxNode } | null;
   /** Language-specific function name extraction from an AST node.
    *  Replaces the generic name-field lookup for languages with non-standard
    *  AST structures (C/C++ declarator unwrapping, Swift init/deinit, etc.).

--- a/gitnexus/src/core/ingestion/type-extractors/elixir.ts
+++ b/gitnexus/src/core/ingestion/type-extractors/elixir.ts
@@ -1,0 +1,19 @@
+import type { LanguageTypeConfig } from './types.js';
+
+/**
+ * Elixir type extractor — minimal implementation.
+ *
+ * Elixir is dynamically typed with no mandatory type annotations.
+ * Typespecs (@spec) exist but are comments to the compiler and
+ * don't appear as typed AST nodes in tree-sitter-elixir. Pattern
+ * matching in function heads provides structural dispatch, not type
+ * dispatch, so Tier 0 declaration extraction is not applicable.
+ *
+ * This config is intentionally minimal. Tier 1 constructor inference
+ * and Tier 2 propagation can be added as a follow-up when needed.
+ */
+export const typeConfig: LanguageTypeConfig = {
+  declarationNodeTypes: new Set<string>(),
+  extractDeclaration: () => {},
+  extractParameter: () => {},
+};

--- a/gitnexus/src/core/ingestion/utils/ast-helpers.ts
+++ b/gitnexus/src/core/ingestion/utils/ast-helpers.ts
@@ -269,6 +269,8 @@ export const findEnclosingClassInfo = (
   node: SyntaxNode,
   filePath: string,
   resolveEnclosingOwner?: (node: SyntaxNode) => SyntaxNode | null,
+  isClassContainerNode?: (node: SyntaxNode) => boolean,
+  extractEnclosingClassInfo?: (node: SyntaxNode, filePath: string) => EnclosingClassInfo | null,
 ): EnclosingClassInfo | null => {
   let current = node.parent;
   let iterations = 0;
@@ -319,7 +321,9 @@ export const findEnclosingClassInfo = (
         }
       }
     }
-    if (CLASS_CONTAINER_TYPES.has(current.type)) {
+    const isStandardContainer = CLASS_CONTAINER_TYPES.has(current.type);
+    const isProviderContainer = isClassContainerNode?.(current) === true;
+    if (isStandardContainer || isProviderContainer) {
       // Delegate language-specific container remapping to the provider hook.
       if (resolveEnclosingOwner) {
         if (visitedContainers.has(current)) {
@@ -341,6 +345,13 @@ export const findEnclosingClassInfo = (
           current = resolved;
           continue;
         }
+      }
+
+      const providerInfo = extractEnclosingClassInfo?.(current, filePath);
+      if (providerInfo) return providerInfo;
+      if (isProviderContainer && !isStandardContainer) {
+        current = current.parent;
+        continue;
       }
 
       // Rust impl_item: for `impl Trait for Struct {}`, pick the type after `for`

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -579,6 +579,8 @@ const findEnclosingFunctionId = (
           current,
           filePath,
           provider.resolveEnclosingOwner,
+          provider.isClassContainerNode,
+          provider.extractEnclosingClassInfo,
         );
         const encLang = getLanguageFromFilename(filePath);
         const standaloneMethodInfo =
@@ -639,22 +641,24 @@ const findEnclosingFunctionId = (
       const customResult = provider.enclosingFunctionFinder(current);
       if (customResult) {
         let finalLabel: NodeLabel = customResult.label;
+        const sigNode = customResult.definitionNode ?? current.previousSibling ?? current;
         if (provider.labelOverride) {
-          const override = provider.labelOverride(current.previousSibling, finalLabel);
+          const override = provider.labelOverride(sigNode, finalLabel);
           if (override !== null) finalLabel = override;
         }
         // Qualify custom result with enclosing class
         const classInfo = cachedFindEnclosingClassInfo(
-          current.previousSibling ?? current,
+          sigNode,
           filePath,
           provider.resolveEnclosingOwner,
+          provider.isClassContainerNode,
+          provider.extractEnclosingClassInfo,
         );
         const qualifiedName = classInfo
           ? `${classInfo.className}.${customResult.funcName}`
           : customResult.funcName;
         // Include #<arity> suffix to match definition-phase Method/Constructor IDs.
         // When same-arity collisions exist, also append ~type1,type2.
-        const sigNode = current.previousSibling ?? current;
         let arity2: number | undefined;
         let encTypeTag2 = '';
         if (finalLabel === 'Method' || finalLabel === 'Constructor') {
@@ -699,11 +703,19 @@ const cachedFindEnclosingClassInfo = (
   node: SyntaxNode,
   filePath: string,
   resolveEnclosingOwner?: (node: SyntaxNode) => SyntaxNode | null,
+  isClassContainerNode?: (node: SyntaxNode) => boolean,
+  extractEnclosingClassInfo?: (node: SyntaxNode, filePath: string) => EnclosingClassInfo | null,
 ): EnclosingClassInfo | null => {
   const cached = classIdCache.get(node);
   if (cached !== undefined) return cached;
 
-  const result = findEnclosingClassInfo(node, filePath, resolveEnclosingOwner);
+  const result = findEnclosingClassInfo(
+    node,
+    filePath,
+    resolveEnclosingOwner,
+    isClassContainerNode,
+    extractEnclosingClassInfo,
+  );
   classIdCache.set(node, result);
   return result;
 };
@@ -1810,6 +1822,8 @@ const processFileGroup = (
                   captureMap['call'],
                   file.path,
                   provider.resolveEnclosingOwner,
+                  provider.isClassContainerNode,
+                  provider.extractEnclosingClassInfo,
                 );
                 const propEnclosingClassId = propEnclosingInfo?.classId ?? null;
                 // Enrich routed properties with FieldExtractor metadata
@@ -2055,6 +2069,8 @@ const processFileGroup = (
             nameNode || definitionNode,
             file.path,
             provider.resolveEnclosingOwner,
+            provider.isClassContainerNode,
+            provider.extractEnclosingClassInfo,
           )
         : null;
       const enclosingClassId = enclosingClassInfo?.classId ?? null;

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -45,6 +45,11 @@ let Kotlin: TreeSitterLanguage | null = null;
 try {
   Kotlin = _require('tree-sitter-kotlin');
 } catch {}
+
+let Elixir: TreeSitterLanguage | null = null;
+try {
+  Elixir = _require('tree-sitter-elixir');
+} catch {}
 import { getLanguageFromFilename } from 'gitnexus-shared';
 import {
   FUNCTION_NODE_TYPES,
@@ -328,6 +333,7 @@ const languageMap: Record<string, TreeSitterLanguage> = {
   [SupportedLanguages.Vue]: TypeScript.typescript,
   ...(Dart ? { [SupportedLanguages.Dart]: Dart } : {}),
   ...(Swift ? { [SupportedLanguages.Swift]: Swift } : {}),
+  ...(Elixir ? { [SupportedLanguages.Elixir]: Elixir } : {}),
 };
 
 /**

--- a/gitnexus/src/core/tree-sitter/parser-loader.ts
+++ b/gitnexus/src/core/tree-sitter/parser-loader.ts
@@ -161,6 +161,14 @@ const SOURCES: Record<string, GrammarSource> = {
       'Kotlin parsing disabled: `tree-sitter-kotlin` is an optionalDependency ' +
       'and is not installed (or its native binding failed to build).',
   },
+  [SupportedLanguages.Elixir]: {
+    load: () => _require('tree-sitter-elixir'),
+    optional: true,
+    severity: 'error',
+    unavailableNote:
+      'Elixir parsing disabled: `tree-sitter-elixir` could not be loaded. ' +
+      'Try `npm rebuild tree-sitter-elixir` or reinstalling, then re-run analyze.',
+  },
 };
 
 type LoadResult =

--- a/gitnexus/src/storage/parse-cache.ts
+++ b/gitnexus/src/storage/parse-cache.ts
@@ -44,7 +44,7 @@ import type { ParseWorkerResult } from '../core/ingestion/workers/parse-worker.j
  * On version mismatch, `loadParseCache` returns an empty cache and the
  * next save overwrites the on-disk file with the new version baked in.
  */
-const SCHEMA_BUMP = 1;
+const SCHEMA_BUMP = 2;
 const GITNEXUS_PKG_VERSION = (() => {
   try {
     // package.json sits at gitnexus/package.json — two levels up from

--- a/gitnexus/test/fixtures/sample-code/simple.ex
+++ b/gitnexus/test/fixtures/sample-code/simple.ex
@@ -1,0 +1,35 @@
+defmodule MyApp.User do
+  alias MyApp.Repo
+  import Ecto.Query, only: [from: 2]
+  use Phoenix.LiveView
+  require Logger
+
+  @behaviour MyApp.UserBehaviour
+
+  def get(id) do
+    Repo.get(MyApp.User, id)
+  end
+
+  def get_by_email(email) do
+    from(u in MyApp.User, where: u.email == ^email)
+    |> Repo.one()
+  end
+
+  defp validate(user) do
+    user
+  end
+
+  def create(attrs) do
+    %MyApp.User{}
+    |> MyApp.User.changeset(attrs)
+    |> Repo.insert()
+  end
+end
+
+defmodule MyApp.UserProtocol do
+  @doc "A protocol for user operations"
+end
+
+defprotocol MyApp.Serializable do
+  def serialize(data)
+end

--- a/gitnexus/test/integration/tree-sitter-languages.test.ts
+++ b/gitnexus/test/integration/tree-sitter-languages.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { loadParser, loadLanguage } from '../../src/core/tree-sitter/parser-loader.js';
 import { SupportedLanguages, getLanguageFromFilename } from 'gitnexus-shared';
 import { getProvider } from '../../src/core/ingestion/languages/index.js';
+import { findEnclosingClassInfo } from '../../src/core/ingestion/utils/ast-helpers.js';
 import Parser from 'tree-sitter';
 
 const fixturesDir = path.resolve(__dirname, '..', 'fixtures', 'sample-code');
@@ -663,6 +664,90 @@ describe('Tree-sitter multi-language parsing', () => {
         const defs = extractDefinitions(matches);
         expect(defs.length, `${lang} (${fixture}) should have definitions`).toBeGreaterThan(0);
       }
+    });
+  });
+
+  describe('Elixir', () => {
+    const elixirQueries = () => getProvider(SupportedLanguages.Elixir).treeSitterQueries;
+
+    function loadElixirOrSkip() {
+      return loadLanguage(SupportedLanguages.Elixir).catch(() => null);
+    }
+
+    it('parses modules, functions, and protocols', async () => {
+      if (!(await loadElixirOrSkip())) return;
+      const { matches } = parseAndQuery(parser, readFixture('simple.ex'), elixirQueries());
+      const defs = extractDefinitions(matches);
+      const defTypes = defs.map((d) => d.type);
+      const defNames = defs.map((d) => d.name);
+
+      expect(defTypes).toContain('definition.class');
+      expect(defTypes).toContain('definition.function');
+      expect(defTypes).toContain('definition.interface');
+
+      expect(defNames).toContain('MyApp.User');
+      expect(defNames).toContain('get');
+      expect(defNames).toContain('get_by_email');
+      expect(defNames).toContain('validate');
+      expect(defNames).toContain('create');
+      expect(defNames).toContain('MyApp.Serializable');
+    });
+
+    it('captures import/alias/use/require as @import', async () => {
+      if (!(await loadElixirOrSkip())) return;
+      const { matches } = parseAndQuery(parser, readFixture('simple.ex'), elixirQueries());
+      const importSources: string[] = [];
+      for (const match of matches) {
+        for (const c of match.captures) {
+          if (c.name === 'import.source') importSources.push(c.node.text);
+        }
+      }
+      expect(importSources).toEqual(['MyApp.Repo', 'Ecto.Query', 'Phoenix.LiveView', 'Logger']);
+    });
+
+    it('extracts real calls once and skips definitions/attributes', async () => {
+      if (!(await loadElixirOrSkip())) return;
+      const { matches } = parseAndQuery(parser, readFixture('simple.ex'), elixirQueries());
+      const provider = getProvider(SupportedLanguages.Elixir);
+      const callNames: string[] = [];
+      for (const match of matches) {
+        const captureMap: Record<string, any> = {};
+        for (const c of match.captures) {
+          captureMap[c.name] = c.node;
+        }
+        if (captureMap['call']) {
+          const extracted = provider.callExtractor?.extract(
+            captureMap['call'],
+            captureMap['call.name'],
+          );
+          if (extracted) callNames.push(extracted.calledName);
+        }
+      }
+
+      expect(callNames).toEqual(['get', 'from', 'one', 'changeset', 'insert']);
+    });
+
+    it('resolves defmodule as the enclosing owner for functions', async () => {
+      if (!(await loadElixirOrSkip())) return;
+      const { matches } = parseAndQuery(parser, readFixture('simple.ex'), elixirQueries());
+      const provider = getProvider(SupportedLanguages.Elixir);
+      let createNode: any;
+      for (const match of matches) {
+        const hasFunctionDef = match.captures.some((c: any) => c.name === 'definition.function');
+        const nameCapture = match.captures.find((c: any) => c.name === 'name');
+        if (hasFunctionDef && nameCapture?.node.text === 'create') {
+          createNode = nameCapture.node;
+        }
+      }
+
+      const owner = findEnclosingClassInfo(
+        createNode,
+        'lib/my_app/user.ex',
+        provider.resolveEnclosingOwner,
+        provider.isClassContainerNode,
+        provider.extractEnclosingClassInfo,
+      );
+      expect(owner?.className).toBe('MyApp.User');
     });
   });
 

--- a/gitnexus/test/integration/worker-pool.test.ts
+++ b/gitnexus/test/integration/worker-pool.test.ts
@@ -83,6 +83,25 @@ describe('worker pool integration', () => {
     expect(names).toContain('validateInput');
   });
 
+  it.skipIf(!hasDistWorker)('parses an Elixir file through worker', async () => {
+    const workerUrl = pathToFileURL(DIST_WORKER) as URL;
+    pool = createWorkerPool(workerUrl, 1);
+
+    const fixtureFile = path.resolve(__dirname, '..', 'fixtures', 'sample-code', 'simple.ex');
+    const content = fs.readFileSync(fixtureFile, 'utf-8');
+
+    const results = await pool.dispatch<any, any>([{ path: 'lib/my_app/user.ex', content }]);
+
+    expect(results).toHaveLength(1);
+    const result = results[0];
+    expect(result.fileCount).toBe(1);
+    expect(result.skippedLanguages).toEqual({});
+
+    const names = result.nodes.map((n: any) => n.properties.name);
+    expect(names).toContain('MyApp.User');
+    expect(names).toContain('create');
+  });
+
   it.skipIf(!hasDistWorker)('parses multiple files across workers', async () => {
     const workerUrl = pathToFileURL(DIST_WORKER) as URL;
     pool = createWorkerPool(workerUrl, 2);


### PR DESCRIPTION
## Summary
- Add Elixir language detection, tree-sitter parser loading, queries, and extractor/provider wiring.
- Add provider-owned container hooks so Elixir defmodule ownership is visible without broadening shared AST container rules.
- Register Elixir in the worker parser path and invalidate stale parse-worker cache output.

## Validation
- npm run build
- npm test -- worker-pool.test.ts tree-sitter-languages.test.ts incremental-parse-cache.test.ts
- npm test -- tree-sitter-languages.test.ts language-skip.test.ts framework-detection.test.ts call-extraction.test.ts
- npx tsc --noEmit
- git diff --check
- gitnexus detect-changes --scope all --repo GitNexus

## Risk / rollback
- Elixir parser support is additive and marked experimental.
- Parse-cache schema bump forces old worker output to be rebuilt after install.