### PR TITLE
fix(ci): bump publish job to Node 24 for npm OIDC support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -371,7 +371,15 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          # Node 24 ships with npm >= 11.5.x, which is the minimum that
+          # supports npm Trusted Publishing OIDC. Node 22 ships with npm
+          # 10.9.x (no OIDC) and `npm install -g npm@latest` to self-upgrade
+          # is fragile — it can crash the in-flight reify with
+          # `MODULE_NOT_FOUND` on `promise-retry` etc. Bumping the Node
+          # version is the clean fix; the package's `engines` field is
+          # `>=22.0.0` so consumer-side compatibility is unaffected (this
+          # Node version is only used during publish, not by package users).
+          node-version: 24
           # `registry-url:` is intentionally OMITTED. Under npm Trusted
           # Publishing, OIDC only engages when no credential is configured.
           # Setting `registry-url:` would make setup-node write
@@ -387,18 +395,6 @@ jobs:
           # default packageManager-based caching (clears the zizmor
           # cache-poisoning audit). ~30s slower per release; runs rarely.
           package-manager-cache: false
-
-      # npm Trusted Publishing requires npm >= 11.5.1. The Node 22 runner
-      # currently ships with npm 10.9.x which has no OIDC support — without
-      # this upgrade, `npm publish` falls back to classic auth and the
-      # registry returns 404 because no token is configured. Upgrade
-      # globally so subsequent `npm` invocations in this job use the new
-      # binary.
-      - name: Upgrade npm for Trusted Publishing
-        shell: bash
-        run: |
-          npm install -g npm@latest
-          npm --version
 
       - name: Build gitnexus-shared
         run: npm install && npm run build


### PR DESCRIPTION
## Why

PR #1627 fixed two of three things needed for npm Trusted Publishing OIDC:
- Removed `registry-url:` from setup-node so no stale credential gets injected ✅
- Tried to upgrade npm with `npm install -g npm@latest` to reach the >=11.5.1 minimum ❌

The second part broke. First live-fire RC after #1627 (run [25956326137](https://github.com/abhigyanpatwari/GitNexus/actions/runs/25956326137)) failed at the `Upgrade npm for Trusted Publishing` step:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/.../arborist/.../rebuild.js
```

Known fragility — npm replacing itself mid-install can leave the global node_modules tree half-populated. Retry doesn't help on the same runner image.

## Fix

**Bump the publish job to Node 24.** Node 24 LTS ships with npm 11.x natively, which supports OIDC Trusted Publishing out of the box. No self-upgrade dance needed.

```diff
       - uses: actions/setup-node@…
         with:
-          node-version: 22
+          node-version: 24
           # registry-url: omitted (per #1627)
           package-manager-cache: false

-      - name: Upgrade npm for Trusted Publishing
-        shell: bash
-        run: |
-          npm install -g npm@latest
-          npm --version
```

Net: -13 / +9 lines including the explanatory comment.

## Compatibility check

| Concern | Result |
|---|---|
| Package consumers | Unaffected — this Node version is used **only** by the publish workflow, not by anyone installing `gitnexus`. |
| `package.json` `engines.node` | `>=22.0.0` — Node 24 satisfies. |
| CI test matrix | Unchanged — `ci-tests.yml` keeps testing against Node 22 (the package's actual minimum). |
| Build correctness | The publish workflow ran `Build gitnexus-shared` and `Build gitnexus` on Node 22 in run 25956326137 and succeeded. Node 24 is a superset (same ECMAScript, newer V8); standard build should work. |

## Live-fire test plan

Same as before — merge, push-to-main fires `publish.yml`, expected outcome:

1. App token mint ✅ (already validated)
2. RC checkout ✅ (already validated)
3. Build steps ✅ (already validated on Node 22; Node 24 is forward-compatible)
4. Atomic tag + marker push ✅ (already validated)
5. **`npm publish` engages OIDC** — the actual untested-until-now path
6. GitHub Release + docker.yml downstream

If OIDC still fails for any reason, the `if: failure()` cleanup auto-removes the v-tag + marker (already proven in both prior live-fire attempts).

## Source

[remarkablemark blog: How to set up trusted publishing for npm](https://remarkablemark.org/blog/2025/12/19/npm-trusted-publishing/) — explicitly recommends "Use Node 24 / npm latest" for OIDC Trusted Publishing.