### PR TITLE
Avoid in-place LadybugDB full rebuilds

### DIFF
--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -10,7 +10,6 @@
  */
 
 import path from 'path';
-import fs from 'fs/promises';
 import { execFileSync } from 'child_process';
 import { runPipelineFromRepo } from './ingestion/pipeline.js';
 import {
@@ -34,6 +33,9 @@ import {
   registerRepo,
   cleanupOldKuzuFiles,
   INCREMENTAL_SCHEMA_VERSION,
+  createStagedLbugRebuildPath,
+  publishStagedLbugRebuild,
+  cleanupStagedLbugRebuild,
 } from '../storage/repo-manager.js';
 import { computeFileHashes, diffFileHashes } from '../storage/file-hash.js';
 import {
@@ -179,6 +181,7 @@ export async function runFullAnalysis(
     callbacks.onProgress(phase, percent, message);
 
   const { storagePath, lbugPath } = getStoragePaths(repoPath);
+  let stagedLbugPath: string | null = null;
 
   // Clean up stale KuzuDB files from before the LadybugDB migration.
   const kuzuResult = await cleanupOldKuzuFiles(storagePath);
@@ -422,19 +425,16 @@ export async function runFullAnalysis(
       },
     });
   } else {
-    // Full rebuild path: wipe DB files first.
+    // Full rebuild path: write a fresh LadybugDB beside the published DB.
+    // Publishing happens only after the staged DB is fully written and closed,
+    // so MCP readers that already have `.gitnexus/lbug` open are not disrupted
+    // by an analyze-time delete/recreate cycle.
     await closeLbug();
-    const lbugFiles = [lbugPath, `${lbugPath}.wal`, `${lbugPath}.lock`];
-    for (const f of lbugFiles) {
-      try {
-        await fs.rm(f, { recursive: true, force: true });
-      } catch {
-        /* swallow */
-      }
-    }
+    stagedLbugPath = await createStagedLbugRebuildPath(storagePath);
   }
 
-  await initLbug(lbugPath);
+  const activeLbugPath = stagedLbugPath ?? lbugPath;
+  await initLbug(activeLbugPath);
   try {
     // All work after initLbug is wrapped in try/finally to ensure closeLbug()
     // is called even if an error occurs — the module-level singleton DB handle
@@ -789,6 +789,14 @@ export async function runFullAnalysis(
       fileHashes: hasGitDir(repoPath) ? newFileHashesRecord : undefined,
       incrementalInProgress: undefined as { startedAt: number; toWriteCount: number } | undefined,
     };
+    if (stagedLbugPath) {
+      progress('done', 98, 'Publishing LadybugDB index...');
+      await closeLbug();
+      await publishStagedLbugRebuild({ stagedPath: stagedLbugPath, lbugPath });
+      stagedLbugPath = null;
+      progress('done', 98, 'Saving metadata...');
+    }
+
     await saveMeta(storagePath, meta);
 
     // Persist the incremental parse cache for the next run. Wraps in
@@ -878,6 +886,7 @@ export async function runFullAnalysis(
     } catch {
       /* swallow */
     }
+    await cleanupStagedLbugRebuild(stagedLbugPath);
     throw err;
   }
 }

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -10,6 +10,7 @@ import fs from 'fs/promises';
 import { realpathSync } from 'fs';
 import path from 'path';
 import os from 'os';
+import { randomUUID } from 'crypto';
 import { getInferredRepoName, resolveRepoIdentityRoot } from './git.js';
 import { logger } from '../core/logger.js';
 
@@ -130,6 +131,8 @@ export interface RegistryEntry {
 
 const GITNEXUS_DIR = '.gitnexus';
 const GITNEXUS_EXCLUDE_ENTRY = `${GITNEXUS_DIR}/`;
+const LBUG_REBUILD_PREFIX = 'lbug.rebuild-';
+const LBUG_SIDECAR_SUFFIXES = ['', '.wal', '.lock'];
 
 // ─── Local Storage Helpers ─────────────────────────────────────────────
 
@@ -150,6 +153,65 @@ export const getStoragePaths = (repoPath: string) => {
     lbugPath: path.join(storagePath, 'lbug'),
     metaPath: path.join(storagePath, 'meta.json'),
   };
+};
+
+export interface StagedLbugRebuild {
+  stagedPath: string;
+  lbugPath: string;
+}
+
+/**
+ * Return a unique staging path for a full LadybugDB rebuild.
+ *
+ * Full rebuilds must not delete or write the published `.gitnexus/lbug`
+ * database in place: MCP readers may already have that file open. The
+ * analyzer writes to this staging path, closes LadybugDB, and then publishes
+ * the completed file with a single rename over the canonical path.
+ */
+export const createStagedLbugRebuildPath = async (storagePath: string): Promise<string> => {
+  await fs.mkdir(storagePath, { recursive: true });
+  return path.join(
+    storagePath,
+    `${LBUG_REBUILD_PREFIX}${process.pid}-${Date.now()}-${randomUUID()}`,
+  );
+};
+
+/**
+ * Publish a completed staged LadybugDB rebuild.
+ *
+ * Do not remove the published DB before this rename. On POSIX systems, the
+ * rename replaces the directory entry atomically while existing MCP readers
+ * continue using their already-open handle to the previous file.
+ */
+export const publishStagedLbugRebuild = async ({
+  stagedPath,
+  lbugPath,
+}: StagedLbugRebuild): Promise<void> => {
+  await fs.rename(stagedPath, lbugPath);
+
+  for (const suffix of LBUG_SIDECAR_SUFFIXES.slice(1)) {
+    try {
+      await fs.rename(`${stagedPath}${suffix}`, `${lbugPath}${suffix}`);
+    } catch (err: any) {
+      if (err?.code !== 'ENOENT') throw err;
+    }
+  }
+};
+
+/**
+ * Best-effort cleanup for abandoned staged rebuild files.
+ */
+export const cleanupStagedLbugRebuild = async (
+  stagedPath: string | null | undefined,
+): Promise<void> => {
+  if (!stagedPath) return;
+  for (const suffix of LBUG_SIDECAR_SUFFIXES) {
+    try {
+      await fs.rm(`${stagedPath}${suffix}`, { recursive: true, force: true });
+    } catch {
+      /* missing staged artifact or cleanup failure — original error wins */
+    }
+  }
 };
 
 /**

--- a/gitnexus/test/unit/repo-manager.test.ts
+++ b/gitnexus/test/unit/repo-manager.test.ts
@@ -12,6 +12,9 @@ import { _captureLogger } from '../../src/core/logger.js';
 import {
   getStoragePath,
   getStoragePaths,
+  createStagedLbugRebuildPath,
+  publishStagedLbugRebuild,
+  cleanupStagedLbugRebuild,
   ensureGitNexusIgnored,
   readRegistry,
   loadCLIConfig,
@@ -61,6 +64,63 @@ describe('getStoragePaths', () => {
     const paths = getStoragePaths('/home/user/project');
     expect(paths.lbugPath.startsWith(paths.storagePath)).toBe(true);
     expect(paths.metaPath.startsWith(paths.storagePath)).toBe(true);
+  });
+});
+
+// ─── Staged LadybugDB rebuilds ─────────────────────────────────────────────
+
+describe('staged LadybugDB rebuild publication', () => {
+  let tmpRepo: Awaited<ReturnType<typeof createTempDir>>;
+
+  beforeEach(async () => {
+    tmpRepo = await createTempDir('gitnexus-lbug-stage-');
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await tmpRepo.cleanup();
+  });
+
+  it('creates a rebuild path under storage without targeting the published lbug file', async () => {
+    const { storagePath, lbugPath } = getStoragePaths(tmpRepo.dbPath);
+    const stagedPath = await createStagedLbugRebuildPath(storagePath);
+
+    expect(stagedPath).not.toBe(lbugPath);
+    expect(stagedPath.startsWith(storagePath + path.sep)).toBe(true);
+    expect(path.basename(stagedPath)).toMatch(/^lbug\.rebuild-/);
+  });
+
+  it('publishes staged rebuilds by renaming over the canonical DB without pre-deleting it', async () => {
+    const { storagePath, lbugPath } = getStoragePaths(tmpRepo.dbPath);
+    await fs.mkdir(storagePath, { recursive: true });
+    await fs.writeFile(lbugPath, 'old published db', 'utf-8');
+    const stagedPath = await createStagedLbugRebuildPath(storagePath);
+    await fs.writeFile(stagedPath, 'new staged db', 'utf-8');
+
+    const rmSpy = vi.spyOn(fs, 'rm');
+
+    await publishStagedLbugRebuild({ stagedPath, lbugPath });
+
+    await expect(fs.readFile(lbugPath, 'utf-8')).resolves.toBe('new staged db');
+    await expect(fs.access(stagedPath)).rejects.toThrow();
+    expect(rmSpy).not.toHaveBeenCalled();
+  });
+
+  it('cleans abandoned staged rebuild files and sidecars without touching the published DB', async () => {
+    const { storagePath, lbugPath } = getStoragePaths(tmpRepo.dbPath);
+    await fs.mkdir(storagePath, { recursive: true });
+    await fs.writeFile(lbugPath, 'published db', 'utf-8');
+    const stagedPath = await createStagedLbugRebuildPath(storagePath);
+    await fs.writeFile(stagedPath, 'abandoned staged db', 'utf-8');
+    await fs.writeFile(`${stagedPath}.wal`, 'abandoned wal', 'utf-8');
+    await fs.writeFile(`${stagedPath}.lock`, 'abandoned lock', 'utf-8');
+
+    await cleanupStagedLbugRebuild(stagedPath);
+
+    await expect(fs.readFile(lbugPath, 'utf-8')).resolves.toBe('published db');
+    await expect(fs.access(stagedPath)).rejects.toThrow();
+    await expect(fs.access(`${stagedPath}.wal`)).rejects.toThrow();
+    await expect(fs.access(`${stagedPath}.lock`)).rejects.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary

Full rebuilds currently close LadybugDB, delete the published `.gitnexus/lbug` files, and then initialize the new DB at the same canonical path. That is fragile when MCP readers already have the published LadybugDB open, especially on macOS where the observed failure mode is DB lock/FTS instability during analyze + MCP usage.

This PR changes the full rebuild path to:

- create a unique staged LadybugDB path under `.gitnexus/`
- initialize/write/index the staged DB instead of the published `.gitnexus/lbug`
- close LadybugDB before publication
- publish the completed staged DB by renaming it over the canonical DB
- clean abandoned staged files on failure

Incremental runs continue to use the published DB because they intentionally mutate existing rows in place.

## Tests

- `npm test -- test/unit/repo-manager.test.ts`
- `npm test -- test/unit/run-analyze.test.ts`
- `npm test -- test/unit/incremental-orchestration.test.ts`
- `npm test -- test/unit/repo-manager.test.ts test/unit/run-analyze.test.ts test/unit/incremental-orchestration.test.ts`
- `npm run build`
- `npm test` -> 320 files passed, 8843 tests passed, 1 skipped
