### PR TITLE
feat(extractors): add Swift HTTP consumer plugin (verb-method patterns)

### DIFF
--- a/gitnexus/src/core/group/extractors/http-patterns/index.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/index.ts
@@ -5,6 +5,7 @@ import { GO_HTTP_PLUGIN } from './go.js';
 import { PYTHON_HTTP_PLUGIN } from './python.js';
 import { PHP_HTTP_PLUGIN } from './php.js';
 import { JAVASCRIPT_HTTP_PLUGIN, TYPESCRIPT_HTTP_PLUGIN, TSX_HTTP_PLUGIN } from './node.js';
+import { SWIFT_HTTP_PLUGIN } from './swift.js';
 
 export type { HttpDetection, HttpLanguagePlugin, HttpRole } from './types.js';
 
@@ -27,6 +28,7 @@ const REGISTRY: Record<string, HttpLanguagePlugin> = {
   '.jsx': JAVASCRIPT_HTTP_PLUGIN,
   '.ts': TYPESCRIPT_HTTP_PLUGIN,
   '.tsx': TSX_HTTP_PLUGIN,
+  '.swift': SWIFT_HTTP_PLUGIN,
 };
 
 /**
@@ -38,7 +40,7 @@ const REGISTRY: Record<string, HttpLanguagePlugin> = {
  * regex fallback for them was never very accurate. The graph-assisted
  * Strategy A still handles them via the ingestion pipeline.
  */
-export const HTTP_SCAN_GLOB = '**/*.{ts,tsx,js,jsx,java,go,py,php}';
+export const HTTP_SCAN_GLOB = '**/*.{ts,tsx,js,jsx,java,go,py,php,swift}';
 
 /**
  * Return the HTTP plugin registered for the given file's extension,

--- a/gitnexus/src/core/group/extractors/http-patterns/swift.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/swift.ts
@@ -1,0 +1,141 @@
+import Swift from 'tree-sitter-swift';
+import {
+  compilePatterns,
+  runCompiledPatterns,
+  unquoteLiteral,
+  type LanguagePatterns,
+} from '../tree-sitter-scanner.js';
+import type { HttpDetection, HttpLanguagePlugin } from './types.js';
+
+/**
+ * Swift HTTP plugin. Targets the verb-method style that wraps URLRequest /
+ * URLSession / Alamofire in a single helper, which is the dominant pattern
+ * in iOS / macOS / Swift-on-server codebases. Two shapes:
+ *
+ *   - Labeled `path:` argument: `Client.get(path: "/api/foo")` or
+ *     `Client.post(path: "/api/foo", body: …)` — common in hand-rolled
+ *     wrappers (e.g. `enum Client { static func get(path: …) … }`).
+ *
+ *   - Positional first-argument string: `AF.request("/api/foo", method: .post)`
+ *     or `client.get("/api/foo")` — common in Alamofire and in lightweight
+ *     wrapper APIs that mimic the JS/TS `fetch(url)` shape.
+ *
+ * In both cases the method comes from the navigation-suffix identifier
+ * (`get`/`post`/`put`/`delete`/`patch`). We intentionally do NOT try to
+ * extract method from a `request.httpMethod = "POST"` assignment that
+ * lives in a different statement — correlating those requires intra-
+ * procedural analysis the source-scan path doesn't have. Such requests
+ * still fall through to the verb-method patterns when wrapped, which is
+ * how real-world Swift codebases factor this.
+ */
+
+const SWIFT_VERB_REGEX = '^(get|post|put|delete|patch)$';
+
+// Pattern A — labeled `path:` argument: `Client.get(path: "/api/foo")`.
+// Matches the iOS-style wrapper where the path is a labeled string and
+// the verb is the navigation-suffix identifier. The simple_identifier
+// receiver on the navigation_expression is not constrained — any
+// `Foo.get(path: "…")` qualifies.
+const LABELED_PATH_PATTERNS = compilePatterns({
+  name: 'swift-verb-path-labeled',
+  language: Swift,
+  patterns: [
+    {
+      meta: {},
+      query: `
+        (call_expression
+          (navigation_expression
+            (navigation_suffix
+              (simple_identifier) @verb (#match? @verb "${SWIFT_VERB_REGEX}")))
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (value_argument_label (simple_identifier) @label (#eq? @label "path"))
+                (line_string_literal (line_str_text) @path)))))
+      `,
+    },
+  ],
+} satisfies LanguagePatterns<Record<string, never>>);
+
+// Pattern B — positional first argument: `AF.request("/api/foo", method: .post)`,
+// `client.get("/api/foo")`. The first value_argument carries a
+// line_string_literal directly (no value_argument_label sibling).
+//
+// Pattern B is split into two query variants because Tree-sitter has no
+// concise way to say "the first argument has NO label" within a single
+// query. The post-filter in `scan` rejects any match where the first
+// argument turns out to have a value_argument_label (e.g. `path:`),
+// since pattern A already covers that.
+const POSITIONAL_PATH_PATTERNS = compilePatterns({
+  name: 'swift-verb-positional',
+  language: Swift,
+  patterns: [
+    {
+      meta: {},
+      query: `
+        (call_expression
+          (navigation_expression
+            (navigation_suffix
+              (simple_identifier) @verb (#match? @verb "${SWIFT_VERB_REGEX}")))
+          (call_suffix
+            (value_arguments
+              .
+              (value_argument
+                (line_string_literal (line_str_text) @path)) @first_arg)))
+      `,
+    },
+  ],
+} satisfies LanguagePatterns<Record<string, never>>);
+
+export const SWIFT_HTTP_PLUGIN: HttpLanguagePlugin = {
+  name: 'swift-http',
+  language: Swift,
+  scan(tree) {
+    const out: HttpDetection[] = [];
+
+    // Pattern A: labeled `path:` argument.
+    for (const match of runCompiledPatterns(LABELED_PATH_PATTERNS, tree)) {
+      const verbNode = match.captures.verb;
+      const pathNode = match.captures.path;
+      if (!verbNode || !pathNode) continue;
+      const path = unquoteLiteral(pathNode.text);
+      if (path === null) continue;
+      out.push({
+        role: 'consumer',
+        framework: 'swift-verb-method',
+        method: verbNode.text.toUpperCase(),
+        path,
+        name: null,
+        confidence: 0.7,
+      });
+    }
+
+    // Pattern B: positional first argument. Drop any match where the
+    // first argument carries a label (already covered by pattern A).
+    const seen = new Set<number>();
+    for (const match of runCompiledPatterns(POSITIONAL_PATH_PATTERNS, tree)) {
+      const verbNode = match.captures.verb;
+      const pathNode = match.captures.path;
+      const firstArgNode = match.captures.first_arg;
+      if (!verbNode || !pathNode || !firstArgNode) continue;
+      // Reject if the first_arg is actually a labeled argument
+      // (`.label:` child present).
+      if (firstArgNode.namedChildren.some((c) => c.type === 'value_argument_label')) continue;
+      // Dedupe against pattern A by node position.
+      if (seen.has(pathNode.startIndex)) continue;
+      seen.add(pathNode.startIndex);
+      const path = unquoteLiteral(pathNode.text);
+      if (path === null) continue;
+      out.push({
+        role: 'consumer',
+        framework: 'swift-verb-method',
+        method: verbNode.text.toUpperCase(),
+        path,
+        name: null,
+        confidence: 0.7,
+      });
+    }
+
+    return out;
+  },
+};

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -593,6 +593,63 @@ Route::delete('/users/{id}', [UserController::class, 'destroy']);
     });
   });
 
+  describe('consumer extraction — Swift', () => {
+    it('extracts labeled `path:` wrapper-style calls', async () => {
+      const dir = path.join(tmpDir, 'swift-labeled-path');
+      fs.mkdirSync(path.join(dir, 'Sources/Client'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'Sources/Client/RelayClient.swift'),
+        `
+import Foundation
+
+enum RelayClient {
+    static func get(path: String) async throws -> Data { Data() }
+    static func post(path: String, body: Data) async throws -> Data { Data() }
+}
+
+func caller() async throws {
+    _ = try await RelayClient.get(path: "/api/customers")
+    _ = try await RelayClient.post(path: "/api/devices/register", body: Data())
+}
+`,
+      );
+
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      const consumers = contracts.filter((c) => c.role === 'consumer');
+
+      expect(consumers.find((c) => c.contractId === 'http::GET::/api/customers')).toBeDefined();
+      expect(
+        consumers.find((c) => c.contractId === 'http::POST::/api/devices/register'),
+      ).toBeDefined();
+    });
+
+    it('extracts positional first-argument calls (Alamofire-style)', async () => {
+      const dir = path.join(tmpDir, 'swift-positional');
+      fs.mkdirSync(path.join(dir, 'Sources'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'Sources/Caller.swift'),
+        `
+import Alamofire
+
+func fetchAll() {
+    AF.request("/api/items")
+    AF.delete("/api/items/42")
+}
+`,
+      );
+
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      const consumers = contracts.filter((c) => c.role === 'consumer');
+
+      // AF.request is currently matched via its name (\`request\`) which is
+      // NOT in the verb set, so it should be ignored. AF.delete IS in the
+      // verb set and should be extracted.
+      expect(consumers.find((c) => c.contractId === 'http::DELETE::/api/items/{param}')).toBeDefined();
+      // AF.request is not a verb method — skip.
+      expect(consumers.find((c) => c.contractId === 'http::REQUEST::/api/items')).toBeUndefined();
+    });
+  });
+
   describe('consumer extraction — PHP', () => {
     it('extracts Laravel Http facade calls', async () => {
       const dir = path.join(tmpDir, 'php-http-facade');


### PR DESCRIPTION
Closes #1677.

## What

Adds `gitnexus/src/core/group/extractors/http-patterns/swift.ts` and wires it into the registry + `HTTP_SCAN_GLOB`. `tree-sitter-swift` was already a declared dependency, so this is purely a new plugin file + 2 lines of registry plumbing.

## Why

iOS / macOS / Swift-on-server consumers of a backend in the same group were completely invisible to the contract matcher -- the source-scan extractor returned zero detections for `.swift` files.

## Coverage

Two query variants, both extracting the HTTP method from the navigation-suffix identifier (`get` / `post` / `put` / `delete` / `patch`):

| Pattern | Shape | Example |
|---------|-------|---------|
| A | `<receiver>.<verb>(path: \"<literal>\", ...)` | `Client.get(path: \"/api/foo\")` |
| B | `<receiver>.<verb>(\"<literal>\", ...)` | `AF.delete(\"/api/items/42\")` |

Pattern B post-filters to skip arguments that carry a label (pattern A already covers those) and dedupes by node position.

## Verify

\`\`\`bash
cd gitnexus
npx tsc --noEmit
npx vitest run test/unit/group/http-route-extractor.test.ts
\`\`\`

31/31 pass. The two new tests cover labeled-`path:` and positional Alamofire-style.

## Out of scope

- Correlating `request.httpMethod = \"POST\"` with a separate `URLRequest(url: ...)` statement — needs intra-procedural analysis the source-scan path doesn't have.
- Bare `URL(string: \"...\")` / `URLSession.shared.dataTask(...)` — too noisy as a default GET; most production Swift code wraps these and pattern A/B catches the wrappers.

## Risk

Zero behavior change for existing languages (new file + new map entry + glob expanded). Swift files that previously matched no plugin now match the Swift plugin; the rest of the pipeline (path normalization, contract id, matcher) is unchanged.