### PR TITLE
fix(extractors): match `mux.HandleFunc` and method-reference handlers

### DIFF
--- a/gitnexus/src/core/group/extractors/http-patterns/go.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/go.ts
@@ -37,7 +37,17 @@ const FRAMEWORK_ROUTE_PATTERNS = compilePatterns({
   ],
 } satisfies LanguagePatterns<Record<string, never>>);
 
-// ─── Provider: net/http `http.HandleFunc("/p", handler)` ─────────────
+// ─── Provider: any `<receiver>.HandleFunc("/p", handler)` ────────────
+// Matches the stdlib `http.HandleFunc(...)` form AND the idiomatic
+// `mux.HandleFunc(...)` / `router.HandleFunc(...)` form used by code
+// that wires a local `*http.ServeMux` or gorilla/mux router. The
+// operand is not constrained to a particular identifier; the field
+// name `HandleFunc` plus the (path, handler) argument shape is
+// sufficient signal to identify a stdlib-compatible route registration.
+//
+// Two pattern variants cover both bare-identifier handlers
+// (`HandleFunc("/p", handler)`) and method-reference handlers
+// (`HandleFunc("/p", apiHandler.Foo)`), which are equally common.
 const HANDLE_FUNC_PATTERNS = compilePatterns({
   name: 'go-handle-func',
   language: Go,
@@ -47,11 +57,21 @@ const HANDLE_FUNC_PATTERNS = compilePatterns({
       query: `
         (call_expression
           function: (selector_expression
-            operand: (identifier) @pkg (#eq? @pkg "http")
             field: (field_identifier) @fn (#eq? @fn "HandleFunc"))
           arguments: (argument_list
             (interpreted_string_literal) @path
             (identifier) @handler))
+      `,
+    },
+    {
+      meta: {},
+      query: `
+        (call_expression
+          function: (selector_expression
+            field: (field_identifier) @fn (#eq? @fn "HandleFunc"))
+          arguments: (argument_list
+            (interpreted_string_literal) @path
+            (selector_expression) @handler))
       `,
     },
   ],

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -223,6 +223,54 @@ func main() {
       expect(healthRoute?.symbolName).toBe('healthHandler');
     });
 
+    it('extracts mux.HandleFunc providers (local ServeMux receiver)', async () => {
+      const dir = path.join(tmpDir, 'go-mux-provider');
+      fs.mkdirSync(path.join(dir, 'cmd'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'cmd', 'server.go'),
+        `
+package main
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {}
+
+func main() {
+  mux := http.NewServeMux()
+  mux.HandleFunc("/api/health", healthHandler)
+}
+`,
+      );
+
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      const providers = contracts.filter((c) => c.role === 'provider');
+
+      const healthRoute = providers.find((c) => c.contractId === 'http::GET::/api/health');
+      expect(healthRoute).toBeDefined();
+      expect(healthRoute?.symbolName).toBe('healthHandler');
+    });
+
+    it('extracts HandleFunc providers with method-reference handlers', async () => {
+      const dir = path.join(tmpDir, 'go-method-handler-provider');
+      fs.mkdirSync(path.join(dir, 'cmd'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'cmd', 'server.go'),
+        `
+package main
+
+func main() {
+  mux := http.NewServeMux()
+  mux.HandleFunc("/api/users", apiHandler.ListUsers)
+}
+`,
+      );
+
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      const providers = contracts.filter((c) => c.role === 'provider');
+
+      const usersRoute = providers.find((c) => c.contractId === 'http::GET::/api/users');
+      expect(usersRoute).toBeDefined();
+      expect(usersRoute?.symbolName).toBe('apiHandler.ListUsers');
+    });
+
     it('extracts NestJS controller decorators', async () => {
       const dir = path.join(tmpDir, 'nestjs');
       fs.mkdirSync(path.join(dir, 'src'), { recursive: true });


### PR DESCRIPTION
Closes #1668.

## What

The Go HTTP provider extractor at `gitnexus/src/core/group/extractors/http-patterns/go.ts` hard-coded the operand identifier as `http` and the handler argument as a bare `identifier`. Two idiomatic Go patterns are silently dropped as a result:

1. **Local-receiver routers** -- `mux.HandleFunc(...)` / `router.HandleFunc(...)`. This is the canonical pattern for code that wires routes onto a local `*http.ServeMux` or `gorilla/mux.Router` rather than the package-level `http.DefaultServeMux`.
2. **Method-reference handlers** -- `mux.HandleFunc(\"/p\", h.Foo)`, where the handler arg is a `selector_expression` rather than an `identifier`.

## How

- Drop the operand constraint -- `HandleFunc` as a field name plus the (string, callable) argument shape is sufficient signal.
- Emit a second pattern variant that accepts `selector_expression` handlers.

## Verify

\`\`\`bash
cd gitnexus
npx tsc --noEmit
npx vitest run test/unit/group/http-route-extractor.test.ts -t HandleFunc
\`\`\`

Three tests pass: the existing \`http.HandleFunc\` test plus two new ones covering \`mux.HandleFunc\` (local ServeMux) and method-reference handlers.

## Risk

Low. The new patterns are strictly broader than the old one; the existing stdlib-`http.HandleFunc` form continues to match. No call sites changed.