### PR TITLE
fix(extractors): emit HandleFunc providers for all common verbs

### DIFF
--- a/gitnexus/src/core/group/extractors/http-patterns/go.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/go.ts
@@ -148,21 +148,31 @@ export const GO_HTTP_PLUGIN: HttpLanguagePlugin = {
       });
     }
 
-    // net/http HandleFunc: default method GET
+    // net/http HandleFunc: registers a handler for ALL HTTP methods.
+    // The method check happens inside the handler body, not at
+    // registration. Emitting only method='GET' silently breaks
+    // cross-repo matching for every consumer doing POST/PUT/DELETE/
+    // PATCH against a HandleFunc-registered route. Emit one
+    // detection per common verb so the matcher can pair any
+    // consumer method; confidence is lowered (0.6) since we don't
+    // actually know which methods the handler accepts.
+    const HANDLE_FUNC_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] as const;
     for (const match of runCompiledPatterns(HANDLE_FUNC_PATTERNS, tree)) {
       const pathNode = match.captures.path;
       const handlerNode = match.captures.handler;
       if (!pathNode) continue;
       const path = unquoteLiteral(pathNode.text);
       if (path === null) continue;
-      out.push({
-        role: 'provider',
-        framework: 'go-stdlib',
-        method: 'GET',
-        path,
-        name: handlerNode?.text ?? null,
-        confidence: 0.8,
-      });
+      for (const method of HANDLE_FUNC_METHODS) {
+        out.push({
+          role: 'provider',
+          framework: 'go-stdlib',
+          method,
+          path,
+          name: handlerNode?.text ?? null,
+          confidence: 0.6,
+        });
+      }
     }
 
     // net/http client: http.Get/Post/Head

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -199,7 +199,7 @@ func main() {
       expect(echoRoute?.symbolName).toBe('listOrders');
     });
 
-    it('extracts stdlib HandleFunc providers', async () => {
+    it('extracts stdlib HandleFunc providers (all common verbs)', async () => {
       const dir = path.join(tmpDir, 'go-stdlib-provider');
       fs.mkdirSync(path.join(dir, 'cmd'), { recursive: true });
       fs.writeFileSync(
@@ -218,9 +218,14 @@ func main() {
       const contracts = await extractor.extract(null, dir, makeRepo(dir));
       const providers = contracts.filter((c) => c.role === 'provider');
 
-      const healthRoute = providers.find((c) => c.contractId === 'http::GET::/api/health');
-      expect(healthRoute).toBeDefined();
-      expect(healthRoute?.symbolName).toBe('healthHandler');
+      // HandleFunc registers a handler for ALL methods; the matcher
+      // needs one provider entry per common verb so non-GET consumer
+      // calls (POST /api/health, etc.) still cross-link.
+      for (const method of ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']) {
+        const route = providers.find((c) => c.contractId === `http::${method}::/api/health`);
+        expect(route, `expected ${method} /api/health provider`).toBeDefined();
+        expect(route?.symbolName).toBe('healthHandler');
+      }
     });
 
     it('extracts NestJS controller decorators', async () => {


### PR DESCRIPTION
Closes #1670.

## What

`net/http.HandleFunc` registers a handler for **all** HTTP methods; the method dispatch happens inside the handler body, not at registration. The extractor was hard-coding `method: 'GET'`, so any consumer doing POST/PUT/DELETE/PATCH against a HandleFunc-registered provider failed the exact-match cascade and never cross-linked.

## How

Emit one provider detection per common verb (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`) for each HandleFunc call. Confidence drops from 0.8 to 0.6 to reflect that we don't actually know which methods the handler accepts (it's a registration-time inference, not a declaration).

## Verify

\`\`\`bash
cd gitnexus
npx tsc --noEmit
npx vitest run test/unit/group/http-route-extractor.test.ts -t HandleFunc
\`\`\`

The existing test grew an assertion loop covering all five verbs.

## Risk

- Provider rows grow 5x for each HandleFunc call (a few hundred per typical Go service). Memory + sync time impact is small; the matcher dedups by contractId before output.
- Confidence drop from 0.8 to 0.6 puts these slightly below framework routes (gin/echo/chi at 0.8) for tiebreaking. Intentional -- we genuinely have less information.

## Alternative considered

Emit a single provider with a sentinel `ANY` method and teach the matcher to treat it as a wildcard. More invasive (matcher changes + a meta field), so the per-verb emission is the smaller surface.