### PR TITLE
fix(workers): isolate native parser crashes via split-and-skip (#1665)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Commands and gotchas live under **Repo reference** below and in **[CONTRIBUTING.
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **GitNexus** (26675 symbols, 35395 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **GitNexus** (27408 symbols, 42581 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -100,26 +100,6 @@ This project is indexed by GitNexus as **GitNexus** (26675 symbols, 35395 relati
 | Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
 | Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
 | Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
-| Work in the Ingestion area (239 symbols) | `.claude/skills/generated/ingestion/SKILL.md` |
-| Work in the Extractors area (135 symbols) | `.claude/skills/generated/extractors/SKILL.md` |
-| Work in the Components area (112 symbols) | `.claude/skills/generated/components/SKILL.md` |
-| Work in the Lbug area (96 symbols) | `.claude/skills/generated/lbug/SKILL.md` |
-| Work in the Group area (94 symbols) | `.claude/skills/generated/group/SKILL.md` |
-| Work in the Cli area (92 symbols) | `.claude/skills/generated/cli/SKILL.md` |
-| Work in the Configs area (92 symbols) | `.claude/skills/generated/configs/SKILL.md` |
-| Work in the Type-extractors area (90 symbols) | `.claude/skills/generated/type-extractors/SKILL.md` |
-| Work in the Hooks area (88 symbols) | `.claude/skills/generated/hooks/SKILL.md` |
-| Work in the Unit area (80 symbols) | `.claude/skills/generated/unit/SKILL.md` |
-| Work in the Cpp area (73 symbols) | `.claude/skills/generated/cpp/SKILL.md` |
-| Work in the Scope-resolution area (72 symbols) | `.claude/skills/generated/scope-resolution/SKILL.md` |
-| Work in the Server area (66 symbols) | `.claude/skills/generated/server/SKILL.md` |
-| Work in the Local area (61 symbols) | `.claude/skills/generated/local/SKILL.md` |
-| Work in the Wiki area (60 symbols) | `.claude/skills/generated/wiki/SKILL.md` |
-| Work in the Workers area (57 symbols) | `.claude/skills/generated/workers/SKILL.md` |
-| Work in the Embeddings area (56 symbols) | `.claude/skills/generated/embeddings/SKILL.md` |
-| Work in the Typescript area (53 symbols) | `.claude/skills/generated/typescript/SKILL.md` |
-| Work in the Storage area (51 symbols) | `.claude/skills/generated/storage/SKILL.md` |
-| Work in the Php area (48 symbols) | `.claude/skills/generated/php/SKILL.md` |
 
 <!-- gitnexus:end -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ See the `<!-- gitnexus:start --> … <!-- gitnexus:end -->` block in **[AGENTS.m
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **GitNexus** (26675 symbols, 35395 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **GitNexus** (27408 symbols, 42581 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -94,25 +94,5 @@ This project is indexed by GitNexus as **GitNexus** (26675 symbols, 35395 relati
 | Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
 | Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
 | Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
-| Work in the Ingestion area (239 symbols) | `.claude/skills/generated/ingestion/SKILL.md` |
-| Work in the Extractors area (135 symbols) | `.claude/skills/generated/extractors/SKILL.md` |
-| Work in the Components area (112 symbols) | `.claude/skills/generated/components/SKILL.md` |
-| Work in the Lbug area (96 symbols) | `.claude/skills/generated/lbug/SKILL.md` |
-| Work in the Group area (94 symbols) | `.claude/skills/generated/group/SKILL.md` |
-| Work in the Cli area (92 symbols) | `.claude/skills/generated/cli/SKILL.md` |
-| Work in the Configs area (92 symbols) | `.claude/skills/generated/configs/SKILL.md` |
-| Work in the Type-extractors area (90 symbols) | `.claude/skills/generated/type-extractors/SKILL.md` |
-| Work in the Hooks area (88 symbols) | `.claude/skills/generated/hooks/SKILL.md` |
-| Work in the Unit area (80 symbols) | `.claude/skills/generated/unit/SKILL.md` |
-| Work in the Cpp area (73 symbols) | `.claude/skills/generated/cpp/SKILL.md` |
-| Work in the Scope-resolution area (72 symbols) | `.claude/skills/generated/scope-resolution/SKILL.md` |
-| Work in the Server area (66 symbols) | `.claude/skills/generated/server/SKILL.md` |
-| Work in the Local area (61 symbols) | `.claude/skills/generated/local/SKILL.md` |
-| Work in the Wiki area (60 symbols) | `.claude/skills/generated/wiki/SKILL.md` |
-| Work in the Workers area (57 symbols) | `.claude/skills/generated/workers/SKILL.md` |
-| Work in the Embeddings area (56 symbols) | `.claude/skills/generated/embeddings/SKILL.md` |
-| Work in the Typescript area (53 symbols) | `.claude/skills/generated/typescript/SKILL.md` |
-| Work in the Storage area (51 symbols) | `.claude/skills/generated/storage/SKILL.md` |
-| Work in the Php area (48 symbols) | `.claude/skills/generated/php/SKILL.md` |
 
 <!-- gitnexus:end -->

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -212,13 +212,34 @@ const processParsingWithWorkers = async (
 
   const total = files.length;
 
+  // Files whose parse worker aborted with a native crash (e.g. tree-sitter
+  // threw an uncatchable C++ `Napi::Error` — see GitNexus#1665). The pool
+  // isolates them via binary-search retry, then skips the offender so
+  // indexing can continue. We collect them here so the analyze summary
+  // can surface them as "skipped (native parser crash)" instead of having
+  // them silently disappear from the resulting graph.
+  const crashedPaths: string[] = [];
+
   // Dispatch to worker pool — pool handles splitting into chunks and sub-batching
   const chunkResults = await workerPool.dispatch<ParseWorkerInput, ParseWorkerResult>(
     parseableFiles,
     (filesProcessed) => {
       onFileProgress?.(Math.min(filesProcessed, total), total, 'Parsing...');
     },
+    (item) => {
+      crashedPaths.push(item.path);
+    },
   );
+
+  if (crashedPaths.length > 0) {
+    const preview = crashedPaths.slice(0, 5).join(', ');
+    const more = crashedPaths.length > 5 ? `, … (${crashedPaths.length - 5} more)` : '';
+    logger.warn(
+      { crashedPaths },
+      `[ingestion] Skipped ${crashedPaths.length} file(s) that crashed the parser worker: ${preview}${more}. ` +
+        `These files are excluded from the index. See GitNexus#1665.`,
+    );
+  }
 
   // Capture the raw chunk results for the incremental parse cache before
   // merging — the cache stores the unmerged worker output so a future run

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -212,12 +212,7 @@ const processParsingWithWorkers = async (
 
   const total = files.length;
 
-  // Files whose parse worker aborted with a native crash (e.g. tree-sitter
-  // threw an uncatchable C++ `Napi::Error` — see GitNexus#1665). The pool
-  // isolates them via binary-search retry, then skips the offender so
-  // indexing can continue. We collect them here so the analyze summary
-  // can surface them as "skipped (native parser crash)" instead of having
-  // them silently disappear from the resulting graph.
+  // Files skipped due to native parser crash (see GitNexus#1665).
   const crashedPaths: string[] = [];
 
   // Dispatch to worker pool — pool handles splitting into chunks and sub-batching

--- a/gitnexus/src/core/ingestion/workers/worker-pool.ts
+++ b/gitnexus/src/core/ingestion/workers/worker-pool.ts
@@ -356,31 +356,15 @@ export const createWorkerPool = (
       };
 
       /**
-       * Worker exited unexpectedly mid-job (non-zero exit, settled=false).
-       * The most common cause is a native parser binding throwing an
-       * unrecoverable C++ exception (`terminate called after throwing an
-       * instance of 'Napi::Error'`) — `worker_threads` cannot catch
-       * `std::terminate`, so the entire worker process aborts.
-       *
-       * Strategy: mirror `requeueAfterTimeout`. If the job had more than
-       * one item we cannot tell which one killed the worker, so split the
-       * job in half and re-queue both halves (binary-search isolation).
-       * Once isolated to a single item we know that item is the killer:
-       * skip it, notify the caller via `onItemCrash`, and continue.
-       *
-       * Returns true if the pool should keep going (worker should be
-       * replaced and another job pulled), false if the situation is
-       * unrecoverable and the pool should fail. Under the current rules
-       * this only returns false when `replaceWorker` itself ultimately
-       * fails — see `exitHandler`.
-       *
-       * See GitNexus#1665.
+       * Mirror of {@link requeueAfterTimeout} for the worker-exit path:
+       * binary-search the offending file via job splitting, then skip
+       * the isolated single item. See GitNexus#1665.
        */
       const requeueAfterCrash = (
         workerIndex: number,
         job: WorkerJob<TInput>,
         exitCode: number,
-      ): boolean => {
+      ): void => {
         if (job.items.length > 1) {
           const midpoint = Math.ceil(job.items.length / 2);
           const firstItems = job.items.slice(0, midpoint);
@@ -410,19 +394,14 @@ export const createWorkerPool = (
               firstSplitItems: first.items.length,
               secondSplitItems: second.items.length,
             },
-            `Worker ${workerIndex} exited with code ${exitCode}. Splitting job into ${first.items.length}/${second.items.length} items to isolate the offending file (likely native parser crash — see GitNexus#1665).`,
+            `Worker ${workerIndex} exited with code ${exitCode}. Splitting into ${first.items.length}/${second.items.length} item jobs to isolate the offending file (likely native parser crash — see GitNexus#1665).`,
           );
           jobs.unshift(first, second);
-          return true;
+          return;
         }
 
         const item = job.items[0];
         const offendingPath = itemPath(item) ?? '<unknown>';
-        const reason = new Error(
-          `Worker ${workerIndex} crashed (exit ${exitCode}) parsing ${offendingPath}. ` +
-            `Skipping file — native tree-sitter binding likely threw an unrecoverable ` +
-            `C++ exception (see GitNexus#1665). Other files continue indexing.`,
-        );
         logger.warn(
           {
             workerIndex,
@@ -433,20 +412,10 @@ export const createWorkerPool = (
           `Worker ${workerIndex} crashed on a single file (${offendingPath}). Skipping and continuing.`,
         );
         if (onItemCrash) {
-          try {
-            onItemCrash(item, reason);
-          } catch (callbackErr) {
-            logger.warn(
-              { err: callbackErr },
-              'onItemCrash callback threw — continuing with item skipped.',
-            );
-          }
+          onItemCrash(item, new Error(`exit ${exitCode} parsing ${offendingPath}`));
         }
-        // The file is now considered "processed" for progress accounting —
-        // it has reached a terminal state, just not a successful one.
         completedFiles += 1;
         reportProgress();
-        return true;
       };
 
       const runWorker = (workerIndex: number) => {
@@ -555,26 +524,10 @@ export const createWorkerPool = (
           cleanup();
           inFlightProgress[workerIndex] = 0;
 
-          // Clean exit shouldn't really happen mid-job (the worker stays
-          // alive until terminated by the pool), but if it does just move
-          // on to the next job without poisoning the pool.
-          if (code === 0) {
-            activeWorkers--;
-            runWorker(workerIndex);
-            maybeDone();
-            return;
-          }
-
-          // Non-zero exit mid-job: most commonly a native parser binding
-          // aborted the worker process (e.g. `terminate called after
-          // throwing an instance of 'Napi::Error'`). Try to isolate and
-          // skip the offending file rather than failing the whole pool.
+          // Native parser crash (e.g. `Napi::Error` thrown out of
+          // tree-sitter) — isolate and skip rather than poison the pool.
           // See GitNexus#1665.
-          const shouldContinue = requeueAfterCrash(workerIndex, job, code);
-          if (!shouldContinue) {
-            activeWorkers--;
-            return;
-          }
+          requeueAfterCrash(workerIndex, job, code);
 
           void (async () => {
             try {

--- a/gitnexus/src/core/ingestion/workers/worker-pool.ts
+++ b/gitnexus/src/core/ingestion/workers/worker-pool.ts
@@ -8,10 +8,16 @@ export interface WorkerPool {
   /**
    * Dispatch items across workers. Items are split into bounded jobs, each job
    * is committed independently, and stalled jobs are split/retried locally.
+   *
+   * `onItemCrash` is invoked when a single item killed its worker (typically
+   * a native parser binding throwing an unrecoverable C++ exception — see
+   * GitNexus#1665). When omitted, crashes still produce a logger.warn but
+   * the caller has no programmatic handle on which inputs were skipped.
    */
   dispatch<TInput, TResult>(
     items: TInput[],
     onProgress?: (filesProcessed: number) => void,
+    onItemCrash?: (item: TInput, reason: Error) => void,
   ): Promise<TResult[]>;
 
   /** Terminate all workers. Must be called when done. */
@@ -198,6 +204,7 @@ export const createWorkerPool = (
   const dispatch = <TInput, TResult>(
     items: TInput[],
     onProgress?: (filesProcessed: number) => void,
+    onItemCrash?: (item: TInput, reason: Error) => void,
   ): Promise<TResult[]> => {
     if (poolBroken) {
       const reason = poolFailure ? `: ${poolFailure.message}` : '';
@@ -348,6 +355,100 @@ export const createWorkerPool = (
         return false;
       };
 
+      /**
+       * Worker exited unexpectedly mid-job (non-zero exit, settled=false).
+       * The most common cause is a native parser binding throwing an
+       * unrecoverable C++ exception (`terminate called after throwing an
+       * instance of 'Napi::Error'`) — `worker_threads` cannot catch
+       * `std::terminate`, so the entire worker process aborts.
+       *
+       * Strategy: mirror `requeueAfterTimeout`. If the job had more than
+       * one item we cannot tell which one killed the worker, so split the
+       * job in half and re-queue both halves (binary-search isolation).
+       * Once isolated to a single item we know that item is the killer:
+       * skip it, notify the caller via `onItemCrash`, and continue.
+       *
+       * Returns true if the pool should keep going (worker should be
+       * replaced and another job pulled), false if the situation is
+       * unrecoverable and the pool should fail. Under the current rules
+       * this only returns false when `replaceWorker` itself ultimately
+       * fails — see `exitHandler`.
+       *
+       * See GitNexus#1665.
+       */
+      const requeueAfterCrash = (
+        workerIndex: number,
+        job: WorkerJob<TInput>,
+        exitCode: number,
+      ): boolean => {
+        if (job.items.length > 1) {
+          const midpoint = Math.ceil(job.items.length / 2);
+          const firstItems = job.items.slice(0, midpoint);
+          const secondItems = job.items.slice(midpoint);
+          const first: WorkerJob<TInput> = {
+            startIndex: job.startIndex,
+            items: firstItems,
+            estimatedBytes: firstItems.reduce((sum, item) => sum + estimateItemBytes(item), 0),
+            attempt: job.attempt,
+            splitDepth: job.splitDepth + 1,
+            timeoutMs: job.timeoutMs,
+          };
+          const second: WorkerJob<TInput> = {
+            startIndex: job.startIndex + midpoint,
+            items: secondItems,
+            estimatedBytes: secondItems.reduce((sum, item) => sum + estimateItemBytes(item), 0),
+            attempt: job.attempt,
+            splitDepth: job.splitDepth + 1,
+            timeoutMs: job.timeoutMs,
+          };
+          logger.warn(
+            {
+              workerIndex,
+              exitCode,
+              items: job.items.length,
+              estimatedBytes: job.estimatedBytes,
+              firstSplitItems: first.items.length,
+              secondSplitItems: second.items.length,
+            },
+            `Worker ${workerIndex} exited with code ${exitCode}. Splitting job into ${first.items.length}/${second.items.length} items to isolate the offending file (likely native parser crash — see GitNexus#1665).`,
+          );
+          jobs.unshift(first, second);
+          return true;
+        }
+
+        const item = job.items[0];
+        const offendingPath = itemPath(item) ?? '<unknown>';
+        const reason = new Error(
+          `Worker ${workerIndex} crashed (exit ${exitCode}) parsing ${offendingPath}. ` +
+            `Skipping file — native tree-sitter binding likely threw an unrecoverable ` +
+            `C++ exception (see GitNexus#1665). Other files continue indexing.`,
+        );
+        logger.warn(
+          {
+            workerIndex,
+            exitCode,
+            path: offendingPath,
+            bytes: job.estimatedBytes,
+          },
+          `Worker ${workerIndex} crashed on a single file (${offendingPath}). Skipping and continuing.`,
+        );
+        if (onItemCrash) {
+          try {
+            onItemCrash(item, reason);
+          } catch (callbackErr) {
+            logger.warn(
+              { err: callbackErr },
+              'onItemCrash callback threw — continuing with item skipped.',
+            );
+          }
+        }
+        // The file is now considered "processed" for progress accounting —
+        // it has reached a terminal state, just not a successful one.
+        completedFiles += 1;
+        reportProgress();
+        return true;
+      };
+
       const runWorker = (workerIndex: number) => {
         if (stopped) return;
         const job = jobs.shift();
@@ -449,15 +550,45 @@ export const createWorkerPool = (
         };
 
         const exitHandler = (code: number) => {
-          if (!settled) {
-            settled = true;
-            cleanup();
-            void fail(
-              new Error(
-                `Worker ${workerIndex} exited with code ${code}. Likely OOM or native addon failure.`,
-              ),
-            );
+          if (settled) return;
+          settled = true;
+          cleanup();
+          inFlightProgress[workerIndex] = 0;
+
+          // Clean exit shouldn't really happen mid-job (the worker stays
+          // alive until terminated by the pool), but if it does just move
+          // on to the next job without poisoning the pool.
+          if (code === 0) {
+            activeWorkers--;
+            runWorker(workerIndex);
+            maybeDone();
+            return;
           }
+
+          // Non-zero exit mid-job: most commonly a native parser binding
+          // aborted the worker process (e.g. `terminate called after
+          // throwing an instance of 'Napi::Error'`). Try to isolate and
+          // skip the offending file rather than failing the whole pool.
+          // See GitNexus#1665.
+          const shouldContinue = requeueAfterCrash(workerIndex, job, code);
+          if (!shouldContinue) {
+            activeWorkers--;
+            return;
+          }
+
+          void (async () => {
+            try {
+              await replaceWorker(workerIndex);
+            } catch (err) {
+              void fail(err instanceof Error ? err : new Error(String(err)));
+              return;
+            } finally {
+              activeWorkers--;
+            }
+            reportProgress();
+            runWorker(workerIndex);
+            maybeDone();
+          })();
         };
 
         worker.on('message', handler);


### PR DESCRIPTION
# PR Draft — fix(workers): isolate native parser crashes via split-and-skip (#1665)

**Branch (local-only, not pushed):** `fix/issue-1665-napi-error-skip-on-crash`
**Repo:** `/home/drdave/_work/repos/GitNexus`
**Closes:** GitNexus#1665 — `Napi::Error` mid-analyze on TF Lite Micro + executorch

---

## Summary

- A single C/C++ file in `tensorflow-lite-micro` + `executorch` aborts the
  whole `gitnexus analyze` run with `terminate called after throwing an
  instance of 'Napi::Error'`. The throw originates inside a tree-sitter
  native binding; `worker_threads` cannot intercept `std::terminate`, so
  no amount of JS-level `try/catch` rescues it.
- Today, the worker pool's `exitHandler` reacts to the resulting non-zero
  worker exit by calling `fail()` — poisoning the pool and rejecting the
  entire dispatch. One pathological file ⇒ no index.
- This PR extends the **split-and-retry** strategy already used for idle
  timeouts (`requeueAfterTimeout`) to the exit path: halve until isolated
  to the killer file, then **skip-with-warning** instead of failing.

## Behaviour change

Before:
```
[parse chunk 11/86] worker exits → pool fails → analyze aborts
```

After:
```
[parse chunk 11/86] worker exits → split job into 2 → re-queue
… (binary-search) …
[isolated to badFile.h] worker exits → logger.warn(path) → skip → continue
[analyze done] N nodes indexed, 1 file skipped (native parser crash)
```

## Files

- `gitnexus/src/core/ingestion/workers/worker-pool.ts`
  - New `requeueAfterCrash(workerIndex, job, exitCode)` helper, modeled on
    the existing `requeueAfterTimeout`. Halves the job when possible;
    otherwise calls the new `onItemCrash` callback and bumps the progress
    counter so the file is accounted for.
  - `exitHandler` no longer calls `fail()` on non-zero exit — it delegates
    to `requeueAfterCrash` then replaces the worker and pulls the next
    job. `fail()` still fires if `replaceWorker` itself can't bring a new
    worker online (existing behaviour preserved).
  - Public `dispatch` signature gains an optional 3rd parameter:
    `onItemCrash?: (item: TInput, reason: Error) => void`. All existing
    callers remain source-compatible.

- `gitnexus/src/core/ingestion/parsing-processor.ts`
  - `processParsingWithWorkers` now supplies `onItemCrash`, collects the
    skipped paths, and emits a summary `logger.warn` with the first 5
    paths (and a "… (N more)" tail). This is what operators see in the
    analyze output when a native crash is recovered.

## Test plan

- [ ] Run analyze on the original `tensorflow-lite-micro` + `executorch`
  repos and confirm the run completes with a per-file skip warning rather
  than aborting. *(Cannot verify locally — the repro repos are not in this
  worktree; left to the reporter / a maintainer with the workload.)*
- [ ] Add an integration test in
  `gitnexus/test/integration/worker-pool.test.ts` that spawns a worker
  fixture which calls `process.exit(1)` immediately on receiving a
  `sub-batch` message containing a designated "killer" path. Assert that:
  - dispatch resolves (does not reject)
  - the `onItemCrash` callback fires exactly once for the killer path
  - results for non-killer paths are returned
  - progress reaches `items.length`
- [ ] Confirm existing `'rejects dispatch when replacement worker crashes
  during startup'` test still passes — this PR only changes the exit
  path, not the timeout-then-replace path it exercises.
- [ ] Confirm `'preserves global path order across split-and-retry'`
  still passes — the new `requeueAfterCrash` uses the same `jobs.unshift`
  ordering as `requeueAfterTimeout`.

## Limitations / explicitly out of scope

A truly crash-tolerant parsing pipeline would isolate each file in a
`child_process` rather than a `worker_thread`. That is a larger
architectural change (~serialise inputs/outputs across pipe instead of
structured-clone, plus restart overhead) and is intentionally deferred.
This PR is the minimum-viable, lowest-risk fix that converts a hard
abort into a recoverable per-file skip.
