### PR TITLE
fix(ci): engage npm Trusted Publishing OIDC properly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -372,12 +372,33 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
+          # `registry-url:` is intentionally OMITTED. Under npm Trusted
+          # Publishing, OIDC only engages when no credential is configured.
+          # Setting `registry-url:` would make setup-node write
+          # `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into the
+          # runner's .npmrc AND export NODE_AUTH_TOKEN from its `token:`
+          # input (default github.token). `npm publish` would then attempt
+          # GITHUB_TOKEN as the npm token, get rejected with 404, and OIDC
+          # would never be tried. See actions/setup-node#1440 and the GitHub
+          # Community discussion #176761 for the upstream bug and consensus
+          # workaround.
+          #
           # Hermetic install for published artifacts — opt out of the v5+
           # default packageManager-based caching (clears the zizmor
-          # zizmor cache-poisoning audit). ~30s slower per
-          # release; runs rarely.
+          # cache-poisoning audit). ~30s slower per release; runs rarely.
           package-manager-cache: false
+
+      # npm Trusted Publishing requires npm >= 11.5.1. The Node 22 runner
+      # currently ships with npm 10.9.x which has no OIDC support — without
+      # this upgrade, `npm publish` falls back to classic auth and the
+      # registry returns 404 because no token is configured. Upgrade
+      # globally so subsequent `npm` invocations in this job use the new
+      # binary.
+      - name: Upgrade npm for Trusted Publishing
+        shell: bash
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Build gitnexus-shared
         run: npm install && npm run build
@@ -741,19 +762,28 @@ jobs:
           echo "vtag verified: ${VTAG} (mode=${MODE})"
           echo "vtag=${VTAG}" >> "$GITHUB_OUTPUT"
 
-      # npm Trusted Publishing (GA'd 2025-07-31). With the package registered
-      # as a trusted publisher on npmjs.com bound to this repo + this
-      # workflow file, npm authenticates via OIDC at publish time —
-      # NODE_AUTH_TOKEN is intentionally NOT set (an empty string would
-      # short-circuit the OIDC fallback; the env var must be unset, not
-      # blanked). Provenance is auto-attached by the registry on
-      # trusted-publisher publishes, so the explicit --provenance flag is
-      # dropped.
+      # npm Trusted Publishing (GA'd 2025-07-31). OIDC authentication only
+      # engages when no npm credential is configured anywhere — the absence
+      # is the signal. Two upstream behaviors had to be neutralized for
+      # this to work:
       #
-      # Prerequisite: configure the package as a trusted publisher at
+      #   1. setup-node's `registry-url:` is omitted (see the setup-node
+      #      step above). With it, setup-node writes
+      #      `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into
+      #      .npmrc and exports NODE_AUTH_TOKEN from `token:` (defaulting
+      #      to github.token). npm publish then sends GITHUB_TOKEN as the
+      #      bearer credential and the registry returns 404. OIDC is never
+      #      tried because npm thinks it already has a credential.
+      #   2. The runner's bundled npm (10.9.x on Node 22) has no OIDC
+      #      support; the upgrade step above pins it to >= 11.5.1.
+      #
+      # Provenance is auto-attached by the registry on trusted-publisher
+      # publishes — no --provenance flag needed.
+      #
+      # Prerequisite: register the package as a trusted publisher at
       # https://www.npmjs.com/package/gitnexus/access (Publishing access →
-      # Trusted Publishers → GitHub Actions) bound to:
-      #   Owner:       <repo owner>
+      # Trusted Publishers → GitHub Actions):
+      #   Owner:       abhigyanpatwari
       #   Repository:  GitNexus
       #   Workflow:    publish.yml
       #   Environment: (none)


### PR DESCRIPTION
## Why

First live-fire RC publish after the #1610 unification (run [25955355853](https://github.com/abhigyanpatwari/GitNexus/actions/runs/25955355853)) failed at `npm publish` with `E404 PUT https://registry.npmjs.org/gitnexus`. The `if: failure()` cleanup step worked correctly — the partial `v1.6.5-rc.47` tag and rc-marker were auto-deleted from origin, so no manual recovery needed.

But OIDC never engaged. Researching the root cause surfaced two coordinated upstream bugs that this PR fixes.

## Root cause

**Bug 1 — `actions/setup-node` injects a stale credential.** With `registry-url: https://registry.npmjs.org`, setup-node writes
```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```
into the runner's `.npmrc` AND exports `NODE_AUTH_TOKEN` from its `token:` input (defaulting to `${{ github.token }}`, i.e. `GITHUB_TOKEN`). `npm publish` then sends `GITHUB_TOKEN` as the bearer credential, the registry rejects it with 404, and OIDC is never attempted — npm thinks it already has a credential.

This is the open upstream issue [actions/setup-node#1440](https://github.com/actions/setup-node/issues/1440). The community-validated workaround per [GitHub Community discussion #176761](https://github.com/orgs/community/discussions/176761) is to **omit `registry-url:` entirely**.

**Bug 2 — runner's npm is too old.** Node 22 ships with npm 10.9.x; npm Trusted Publishing OIDC support requires **npm >= 11.5.1**. Even with Bug 1 fixed, the publish would have fallen back to classic auth and 404'd.

## Fix

```diff
       - uses: actions/setup-node@…
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
+          # registry-url: omitted — see comment block
           package-manager-cache: false
+
+      - name: Upgrade npm for Trusted Publishing
+        shell: bash
+        run: |
+          npm install -g npm@latest
+          npm --version
```

Comment block in the workflow explains the WHY in full so the next maintainer doesn't accidentally re-add `registry-url:`.

`--provenance` flag is NOT added: npm auto-attaches provenance under Trusted Publishing.

## What's already verified

- Trusted Publisher correctly configured on npmjs.com (binding to `publish.yml` workflow filename, no environment) — confirmed by the user.
- App token + secrets setup correct (App token mint, Workflows: write tag push, atomic v-tag + rc-marker push all succeeded in run 25955355853).
- `package.json` has the `"repository":` field (required for provenance).
- `if: failure()` cleanup works end-to-end (auto-deleted the failed publish's partial state — no manual cleanup was required).

## What this PR does NOT change

The architecture of the unified workflow (route → rc-guard → ci → publish → docker), the App-token flow, the vtag integrity gate, the auto-cleanup behavior — all stay exactly as #1610 landed them. This is a one-step fix to make OIDC actually engage.

## Live-fire test plan

Once this PR merges, the next push to main fires `publish.yml`, which mints a fresh App token and publishes `gitnexus@1.6.5-rc.48` (active cycle continues). The `if: failure()` cleanup is in place as the safety net — if OIDC still fails, the v-tag + marker are auto-removed and recovery is a redispatch.

## Sources

- [npm Trusted Publishers docs](https://docs.npmjs.com/trusted-publishers/)
- [GitHub blog: npm Trusted Publishing GA](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/)
- [actions/setup-node#1440](https://github.com/actions/setup-node/issues/1440)
- [Community discussion #176761](https://github.com/orgs/community/discussions/176761)