### PR TITLE
fix(grpc): exclude build-tool config files from proto scan

### DIFF
--- a/gitnexus/src/core/group/extractors/grpc-extractor.ts
+++ b/gitnexus/src/core/group/extractors/grpc-extractor.ts
@@ -35,6 +35,20 @@ import {
  *    tree-sitter grammars or query strings — each plugin owns its own.
  */
 
+// ─── Build-tool config file filter ───────────────────────────────────────────
+//
+// Matches well-known build-tool config files by name convention.
+// These files are never gRPC sources but can trigger false-positive contracts
+// when their plugin instantiation patterns look like `loadPackageDefinition`.
+//
+// Only files whose names follow established build-tool conventions are excluded.
+// Generic names like `grpc.config.ts` or `server.config.ts` are intentionally
+// left unfiltered — they may contain legitimate gRPC client setup.
+//
+// @internal exported for testing only
+export const BUILD_TOOL_CONFIG_RE =
+  /(?:^|\/)(webpack|rollup|vite|esbuild|babel|jest|vitest|postcss|tailwind|next|nuxt|svelte|astro)\.config(\.[^/]+)?\.[cm]?[jt]sx?$/i;
+
 // ─── .proto fallback parser (used only when tree-sitter-proto is absent) ───
 
 function contractId(pkg: string, service: string, method: string): string {
@@ -419,9 +433,21 @@ export class GrpcExtractor implements ContractExtractor {
       ignore: sourceIgnoreFilter,
       nodir: true,
     });
+    // Exclude well-known build-tool config files. These files never contain
+    // gRPC service definitions or client calls, but their plugin instantiation
+    // patterns (e.g. `new UglifyJsPlugin()`) can look like gRPC
+    // `loadPackageDefinition` usage and trigger false-positive contracts.
+    //
+    // The list is intentionally conservative: only files whose *names* are
+    // established conventions for specific build tools are excluded.
+    // Generic names like `grpc.config.ts` or `server.config.ts` are NOT
+    // excluded because they may legitimately contain gRPC client setup.
+    const filteredSourceFiles = sourceFiles.filter(
+      (rel) => !BUILD_TOOL_CONFIG_RE.test(rel.replace(/\\/g, '/')),
+    );
 
     const parser = new Parser();
-    for (const rel of sourceFiles) {
+    for (const rel of filteredSourceFiles) {
       const plugin = getPluginForFile(rel);
       if (!plugin) continue;
       const content = readSafe(repoPath, rel);

--- a/gitnexus/test/unit/group/grpc-extractor.test.ts
+++ b/gitnexus/test/unit/group/grpc-extractor.test.ts
@@ -15,6 +15,7 @@ import {
   buildProtoMap,
   resolveProtoConflict,
   serviceContractId,
+  BUILD_TOOL_CONFIG_RE,
 } from '../../../src/core/group/extractors/grpc-extractor.js';
 import type { ProtoServiceInfo } from '../../../src/core/group/extractors/grpc-extractor.js';
 import type { RepoHandle } from '../../../src/core/group/types.js';
@@ -1118,5 +1119,117 @@ service AuthService {
     );
     expect(protoProvider).toBeDefined();
     expect(protoProvider!.contractId).toBe('grpc::auth.v1.AuthService/Login');
+  });
+});
+
+describe('BUILD_TOOL_CONFIG_RE', () => {
+  it.each([
+    // Standard two-segment names
+    'webpack.config.js',
+    'webpack.config.ts',
+    'vite.config.ts',
+    'vite.config.mjs',
+    'babel.config.js',
+    'babel.config.cjs',
+    'jest.config.ts',
+    'vitest.config.ts',
+    'rollup.config.js',
+    'esbuild.config.ts',
+    'postcss.config.js',
+    'tailwind.config.ts',
+    'next.config.js',
+    'nuxt.config.ts',
+    'svelte.config.js',
+    'astro.config.mjs',
+    // Three-segment names (env suffix)
+    'webpack.config.prod.js',
+    'vite.config.test.ts',
+    // Path-prefixed
+    'src/webpack.config.js',
+    'config/vite.config.ts',
+  ])('matches build-tool config: %s', (path) => {
+    expect(BUILD_TOOL_CONFIG_RE.test(path)).toBe(true);
+  });
+
+  it.each([
+    // Generic config names that may contain gRPC — must NOT be filtered
+    'grpc.config.ts',
+    'server.config.ts',
+    'db.config.js',
+    'app.config.ts',
+    // Utility files that happen to contain the keyword
+    'my-webpack-utils.ts',
+    'vite-plugin-grpc.ts',
+    // Non-config webpack files
+    'webpack.common.js',
+    'webpack.dev.js',
+    'webpack.prod.js',
+  ])('does not match non-config file: %s', (path) => {
+    expect(BUILD_TOOL_CONFIG_RE.test(path)).toBe(false);
+  });
+});
+
+describe('GrpcExtractor — build-tool config filter integration', () => {
+  let tmpDir: string;
+  const extractor = new GrpcExtractor();
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'grpc-build-tool-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does not extract gRPC consumer from webpack.config.ts even if it contains loadPackageDefinition', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'webpack.config.ts'),
+      `import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+const def = protoLoader.loadSync('service.proto');
+const pkg = grpc.loadPackageDefinition(def);
+export default { plugins: [] };`,
+    );
+    fs.mkdirSync(path.join(tmpDir, 'proto'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'proto', 'service.proto'),
+      `syntax = "proto3"; package svc; service Svc { rpc Call(Req) returns (Res); }`,
+    );
+
+    const repo: RepoHandle = {
+      id: 'test-repo',
+      path: 'test/app',
+      repoPath: tmpDir,
+      storagePath: path.join(tmpDir, '.gitnexus'),
+    };
+    const contracts = await extractor.extract(null, tmpDir, repo);
+    const consumers = contracts.filter((c) => c.role === 'consumer');
+    expect(consumers).toHaveLength(0);
+  });
+
+  it('still extracts gRPC consumer from grpc.config.ts (generic name, not a build-tool config)', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'grpc.config.ts'),
+      `import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+const definition = protoLoader.loadSync('proto/service.proto');
+const pkg = grpc.loadPackageDefinition(definition) as any;
+export const client = new pkg.svc.Svc('localhost:50051', grpc.credentials.createInsecure());`,
+    );
+    fs.mkdirSync(path.join(tmpDir, 'proto'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'proto', 'service.proto'),
+      `syntax = "proto3"; package svc; service Svc { rpc Call(Req) returns (Res); }`,
+    );
+
+    const repo: RepoHandle = {
+      id: 'test-repo',
+      path: 'test/app',
+      repoPath: tmpDir,
+      storagePath: path.join(tmpDir, '.gitnexus'),
+    };
+    const contracts = await extractor.extract(null, tmpDir, repo);
+    const consumers = contracts.filter((c) => c.role === 'consumer');
+    expect(consumers.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Add BUILD_TOOL_CONFIG_RE to filter out well-known build-tool config files (webpack/vite/babel/jest/etc.) before scanning for gRPC contracts. These files never contain gRPC service definitions or client calls, but their plugin instantiation patterns can match `loadPackageDefinition` and produce false-positive contracts.

Only files whose names follow established build-tool conventions are excluded; generic names like `grpc.config.ts` are intentionally kept to avoid filtering legitimate gRPC client setup files.

## Summary

<!-- One or two sentences: what does this PR change? -->

## Motivation / context

<!-- Why is this change needed? Link issues, ADRs, or prior discussion. -->

## Areas touched

<!-- Check all that apply -->

- [ ] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- <!-- bullets -->

**Explicitly out of scope / not done here**

- <!-- bullets — prevents reviewers assuming missing work is an oversight -->

## Implementation notes

<!-- Optional: design choices, tradeoffs, follow-ups -->

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [ ] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [ ] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(if web changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

## Risk & rollout

<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->

## Checklist

- [ ] PR body meets repo minimum length (workflow may label short descriptions)
- [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [ ] No secrets, tokens, or machine-specific paths committed
