### PR TITLE
feat(ingestion): Add C++ parameter type class sidecar

### DIFF
--- a/gitnexus-shared/src/index.ts
+++ b/gitnexus-shared/src/index.ts
@@ -26,7 +26,7 @@ export type { PipelinePhase, PipelineProgress } from './pipeline.js';
 
 // ─── Scope-based resolution — RFC #909 (Ring 1 #910) ────────────────────────
 // Data model (RFC §2)
-export type { SymbolDefinition } from './scope-resolution/symbol-definition.js';
+export type { ParameterTypeClass, SymbolDefinition } from './scope-resolution/symbol-definition.js';
 export type {
   ScopeId,
   DefId,

--- a/gitnexus-shared/src/scope-resolution/symbol-definition.ts
+++ b/gitnexus-shared/src/scope-resolution/symbol-definition.ts
@@ -11,6 +11,17 @@
 
 import type { NodeLabel } from '../graph/types.js';
 
+export interface ParameterTypeClass {
+  /** Normalized base type, matching the coarse `parameterTypes` vocabulary when known. */
+  base: string;
+  /** Top-level cv signal preserved from the original C++ parameter spelling. */
+  cv: 'none' | 'const' | 'volatile' | 'const volatile' | 'unknown';
+  /** Coarse value/reference/pointer shape. */
+  indirection: 'value' | 'lvalue-ref' | 'rvalue-ref' | 'pointer' | 'unknown';
+  /** Number of pointer markers when indirection is `pointer`; otherwise 0. */
+  pointerDepth: number;
+}
+
 export interface SymbolDefinition {
   nodeId: string;
   filePath: string;
@@ -26,6 +37,9 @@ export interface SymbolDefinition {
   /** Per-parameter type names for overload disambiguation (e.g. ['int', 'String']).
    *  Populated when parameter types are resolvable from AST (any typed language). */
   parameterTypes?: string[];
+  /** Additive per-parameter type shape sidecar for languages that need cv/ref/pointer distinctions.
+   *  Does not participate in graph node identity unless a resolver explicitly opts in. */
+  parameterTypeClasses?: ParameterTypeClass[];
   /** Raw return type text extracted from AST (e.g. 'User', 'Promise<User>') */
   returnType?: string;
   /** Declared type for non-callable symbols — fields/properties (e.g. 'Address', 'List<User>') */

--- a/gitnexus/src/core/ingestion/languages/cpp/arity-metadata.ts
+++ b/gitnexus/src/core/ingestion/languages/cpp/arity-metadata.ts
@@ -1,9 +1,11 @@
 import type { SyntaxNode } from '../../utils/ast-helpers.js';
+import type { ParameterTypeClass } from 'gitnexus-shared';
 
 export interface CppArityInfo {
   parameterCount?: number;
   requiredParameterCount?: number;
   parameterTypes?: string[];
+  parameterTypeClasses?: ParameterTypeClass[];
 }
 
 /**
@@ -73,26 +75,35 @@ export function computeCppDeclarationArity(node: SyntaxNode): CppArityInfo {
   const totalNonVariadic = requiredCount + optionalCount;
 
   const types: string[] = [];
+  const typeClasses: ParameterTypeClass[] = [];
   for (const p of params) {
     if (p.type === 'variadic_parameter') {
       types.push('...');
+      typeClasses.push(unknownTypeClass('...'));
     } else if (p.type === 'variadic_parameter_declaration') {
       // Parameter pack: treated as variadic
       types.push('...');
+      typeClasses.push(unknownTypeClass('...'));
     } else {
       const typeNode = p.childForFieldName('type');
-      types.push(normalizeCppParamType(typeNode?.text ?? 'unknown'));
+      const rawType = typeNode?.text ?? 'unknown';
+      types.push(normalizeCppParamType(rawType));
+      typeClasses.push(
+        classifyCppParameterType(rawType, p.childForFieldName('declarator')?.text, p.text),
+      );
     }
   }
   // Append '...' for C-style variadic if not already in types
   if (hasEllipsis && !types.includes('...')) {
     types.push('...');
+    typeClasses.push(unknownTypeClass('...'));
   }
 
   return {
     parameterCount: isVariadic ? undefined : totalNonVariadic,
     requiredParameterCount: requiredCount,
     parameterTypes: types,
+    parameterTypeClasses: typeClasses,
   };
 }
 
@@ -120,6 +131,12 @@ export function computeCppCallArity(node: SyntaxNode): number {
  * so that `narrowOverloadCandidates` can match against literal-inferred
  * argument types (e.g. `inferCppLiteralType` returns `'string'` for
  * string literals, not `'std::string'`).
+ *
+ * This intentionally remains coarse and graph-ID-stable: cv-qualifiers,
+ * reference markers, and pointer markers are stripped here. C++ callers
+ * that need those distinctions should read `parameterTypeClasses`, which
+ * is an additive sidecar and does not participate in overload node ID
+ * hashing.
  */
 function normalizeCppParamType(raw: string): string {
   let t = raw.trim();
@@ -156,6 +173,52 @@ function normalizeCppParamType(raw: string): string {
     'std::nullptr_t': 'null',
   };
   return STD_MAP[t] ?? t;
+}
+
+export function classifyCppParameterType(
+  rawType: string,
+  declaratorText?: string,
+  fullParameterText?: string,
+): ParameterTypeClass {
+  const source = fullParameterText ?? `${rawType} ${declaratorText ?? ''}`.trim();
+  if (rawType === 'unknown') return unknownTypeClass('unknown');
+
+  const hasConst = /\bconst\b/.test(source);
+  const hasVolatile = /\bvolatile\b/.test(source);
+  const cv: ParameterTypeClass['cv'] =
+    hasConst && hasVolatile
+      ? 'const volatile'
+      : hasConst
+        ? 'const'
+        : hasVolatile
+          ? 'volatile'
+          : 'none';
+
+  const pointerDepth = (source.match(/\*/g) ?? []).length;
+  const indirection: ParameterTypeClass['indirection'] =
+    pointerDepth > 0
+      ? 'pointer'
+      : /&&/.test(source)
+        ? 'rvalue-ref'
+        : /&/.test(source)
+          ? 'lvalue-ref'
+          : 'value';
+
+  return {
+    base: normalizeCppParamType(rawType),
+    cv,
+    indirection,
+    pointerDepth,
+  };
+}
+
+function unknownTypeClass(base: string): ParameterTypeClass {
+  return {
+    base,
+    cv: 'unknown',
+    indirection: 'unknown',
+    pointerDepth: 0,
+  };
 }
 
 function findFuncDeclarator(node: SyntaxNode): SyntaxNode | null {

--- a/gitnexus/src/core/ingestion/languages/cpp/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/cpp/captures.ts
@@ -114,6 +114,13 @@ export function emitCppScopeCaptures(
             JSON.stringify(arity.parameterTypes),
           );
         }
+        if (arity.parameterTypeClasses !== undefined) {
+          grouped['@declaration.parameter-type-classes'] = syntheticCapture(
+            '@declaration.parameter-type-classes',
+            fnNode,
+            JSON.stringify(arity.parameterTypeClasses),
+          );
+        }
 
         // Detect static storage class (file-local linkage)
         if (hasStaticStorageClass(fnNode)) {

--- a/gitnexus/src/core/ingestion/model/symbol-table.ts
+++ b/gitnexus/src/core/ingestion/model/symbol-table.ts
@@ -34,7 +34,7 @@
  * logic up the dependency chain instead.
  */
 
-import type { NodeLabel, SymbolDefinition } from 'gitnexus-shared';
+import type { NodeLabel, ParameterTypeClass, SymbolDefinition } from 'gitnexus-shared';
 
 /**
  * Class-like NodeLabels — used for qualifiedName fallback inside
@@ -126,6 +126,7 @@ export interface AddMetadata {
   parameterCount?: number;
   requiredParameterCount?: number;
   parameterTypes?: string[];
+  parameterTypeClasses?: ParameterTypeClass[];
   returnType?: string;
   declaredType?: string;
   templateArguments?: string[];
@@ -275,6 +276,9 @@ export const createSymbolTable = (): InternalSymbolTable => {
         : {}),
       ...(metadata?.parameterTypes !== undefined
         ? { parameterTypes: metadata.parameterTypes }
+        : {}),
+      ...(metadata?.parameterTypeClasses !== undefined
+        ? { parameterTypeClasses: metadata.parameterTypeClasses }
         : {}),
       ...(metadata?.returnType !== undefined ? { returnType: metadata.returnType } : {}),
       ...(metadata?.declaredType !== undefined ? { declaredType: metadata.declaredType } : {}),

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -1,4 +1,4 @@
-import type { GraphNode, GraphRelationship, NodeLabel } from 'gitnexus-shared';
+import type { GraphNode, GraphRelationship, NodeLabel, ParameterTypeClass } from 'gitnexus-shared';
 import { KnowledgeGraph } from '../graph/types.js';
 import Parser from 'tree-sitter';
 import { loadParser, loadLanguage, isLanguageAvailable } from '../tree-sitter/parser-loader.js';
@@ -128,6 +128,7 @@ export const mergeChunkResults = (
         parameterCount: sym.parameterCount,
         requiredParameterCount: sym.requiredParameterCount,
         parameterTypes: sym.parameterTypes,
+        parameterTypeClasses: sym.parameterTypeClasses,
         returnType: sym.returnType,
         declaredType: sym.declaredType,
         templateArguments: sym.templateArguments,
@@ -744,6 +745,7 @@ const processParsingSequential = async (
         parameterCount: methodProps.parameterCount as number | undefined,
         requiredParameterCount: methodProps.requiredParameterCount as number | undefined,
         parameterTypes: methodProps.parameterTypes as string[] | undefined,
+        parameterTypeClasses: methodProps.parameterTypeClasses as ParameterTypeClass[] | undefined,
         returnType: methodProps.returnType as string | undefined,
         declaredType,
         templateArguments: classTemplateArguments,

--- a/gitnexus/src/core/ingestion/scope-extractor.ts
+++ b/gitnexus/src/core/ingestion/scope-extractor.ts
@@ -63,6 +63,7 @@ import type {
   BindingRef,
   CaptureMatch,
   ImportEdge,
+  ParameterTypeClass,
   ParsedFile,
   ParsedImport,
   ReferenceSite,
@@ -545,6 +546,9 @@ function buildDefFromDeclarationMatch(
   const parameterCount = parseIntCapture(match['@declaration.parameter-count']);
   const requiredParameterCount = parseIntCapture(match['@declaration.required-parameter-count']);
   const parameterTypes = parseJsonStringArrayCapture(match['@declaration.parameter-types']);
+  const parameterTypeClasses = parseJsonParameterTypeClassesCapture(
+    match['@declaration.parameter-type-classes'],
+  );
   const declaredType = match['@declaration.field-type']?.text;
   const returnType = match['@declaration.return-type']?.text;
 
@@ -556,6 +560,7 @@ function buildDefFromDeclarationMatch(
     ...(parameterCount !== undefined ? { parameterCount } : {}),
     ...(requiredParameterCount !== undefined ? { requiredParameterCount } : {}),
     ...(parameterTypes !== undefined ? { parameterTypes } : {}),
+    ...(parameterTypeClasses !== undefined ? { parameterTypeClasses } : {}),
     ...(declaredType !== undefined ? { declaredType } : {}),
     ...(returnType !== undefined ? { returnType } : {}),
     ...(templateArguments !== undefined ? { templateArguments } : {}),
@@ -566,6 +571,52 @@ function parseIntCapture(cap: { readonly text: string } | undefined): number | u
   if (cap === undefined) return undefined;
   const n = Number.parseInt(cap.text, 10);
   return Number.isFinite(n) ? n : undefined;
+}
+
+function parseJsonParameterTypeClassesCapture(
+  cap: { readonly text: string } | undefined,
+): ParameterTypeClass[] | undefined {
+  if (cap === undefined) return undefined;
+  try {
+    const parsed = JSON.parse(cap.text);
+    if (!Array.isArray(parsed)) return undefined;
+    const out: ParameterTypeClass[] = [];
+    for (const item of parsed) {
+      if (item === null || typeof item !== 'object') return undefined;
+      const o = item as Record<string, unknown>;
+      if (typeof o.base !== 'string') return undefined;
+      if (
+        o.cv !== 'none' &&
+        o.cv !== 'const' &&
+        o.cv !== 'volatile' &&
+        o.cv !== 'const volatile' &&
+        o.cv !== 'unknown'
+      ) {
+        return undefined;
+      }
+      if (
+        o.indirection !== 'value' &&
+        o.indirection !== 'lvalue-ref' &&
+        o.indirection !== 'rvalue-ref' &&
+        o.indirection !== 'pointer' &&
+        o.indirection !== 'unknown'
+      ) {
+        return undefined;
+      }
+      if (typeof o.pointerDepth !== 'number' || !Number.isFinite(o.pointerDepth)) {
+        return undefined;
+      }
+      out.push({
+        base: o.base,
+        cv: o.cv,
+        indirection: o.indirection,
+        pointerDepth: o.pointerDepth,
+      });
+    }
+    return out;
+  } catch {
+    return undefined;
+  }
 }
 
 function parseJsonStringArrayCapture(

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -71,7 +71,7 @@ import {
   isVueSetupTopLevel,
 } from '../vue-sfc-extractor.js';
 import type { NamedBinding } from '../named-bindings/types.js';
-import type { NodeLabel } from 'gitnexus-shared';
+import type { NodeLabel, ParameterTypeClass } from 'gitnexus-shared';
 import type { FieldInfo, FieldExtractorContext } from '../field-types.js';
 import type { MethodInfo, MethodExtractorContext } from '../method-types.js';
 import type { VariableExtractorContext } from '../variable-types.js';
@@ -128,6 +128,7 @@ interface ParsedSymbol {
   parameterCount?: number;
   requiredParameterCount?: number;
   parameterTypes?: string[];
+  parameterTypeClasses?: ParameterTypeClass[];
   returnType?: string;
   declaredType?: string;
   templateArguments?: string[];
@@ -2306,6 +2307,7 @@ const processFileGroup = (
         parameterCount: methodProps.parameterCount as number | undefined,
         requiredParameterCount: methodProps.requiredParameterCount as number | undefined,
         parameterTypes: methodProps.parameterTypes as string[] | undefined,
+        parameterTypeClasses: methodProps.parameterTypeClasses as ParameterTypeClass[] | undefined,
         returnType: methodProps.returnType as string | undefined,
         ...(declaredType !== undefined ? { declaredType } : {}),
         ...(classTemplateArguments !== undefined && classTemplateArguments.length > 0

--- a/gitnexus/test/unit/scope-resolution/cpp/cpp-arity.test.ts
+++ b/gitnexus/test/unit/scope-resolution/cpp/cpp-arity.test.ts
@@ -7,6 +7,7 @@ import { cppArityCompatibility } from '../../../../src/core/ingestion/languages/
 import {
   computeCppDeclarationArity,
   computeCppCallArity,
+  classifyCppParameterType,
 } from '../../../../src/core/ingestion/languages/cpp/arity-metadata.js';
 import { getCppParser } from '../../../../src/core/ingestion/languages/cpp/query.js';
 import type { SyntaxNode } from '../../../../src/core/ingestion/utils/ast-helpers.js';
@@ -97,6 +98,40 @@ describe('computeCppDeclarationArity', () => {
     expect(node).not.toBeNull();
     const arity = computeCppDeclarationArity(node!);
     expect(arity.parameterCount).toBe(1);
+  });
+
+  it('keeps coarse parameterTypes stable while preserving pointer/reference sidecar classes', () => {
+    const node = parseFuncDef('void f(int value, const int* ptr, int& ref, int&& move) {}');
+    expect(node).not.toBeNull();
+    const arity = computeCppDeclarationArity(node!);
+    expect(arity.parameterTypes).toEqual(['int', 'int', 'int', 'int']);
+    expect(arity.parameterTypeClasses).toEqual([
+      { base: 'int', cv: 'none', indirection: 'value', pointerDepth: 0 },
+      { base: 'int', cv: 'const', indirection: 'pointer', pointerDepth: 1 },
+      { base: 'int', cv: 'none', indirection: 'lvalue-ref', pointerDepth: 0 },
+      { base: 'int', cv: 'none', indirection: 'rvalue-ref', pointerDepth: 0 },
+    ]);
+  });
+
+  it('classifies int, int*, and int& as distinct sidecar shapes for future is_same_v consumers', () => {
+    expect(classifyCppParameterType('int')).toEqual({
+      base: 'int',
+      cv: 'none',
+      indirection: 'value',
+      pointerDepth: 0,
+    });
+    expect(classifyCppParameterType('int', '* p')).toEqual({
+      base: 'int',
+      cv: 'none',
+      indirection: 'pointer',
+      pointerDepth: 1,
+    });
+    expect(classifyCppParameterType('int', '& r')).toEqual({
+      base: 'int',
+      cv: 'none',
+      indirection: 'lvalue-ref',
+      pointerDepth: 0,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add an additive `parameterTypeClasses` sidecar on `SymbolDefinition`
- preserve C++ cv/ref/pointer shape from parameter declarations while keeping coarse `parameterTypes` unchanged
- thread the sidecar through C++ scope captures and symbol-table metadata
- document that the sidecar does not participate in graph node identity

Fixes #1630

## Tests
- npx vitest run test/unit/scope-resolution/cpp/cpp-arity.test.ts
- npx tsc --noEmit
- npx vitest run test/integration/resolvers/cpp.test.ts
- REGISTRY_PRIMARY_CPP=0 npx vitest run test/integration/resolvers/cpp.test.ts
- git diff --check

Note: `npx gitnexus impact ...` / `detect_changes ...` currently exit 1 with no output in this checkout because the local GitNexus index/registry is unavailable, so the change was kept narrowly scoped and validated manually with the C++ resolver suites.
