### PR TITLE
ci(web): use npm ci for deterministic Vercel installs

### DIFF
--- a/gitnexus-web/vercel.json
+++ b/gitnexus-web/vercel.json
@@ -1,3 +1,3 @@
 {
-  "installCommand": "cd ../gitnexus-shared && npm install && npm run build && cd ../gitnexus-web && npm install"
+  "installCommand": "cd ../gitnexus-shared && npm install && npm run build && cd ../gitnexus-web && npm ci --include=dev"
 }


### PR DESCRIPTION
## Summary

Switch the `gitnexus-web` Vercel install from `npm install` to `npm ci --include=dev` so the deployment install is deterministic and immune to build-cache drift.

## Motivation / context

Vercel restores a cached `node_modules` snapshot and runs the custom `installCommand` incrementally. With `npm install`, a lockfile change makes the incremental reconcile leave `gitnexus-web` without a usable `tsc` binary, so `npm run build` (`tsc -b && vite build`) fails with `sh: line 1: tsc: command not found` (exit 127). This is exactly what blocks #1705, whose dependency-graph change invalidated the cached snapshot.

`npm ci` is the npm-sanctioned install for CI/deploy: it ignores whatever is in the restored tree and installs exactly what `package-lock.json` specifies, so the build tooling (typescript, vite) is always present. `--include=dev` keeps devDependencies installed even if the build env sets `NODE_ENV=production`.

Related: #1705

## Areas touched

- [x] `gitnexus-web/` (Vite / React UI) — deployment config only (`vercel.json`)

## Scope & constraints

**In scope**

- `gitnexus-web/vercel.json` installCommand: `npm install` -> `npm ci --include=dev` for the web install step.

**Explicitly out of scope / not done here**

- The `gitnexus-shared` install step is left as-is (it builds cleanly today).
- No dependency version changes; no application/runtime source changes.

## Testing & verification

- Config-only change (no TS/source touched), so package typecheck/tests are unaffected.
- Real verification is the Vercel preview deploy on this PR — it should build green using `npm ci`.

## Risk & rollout

- Low. `npm ci` adds ~30s per deploy (relink only; Vercel still caches the npm download store, so nothing is re-downloaded). It does **not** disable Vercel's cache.
- Requires `package-lock.json` in sync with `package.json` (true on `main`). If it ever drifts, `npm ci` fails fast and visibly instead of silently shipping a broken install.
- Rollback: revert this one-line change.

## Checklist

- [x] PR body meets repo minimum length
- [x] No secrets, tokens, or machine-specific paths committed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change affecting deployment installs; main impact is deploy-time behavior (fails fast if `package-lock.json` is out of sync).
> 
> **Overview**
> Switches `gitnexus-web`’s Vercel `installCommand` from `npm install` to `npm ci --include=dev` to ensure deterministic installs and reliably include build tooling during deploys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 317fc1f00c1592574cda41ad06f1a7e633419cd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->