### PR TITLE
docs: mention index-only analyze mode in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ npx gitnexus analyze
 
 That's it. This indexes the codebase, installs agent skills, registers Claude Code hooks, and creates `AGENTS.md` / `CLAUDE.md` context files — all in one command.
 
+If you only want to refresh the index and leave existing agent files and skills untouched, use:
+
+```bash
+npx gitnexus analyze --index-only
+```
+
 To configure MCP for your editor, run `npx gitnexus setup` once — or set it up manually below.
 
 > **Faster install (no C++ toolchain needed):** set `GITNEXUS_SKIP_OPTIONAL_GRAMMARS=1` before `npm install -g gitnexus` to skip the native `tree-sitter-dart` and `tree-sitter-proto` builds. Dart/Proto files won't be parsed, but install completes in seconds without `python3`/`make`/`g++`. Strict `=1` only — any other value falls through to the rebuild.

--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -24,6 +24,12 @@ npx gitnexus analyze
 
 That's it. This indexes the codebase, installs agent skills, registers Claude Code hooks, and creates `AGENTS.md` / `CLAUDE.md` context files — all in one command.
 
+If you only want to refresh the index and leave existing agent files and skills untouched, use:
+
+```bash
+npx gitnexus analyze --index-only
+```
+
 To configure MCP for your editor, run `npx gitnexus setup` once — or set it up manually below.
 
 `gitnexus setup` auto-detects your editors and writes the correct global MCP config. You only need to run it once.


### PR DESCRIPTION
Summary
- Document `npx gitnexus analyze --index-only` in both quick start sections.
- Clarify that this mode refreshes the index without touching existing agent files and skills.

Testing
- git diff --check HEAD~1 HEAD
- rg "analyze --index-only|leave existing agent files" README.md gitnexus/README.md

Notes
- Related to #1663