### PR TITLE
fix(eval-server): localhost now doesn't normalize into IPv4 instead lets OS decide which to bind

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -211,6 +211,8 @@ environment:
 
 Defaults are `port: 4848` and `host: 127.0.0.1` (loopback only). Use `0.0.0.0` only when the agent container needs to reach the eval-server from a separate network namespace. The health probe and tool scripts connect via the configured bind host (defaulting to `127.0.0.1`), which is reachable for both loopback and all-interface binds.
 
+`"localhost"` is also a valid `eval_server_host` value. The OS resolves it at bind time — to `127.0.0.1` on IPv4 systems and `::1` on IPv6-only systems. The READY signal will reflect the actual bound address (e.g. `GITNEXUS_EVAL_SERVER_READY:127.0.0.1:4848` or `GITNEXUS_EVAL_SERVER_READY:[::1]:4848`), not the literal string `localhost`. Use this when you want the server to bind to whichever loopback address the OS prefers rather than forcing IPv4.
+
 **Running eval-server directly in Docker / Docker Compose:**
 
 ```bash

--- a/eval/README.md
+++ b/eval/README.md
@@ -211,7 +211,7 @@ environment:
 
 Defaults are `port: 4848` and `host: 127.0.0.1` (loopback only). Use `0.0.0.0` only when the agent container needs to reach the eval-server from a separate network namespace. The health probe and tool scripts connect via the configured bind host (defaulting to `127.0.0.1`), which is reachable for both loopback and all-interface binds.
 
-`"localhost"` is also a valid `eval_server_host` value. The OS resolves it at bind time — to `127.0.0.1` on IPv4 systems and `::1` on IPv6-only systems. The READY signal will reflect the actual bound address (e.g. `GITNEXUS_EVAL_SERVER_READY:127.0.0.1:4848` or `GITNEXUS_EVAL_SERVER_READY:[::1]:4848`), not the literal string `localhost`. Use this when you want the server to bind to whichever loopback address the OS prefers rather than forcing IPv4.
+`"localhost"` is also a valid `eval_server_host` value. The OS resolves it at bind time — typically `127.0.0.1` on dual-stack or IPv4-only systems, and `::1` on IPv6-only systems. The exact result depends on your `/etc/hosts` and `gai.conf`. The READY signal will reflect the actual bound address (e.g. `GITNEXUS_EVAL_SERVER_READY:127.0.0.1:4848` or `GITNEXUS_EVAL_SERVER_READY:[::1]:4848`), not the literal string `localhost`. Use this when you want the server to bind to whichever loopback address the OS prefers rather than forcing IPv4.
 
 **Running eval-server directly in Docker / Docker Compose:**
 

--- a/gitnexus/src/cli/eval-server.ts
+++ b/gitnexus/src/cli/eval-server.ts
@@ -472,7 +472,9 @@ export async function evalServerCommand(options?: EvalServerOptions): Promise<vo
         { code: err.code, port, host },
       );
     } else if (err.code === 'EADDRNOTAVAIL') {
-      const isIPv6Host = isIPv6(host);
+      // "localhost" may resolve to ::1 on IPv6-only systems; treat it as
+      // potentially IPv6 so the user gets the right diagnostic hint.
+      const isIPv6Host = isIPv6(host) || host === 'localhost';
       cliError(
         `\nGitNexus eval-server failed to start:\n` +
           `  Address ${host} is not available on this machine.\n\n` +
@@ -542,8 +544,7 @@ export async function evalServerCommand(options?: EvalServerOptions): Promise<vo
     });
     try {
       // Use fd 1 directly — LadybugDB captures process.stdout (#324)
-      const readyHost = boundAddress.includes(':') ? `[${boundAddress}]` : boundAddress;
-      writeSync(1, `GITNEXUS_EVAL_SERVER_READY:${readyHost}:${boundPort}\n`);
+      writeSync(1, `GITNEXUS_EVAL_SERVER_READY:${displayHost}:${boundPort}\n`);
     } catch {
       // stdout may not be available (e.g., broken pipe)
     }

--- a/gitnexus/src/cli/eval-server.ts
+++ b/gitnexus/src/cli/eval-server.ts
@@ -479,7 +479,7 @@ export async function evalServerCommand(options?: EvalServerOptions): Promise<vo
         `\nGitNexus eval-server failed to start:\n` +
           `  Address ${host} is not available on this machine.\n\n` +
           (isIPv6Host
-            ? `  IPv6 address ${host} is not reachable — IPv6 may be disabled on this system or container.\n` +
+            ? `  Address ${host} resolved but is not reachable — IPv6 may be disabled, or the loopback interface may be unavailable.\n` +
               `  Docker containers and many CI environments disable IPv6 by default.\n\n`
             : `  The --host value must be an IP assigned to a local network interface.\n` +
               `  Run \`ip addr\` (Linux) or \`ipconfig\` (Windows) to list available addresses.\n\n`) +
@@ -514,8 +514,16 @@ export async function evalServerCommand(options?: EvalServerOptions): Promise<vo
     // actually bound to, not the input host string. This matters when "localhost"
     // is passed: the OS may resolve it to ::1 on some systems.
     const addr = server.address();
-    const boundPort = typeof addr === 'object' && addr !== null ? addr.port : port;
-    const boundAddress = typeof addr === 'object' && addr !== null ? addr.address : host;
+    // server.listen callback only fires after a successful TCP bind, so
+    // server.address() is guaranteed to return an AddressInfo object here.
+    if (typeof addr !== 'object' || addr === null) {
+      cliError(
+        `\nGitNexus eval-server: unexpected server.address() value after bind: ${JSON.stringify(addr)}\n`,
+      );
+      process.exit(1);
+    }
+    const boundPort = addr.port;
+    const boundAddress = addr.address;
     const displayHost = boundAddress.includes(':') ? `[${boundAddress}]` : boundAddress;
     const bannerLines = [
       `GitNexus eval-server: listening on http://${displayHost}:${boundPort}`,

--- a/gitnexus/src/cli/eval-server.ts
+++ b/gitnexus/src/cli/eval-server.ts
@@ -44,10 +44,12 @@ export interface EvalServerOptions {
 
 /**
  * Validate the --host value. Accepts IPv4, IPv6, or "localhost".
- * Returns the normalised host string, or null if invalid.
+ * Returns the host string unchanged, or null if invalid.
+ * "localhost" is passed through so the OS resolves it to the correct loopback
+ * address (127.0.0.1 or ::1) at bind time rather than forcing IPv4.
  */
 export function validateHost(raw: string): string | null {
-  if (raw === 'localhost') return '127.0.0.1';
+  if (raw === 'localhost') return raw;
   if (isIPv4(raw) || isIPv6(raw)) return raw;
   return null;
 }
@@ -506,10 +508,13 @@ export async function evalServerCommand(options?: EvalServerOptions): Promise<vo
     // Plain-text banner for the human watching stderr; structured record
     // for log aggregation (split into two so the user sees a real banner
     // not `{"level":30,"msg":"...","port":4747,"endpoints":[...]}`).
-    // Use server.address().port so --port 0 (OS-assigned) emits the real port.
+    // Use server.address() so the banner and READY signal reflect what the OS
+    // actually bound to, not the input host string. This matters when "localhost"
+    // is passed: the OS may resolve it to ::1 on some systems.
     const addr = server.address();
     const boundPort = typeof addr === 'object' && addr !== null ? addr.port : port;
-    const displayHost = host.includes(':') ? `[${host}]` : host;
+    const boundAddress = typeof addr === 'object' && addr !== null ? addr.address : host;
+    const displayHost = boundAddress.includes(':') ? `[${boundAddress}]` : boundAddress;
     const bannerLines = [
       `GitNexus eval-server: listening on http://${displayHost}:${boundPort}`,
       `  POST /tool/query    — search execution flows`,
@@ -537,7 +542,7 @@ export async function evalServerCommand(options?: EvalServerOptions): Promise<vo
     });
     try {
       // Use fd 1 directly — LadybugDB captures process.stdout (#324)
-      const readyHost = host.includes(':') ? `[${host}]` : host;
+      const readyHost = boundAddress.includes(':') ? `[${boundAddress}]` : boundAddress;
       writeSync(1, `GITNEXUS_EVAL_SERVER_READY:${readyHost}:${boundPort}\n`);
     } catch {
       // stdout may not be available (e.g., broken pipe)

--- a/gitnexus/test/integration/cli-e2e.test.ts
+++ b/gitnexus/test/integration/cli-e2e.test.ts
@@ -1408,5 +1408,102 @@ describe('CLI end-to-end', () => {
         }, 30000);
       });
     }, 35000);
+
+    it('emits READY signal with bound IP (not literal "localhost") when --host localhost is used', () => {
+      return new Promise<void>((resolve, reject) => {
+        const child = spawn(
+          process.execPath,
+          [
+            '--import',
+            tsxImportUrl,
+            cliEntry,
+            'eval-server',
+            '--port',
+            '0',
+            '--host',
+            'localhost',
+            '--idle-timeout',
+            '3',
+          ],
+          {
+            cwd: MINI_REPO,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            env: cliEnv(),
+          },
+        );
+
+        let stdoutBuffer = '';
+        let settled = false;
+
+        const settle = (fn: () => void) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          child.kill('SIGTERM');
+          fn();
+        };
+
+        child.stdout.on('data', async (chunk: Buffer) => {
+          stdoutBuffer += chunk.toString();
+          const readyLine = stdoutBuffer
+            .split('\n')
+            .find((l) => l.startsWith('GITNEXUS_EVAL_SERVER_READY:'));
+          if (!readyLine || settled) return;
+
+          // The signal must contain a real bound IP, not the literal input string
+          if (readyLine.includes(':localhost:')) {
+            settle(() =>
+              reject(
+                new Error(
+                  `READY signal contained literal "localhost" instead of a bound IP:\n${readyLine}`,
+                ),
+              ),
+            );
+            return;
+          }
+
+          // Parse host and port: everything after the prefix up to the last colon
+          const withoutPrefix = readyLine.slice('GITNEXUS_EVAL_SERVER_READY:'.length);
+          const lastColon = withoutPrefix.lastIndexOf(':');
+          const signalHost = withoutPrefix.slice(0, lastColon); // "127.0.0.1" or "[::1]"
+          const boundPort = withoutPrefix.slice(lastColon + 1).trim();
+          if (!boundPort || isNaN(Number(boundPort))) {
+            settle(() => reject(new Error(`Could not parse port from READY signal: ${readyLine}`)));
+            return;
+          }
+
+          // Probe /health at the bound address to confirm the server is reachable
+          try {
+            const res = await fetch(`http://${signalHost}:${boundPort}/health`);
+            if (res.status === 200) {
+              settle(resolve);
+            } else {
+              settle(() => reject(new Error(`/health returned ${res.status}, expected 200`)));
+            }
+          } catch (err) {
+            settle(() =>
+              reject(
+                new Error(
+                  `eval-server bound to localhost but /health unreachable at ${signalHost}:${boundPort}: ${err}`,
+                ),
+              ),
+            );
+          }
+        });
+
+        child.stderr.on('data', (chunk: Buffer) => {
+          const text = chunk.toString();
+          if (text.includes('unknown option') || text.includes('error: unknown')) {
+            settle(() => reject(new Error(`eval-server rejected --host flag:\n${text}`)));
+          }
+        });
+
+        const timer = setTimeout(() => {
+          settle(() =>
+            reject(new Error('eval-server --host localhost did not emit READY signal within 30s')),
+          );
+        }, 30000);
+      });
+    }, 35000);
   });
 });

--- a/gitnexus/test/unit/eval-formatters.test.ts
+++ b/gitnexus/test/unit/eval-formatters.test.ts
@@ -19,8 +19,8 @@ import {
 // ─── validateHost ────────────────────────────────────────────────────
 
 describe('validateHost', () => {
-  it('normalizes "localhost" to "127.0.0.1"', () => {
-    expect(validateHost('localhost')).toBe('127.0.0.1');
+  it('passes "localhost" through unchanged', () => {
+    expect(validateHost('localhost')).toBe('localhost');
   });
 
   it('accepts valid IPv4 addresses', () => {


### PR DESCRIPTION
## Summary
`localhost` as `gitnexus eval-server --host <value>` now lets the running OS to decide which (IPv4 / IPv6) to be binded.
<!-- One or two sentences: what does this PR change? -->

## Motivation / context
Related to Issue: #1723

Current state of `gitnexus eval-server --host <value>` resolve `localhost` into `127.0.0.1` which is too optioned and could cause problem for devices that only accepts IPv6.

<!-- Why is this change needed? Link issues, ADRs, or prior discussion. -->

## Areas touched

<!-- Check all that apply -->

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**
- changed `validateHost()` to not normalize `localhost` into IPv4 (127.0.0.1)
- updated the comments reflecting the code behavior
- updated the unit test for eval-server

<!-- bullets -->

**Explicitly out of scope / not done here**
- the siblings `gitnexus serve` has many gaps compared to `gitnexus eval-server` (this should be a different issue)

<!-- bullets — prevents reviewers assuming missing work is an oversight -->

## Implementation notes

<!-- Optional: design choices, tradeoffs, follow-ups -->

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [x] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [x] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(if web changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

## Risk & rollout

<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed
