### PR TITLE
fix(lbug): probe-then-load FTS extension on Windows (#1690)

### DIFF
--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -16,6 +16,8 @@
  */
 
 import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
 import lbug from '@ladybugdb/core';
 import { isReadOnlyDbError, loadFTSExtension } from './lbug-adapter.js';
 import {
@@ -23,6 +25,41 @@ import {
   isWalCorruptionError,
   WAL_RECOVERY_SUGGESTION,
 } from './lbug-config.js';
+
+/**
+ * Probe whether a Windows FTS extension binary is locally installed under
+ * ~/.lbdb/extension/<any-version>/win_amd64/fts/. Returns true on the first
+ * version dir whose libfts.lbug_extension exists on disk; false if the
+ * extension root is missing or contains no FTS binary.
+ *
+ * Gates the Windows skip-FTS-load guard below so we only skip the load
+ * when no extension binary is present. When at least one binary exists,
+ * loadFTSExtension is called with policy: 'load-only' — LadybugDB resolves
+ * LOAD EXTENSION fts to its version-specific path internally, and the
+ * ExtensionManager's tryLoad try/catch handles version-mismatch errors
+ * cleanly without ever attempting dlopen of a stale binary. The install
+ * path that the #1199/#1217 SIGSEGV documented is never exercised at
+ * query time.
+ */
+async function hasLocalWinFtsExtension(): Promise<boolean> {
+  try {
+    const extRoot = path.join(os.homedir(), '.lbdb', 'extension');
+    const versions = await fs.readdir(extRoot);
+    for (const v of versions) {
+      try {
+        await fs.stat(
+          path.join(extRoot, v, 'win_amd64', 'fts', 'libfts.lbug_extension'),
+        );
+        return true;
+      } catch {
+        /* missing for this version, keep looking */
+      }
+    }
+  } catch {
+    /* no .lbdb/extension dir */
+  }
+  return false;
+}
 
 /** Per-repo pool: one Database, many Connections */
 interface PoolEntry {
@@ -423,14 +460,24 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
   // install; analyze owns extension installation. If LOAD fails, search
   // features degrade gracefully and the user-facing query path proceeds.
   if (!shared.ftsLoaded) {
-    // Windows guard: LOAD EXTENSION fts crashes with SIGSEGV on Windows when
-    // the FTS extension binary is not installed locally (@ladybugdb/core native
-    // bug — the extension loader hits an unhandled error path that signals SIGSEGV
-    // rather than throwing a JS exception, so try/catch cannot protect here).
-    // Skip the load on Windows; bm25-index.js catches the resulting Kuzu catalog
-    // errors and returns empty BM25 results gracefully. Graph queries are unaffected.
+    // Windows guard: LOAD EXTENSION fts crashes with SIGSEGV on Windows during
+    // *install* — the @ladybugdb/core out-of-process installer hits an unhandled
+    // error path that signals SIGSEGV instead of throwing (see #1199, #1217).
+    // The previous unconditional skip was over-broad: it also disabled FTS on
+    // hosts where the binary was already on disk and only needed LOAD, leaving
+    // BM25 silently degraded with no error path (see #1690).
+    //
+    // Probe ~/.lbdb/extension/*/win_amd64/fts/ first. If any binary is on disk
+    // we run loadFTSExtension(..., 'load-only'); the install path is never
+    // exercised, and LadybugDB's version-specific resolution + ExtensionManager
+    // try/catch handle stale/zero-byte siblings cleanly (verified empirically
+    // on Win10 + Node 22.19 + gitnexus 1.6.5 + @ladybugdb/core 0.16.1). With
+    // no binary at all, we fall back to the upstream skip so install-time
+    // SIGSEGV continues to be avoided.
     if (process.platform === 'win32') {
-      shared.ftsLoaded = true;
+      shared.ftsLoaded = (await hasLocalWinFtsExtension())
+        ? await loadFTSExtension(available[0], { policy: 'load-only' })
+        : true;
     } else {
       shared.ftsLoaded = await loadFTSExtension(available[0], { policy: 'load-only' });
     }
@@ -497,10 +544,12 @@ export async function initLbugWithDb(
   // Load FTS extension if not already loaded on this Database.
   // policy: 'load-only' — same contract as initLbug above; the read pool
   // must not block on a network install during query execution.
-  // Windows guard: same SIGSEGV risk as doInitLbug above — skip on Windows.
+  // Windows guard: same probe-then-load policy as doInitLbug above.
   if (!shared.ftsLoaded) {
     if (process.platform === 'win32') {
-      shared.ftsLoaded = true;
+      shared.ftsLoaded = (await hasLocalWinFtsExtension())
+        ? await loadFTSExtension(available[0], { policy: 'load-only' })
+        : true;
     } else {
       shared.ftsLoaded = await loadFTSExtension(available[0], { policy: 'load-only' });
     }

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -40,16 +40,17 @@ import {
  * cleanly without ever attempting dlopen of a stale binary. The install
  * path that the #1199/#1217 SIGSEGV documented is never exercised at
  * query time.
+ *
+ * Exported so unit tests can exercise the probe directly against a
+ * temp-dir plus spied `os.homedir()` — see lbug-pool-win-fts-probe.test.ts.
  */
-async function hasLocalWinFtsExtension(): Promise<boolean> {
+export async function hasLocalWinFtsExtension(): Promise<boolean> {
   try {
     const extRoot = path.join(os.homedir(), '.lbdb', 'extension');
     const versions = await fs.readdir(extRoot);
     for (const v of versions) {
       try {
-        await fs.stat(
-          path.join(extRoot, v, 'win_amd64', 'fts', 'libfts.lbug_extension'),
-        );
+        await fs.stat(path.join(extRoot, v, 'win_amd64', 'fts', 'libfts.lbug_extension'));
         return true;
       } catch {
         /* missing for this version, keep looking */

--- a/gitnexus/test/unit/lbug-pool-win-fts-probe.test.ts
+++ b/gitnexus/test/unit/lbug-pool-win-fts-probe.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for the Windows FTS probe in pool-adapter.ts.
+ *
+ * Covers `hasLocalWinFtsExtension()` — the helper that gates the
+ * Windows-only skip of `loadFTSExtension` in `doInitLbug` and
+ * `initLbugWithDb`. Issue #1690 / PR #1692.
+ *
+ * The probe is exercised against a real temp filesystem with
+ * `os.homedir()` spied to point at the tempdir. This tests the
+ * actual fs surface (readdir/stat semantics, missing-dir behavior,
+ * zero-byte file handling) rather than mocking fs internals.
+ *
+ * The Windows-branch conditional in `doInitLbug` / `initLbugWithDb`
+ * is intentionally not unit-tested in isolation: those functions
+ * require a fully constructed `lbug.Database` + `Connection` pool
+ * and are exercised end-to-end by `test/integration/lbug-pool*.test.ts`
+ * on the `windows-latest` matrix. The conditional itself is a single
+ * expression — `(await hasLocalWinFtsExtension()) ? load : true` —
+ * whose correctness reduces to the probe being correctly tested here.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+
+// Stub out the LadybugDB native loader and its transitive importers so that
+// importing pool-adapter.ts in this unit test does not pull in the .node binary
+// (which is built by the postinstall script and is not always present in the
+// dev install used for unit tests).
+vi.mock('@ladybugdb/core', () => ({
+  default: { Database: vi.fn(), Connection: vi.fn() },
+}));
+vi.mock('../../src/core/lbug/lbug-adapter.js', () => ({
+  isReadOnlyDbError: vi.fn(() => false),
+  loadFTSExtension: vi.fn(),
+}));
+vi.mock('../../src/core/lbug/lbug-config.js', () => ({
+  createLbugDatabase: vi.fn(),
+  isWalCorruptionError: vi.fn(() => false),
+  WAL_RECOVERY_SUGGESTION: '',
+}));
+
+import { hasLocalWinFtsExtension } from '../../src/core/lbug/pool-adapter.js';
+
+describe('hasLocalWinFtsExtension', () => {
+  let tmpHome: string;
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-fts-probe-'));
+    vi.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tmpHome, { recursive: true, force: true });
+  });
+
+  it('returns false when ~/.lbdb/extension does not exist', async () => {
+    // tmpHome is empty; the probe should swallow the readdir ENOENT and return false.
+    await expect(hasLocalWinFtsExtension()).resolves.toBe(false);
+  });
+
+  it('returns false when ~/.lbdb/extension exists but has no version dirs', async () => {
+    await fs.mkdir(path.join(tmpHome, '.lbdb', 'extension'), { recursive: true });
+    await expect(hasLocalWinFtsExtension()).resolves.toBe(false);
+  });
+
+  it('returns true when a single version dir contains the FTS binary', async () => {
+    const ftsDir = path.join(tmpHome, '.lbdb', 'extension', '0.16.0', 'win_amd64', 'fts');
+    await fs.mkdir(ftsDir, { recursive: true });
+    await fs.writeFile(path.join(ftsDir, 'libfts.lbug_extension'), Buffer.from('mock-binary'));
+    await expect(hasLocalWinFtsExtension()).resolves.toBe(true);
+  });
+
+  it('returns true when the binary is a zero-byte stub (LOAD failure handled downstream)', async () => {
+    // Empirically verified in #1690 thread: LadybugDB resolves LOAD EXTENSION fts to a
+    // version-specific path internally and the ExtensionManager's tryLoad try/catch
+    // catches the resulting load error cleanly. Probe is intentionally generous here;
+    // safety lives in the loader, not the probe.
+    const ftsDir = path.join(tmpHome, '.lbdb', 'extension', '0.16.0', 'win_amd64', 'fts');
+    await fs.mkdir(ftsDir, { recursive: true });
+    await fs.writeFile(path.join(ftsDir, 'libfts.lbug_extension'), '');
+    await expect(hasLocalWinFtsExtension()).resolves.toBe(true);
+  });
+
+  it('returns true when multiple version dirs exist and only one carries the binary', async () => {
+    const versions = ['0.15.0', '0.16.0', '0.17.0'];
+    for (const v of versions) {
+      await fs.mkdir(path.join(tmpHome, '.lbdb', 'extension', v, 'win_amd64', 'fts'), {
+        recursive: true,
+      });
+    }
+    // Only 0.16.0 has the binary; the probe should keep iterating past empty siblings.
+    await fs.writeFile(
+      path.join(
+        tmpHome,
+        '.lbdb',
+        'extension',
+        '0.16.0',
+        'win_amd64',
+        'fts',
+        'libfts.lbug_extension',
+      ),
+      Buffer.from('mock-binary'),
+    );
+    await expect(hasLocalWinFtsExtension()).resolves.toBe(true);
+  });
+
+  it('returns false when version dirs exist but none contain the binary', async () => {
+    // Adversarial topology raised by #1690 review: tree exists (Nix store, Bazel
+    // sandbox seeding, corporate MDM-prepopulated user dirs) but the actual
+    // libfts.lbug_extension file is absent. Probe must distinguish file from dir.
+    const versions = ['0.15.0', '0.16.0', '0.17.0'];
+    for (const v of versions) {
+      await fs.mkdir(path.join(tmpHome, '.lbdb', 'extension', v, 'win_amd64', 'fts'), {
+        recursive: true,
+      });
+    }
+    await expect(hasLocalWinFtsExtension()).resolves.toBe(false);
+  });
+
+  it('returns false when fs.readdir throws (e.g. permission denied on the extension root)', async () => {
+    // Cover the outer try/catch — any fs error walking the extension root is
+    // treated as "no binary present", matching the upstream skip-guard intent.
+    const eaccess = Object.assign(new Error('EACCES: permission denied'), {
+      code: 'EACCES',
+    }) as NodeJS.ErrnoException;
+    vi.spyOn(fs, 'readdir').mockRejectedValue(eaccess);
+    await expect(hasLocalWinFtsExtension()).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1690.

## Problem

The Windows skip-on-`process.platform === 'win32'` guard in `gitnexus/src/core/lbug/pool-adapter.ts` (both `doInitLbug` and `initLbugWithDb`) hard-skips `loadFTSExtension()` on every Windows host — even when the FTS extension binary is already present locally at `~/.lbdb/extension/<version>/win_amd64/fts/libfts.lbug_extension`.

That made sense as a workaround for the install-time SIGSEGV documented in #1199 / #1217. But once the binary is on disk it becomes too aggressive: `LOAD EXTENSION fts` would succeed, yet `loadFTSExtension` is never called. BM25 silently returns 0 hits on hosts with a working FTS extension; `gitnexus doctor` still reports FTS as available. Repro and root-cause analysis in #1690.

## Fix

Add `hasLocalWinFtsExtension()` and gate the Windows skip on it:

```ts
if (process.platform === 'win32') {
  shared.ftsLoaded = (await hasLocalWinFtsExtension())
    ? await loadFTSExtension(available[0], { policy: 'load-only' })
    : true;
} else {
  shared.ftsLoaded = await loadFTSExtension(available[0], { policy: 'load-only' });
}
```

`hasLocalWinFtsExtension()` probes `~/.lbdb/extension/*/win_amd64/fts/libfts.lbug_extension`. If at least one version dir has the binary on disk, we call `loadFTSExtension(..., { policy: 'load-only' })`. The crashing install path is never exercised — `load-only` short-circuits `extensionManager.ensure` before reaching `installDuckDbExtensionOutOfProcess`. Applied at both guard sites.

## Why the original SIGSEGV doesn't reappear

`#1199` / `#1217` documented the crash inside the install path. Two empirical reasons it stays mitigated here:

1. **`load-only` skips install entirely** — `extensionManager.ensure` returns false without invoking the installer when LOAD fails under `load-only`. `bm25-index.js`'s downstream noop continues to handle the unavailable case gracefully.

2. **LadybugDB resolves `LOAD EXTENSION fts` to a single version-specific path internally** — it does not glob across `~/.lbdb/extension/*/`. Stale or zero-byte sibling version dirs are inert: LadybugDB never `dlopen`s them. Errors at the resolution path (missing binary, zero-byte stub) propagate as JS exceptions and are caught by `tryLoad`'s `try/catch` in `gitnexus/src/core/lbug/extension-loader.ts`, then funneled through `markUnavailable`. No silent greenlight, no `dlopen` of a stale binary.

## Verification (Windows 10 Pro Education 10.0.19045 + Node 22.19.0 + gitnexus 1.6.5 + @ladybugdb/core 0.16.1 + FTS extension cached at 0.16.0)

| Scenario                                                                                                                | Exit | FTS-unavailable log? | BM25 ms | Outcome              |
| ----------------------------------------------------------------------------------------------------------------------- | ---- | -------------------- | ------- | -------------------- |
| Real 0.16.0 binary only                                                                                                 | 0    | no                   | ~1100   | Real hits            |
| Real 0.16.0 binary + stubs at 0.15.0, 0.16.1, 0.17.0 (adversarial mixed)                                                 | 0    | no                   | ~8000   | Real hits            |
| Stub-only at non-resolution path 0.16.1                                                                                 | 0    | yes (`extension not pre-installed`)             | ~120    | FTS unavailable      |
| Stub-only at exact resolution path 0.16.0                                                                                | 0    | yes (`extension not pre-installed`)             | ~115    | FTS unavailable      |
| No `~/.lbdb/extension/` dir                                                                                              | 0    | no                   | 0       | Upstream skip path (preserved) |

No crashes, no silent greenlights, BM25 timings prove FTS actually ran when the binary was present, `gitnexus context` / `impact` / `cypher` unaffected on every variant.

## Notes / follow-ups not addressed here

- `gitnexus doctor` still reports `Full-text search: available` regardless of actual load state — covered by #1217's last bullet, deliberately scoped out of this PR. Happy to send a follow-up that has `doctor` consult `extensionManager.getCapabilities()` instead.
- An optimization is possible: version-scope the probe to `~/.lbdb/extension/<core-expected-version>/win_amd64/fts/...` to skip a guaranteed-to-fail load attempt when only stale version dirs are on disk (saves ~120ms in that edge case). Not done here because identifying "the version LadybugDB expects" from JS isn't trivially derived — on this build, `@ladybugdb/core` package version is 0.16.1 but the resolved FTS binary version is 0.16.0. The broad probe is correct; the perf nit is genuinely a perf nit.
- Happy to gate behind `GITNEXUS_LBUG_EXTENSION_LOAD_ON_WIN32=allow-if-present` env var if a more conservative rollout shape is preferred.