### PR TITLE
fix(group): detect httpx AsyncClient alias imports

### DIFF
--- a/gitnexus/src/core/group/extractors/http-patterns/python.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/python.ts
@@ -225,13 +225,32 @@ function trackedClientScopeKey(clientNode: Parser.SyntaxNode): string {
 }
 
 function callScopeKeys(clientNode: Parser.SyntaxNode): string[] {
-  const keys = new Set<string>();
-  const preferClass = clientNode.text.includes('.');
-  const nearestScope = getScopeKey(clientNode.parent, preferClass);
+  return [getScopeKey(clientNode.parent, clientNode.text.includes('.'))];
+}
 
-  keys.add(nearestScope);
-
-  return [...keys];
+// Returns the scope key that a rebind of an imported alias would shadow under
+// Python LEGB rules, or `null` when the rebind does not shadow anything that
+// could produce a false-positive consumer detection.
+//   - Rebind inside a function/method → that function's scope.
+//   - Rebind at module top level → 'module' (shadows the whole file).
+//   - Rebind in a class body without an enclosing function → null. Python
+//     class attributes do not shadow bare-name lookups inside methods (methods
+//     see the module binding, not the class attribute), so we must not poison
+//     them.
+function shadowScopeKey(node: Parser.SyntaxNode | null): string | null {
+  let current = node;
+  let passedThroughClass = false;
+  while (current) {
+    if (current.type === 'function_definition') {
+      // Reuse getScopeKey's key format so the two helpers cannot drift apart.
+      return getScopeKey(current);
+    }
+    if (current.type === 'class_definition') {
+      passedThroughClass = true;
+    }
+    current = current.parent;
+  }
+  return passedThroughClass ? null : 'module';
 }
 
 function collectHttpxImportAliases(tree: Parser.Tree): {
@@ -261,18 +280,29 @@ function collectHttpxImportAliases(tree: Parser.Tree): {
 }
 
 // Tracks local rebindings (`AsyncClient = ...`, `hx = ...`) that shadow an
-// imported alias inside a function or class scope. We treat the whole enclosing
-// scope as poisoned for that alias.
-const ALIAS_REBIND_PATTERNS = compilePatterns({
-  name: 'python-httpx-alias-rebind',
+// imported alias. We treat the whole enclosing scope (module, class, or
+// function) as shadowed for that alias name, so subsequent constructions in
+// that scope are not falsely detected as httpx consumers. Covers bare-identifier
+// targets and the common tuple / list destructuring shapes.
+const ALIAS_SHADOW_PATTERNS = compilePatterns({
+  name: 'python-httpx-alias-shadow',
   language: Python,
   patterns: [
     {
       meta: {},
-      query: `
-        (assignment
-          left: (identifier) @name)
-      `,
+      query: `(assignment left: (identifier) @name)`,
+    },
+    {
+      meta: {},
+      query: `(assignment left: (pattern_list (identifier) @name))`,
+    },
+    {
+      meta: {},
+      query: `(assignment left: (tuple_pattern (identifier) @name))`,
+    },
+    {
+      meta: {},
+      query: `(assignment left: (list_pattern (identifier) @name))`,
     },
   ],
 } satisfies LanguagePatterns<Record<string, never>>);
@@ -284,11 +314,11 @@ function collectAliasShadowScopes(
   const shadowed = new Map<string, Set<string>>();
   if (aliases.size === 0) return shadowed;
 
-  for (const match of runCompiledPatterns(ALIAS_REBIND_PATTERNS, tree)) {
+  for (const match of runCompiledPatterns(ALIAS_SHADOW_PATTERNS, tree)) {
     const nameNode = match.captures.name;
     if (!nameNode || !aliases.has(nameNode.text)) continue;
-    const scopeKey = getScopeKey(nameNode.parent);
-    if (scopeKey === 'module') continue;
+    const scopeKey = shadowScopeKey(nameNode.parent);
+    if (scopeKey === null) continue;
     const set = shadowed.get(nameNode.text) ?? new Set<string>();
     set.add(scopeKey);
     shadowed.set(nameNode.text, set);
@@ -306,23 +336,26 @@ function isAliasShadowed(
   if (!scopes || scopes.size === 0) return false;
   let current: Parser.SyntaxNode | null = node.parent;
   while (current) {
-    if (current.type === 'function_definition' || current.type === 'class_definition') {
-      const key =
-        current.type === 'class_definition'
-          ? `class:${current.startIndex}:${current.endIndex}`
-          : `function:${current.startIndex}:${current.endIndex}`;
-      if (scopes.has(key)) return true;
+    if (current.type === 'function_definition') {
+      // Reuse getScopeKey's key format so the two helpers cannot drift apart.
+      if (scopes.has(getScopeKey(current))) return true;
     }
     current = current.parent;
   }
-  return false;
+  // A module-level rebind shadows the alias for the entire file.
+  return scopes.has('module');
 }
 
 function collectHttpxAsyncClients(tree: Parser.Tree): Map<string, Set<string>> {
   const clients = new Map<string, Set<string>>();
   const { moduleAliases, asyncClientAliases } = collectHttpxImportAliases(tree);
-  const shadowedModule = collectAliasShadowScopes(tree, moduleAliases);
-  const shadowedAsyncClient = collectAliasShadowScopes(tree, asyncClientAliases);
+  // Module aliases (`hx`) and AsyncClient aliases (`AsyncClient`,
+  // `HttpxAsyncClient`) share disjoint name spaces, so one shadow map keyed by
+  // alias name serves both lookups and we only walk the tree for rebinds once.
+  const shadowed = collectAliasShadowScopes(
+    tree,
+    new Set([...moduleAliases, ...asyncClientAliases]),
+  );
 
   const addClient = (clientNode: Parser.SyntaxNode | undefined) => {
     if (!clientNode) return;
@@ -338,14 +371,14 @@ function collectHttpxAsyncClients(tree: Parser.Tree): Map<string, Set<string>> {
     const classNode = match.captures.client_class;
     if (!moduleNode || !classNode) continue;
     if (!moduleAliases.has(moduleNode.text) || classNode.text !== 'AsyncClient') continue;
-    if (isAliasShadowed(shadowedModule, moduleNode.text, moduleNode)) continue;
+    if (isAliasShadowed(shadowed, moduleNode.text, moduleNode)) continue;
     addClient(match.captures.client);
   }
 
   for (const match of runCompiledPatterns(HTTPX_ASYNC_CLIENT_DIRECT_ASSIGN_PATTERNS, tree)) {
     const classNode = match.captures.client_class;
     if (!classNode || !asyncClientAliases.has(classNode.text)) continue;
-    if (isAliasShadowed(shadowedAsyncClient, classNode.text, classNode)) continue;
+    if (isAliasShadowed(shadowed, classNode.text, classNode)) continue;
     addClient(match.captures.client);
   }
 
@@ -354,14 +387,14 @@ function collectHttpxAsyncClients(tree: Parser.Tree): Map<string, Set<string>> {
     const classNode = match.captures.client_class;
     if (!moduleNode || !classNode) continue;
     if (!moduleAliases.has(moduleNode.text) || classNode.text !== 'AsyncClient') continue;
-    if (isAliasShadowed(shadowedModule, moduleNode.text, moduleNode)) continue;
+    if (isAliasShadowed(shadowed, moduleNode.text, moduleNode)) continue;
     addClient(match.captures.client);
   }
 
   for (const match of runCompiledPatterns(HTTPX_ASYNC_CLIENT_DIRECT_WITH_ALIAS_PATTERNS, tree)) {
     const classNode = match.captures.client_class;
     if (!classNode || !asyncClientAliases.has(classNode.text)) continue;
-    if (isAliasShadowed(shadowedAsyncClient, classNode.text, classNode)) continue;
+    if (isAliasShadowed(shadowed, classNode.text, classNode)) continue;
     addClient(match.captures.client);
   }
 

--- a/gitnexus/src/core/group/extractors/http-patterns/python.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/python.ts
@@ -80,12 +80,50 @@ const REQUESTS_GENERIC_PATTERNS = compilePatterns({
 } satisfies LanguagePatterns<Record<string, never>>);
 
 // ─── Consumer: httpx.AsyncClient assignments ────────────────────────
-// NOTE: This targeted detector only tracks explicit `httpx.AsyncClient(...)`
-// construction. Direct imports (`from httpx import AsyncClient`) and module
-// aliases (`import httpx as hx`) and annotated assignments (`client: httpx.AsyncClient = ...`)
-// are intentionally left for a follow-up. Module-scope clients are only matched
+// Module-scope clients are only matched
 // at module scope; calls inside functions require a function/class-local tracked
 // client to avoid false positives from same-name local variables.
+const HTTPX_MODULE_IMPORT_PATTERNS = compilePatterns({
+  name: 'python-httpx-module-imports',
+  language: Python,
+  patterns: [
+    {
+      meta: {},
+      query: `
+        (import_statement
+          name: (aliased_import
+            name: (dotted_name (identifier) @module)
+            alias: (identifier) @alias))
+      `,
+    },
+  ],
+} satisfies LanguagePatterns<Record<string, never>>);
+
+const HTTPX_ASYNC_CLIENT_IMPORT_PATTERNS = compilePatterns({
+  name: 'python-httpx-async-client-imports',
+  language: Python,
+  patterns: [
+    {
+      meta: {},
+      query: `
+        (import_from_statement
+          module_name: (dotted_name (identifier) @module)
+          name: (dotted_name (identifier) @client_class))
+      `,
+    },
+    {
+      meta: {},
+      query: `
+        (import_from_statement
+          module_name: (dotted_name (identifier) @module)
+          name: (aliased_import
+            name: (dotted_name (identifier) @client_class)
+            alias: (identifier) @alias))
+      `,
+    },
+  ],
+} satisfies LanguagePatterns<Record<string, never>>);
+
 const HTTPX_ASYNC_CLIENT_ASSIGN_PATTERNS = compilePatterns({
   name: 'python-httpx-async-client-assign',
   language: Python,
@@ -97,8 +135,24 @@ const HTTPX_ASYNC_CLIENT_ASSIGN_PATTERNS = compilePatterns({
           left: (_) @client
           right: (call
             function: (attribute
-              object: (identifier) @module (#eq? @module "httpx")
-              attribute: (identifier) @client_class (#eq? @client_class "AsyncClient"))))
+              object: (identifier) @module
+              attribute: (identifier) @client_class)))
+      `,
+    },
+  ],
+} satisfies LanguagePatterns<Record<string, never>>);
+
+const HTTPX_ASYNC_CLIENT_DIRECT_ASSIGN_PATTERNS = compilePatterns({
+  name: 'python-httpx-async-client-direct-assign',
+  language: Python,
+  patterns: [
+    {
+      meta: {},
+      query: `
+        (assignment
+          left: (_) @client
+          right: (call
+            function: (identifier) @client_class))
       `,
     },
   ],
@@ -115,8 +169,24 @@ const HTTPX_ASYNC_CLIENT_WITH_ALIAS_PATTERNS = compilePatterns({
         (as_pattern
           (call
             function: (attribute
-              object: (identifier) @module (#eq? @module "httpx")
-              attribute: (identifier) @client_class (#eq? @client_class "AsyncClient")))
+              object: (identifier) @module
+              attribute: (identifier) @client_class))
+          (as_pattern_target (identifier) @client))
+      `,
+    },
+  ],
+} satisfies LanguagePatterns<Record<string, never>>);
+
+const HTTPX_ASYNC_CLIENT_DIRECT_WITH_ALIAS_PATTERNS = compilePatterns({
+  name: 'python-httpx-async-client-direct-with-alias',
+  language: Python,
+  patterns: [
+    {
+      meta: {},
+      query: `
+        (as_pattern
+          (call
+            function: (identifier) @client_class)
           (as_pattern_target (identifier) @client))
       `,
     },
@@ -159,8 +229,32 @@ function callScopeKeys(clientNode: Parser.SyntaxNode): string[] {
   return [...keys];
 }
 
+function collectHttpxImportAliases(tree: Parser.Tree): {
+  moduleAliases: Set<string>;
+  asyncClientAliases: Set<string>;
+} {
+  const moduleAliases = new Set<string>(['httpx']);
+  const asyncClientAliases = new Set<string>();
+
+  for (const match of runCompiledPatterns(HTTPX_MODULE_IMPORT_PATTERNS, tree)) {
+    const moduleNode = match.captures.module;
+    const aliasNode = match.captures.alias;
+    if (moduleNode?.text === 'httpx' && aliasNode) moduleAliases.add(aliasNode.text);
+  }
+
+  for (const match of runCompiledPatterns(HTTPX_ASYNC_CLIENT_IMPORT_PATTERNS, tree)) {
+    const moduleNode = match.captures.module;
+    const classNode = match.captures.client_class;
+    if (moduleNode?.text !== 'httpx' || classNode?.text !== 'AsyncClient') continue;
+    asyncClientAliases.add(match.captures.alias?.text ?? classNode.text);
+  }
+
+  return { moduleAliases, asyncClientAliases };
+}
+
 function collectHttpxAsyncClients(tree: Parser.Tree): Map<string, Set<string>> {
   const clients = new Map<string, Set<string>>();
+  const { moduleAliases, asyncClientAliases } = collectHttpxImportAliases(tree);
 
   const addClient = (clientNode: Parser.SyntaxNode | undefined) => {
     if (!clientNode) return;
@@ -172,10 +266,30 @@ function collectHttpxAsyncClients(tree: Parser.Tree): Map<string, Set<string>> {
   };
 
   for (const match of runCompiledPatterns(HTTPX_ASYNC_CLIENT_ASSIGN_PATTERNS, tree)) {
+    const moduleNode = match.captures.module;
+    const classNode = match.captures.client_class;
+    if (!moduleNode || !classNode) continue;
+    if (!moduleAliases.has(moduleNode.text) || classNode.text !== 'AsyncClient') continue;
+    addClient(match.captures.client);
+  }
+
+  for (const match of runCompiledPatterns(HTTPX_ASYNC_CLIENT_DIRECT_ASSIGN_PATTERNS, tree)) {
+    const classNode = match.captures.client_class;
+    if (!classNode || !asyncClientAliases.has(classNode.text)) continue;
     addClient(match.captures.client);
   }
 
   for (const match of runCompiledPatterns(HTTPX_ASYNC_CLIENT_WITH_ALIAS_PATTERNS, tree)) {
+    const moduleNode = match.captures.module;
+    const classNode = match.captures.client_class;
+    if (!moduleNode || !classNode) continue;
+    if (!moduleAliases.has(moduleNode.text) || classNode.text !== 'AsyncClient') continue;
+    addClient(match.captures.client);
+  }
+
+  for (const match of runCompiledPatterns(HTTPX_ASYNC_CLIENT_DIRECT_WITH_ALIAS_PATTERNS, tree)) {
+    const classNode = match.captures.client_class;
+    if (!classNode || !asyncClientAliases.has(classNode.text)) continue;
     addClient(match.captures.client);
   }
 

--- a/gitnexus/src/core/group/extractors/http-patterns/python.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/python.ts
@@ -13,7 +13,12 @@ import type { HttpDetection, HttpLanguagePlugin } from './types.js';
  *   - FastAPI `@app.get("/path")` provider decorators
  *   - `requests.get/post/...("url")` consumer calls
  *   - Generic `requests.request("METHOD", "url")` consumer calls
- *   - `httpx.AsyncClient` instances calling `.get/.post/...("url")`
+ *   - `httpx.AsyncClient` instances calling `.get/.post/...("url")`, including
+ *     aliased imports such as `import httpx as hx`,
+ *     `from httpx import AsyncClient`, and
+ *     `from httpx import AsyncClient as HttpxAsyncClient`.
+ *     Locally rebound names (e.g. `AsyncClient = mock_factory()` inside a
+ *     function) are excluded to avoid false-positive consumer contracts.
  */
 
 const FASTAPI_VERBS: Record<string, string> = {
@@ -236,25 +241,88 @@ function collectHttpxImportAliases(tree: Parser.Tree): {
   const moduleAliases = new Set<string>(['httpx']);
   const asyncClientAliases = new Set<string>();
 
+  // The @module capture is a single identifier inside a `dotted_name`, so for
+  // `import package.httpx as hx` the pattern would match the inner `httpx`
+  // segment. Check the full `dotted_name` text via `parent` to anchor the match.
   for (const match of runCompiledPatterns(HTTPX_MODULE_IMPORT_PATTERNS, tree)) {
     const moduleNode = match.captures.module;
     const aliasNode = match.captures.alias;
-    if (moduleNode?.text === 'httpx' && aliasNode) moduleAliases.add(aliasNode.text);
+    if (moduleNode?.parent?.text === 'httpx' && aliasNode) moduleAliases.add(aliasNode.text);
   }
 
   for (const match of runCompiledPatterns(HTTPX_ASYNC_CLIENT_IMPORT_PATTERNS, tree)) {
     const moduleNode = match.captures.module;
     const classNode = match.captures.client_class;
-    if (moduleNode?.text !== 'httpx' || classNode?.text !== 'AsyncClient') continue;
+    if (moduleNode?.parent?.text !== 'httpx' || classNode?.text !== 'AsyncClient') continue;
     asyncClientAliases.add(match.captures.alias?.text ?? classNode.text);
   }
 
   return { moduleAliases, asyncClientAliases };
 }
 
+// Tracks local rebindings (`AsyncClient = ...`, `hx = ...`) that shadow an
+// imported alias inside a function or class scope. We treat the whole enclosing
+// scope as poisoned for that alias.
+const ALIAS_REBIND_PATTERNS = compilePatterns({
+  name: 'python-httpx-alias-rebind',
+  language: Python,
+  patterns: [
+    {
+      meta: {},
+      query: `
+        (assignment
+          left: (identifier) @name)
+      `,
+    },
+  ],
+} satisfies LanguagePatterns<Record<string, never>>);
+
+function collectAliasShadowScopes(
+  tree: Parser.Tree,
+  aliases: Set<string>,
+): Map<string, Set<string>> {
+  const shadowed = new Map<string, Set<string>>();
+  if (aliases.size === 0) return shadowed;
+
+  for (const match of runCompiledPatterns(ALIAS_REBIND_PATTERNS, tree)) {
+    const nameNode = match.captures.name;
+    if (!nameNode || !aliases.has(nameNode.text)) continue;
+    const scopeKey = getScopeKey(nameNode.parent);
+    if (scopeKey === 'module') continue;
+    const set = shadowed.get(nameNode.text) ?? new Set<string>();
+    set.add(scopeKey);
+    shadowed.set(nameNode.text, set);
+  }
+
+  return shadowed;
+}
+
+function isAliasShadowed(
+  shadowed: Map<string, Set<string>>,
+  aliasName: string,
+  node: Parser.SyntaxNode,
+): boolean {
+  const scopes = shadowed.get(aliasName);
+  if (!scopes || scopes.size === 0) return false;
+  let current: Parser.SyntaxNode | null = node.parent;
+  while (current) {
+    if (current.type === 'function_definition' || current.type === 'class_definition') {
+      const key =
+        current.type === 'class_definition'
+          ? `class:${current.startIndex}:${current.endIndex}`
+          : `function:${current.startIndex}:${current.endIndex}`;
+      if (scopes.has(key)) return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
 function collectHttpxAsyncClients(tree: Parser.Tree): Map<string, Set<string>> {
   const clients = new Map<string, Set<string>>();
   const { moduleAliases, asyncClientAliases } = collectHttpxImportAliases(tree);
+  const shadowedModule = collectAliasShadowScopes(tree, moduleAliases);
+  const shadowedAsyncClient = collectAliasShadowScopes(tree, asyncClientAliases);
 
   const addClient = (clientNode: Parser.SyntaxNode | undefined) => {
     if (!clientNode) return;
@@ -270,12 +338,14 @@ function collectHttpxAsyncClients(tree: Parser.Tree): Map<string, Set<string>> {
     const classNode = match.captures.client_class;
     if (!moduleNode || !classNode) continue;
     if (!moduleAliases.has(moduleNode.text) || classNode.text !== 'AsyncClient') continue;
+    if (isAliasShadowed(shadowedModule, moduleNode.text, moduleNode)) continue;
     addClient(match.captures.client);
   }
 
   for (const match of runCompiledPatterns(HTTPX_ASYNC_CLIENT_DIRECT_ASSIGN_PATTERNS, tree)) {
     const classNode = match.captures.client_class;
     if (!classNode || !asyncClientAliases.has(classNode.text)) continue;
+    if (isAliasShadowed(shadowedAsyncClient, classNode.text, classNode)) continue;
     addClient(match.captures.client);
   }
 
@@ -284,12 +354,14 @@ function collectHttpxAsyncClients(tree: Parser.Tree): Map<string, Set<string>> {
     const classNode = match.captures.client_class;
     if (!moduleNode || !classNode) continue;
     if (!moduleAliases.has(moduleNode.text) || classNode.text !== 'AsyncClient') continue;
+    if (isAliasShadowed(shadowedModule, moduleNode.text, moduleNode)) continue;
     addClient(match.captures.client);
   }
 
   for (const match of runCompiledPatterns(HTTPX_ASYNC_CLIENT_DIRECT_WITH_ALIAS_PATTERNS, tree)) {
     const classNode = match.captures.client_class;
     if (!classNode || !asyncClientAliases.has(classNode.text)) continue;
+    if (isAliasShadowed(shadowedAsyncClient, classNode.text, classNode)) continue;
     addClient(match.captures.client);
   }
 

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -545,6 +545,12 @@ from httpx import AsyncClient as HttpxAsyncClient
 # Dotted-package look-alikes — must NOT be detected as httpx.
 import my_pkg.httpx as evil_mod
 from my_pkg.httpx import AsyncClient as evil_async
+# Longer dotted path — must also NOT be detected.
+import a.b.c.httpx as deep_evil
+from a.b.c.httpx import AsyncClient as deep_evil_async
+# Relative import — module_name is a relative_import node, not dotted_name, so
+# it must not produce a contract either.
+from .httpx import AsyncClient as rel_evil_async
 
 module_client = httpx.AsyncClient(base_url="https://svc.local")
 module_alias_client = hx.AsyncClient(base_url="https://svc.local")
@@ -552,6 +558,9 @@ module_direct_client = AsyncClient(base_url="https://svc.local")
 module_renamed_client = HttpxAsyncClient(base_url="https://svc.local")
 evil_mod_client = evil_mod.AsyncClient(base_url="https://svc.local")
 evil_direct_client = evil_async(base_url="https://svc.local")
+deep_evil_mod_client = deep_evil.AsyncClient(base_url="https://svc.local")
+deep_evil_direct_client = deep_evil_async(base_url="https://svc.local")
+rel_evil_direct_client = rel_evil_async(base_url="https://svc.local")
 
 class TopicClient:
     def __init__(self):
@@ -608,12 +617,48 @@ async def shadow_direct_context():
     async with AsyncClient() as client:
         return await client.get("/shadow-direct-context-fp")
 
+def shadow_tuple_destructure():
+    AsyncClient, _other = (lambda: FakeClient()), 42
+    client = AsyncClient()
+    return client.get("/shadow-tuple-fp")
+
+# Class-body assignment of an imported alias is a class attribute under Python
+# LEGB rules — methods inside still see the module binding. The detector must
+# NOT poison the methods, so the legitimate httpx call below should still emit.
+class ClassBodyRebindHolder:
+    AsyncClient = lambda: FakeClient()
+
+    def __init__(self):
+        self._client = httpx.AsyncClient(base_url="https://svc.local")
+
+    async def fetch(self):
+        return await self._client.get("/class-body-rebind-ok")
+
 module_client.get("/module-topic")
 module_alias_client.get("/module-alias-topic")
 module_direct_client.get("/module-direct-topic")
 module_renamed_client.get("/module-renamed-topic")
 evil_mod_client.get("/evil-module-dotted-fp")
 evil_direct_client.get("/evil-direct-dotted-fp")
+deep_evil_mod_client.get("/deep-evil-module-dotted-fp")
+deep_evil_direct_client.get("/deep-evil-direct-dotted-fp")
+rel_evil_direct_client.get("/rel-evil-direct-fp")
+`,
+      );
+
+      // Isolated file for module-level rebind: shadowing applies file-wide, so
+      // it must not affect the assertions in client.py above.
+      fs.writeFileSync(
+        path.join(dir, 'src', 'module_rebind.py'),
+        `
+from httpx import AsyncClient
+
+# Module-level rebind: the rest of this file's bare AsyncClient calls must NOT
+# emit httpx consumer contracts.
+AsyncClient = lambda: FakeClient()
+
+shadowed_module_client = AsyncClient(base_url="https://svc.local")
+shadowed_module_client.get("/module-level-rebind-fp")
 `,
       );
 
@@ -634,6 +679,10 @@ evil_direct_client.get("/evil-direct-dotted-fp")
         'http::GET::/module-alias-topic',
         'http::GET::/module-direct-topic',
         'http::GET::/module-renamed-topic',
+        // Class-body rebind of `AsyncClient` is a class attribute, not a
+        // method-scope shadow — the legitimate httpx.AsyncClient call inside
+        // the class must still emit.
+        'http::GET::/class-body-rebind-ok',
       ];
 
       for (const contractId of expected) {
@@ -641,6 +690,13 @@ evil_direct_client.get("/evil-direct-dotted-fp")
         expect(consumer).toBeDefined();
         expect(consumer?.meta.framework).toBe('python-httpx');
       }
+
+      // Positive control: the legitimate `module_direct_client = AsyncClient(...)`
+      // path was actually exercised, so the negative dotted-package assertions
+      // below are not passing vacuously.
+      expect(
+        consumers.find((c) => c.contractId === 'http::GET::/module-direct-topic'),
+      ).toBeDefined();
 
       expect(consumers.find((c) => c.contractId === 'http::GET::/nope')).toBeUndefined();
       expect(consumers.find((c) => c.contractId === 'http::POST::/nope')).toBeUndefined();
@@ -650,12 +706,22 @@ evil_direct_client.get("/evil-direct-dotted-fp")
       expect(
         consumers.find((c) => c.contractId === 'http::GET::/ignored-module-same-name'),
       ).toBeUndefined();
-      // Finding 1: dotted-package look-alikes (`my_pkg.httpx`) must not be detected.
+      // Finding 1: dotted-package look-alikes (`my_pkg.httpx`, three-segment
+      // `a.b.c.httpx`, and relative `.httpx`) must not be detected.
       expect(
         consumers.find((c) => c.contractId === 'http::GET::/evil-module-dotted-fp'),
       ).toBeUndefined();
       expect(
         consumers.find((c) => c.contractId === 'http::GET::/evil-direct-dotted-fp'),
+      ).toBeUndefined();
+      expect(
+        consumers.find((c) => c.contractId === 'http::GET::/deep-evil-module-dotted-fp'),
+      ).toBeUndefined();
+      expect(
+        consumers.find((c) => c.contractId === 'http::GET::/deep-evil-direct-dotted-fp'),
+      ).toBeUndefined();
+      expect(
+        consumers.find((c) => c.contractId === 'http::GET::/rel-evil-direct-fp'),
       ).toBeUndefined();
       // Finding 2: locally rebound imported aliases must not be detected.
       expect(
@@ -666,6 +732,12 @@ evil_direct_client.get("/evil-direct-dotted-fp")
       ).toBeUndefined();
       expect(
         consumers.find((c) => c.contractId === 'http::GET::/shadow-direct-context-fp'),
+      ).toBeUndefined();
+      // Tuple/list destructuring rebinds must also shadow the alias.
+      expect(consumers.find((c) => c.contractId === 'http::GET::/shadow-tuple-fp')).toBeUndefined();
+      // Module-level rebind in a separate file must shadow the whole file.
+      expect(
+        consumers.find((c) => c.contractId === 'http::GET::/module-level-rebind-fp'),
       ).toBeUndefined();
     });
 

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -443,8 +443,14 @@ def create_order():
         path.join(dir, 'src', 'client.py'),
         `
 import httpx
+import httpx as hx
+from httpx import AsyncClient
+from httpx import AsyncClient as HttpxAsyncClient
 
 module_client = httpx.AsyncClient(base_url="https://svc.local")
+module_alias_client = hx.AsyncClient(base_url="https://svc.local")
+module_direct_client = AsyncClient(base_url="https://svc.local")
+module_renamed_client = HttpxAsyncClient(base_url="https://svc.local")
 
 class TopicClient:
     def __init__(self):
@@ -466,6 +472,18 @@ async def check_duplicate():
         service.request("POST", "/nope")
         return await client.post("https://svc.local/questions/duplicate-check")
 
+async def import_aliases():
+    local_alias_client = hx.AsyncClient(base_url="https://svc.local")
+    local_direct_client = AsyncClient(base_url="https://svc.local")
+    local_renamed_client = HttpxAsyncClient(base_url="https://svc.local")
+    await local_alias_client.get("/alias-topic")
+    await local_direct_client.patch("/direct-topic")
+    await local_renamed_client.request("PUT", "/renamed-topic")
+    async with hx.AsyncClient() as alias_context:
+        await alias_context.delete("/alias-context")
+    async with AsyncClient() as direct_context:
+        return await direct_context.post("/direct-context")
+
 def unrelated_scope_collision():
     client = acquire_cache_client()
     return client.get("/ignored-same-name")
@@ -475,6 +493,9 @@ def module_scope_shadow_collision():
     return client.get("/ignored-module-same-name")
 
 module_client.get("/module-topic")
+module_alias_client.get("/module-alias-topic")
+module_direct_client.get("/module-direct-topic")
+module_renamed_client.get("/module-renamed-topic")
 `,
       );
 
@@ -486,7 +507,15 @@ module_client.get("/module-topic")
         'http::POST::/questions/import',
         'http::DELETE::/topic',
         'http::POST::/questions/duplicate-check',
+        'http::GET::/alias-topic',
+        'http::PATCH::/direct-topic',
+        'http::PUT::/renamed-topic',
+        'http::DELETE::/alias-context',
+        'http::POST::/direct-context',
         'http::GET::/module-topic',
+        'http::GET::/module-alias-topic',
+        'http::GET::/module-direct-topic',
+        'http::GET::/module-renamed-topic',
       ];
 
       for (const contractId of expected) {

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -542,10 +542,16 @@ import httpx as hx
 from httpx import AsyncClient
 from httpx import AsyncClient as HttpxAsyncClient
 
+# Dotted-package look-alikes — must NOT be detected as httpx.
+import my_pkg.httpx as evil_mod
+from my_pkg.httpx import AsyncClient as evil_async
+
 module_client = httpx.AsyncClient(base_url="https://svc.local")
 module_alias_client = hx.AsyncClient(base_url="https://svc.local")
 module_direct_client = AsyncClient(base_url="https://svc.local")
 module_renamed_client = HttpxAsyncClient(base_url="https://svc.local")
+evil_mod_client = evil_mod.AsyncClient(base_url="https://svc.local")
+evil_direct_client = evil_async(base_url="https://svc.local")
 
 class TopicClient:
     def __init__(self):
@@ -587,10 +593,27 @@ def module_scope_shadow_collision():
     client = acquire_cache_client()
     return client.get("/ignored-module-same-name")
 
+def shadow_direct_alias():
+    AsyncClient = lambda: FakeClient()
+    client = AsyncClient()
+    return client.get("/shadow-direct-fp")
+
+def shadow_module_alias():
+    hx = FakeMod()
+    client = hx.AsyncClient()
+    return client.get("/shadow-module-fp")
+
+async def shadow_direct_context():
+    AsyncClient = lambda: FakeClient()
+    async with AsyncClient() as client:
+        return await client.get("/shadow-direct-context-fp")
+
 module_client.get("/module-topic")
 module_alias_client.get("/module-alias-topic")
 module_direct_client.get("/module-direct-topic")
 module_renamed_client.get("/module-renamed-topic")
+evil_mod_client.get("/evil-module-dotted-fp")
+evil_direct_client.get("/evil-direct-dotted-fp")
 `,
       );
 
@@ -626,6 +649,23 @@ module_renamed_client.get("/module-renamed-topic")
       ).toBeUndefined();
       expect(
         consumers.find((c) => c.contractId === 'http::GET::/ignored-module-same-name'),
+      ).toBeUndefined();
+      // Finding 1: dotted-package look-alikes (`my_pkg.httpx`) must not be detected.
+      expect(
+        consumers.find((c) => c.contractId === 'http::GET::/evil-module-dotted-fp'),
+      ).toBeUndefined();
+      expect(
+        consumers.find((c) => c.contractId === 'http::GET::/evil-direct-dotted-fp'),
+      ).toBeUndefined();
+      // Finding 2: locally rebound imported aliases must not be detected.
+      expect(
+        consumers.find((c) => c.contractId === 'http::GET::/shadow-direct-fp'),
+      ).toBeUndefined();
+      expect(
+        consumers.find((c) => c.contractId === 'http::GET::/shadow-module-fp'),
+      ).toBeUndefined();
+      expect(
+        consumers.find((c) => c.contractId === 'http::GET::/shadow-direct-context-fp'),
       ).toBeUndefined();
     });
 


### PR DESCRIPTION
## Summary

- extend Python httpx consumer detection to recognize `import httpx as hx`
- support `from httpx import AsyncClient` and aliased direct imports such as `from httpx import AsyncClient as HttpxAsyncClient`
- add regression coverage for module-scope, function-scope, and `async with` alias/direct-import forms

## Tests

- `cd gitnexus && npm test -- --run test/unit/group/http-route-extractor.test.ts`
- `cd gitnexus && npx tsc --noEmit`

## Notes

- `npx gitnexus impact collectHttpxAsyncClients --direction upstream --repo GitNexus --depth 2` and `npx gitnexus detect-changes --scope staged` currently fail locally with `Cannot destructure property 'package' of 'node.target' as it is null`, so I used the targeted test and typecheck above for validation.
