### PR TITLE
fix(extractors): strip Python string prefixes (f/r/b/u) in `unquoteLiteral`

### DIFF
--- a/gitnexus/src/core/group/extractors/tree-sitter-scanner.ts
+++ b/gitnexus/src/core/group/extractors/tree-sitter-scanner.ts
@@ -174,6 +174,17 @@ export function scanFile<TMeta>(
 export function unquoteLiteral(raw: string): string | null {
   if (!raw) return null;
 
+  // Strip Python string prefixes (`f`, `r`, `b`, `u`, and their two-letter
+  // combinations `fr`/`rf`/`br`/`rb`/`bf` etc.) when followed by a quote.
+  // Without this, f-strings like `f"{x}/api/foo"` survive unquoting with
+  // the `f"` prefix intact, which then poisons downstream path
+  // normalization with literal `f"` at the start of every consumer URL.
+  // The lookahead constraint (`(?=["'`])`) keeps this Python-specific:
+  // the only way 1-2 letters from this set can appear immediately before
+  // a quote in Java/Go/JS/TS source is also a string literal, where
+  // stripping them is harmless because the next pass unquotes the rest.
+  raw = raw.replace(/^[fFrRbBuU]{1,2}(?=["'`])/, '');
+
   // Python triple-quoted
   if (
     (raw.startsWith('"""') && raw.endsWith('"""')) ||

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -436,6 +436,58 @@ def create_order():
         consumers.find((c) => c.contractId === 'http::POST::/api/orders/{param}'),
       ).toBeDefined();
     });
+
+    it('strips Python string prefixes (f/r/b/u) before path normalization', async () => {
+      // Without prefix handling, an f-string `f"{base}/api/items"` survives
+      // unquoteLiteral as `f"{base}/api/items"` (the `f` is part of the raw
+      // token, not the quotes). It then poisons the consumer contractId
+      // with a literal `f"` at the start of the path. Cover the common
+      // prefixes here so the regression is visible.
+      const dir = path.join(tmpDir, 'python-prefix-consumer');
+      fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'src', 'client.py'),
+        `
+import requests
+
+BASE = "https://svc.local"
+
+def call_fstring():
+    return requests.get(f"{BASE}/api/items")
+
+def call_raw():
+    return requests.get(r"/api/raw")
+
+def call_bytes():
+    return requests.request("PUT", b"/api/bytes")
+`,
+      );
+
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      const consumers = contracts.filter((c) => c.role === 'consumer');
+
+      // f-string: `{BASE}` collapses to `{param}` (a base-URL placeholder
+      // appearing as a path segment). We're not trying to be smart about
+      // that here; the test only asserts the `f"` prefix is gone.
+      const fstring = consumers.find((c) =>
+        c.contractId.startsWith('http::GET::') &&
+        c.contractId.includes('/api/items') &&
+        !c.contractId.includes('f"'),
+      );
+      expect(fstring, 'expected f-string consumer with no literal f"').toBeDefined();
+
+      // Raw string: the `r` prefix should also disappear.
+      expect(
+        consumers.find((c) => c.contractId === 'http::GET::/api/raw'),
+        'expected r-string consumer to normalize cleanly',
+      ).toBeDefined();
+
+      // Bytes literal: `b"/api/bytes"` should still produce a consumer entry.
+      expect(
+        consumers.find((c) => c.contractId === 'http::PUT::/api/bytes'),
+        'expected b-string consumer to normalize cleanly',
+      ).toBeDefined();
+    });
     it('extracts Python httpx.AsyncClient calls assigned to attributes or aliases', async () => {
       const dir = path.join(tmpDir, 'python-httpx-consumer');
       fs.mkdirSync(path.join(dir, 'src'), { recursive: true });


### PR DESCRIPTION
Closes #1675.

## What

`unquoteLiteral` inspected only the first and last characters of the raw token, so Python f-strings / r-strings / b-strings survived with their **prefix** intact. Every Python f-string URL ended up with a literal `f\"` baked into the consumer `contractId`, locking the matcher out.

## How

One-liner before the quote-pair check:

\`\`\`ts
raw = raw.replace(/^[fFrRbBuU]{1,2}(?=[\"'\`])/, '');
\`\`\`

Lookahead keeps it Python-specific in practice — 1-2 letters from that set followed by a quote don't appear in Java/Go/JS/TS string literals.

## Verify

\`\`\`bash
cd gitnexus
npx tsc --noEmit
npx vitest run test/unit/group/http-route-extractor.test.ts
\`\`\`

30/30 pass. The new test covers all three prefix flavours (`f\"...\"`, `r\"...\"`, `b\"...\"`).

## Risk

Low. The replace only triggers when the leading 1-2 chars are letters from `[fFrRbBuU]` AND the next char is a quote. The only way that matches in non-Python source is also a string literal whose body would have been preserved verbatim afterwards — stripping the prefix is harmless because the quote-pair check still unwraps the rest.

## Out of scope

Not addressing the base-URL-placeholder issue (`{BASE}/api/items` -> `/api/items`); that's a separate design call.