### PR TITLE
fix(extractors): union graph + source-scan strategies in HTTP route extractor

### DIFF
--- a/gitnexus/src/core/group/extractors/http-route-extractor.ts
+++ b/gitnexus/src/core/group/extractors/http-route-extractor.ts
@@ -192,21 +192,47 @@ export class HttpRouteExtractor implements ContractExtractor {
       return scannedFiles;
     };
 
+    // Polyglot-repo correctness: union the graph-assisted (Strategy A)
+    // and source-scan (Strategy B) results, with graph entries
+    // preferred on contractId collisions for their richer symbol
+    // metadata. The previous ternary fell back to source-scan ONLY
+    // when the graph returned zero entries -- which means in a repo
+    // where one language has a route ingester (e.g. Python's
+    // @app.get / Java's @RequestMapping populate HANDLES_ROUTE
+    // edges) and another doesn't (e.g. Go's mux.HandleFunc), the
+    // source-scan path is skipped for the WHOLE repo and the
+    // non-ingested language's providers are silently dropped.
     const graphProviders =
       dbExecutor != null ? await this.extractProvidersGraph(dbExecutor, getDetections) : [];
-    const providers =
-      graphProviders.length > 0
-        ? graphProviders
-        : this.extractProvidersSourceScan(await getScannedFiles(), getDetections);
+    const providers = await this.unionGraphAndSourceScan(graphProviders, async () =>
+      this.extractProvidersSourceScan(await getScannedFiles(), getDetections),
+    );
 
     const graphConsumers =
       dbExecutor != null ? await this.extractConsumersGraph(dbExecutor, getDetections) : [];
-    const consumers =
-      graphConsumers.length > 0
-        ? graphConsumers
-        : this.extractConsumersSourceScan(await getScannedFiles(), getDetections);
+    const consumers = await this.unionGraphAndSourceScan(graphConsumers, async () =>
+      this.extractConsumersSourceScan(await getScannedFiles(), getDetections),
+    );
 
     return [...providers, ...consumers];
+  }
+
+  /**
+   * Merge graph-assisted contracts with source-scan contracts, preferring
+   * graph entries on `contractId` collisions. Source-scan is invoked
+   * lazily so we don't pay the glob+parse cost when the per-language
+   * supplement isn't needed (e.g. a homogenous Java repo where every
+   * provider already has a HANDLES_ROUTE edge from the ingestion
+   * pipeline). Callers should still await it; the laziness here is just
+   * about ordering and dedup keying.
+   */
+  private async unionGraphAndSourceScan<T extends { contractId: string }>(
+    graph: T[],
+    sourceScan: () => Promise<T[]>,
+  ): Promise<T[]> {
+    const seen = new Set(graph.map((c) => c.contractId));
+    const supplemental = (await sourceScan()).filter((c) => !seen.has(c.contractId));
+    return [...graph, ...supplemental];
   }
 
   private async scanFiles(repoPath: string): Promise<string[]> {

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -94,6 +94,83 @@ public class UserController {
     });
   });
 
+  describe('provider extraction — graph + source-scan union (polyglot repo)', () => {
+    it('does not drop source-scan providers in another language when graph returns any entries', async () => {
+      // Polyglot repo: a Java file is registered in HANDLES_ROUTE (graph
+      // strategy returns one provider), and a Go file has a stdlib
+      // HandleFunc registration that no ingester populated. The union
+      // must include both -- previously the source-scan fallback was
+      // skipped entirely the moment the graph returned any entries.
+      const dir = path.join(tmpDir, 'polyglot');
+      fs.mkdirSync(path.join(dir, 'src/controller'), { recursive: true });
+      fs.mkdirSync(path.join(dir, 'cmd'), { recursive: true });
+
+      fs.writeFileSync(
+        path.join(dir, 'src/controller/UserController.java'),
+        `
+@RestController
+@RequestMapping("/api/v2")
+public class UserController {
+    @GetMapping("/users")
+    public List<User> list() { return service.findAll(); }
+}
+`,
+      );
+
+      fs.writeFileSync(
+        path.join(dir, 'cmd', 'server.go'),
+        `
+package main
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {}
+
+func main() {
+  http.HandleFunc("/api/health", healthHandler)
+}
+`,
+      );
+
+      const mockDbExecutor = async (query: string) => {
+        if (query.includes('HANDLES_ROUTE')) {
+          return [
+            {
+              fileId: 'file-uid-ctrl',
+              filePath: 'src/controller/UserController.java',
+              routePath: '/api/v2/users',
+              routeId: 'route-uid-users',
+              responseKeys: null,
+              routeSource: 'decorator-GetMapping',
+            },
+          ];
+        }
+        if (query.includes('CONTAINS')) {
+          return [
+            {
+              uid: 'uid-ctrl-list',
+              name: 'list',
+              filePath: 'src/controller/UserController.java',
+              labels: ['Method'],
+            },
+          ];
+        }
+        return [];
+      };
+
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const providers = contracts.filter((c) => c.role === 'provider');
+
+      // Graph-derived Java provider
+      const javaRoute = providers.find((c) => c.contractId === 'http::GET::/api/v2/users');
+      expect(javaRoute, 'expected graph-derived Java provider').toBeDefined();
+
+      // Source-scan-derived Go provider must NOT be dropped just because
+      // the graph returned a row for a different file.
+      const goRoute = providers.find((c) => c.contractId === 'http::GET::/api/health');
+      expect(goRoute, 'expected source-scan Go provider to survive the union').toBeDefined();
+      expect(goRoute?.symbolName).toBe('healthHandler');
+    });
+  });
+
   describe('provider extraction — source-scan fallback (Strategy B)', () => {
     it('extracts Spring @GetMapping annotation', async () => {
       const dir = path.join(tmpDir, 'spring');


### PR DESCRIPTION
Closes #1672.

## What

`HttpRouteExtractor` orchestrator fell back to source-scan only when graph-assisted Strategy A returned zero entries. In a polyglot repo this drops providers as soon as one language's ingester populates a single `HANDLES_ROUTE` edge.

## How

Replace the ternary with a union:

\`\`\`ts
private async unionGraphAndSourceScan<T extends { contractId: string }>(
  graph: T[],
  sourceScan: () => Promise<T[]>,
): Promise<T[]> {
  const seen = new Set(graph.map((c) => c.contractId));
  const supplemental = (await sourceScan()).filter((c) => !seen.has(c.contractId));
  return [...graph, ...supplemental];
}
\`\`\`

Graph entries are emitted first and their `contractId`s are taken as authoritative (richer `symbolUid`, real handler names). Source-scan entries that introduce **new** `contractId`s are appended. Source-scan rows that overlap graph rows are dropped, so we don't double-count.

Same logic applies symmetrically to consumers.

## Verify

\`\`\`bash
cd gitnexus
npx tsc --noEmit
npx vitest run test/unit/group/http-route-extractor.test.ts
\`\`\`

30/30 pass. The new polyglot test mixes a graph-resident Java provider with a source-scan-only Go provider and confirms both survive the union.

## Risk

- **Slightly more work in homogeneous-language repos**: source-scan now always runs even when graph returned full coverage. The glob is cheap (single pass, ignore-aware) and detections are cached per file via `getDetections`, so the realistic cost is one extra dedup pass.
- **No matcher changes**: dedup is on `contractId`, which is already the matcher's identity.
- **No behaviour change for repos that previously returned zero graph entries** -- they continue to get pure source-scan results.