### PR TITLE
feat(wiki): support local Claude and Codex providers

### DIFF
--- a/gitnexus/scripts/cross-platform-tests.ts
+++ b/gitnexus/scripts/cross-platform-tests.ts
@@ -79,6 +79,7 @@ const SPAWN_CLI = [
   'test/integration/group/group-cli.test.ts',
   'test/integration/cli/tool-no-index-stderr.test.ts',
   'test/integration/setup-skills.test.ts',
+  'test/unit/local-cli-subprocess.test.ts',
 ];
 
 // Worker threads tests — exercise real worker_threads which have

--- a/gitnexus/src/cli/i18n/en.ts
+++ b/gitnexus/src/cli/i18n/en.ts
@@ -185,7 +185,8 @@ export const en = {
   'help.option.clean.all': 'Clean all indexed repos',
   'help.option.clean.lbugSidecars': 'Clean quarantined LadybugDB missing-shadow WAL sidecars',
   'help.option.wiki.force': 'Force full regeneration even if up to date',
-  'help.option.wiki.provider': 'LLM provider: openai or cursor (default: openai)',
+  'help.option.wiki.provider':
+    'LLM provider: openai, openrouter, azure, custom, cursor, claude, or codex (default: openai)',
   'help.option.wiki.model': 'LLM model or Azure deployment name (default: minimax/minimax-m2.5)',
   'help.option.wiki.baseUrl':
     'LLM API base URL. Azure v1: https://{resource}.openai.azure.com/openai/v1',

--- a/gitnexus/src/cli/i18n/zh-CN.ts
+++ b/gitnexus/src/cli/i18n/zh-CN.ts
@@ -174,7 +174,8 @@ export const zhCN = {
   'help.option.clean.all': '清理所有已索引仓库',
   'help.option.clean.lbugSidecars': '清理已隔离的 LadybugDB missing-shadow WAL sidecar',
   'help.option.wiki.force': '即使已是最新也强制完整重新生成',
-  'help.option.wiki.provider': 'LLM 提供商：openai 或 cursor（默认：openai）',
+  'help.option.wiki.provider':
+    'LLM 提供商：openai、openrouter、azure、custom、cursor、claude 或 codex（默认：openai）',
   'help.option.wiki.model': 'LLM 模型或 Azure deployment 名称（默认：minimax/minimax-m2.5）',
   'help.option.wiki.baseUrl':
     'LLM API base URL。Azure v1：https://{resource}.openai.azure.com/openai/v1',

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -146,7 +146,10 @@ program
   .command('wiki [path]')
   .description('Generate repository wiki from knowledge graph')
   .option('-f, --force', 'Force full regeneration even if up to date')
-  .option('--provider <provider>', 'LLM provider: openai or cursor (default: openai)')
+  .option(
+    '--provider <provider>',
+    'LLM provider: openai, openrouter, azure, custom, cursor, claude, or codex (default: openai)',
+  )
   .option('--model <model>', 'LLM model or Azure deployment name (default: minimax/minimax-m2.5)')
   .option(
     '--base-url <url>',

--- a/gitnexus/src/cli/wiki.ts
+++ b/gitnexus/src/cli/wiki.ts
@@ -56,7 +56,9 @@ function parsePositiveIntegerOption(
   return parsed;
 }
 
-function isLocalProvider(provider: LLMProvider | undefined): provider is 'cursor' | 'claude' | 'codex' {
+function isLocalProvider(
+  provider: LLMProvider | undefined,
+): provider is 'cursor' | 'claude' | 'codex' {
   return provider === 'cursor' || provider === 'claude' || provider === 'codex';
 }
 

--- a/gitnexus/src/cli/wiki.ts
+++ b/gitnexus/src/cli/wiki.ts
@@ -19,6 +19,7 @@ import {
 import { WikiGenerator, type WikiOptions } from '../core/wiki/generator.js';
 import { resolveLLMConfig, type LLMProvider } from '../core/wiki/llm-client.js';
 import { detectCursorCLI } from '../core/wiki/cursor-client.js';
+import { detectLocalCLI } from '../core/wiki/local-cli-client.js';
 import { logger } from '../core/logger.js';
 
 export interface WikiCommandOptions {
@@ -53,6 +54,16 @@ function parsePositiveIntegerOption(
     throw new Error(`${flag} is too large`);
   }
   return parsed;
+}
+
+function isLocalProvider(provider: LLMProvider | undefined): provider is 'cursor' | 'claude' | 'codex' {
+  return provider === 'cursor' || provider === 'claude' || provider === 'codex';
+}
+
+function localModelConfigKey(provider: 'cursor' | 'claude' | 'codex') {
+  if (provider === 'cursor') return 'cursorModel';
+  if (provider === 'claude') return 'claudeModel';
+  return 'codexModel';
 }
 
 /**
@@ -191,10 +202,11 @@ const wikiCommandImpl = async (inputPath?: string, options?: WikiCommandOptions)
     if (options.provider) updates.provider = options.provider;
     if (options.apiVersion) updates.apiVersion = options.apiVersion;
     if (options.reasoningModel !== undefined) updates.isReasoningModel = options.reasoningModel;
-    // Save model to appropriate field based on provider
+    // Save model to appropriate field based on provider.
     if (options.model) {
-      if (options.provider === 'cursor') {
-        updates.cursorModel = options.model;
+      const targetProvider = options.provider ?? existing.provider;
+      if (isLocalProvider(targetProvider)) {
+        updates[localModelConfigKey(targetProvider)] = options.model;
       } else {
         updates.model = options.model;
       }
@@ -205,7 +217,7 @@ const wikiCommandImpl = async (inputPath?: string, options?: WikiCommandOptions)
 
   const savedConfig = await loadCLIConfig();
   const hasSavedConfig = !!(
-    savedConfig.provider === 'cursor' ||
+    isLocalProvider(savedConfig.provider) ||
     (savedConfig.apiKey && savedConfig.baseUrl)
   );
   const hasCLIOverrides = !!(
@@ -231,10 +243,10 @@ const wikiCommandImpl = async (inputPath?: string, options?: WikiCommandOptions)
   if (!hasSavedConfig && !hasCLIOverrides) {
     if (!process.stdin.isTTY) {
       // Non-interactive mode — need either API key or Cursor CLI
-      if (!llmConfig.apiKey && llmConfig.provider !== 'cursor') {
+      if (!llmConfig.apiKey && !isLocalProvider(llmConfig.provider)) {
         console.log('  Error: No LLM API key found.');
         console.log('  Set OPENAI_API_KEY or GITNEXUS_API_KEY environment variable,');
-        console.log('  or pass --api-key <key>, or use --provider cursor.\n');
+        console.log('  or pass --api-key <key>, or use --provider cursor|claude|codex.\n');
         process.exitCode = 1;
         return;
       }
@@ -242,23 +254,51 @@ const wikiCommandImpl = async (inputPath?: string, options?: WikiCommandOptions)
     } else {
       console.log("  No LLM configured. Let's set it up.\n");
       console.log(
-        '  Supports OpenAI, OpenRouter, Azure, any OpenAI-compatible API, or Cursor CLI.\n',
+        '  Supports OpenAI, OpenRouter, Azure, any OpenAI-compatible API, Cursor CLI, Claude CLI, or Codex CLI.\n',
       );
 
-      // Check if Cursor CLI is available
+      // Check if local agent CLIs are available.
       const hasCursor = detectCursorCLI();
+      const hasClaude = detectLocalCLI('claude');
+      const hasCodex = detectLocalCLI('codex');
+      const localChoices: Array<{
+        choice: string;
+        provider: 'cursor' | 'claude' | 'codex';
+      }> = [];
 
       // Provider selection
       console.log('  [1] OpenAI (api.openai.com)');
       console.log('  [2] OpenRouter (openrouter.ai)');
       console.log('  [3] Azure OpenAI');
       console.log('  [4] Custom endpoint');
+      let nextChoice = 5;
       if (hasCursor) {
-        console.log('  [5] Cursor CLI (local, uses your Cursor subscription)');
+        const choice = String(nextChoice++);
+        localChoices.push({
+          choice,
+          provider: 'cursor',
+        });
+        console.log(`  [${choice}] Cursor CLI (local, uses your Cursor subscription)`);
+      }
+      if (hasClaude) {
+        const choice = String(nextChoice++);
+        localChoices.push({
+          choice,
+          provider: 'claude',
+        });
+        console.log(`  [${choice}] Claude CLI (local, uses your Claude Code login)`);
+      }
+      if (hasCodex) {
+        const choice = String(nextChoice++);
+        localChoices.push({
+          choice,
+          provider: 'codex',
+        });
+        console.log(`  [${choice}] Codex CLI (local, uses your Codex login)`);
       }
       console.log('');
 
-      const maxChoice = hasCursor ? '5' : '4';
+      const maxChoice = String(nextChoice - 1);
       const choice = await prompt(`  Select provider (1/${maxChoice}): `);
 
       let baseUrl: string;
@@ -266,21 +306,21 @@ const wikiCommandImpl = async (inputPath?: string, options?: WikiCommandOptions)
       let provider: LLMProvider = 'openai';
       let key = '';
 
-      if (choice === '5' && hasCursor) {
-        // Cursor CLI selected - model defaults to 'auto' (Cursor's default)
-        provider = 'cursor';
+      const selectedLocal = localChoices.find((item) => item.choice === choice);
+      if (selectedLocal) {
+        // Local CLI selected - model defaults to the CLI's configured default.
+        provider = selectedLocal.provider;
         baseUrl = '';
 
-        const modelInput = await prompt('  Model (leave empty for auto): ');
+        const modelInput = await prompt('  Model (leave empty for CLI default): ');
         const model = modelInput || '';
 
-        // Save config for Cursor
-        const cursorConfig: Record<string, string> = { provider: 'cursor' };
-        if (model) cursorConfig.cursorModel = model;
-        await saveCLIConfig(cursorConfig);
+        const localConfig: Record<string, string> = { provider };
+        if (model) localConfig[localModelConfigKey(provider)] = model;
+        await saveCLIConfig(localConfig);
         console.log('  Config saved to ~/.gitnexus/config.json\n');
 
-        llmConfig = { ...llmConfig, provider: 'cursor', model, apiKey: '', baseUrl: '' };
+        llmConfig = { ...llmConfig, provider, model, apiKey: '', baseUrl: '' };
       } else if (choice === '3') {
         // Azure OpenAI guided setup — minimal prompts
         console.log('\n  Azure OpenAI setup.\n');

--- a/gitnexus/src/cli/wiki.ts
+++ b/gitnexus/src/cli/wiki.ts
@@ -317,8 +317,8 @@ const wikiCommandImpl = async (inputPath?: string, options?: WikiCommandOptions)
         const modelInput = await prompt('  Model (leave empty for CLI default): ');
         const model = modelInput || '';
 
-        const localConfig: Record<string, string> = { provider };
-        if (model) localConfig[localModelConfigKey(provider)] = model;
+        const localConfig = { ...savedConfig, provider };
+        if (model) (localConfig as Record<string, unknown>)[localModelConfigKey(provider)] = model;
         await saveCLIConfig(localConfig);
         console.log('  Config saved to ~/.gitnexus/config.json\n');
 
@@ -370,6 +370,7 @@ const wikiCommandImpl = async (inputPath?: string, options?: WikiCommandOptions)
         const azureBaseUrl = `${endpoint}/openai/v1`;
 
         await saveCLIConfig({
+          ...savedConfig,
           apiKey: azureKey,
           baseUrl: azureBaseUrl,
           model: deploymentName,

--- a/gitnexus/src/core/wiki/generator.ts
+++ b/gitnexus/src/core/wiki/generator.ts
@@ -39,6 +39,7 @@ import {
 } from './llm-client.js';
 
 import { callCursorLLM, resolveCursorConfig } from './cursor-client.js';
+import { callClaudeLLM, callCodexLLM, resolveLocalCLIConfig } from './local-cli-client.js';
 
 import {
   GROUPING_SYSTEM_PROMPT,
@@ -203,7 +204,7 @@ export class WikiGenerator {
   }
 
   /**
-   * Route LLM call to the appropriate provider (OpenAI-compatible or Cursor CLI).
+   * Route LLM call to the appropriate provider.
    */
   private async invokeLLM(
     prompt: string,
@@ -216,6 +217,15 @@ export class WikiGenerator {
         workingDirectory: this.repoPath,
       });
       return callCursorLLM(prompt, cursorConfig, systemPrompt, options);
+    }
+    if (this.llmConfig.provider === 'claude' || this.llmConfig.provider === 'codex') {
+      const localConfig = resolveLocalCLIConfig({
+        model: this.llmConfig.model,
+        workingDirectory: this.repoPath,
+      });
+      return this.llmConfig.provider === 'claude'
+        ? callClaudeLLM(prompt, localConfig, systemPrompt, options)
+        : callCodexLLM(prompt, localConfig, systemPrompt, options);
     }
     return callLLM(prompt, this.llmConfig, systemPrompt, options);
   }

--- a/gitnexus/src/core/wiki/generator.ts
+++ b/gitnexus/src/core/wiki/generator.ts
@@ -222,6 +222,7 @@ export class WikiGenerator {
       const localConfig = resolveLocalCLIConfig({
         model: this.llmConfig.model,
         workingDirectory: this.repoPath,
+        requestTimeoutMs: this.llmConfig.requestTimeoutMs,
       });
       return this.llmConfig.provider === 'claude'
         ? callClaudeLLM(prompt, localConfig, systemPrompt, options)

--- a/gitnexus/src/core/wiki/llm-client.ts
+++ b/gitnexus/src/core/wiki/llm-client.ts
@@ -9,7 +9,14 @@ import { CircuitOpenError, ResilientFetchExhaustedError, resilientFetch } from '
  * Config priority: CLI flags > env vars > defaults
  */
 
-export type LLMProvider = 'openai' | 'openrouter' | 'azure' | 'custom' | 'cursor';
+export type LLMProvider =
+  | 'openai'
+  | 'openrouter'
+  | 'azure'
+  | 'custom'
+  | 'cursor'
+  | 'claude'
+  | 'codex';
 
 export interface LLMConfig {
   apiKey: string;
@@ -18,7 +25,7 @@ export interface LLMConfig {
   maxTokens: number;
   temperature: number;
   /** Provider type — controls auth header behaviour */
-  provider?: 'openai' | 'openrouter' | 'azure' | 'custom' | 'cursor';
+  provider?: LLMProvider;
   /** Azure api-version query param (e.g. '2024-10-21'). Appended to URL when set. */
   apiVersion?: string;
   /** When true, strips sampling params and uses max_completion_tokens instead of max_tokens */
@@ -44,6 +51,17 @@ export interface LLMResponse {
 export async function resolveLLMConfig(overrides?: Partial<LLMConfig>): Promise<LLMConfig> {
   const { loadCLIConfig } = await import('../../storage/repo-manager.js');
   const savedConfig = await loadCLIConfig();
+  const savedProvider = overrides?.provider ?? savedConfig.provider;
+  const savedLocalModel =
+    savedProvider === 'cursor'
+      ? savedConfig.cursorModel
+      : savedProvider === 'claude'
+        ? savedConfig.claudeModel
+        : savedProvider === 'codex'
+          ? savedConfig.codexModel
+          : undefined;
+  const localProvider =
+    savedProvider === 'cursor' || savedProvider === 'claude' || savedProvider === 'codex';
 
   const apiKey =
     overrides?.apiKey ||
@@ -62,12 +80,11 @@ export async function resolveLLMConfig(overrides?: Partial<LLMConfig>): Promise<
     model:
       overrides?.model ||
       process.env.GITNEXUS_MODEL ||
-      (savedConfig.provider === 'cursor' ? savedConfig.cursorModel : undefined) ||
-      savedConfig.model ||
-      'minimax/minimax-m2.5',
+      savedLocalModel ||
+      (localProvider ? '' : savedConfig.model || 'minimax/minimax-m2.5'),
     maxTokens: overrides?.maxTokens ?? 16_384,
     temperature: overrides?.temperature ?? 0,
-    provider: overrides?.provider ?? savedConfig.provider ?? 'openai',
+    provider: savedProvider ?? 'openai',
     apiVersion:
       overrides?.apiVersion || process.env.GITNEXUS_AZURE_API_VERSION || savedConfig.apiVersion,
     isReasoningModel: overrides?.isReasoningModel ?? savedConfig.isReasoningModel,

--- a/gitnexus/src/core/wiki/llm-client.ts
+++ b/gitnexus/src/core/wiki/llm-client.ts
@@ -79,7 +79,7 @@ export async function resolveLLMConfig(overrides?: Partial<LLMConfig>): Promise<
       'https://openrouter.ai/api/v1',
     model:
       overrides?.model ||
-      process.env.GITNEXUS_MODEL ||
+      (localProvider ? undefined : process.env.GITNEXUS_MODEL) ||
       savedLocalModel ||
       (localProvider ? '' : savedConfig.model || 'minimax/minimax-m2.5'),
     maxTokens: overrides?.maxTokens ?? 16_384,

--- a/gitnexus/src/core/wiki/local-cli-client.ts
+++ b/gitnexus/src/core/wiki/local-cli-client.ts
@@ -1,0 +1,290 @@
+/**
+ * Local agent CLI clients for wiki generation.
+ *
+ * These providers use the user's authenticated local CLI session instead of
+ * an OpenAI-compatible HTTP API.
+ */
+
+import fs from 'fs/promises';
+import { existsSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync, spawn } from 'child_process';
+import type { LLMResponse, CallLLMOptions } from './llm-client.js';
+
+import { logger } from '../logger.js';
+
+export type LocalAgentProvider = 'claude' | 'codex';
+
+export interface LocalCLIConfig {
+  model?: string;
+  workingDirectory?: string;
+}
+
+const COMMANDS: Record<LocalAgentProvider, string> = {
+  claude: 'claude',
+  codex: 'codex',
+};
+
+interface LocalCommand {
+  displayName: string;
+  command: string;
+  argsPrefix: string[];
+}
+
+function isVerbose(): boolean {
+  return process.env.GITNEXUS_VERBOSE === '1';
+}
+
+function verboseLog(provider: LocalAgentProvider, ...args: unknown[]): void {
+  if (isVerbose()) {
+    logger.info({ provider, args }, '[local-cli]');
+  }
+}
+
+const cachedCommands = new Map<LocalAgentProvider, LocalCommand | null>();
+
+export function detectLocalCLI(provider: LocalAgentProvider): string | null {
+  if (cachedCommands.has(provider)) return cachedCommands.get(provider)?.displayName ?? null;
+  const commandInfo = resolveLocalCommand(provider);
+  try {
+    execFileSync(commandInfo.command, [...commandInfo.argsPrefix, '--version'], { stdio: 'ignore' });
+    cachedCommands.set(provider, commandInfo);
+  } catch {
+    cachedCommands.set(provider, null);
+  }
+  return cachedCommands.get(provider)?.displayName ?? null;
+}
+
+export function resolveLocalCLIConfig(overrides?: Partial<LocalCLIConfig>): LocalCLIConfig {
+  return {
+    model: overrides?.model,
+    workingDirectory: overrides?.workingDirectory,
+  };
+}
+
+export async function callClaudeLLM(
+  prompt: string,
+  config: LocalCLIConfig,
+  systemPrompt?: string,
+  options?: CallLLMOptions,
+): Promise<LLMResponse> {
+  const commandInfo = getDetectedCommand('claude');
+  if (!commandInfo) {
+    throw new Error('Claude CLI not found. Install Claude Code and ensure `claude` is on PATH.');
+  }
+
+  const args = ['-p', '--output-format', 'text', '--no-session-persistence'];
+  if (config.model) {
+    args.push('--model', config.model);
+  }
+  const fullPrompt = systemPrompt ? `${systemPrompt}\n\n---\n\n${prompt}` : prompt;
+
+  return runLocalCLI('claude', commandInfo, args, config, fullPrompt, options);
+}
+
+export async function callCodexLLM(
+  prompt: string,
+  config: LocalCLIConfig,
+  systemPrompt?: string,
+  options?: CallLLMOptions,
+): Promise<LLMResponse> {
+  const commandInfo = getDetectedCommand('codex');
+  if (!commandInfo) {
+    throw new Error('Codex CLI not found. Install Codex CLI and ensure `codex` is on PATH.');
+  }
+
+  const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-wiki-codex-'));
+  const outputPath = path.join(outputDir, 'last-message.txt');
+  const workingDirectory = config.workingDirectory || process.cwd();
+  const fullPrompt = systemPrompt ? `${systemPrompt}\n\n---\n\n${prompt}` : prompt;
+  const args = [
+    'exec',
+    '--cd',
+    workingDirectory,
+    '--sandbox',
+    'read-only',
+    '-c',
+    'approval_policy="never"',
+    '--color',
+    'never',
+    '--output-last-message',
+    outputPath,
+  ];
+
+  if (config.model) {
+    args.push('--model', config.model);
+  }
+  args.push('-');
+
+  try {
+    const response = await runLocalCLI('codex', commandInfo, args, config, fullPrompt, options);
+    const lastMessage = await fs.readFile(outputPath, 'utf-8').catch(() => '');
+    return { content: (lastMessage || response.content).trim() };
+  } finally {
+    await fs.rm(outputDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+function runLocalCLI(
+  provider: LocalAgentProvider,
+  commandInfo: LocalCommand,
+  args: string[],
+  config: LocalCLIConfig,
+  stdinText?: string,
+  options?: CallLLMOptions,
+): Promise<LLMResponse> {
+  const finalArgs = [...commandInfo.argsPrefix, ...args];
+  verboseLog(
+    provider,
+    'Spawning:',
+    commandInfo.command,
+    maskPromptArgs(provider, finalArgs).join(' '),
+  );
+  verboseLog(provider, 'Working directory:', config.workingDirectory || process.cwd());
+  if (config.model) {
+    verboseLog(provider, 'Model:', config.model);
+  } else {
+    verboseLog(provider, 'Model: default');
+  }
+
+  const startTime = Date.now();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(commandInfo.command, finalArgs, {
+      cwd: config.workingDirectory || process.cwd(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        CI: '1',
+      },
+    });
+
+    verboseLog(provider, 'Process spawned with PID:', child.pid);
+
+    let stdout = '';
+    let stderr = '';
+    let stdinError: Error | undefined;
+    let settled = false;
+
+    const rejectOnce = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+
+    const resolveOnce = (response: LLMResponse) => {
+      if (settled) return;
+      settled = true;
+      resolve(response);
+    };
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      const chunkStr = chunk.toString();
+      stdout += chunkStr;
+      verboseLog(provider, `[stdout] received ${chunkStr.length} chars, total: ${stdout.length}`);
+      options?.onChunk?.(stdout.length);
+    });
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      const chunkStr = chunk.toString();
+      stderr += chunkStr;
+      verboseLog(provider, '[stderr]', chunkStr.trim());
+    });
+
+    child.stdin.on('error', (err: Error) => {
+      stdinError = err;
+      verboseLog(provider, 'stdin error:', err.message);
+    });
+
+    child.on('close', (code) => {
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+      verboseLog(provider, `Process exited with code ${code} after ${elapsed}s`);
+
+      if (code !== 0) {
+        const details = stderr.trim() || stdinError?.message || stdout.trim();
+        rejectOnce(new Error(`${provider} CLI exited with code ${code}: ${details}`));
+        return;
+      }
+      if (stdinError) {
+        rejectOnce(new Error(`${provider} CLI stdin error: ${stdinError.message}`));
+        return;
+      }
+      resolveOnce({ content: stdout.trim() });
+    });
+
+    child.on('error', (err) => {
+      rejectOnce(new Error(`Failed to spawn ${provider} CLI: ${err.message}`));
+    });
+
+    child.stdin.end(stdinText);
+  });
+}
+
+function maskPromptArgs(provider: LocalAgentProvider, args: string[]): string[] {
+  if (provider === 'codex') {
+    return args.map((arg) => (arg === '-' ? '[stdin prompt]' : arg));
+  }
+  return args;
+}
+
+function getDetectedCommand(provider: LocalAgentProvider): LocalCommand | null {
+  detectLocalCLI(provider);
+  return cachedCommands.get(provider) ?? null;
+}
+
+function resolveLocalCommand(provider: LocalAgentProvider): LocalCommand {
+  const displayName = COMMANDS[provider];
+  if (process.platform !== 'win32') {
+    return { displayName, command: displayName, argsPrefix: [] };
+  }
+
+  const npmBin = findWindowsCommand(`${displayName}.cmd`) || findWindowsCommand(displayName);
+  if (npmBin) {
+    const binDir = path.dirname(npmBin);
+    if (provider === 'claude') {
+      const exePath = path.join(
+        binDir,
+        'node_modules',
+        '@anthropic-ai',
+        'claude-code',
+        'bin',
+        'claude.exe',
+      );
+      if (existsSync(exePath)) {
+        return { displayName, command: exePath, argsPrefix: [] };
+      }
+    }
+
+    if (provider === 'codex') {
+      const scriptPath = path.join(binDir, 'node_modules', '@openai', 'codex', 'bin', 'codex.js');
+      if (existsSync(scriptPath)) {
+        return { displayName, command: process.execPath, argsPrefix: [scriptPath] };
+      }
+    }
+  }
+
+  // Last-resort fallback for non-npm Windows installations that only expose a
+  // .cmd shim. Prompts are passed via stdin, so repo content is not placed on
+  // the command line.
+  return {
+    displayName,
+    command: process.env.ComSpec || 'cmd.exe',
+    argsPrefix: ['/d', '/s', '/c', displayName],
+  };
+}
+
+function findWindowsCommand(command: string): string | null {
+  try {
+    const output = execFileSync('where.exe', [command], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/gitnexus/src/core/wiki/local-cli-client.ts
+++ b/gitnexus/src/core/wiki/local-cli-client.ts
@@ -48,7 +48,9 @@ export function detectLocalCLI(provider: LocalAgentProvider): string | null {
   if (cachedCommands.has(provider)) return cachedCommands.get(provider)?.displayName ?? null;
   const commandInfo = resolveLocalCommand(provider);
   try {
-    execFileSync(commandInfo.command, [...commandInfo.argsPrefix, '--version'], { stdio: 'ignore' });
+    execFileSync(commandInfo.command, [...commandInfo.argsPrefix, '--version'], {
+      stdio: 'ignore',
+    });
     cachedCommands.set(provider, commandInfo);
   } catch {
     cachedCommands.set(provider, null);
@@ -280,10 +282,12 @@ function findWindowsCommand(command: string): string | null {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
     });
-    return output
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? null;
+    return (
+      output
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find(Boolean) ?? null
+    );
   } catch {
     return null;
   }

--- a/gitnexus/src/core/wiki/local-cli-client.ts
+++ b/gitnexus/src/core/wiki/local-cli-client.ts
@@ -19,6 +19,7 @@ export type LocalAgentProvider = 'claude' | 'codex';
 export interface LocalCLIConfig {
   model?: string;
   workingDirectory?: string;
+  requestTimeoutMs?: number;
 }
 
 const COMMANDS: Record<LocalAgentProvider, string> = {
@@ -62,6 +63,7 @@ export function resolveLocalCLIConfig(overrides?: Partial<LocalCLIConfig>): Loca
   return {
     model: overrides?.model,
     workingDirectory: overrides?.workingDirectory,
+    requestTimeoutMs: overrides?.requestTimeoutMs,
   };
 }
 
@@ -156,6 +158,7 @@ function runLocalCLI(
     const child = spawn(commandInfo.command, finalArgs, {
       cwd: config.workingDirectory || process.cwd(),
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
       env: {
         ...process.env,
         CI: '1',
@@ -168,18 +171,37 @@ function runLocalCLI(
     let stderr = '';
     let stdinError: Error | undefined;
     let settled = false;
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
 
     const rejectOnce = (error: Error) => {
       if (settled) return;
       settled = true;
+      if (killTimer !== undefined) clearTimeout(killTimer);
       reject(error);
     };
 
     const resolveOnce = (response: LLMResponse) => {
       if (settled) return;
       settled = true;
+      if (killTimer !== undefined) clearTimeout(killTimer);
       resolve(response);
     };
+
+    if (config.requestTimeoutMs !== undefined && config.requestTimeoutMs > 0) {
+      killTimer = setTimeout(() => {
+        child.kill();
+        const duration =
+          config.requestTimeoutMs! >= 60_000
+            ? `${Math.round(config.requestTimeoutMs! / 60_000)}m`
+            : `${Math.round(config.requestTimeoutMs! / 1_000)}s`;
+        rejectOnce(
+          new Error(
+            `${provider} CLI timed out after ${duration}. ` +
+              'Increase --timeout or omit it to disable the request timeout.',
+          ),
+        );
+      }, config.requestTimeoutMs);
+    }
 
     child.stdout.on('data', (chunk: Buffer) => {
       const chunkStr = chunk.toString();
@@ -212,7 +234,12 @@ function runLocalCLI(
         rejectOnce(new Error(`${provider} CLI stdin error: ${stdinError.message}`));
         return;
       }
-      resolveOnce({ content: stdout.trim() });
+      const output = stdout.trim();
+      if (!output) {
+        rejectOnce(new Error(`${provider} CLI returned empty output`));
+        return;
+      }
+      resolveOnce({ content: output });
     });
 
     child.on('error', (err) => {

--- a/gitnexus/src/core/wiki/local-cli-client.ts
+++ b/gitnexus/src/core/wiki/local-cli-client.ts
@@ -55,7 +55,9 @@ export function detectLocalCLI(provider: LocalAgentProvider): string | null {
     });
     cachedCommands.set(provider, commandInfo);
   } catch (err: unknown) {
-    if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code !== 'ENOENT') {
+    const isNotFound =
+      err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+    if (!isNotFound && err instanceof Error) {
       logger.warn(
         `${provider} CLI found but --version failed (exit ${(err as { status?: number }).status ?? '?'}). ` +
           `Ensure it is authenticated: run \`${COMMANDS[provider]} --version\` manually.`,

--- a/gitnexus/src/core/wiki/local-cli-client.ts
+++ b/gitnexus/src/core/wiki/local-cli-client.ts
@@ -34,6 +34,21 @@ interface LocalCommand {
   argsPrefix: string[];
 }
 
+function killChildTree(child: import('child_process').ChildProcess): void {
+  if (process.platform === 'win32' && child.pid !== undefined) {
+    try {
+      execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+      return;
+    } catch {
+      // Process may have already exited — fall through to child.kill()
+    }
+  }
+  child.kill();
+}
+
 function isVerbose(): boolean {
   return process.env.GITNEXUS_VERBOSE === '1';
 }
@@ -208,7 +223,7 @@ function runLocalCLI(
 
     if (config.requestTimeoutMs !== undefined && config.requestTimeoutMs > 0) {
       killTimer = setTimeout(() => {
-        child.kill();
+        killChildTree(child);
         const duration =
           config.requestTimeoutMs! >= 60_000
             ? `${Math.round(config.requestTimeoutMs! / 60_000)}m`

--- a/gitnexus/src/core/wiki/local-cli-client.ts
+++ b/gitnexus/src/core/wiki/local-cli-client.ts
@@ -10,6 +10,7 @@ import { existsSync } from 'fs';
 import os from 'os';
 import path from 'path';
 import { execFileSync, spawn } from 'child_process';
+import { StringDecoder } from 'string_decoder';
 import type { LLMResponse, CallLLMOptions } from './llm-client.js';
 
 import { logger } from '../logger.js';
@@ -53,7 +54,13 @@ export function detectLocalCLI(provider: LocalAgentProvider): string | null {
       stdio: 'ignore',
     });
     cachedCommands.set(provider, commandInfo);
-  } catch {
+  } catch (err: unknown) {
+    if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      logger.warn(
+        `${provider} CLI found but --version failed (exit ${(err as { status?: number }).status ?? '?'}). ` +
+          `Ensure it is authenticated: run \`${COMMANDS[provider]} --version\` manually.`,
+      );
+    }
     cachedCommands.set(provider, null);
   }
   return cachedCommands.get(provider)?.displayName ?? null;
@@ -84,7 +91,11 @@ export async function callClaudeLLM(
   }
   const fullPrompt = systemPrompt ? `${systemPrompt}\n\n---\n\n${prompt}` : prompt;
 
-  return runLocalCLI('claude', commandInfo, args, config, fullPrompt, options);
+  const response = await runLocalCLI('claude', commandInfo, args, config, fullPrompt, options);
+  if (!response.content) {
+    throw new Error('claude CLI returned empty output');
+  }
+  return response;
 }
 
 export async function callCodexLLM(
@@ -124,7 +135,11 @@ export async function callCodexLLM(
   try {
     const response = await runLocalCLI('codex', commandInfo, args, config, fullPrompt, options);
     const lastMessage = await fs.readFile(outputPath, 'utf-8').catch(() => '');
-    return { content: (lastMessage || response.content).trim() };
+    const content = (lastMessage || response.content).trim();
+    if (!content) {
+      throw new Error('codex CLI returned empty output');
+    }
+    return { content };
   } finally {
     await fs.rm(outputDir, { recursive: true, force: true }).catch(() => undefined);
   }
@@ -169,6 +184,8 @@ function runLocalCLI(
 
     let stdout = '';
     let stderr = '';
+    const stdoutDecoder = new StringDecoder('utf8');
+    const stderrDecoder = new StringDecoder('utf8');
     let stdinError: Error | undefined;
     let settled = false;
     let killTimer: ReturnType<typeof setTimeout> | undefined;
@@ -204,14 +221,14 @@ function runLocalCLI(
     }
 
     child.stdout.on('data', (chunk: Buffer) => {
-      const chunkStr = chunk.toString();
+      const chunkStr = stdoutDecoder.write(chunk);
       stdout += chunkStr;
       verboseLog(provider, `[stdout] received ${chunkStr.length} chars, total: ${stdout.length}`);
       options?.onChunk?.(stdout.length);
     });
 
     child.stderr.on('data', (chunk: Buffer) => {
-      const chunkStr = chunk.toString();
+      const chunkStr = stderrDecoder.write(chunk);
       stderr += chunkStr;
       verboseLog(provider, '[stderr]', chunkStr.trim());
     });
@@ -222,6 +239,8 @@ function runLocalCLI(
     });
 
     child.on('close', (code) => {
+      stdout += stdoutDecoder.end();
+      stderr += stderrDecoder.end();
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
       verboseLog(provider, `Process exited with code ${code} after ${elapsed}s`);
 
@@ -234,12 +253,7 @@ function runLocalCLI(
         rejectOnce(new Error(`${provider} CLI stdin error: ${stdinError.message}`));
         return;
       }
-      const output = stdout.trim();
-      if (!output) {
-        rejectOnce(new Error(`${provider} CLI returned empty output`));
-        return;
-      }
-      resolveOnce({ content: output });
+      resolveOnce({ content: stdout.trim() });
     });
 
     child.on('error', (err) => {

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -933,8 +933,10 @@ export interface CLIConfig {
   apiKey?: string;
   model?: string;
   baseUrl?: string;
-  provider?: 'openai' | 'openrouter' | 'azure' | 'custom' | 'cursor';
+  provider?: 'openai' | 'openrouter' | 'azure' | 'custom' | 'cursor' | 'claude' | 'codex';
   cursorModel?: string;
+  claudeModel?: string;
+  codexModel?: string;
   /** Azure api-version query param (e.g. '2024-10-21'). Only used when provider is 'azure'. */
   apiVersion?: string;
   /** Set true when the deployment is a reasoning model (o1, o3, o4-mini). Auto-detected for OpenAI; must be set for Azure deployments. */

--- a/gitnexus/test/integration/cli-e2e.test.ts
+++ b/gitnexus/test/integration/cli-e2e.test.ts
@@ -1130,6 +1130,8 @@ describe('CLI end-to-end', () => {
 
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('--provider <provider>');
+      expect(result.stdout).toContain('claude');
+      expect(result.stdout).toContain('codex');
       expect(result.stdout).toContain('--review');
       expect(result.stdout).toContain('-v, --verbose');
       expect(result.stdout).toContain('--model <model>');
@@ -1195,6 +1197,22 @@ describe('CLI end-to-end', () => {
 
       const combined = result.stdout + result.stderr;
       // Should NOT ask for API key — cursor provider doesn't need one
+      expect(combined).not.toMatch(/API key:/);
+    });
+
+    it('wiki --provider claude without API key does not prompt for key in non-TTY', () => {
+      const result = runCliRaw(['wiki', MINI_REPO, '--provider', 'claude'], repoRoot, 15000);
+      if (result.status === null) return;
+
+      const combined = result.stdout + result.stderr;
+      expect(combined).not.toMatch(/API key:/);
+    });
+
+    it('wiki --provider codex without API key does not prompt for key in non-TTY', () => {
+      const result = runCliRaw(['wiki', MINI_REPO, '--provider', 'codex'], repoRoot, 15000);
+      if (result.status === null) return;
+
+      const combined = result.stdout + result.stderr;
       expect(combined).not.toMatch(/API key:/);
     });
 

--- a/gitnexus/test/unit/cli-index-help.test.ts
+++ b/gitnexus/test/unit/cli-index-help.test.ts
@@ -220,6 +220,8 @@ describe('CLI help surface', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('--provider <provider>');
+    expect(result.stdout).toContain('claude');
+    expect(result.stdout).toContain('codex');
     expect(result.stdout).toContain('--review');
     expect(result.stdout).toContain('-v, --verbose');
     expect(result.stdout).toContain('--model <model>');

--- a/gitnexus/test/unit/local-cli-subprocess.test.ts
+++ b/gitnexus/test/unit/local-cli-subprocess.test.ts
@@ -298,9 +298,7 @@ describe('local CLI timeout', () => {
     child.stderr = new EventEmitter();
     child.stdin = new EventEmitter() as any;
     child.pid = 99;
-    child.kill = vi.fn(() => {
-      queueMicrotask(() => child.emit('close', null));
-    });
+    child.kill = vi.fn();
     child.stdin.end = vi.fn();
 
     vi.doMock('child_process', () => ({
@@ -312,8 +310,82 @@ describe('local CLI timeout', () => {
     const promise = callClaudeLLM('prompt', { requestTimeoutMs: 5000 });
 
     vi.advanceTimersByTime(5000);
+    child.emit('close', null);
     await expect(promise).rejects.toThrow('claude CLI timed out after 5s');
-    expect(child.kill).toHaveBeenCalled();
+  });
+
+  it('uses taskkill /T /F /PID on Windows for process-tree kill', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    try {
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdin = new EventEmitter() as any;
+      child.pid = 42;
+      child.kill = vi.fn();
+      child.stdin.end = vi.fn();
+
+      const execFileSyncSpy = vi.fn().mockImplementation((cmd: string, args: string[]) => {
+        if (cmd !== 'taskkill') return 'claude 1.0.0';
+        return '';
+      });
+
+      vi.doMock('child_process', () => ({
+        execFileSync: execFileSyncSpy,
+        spawn: vi.fn(() => child),
+      }));
+      const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+      const promise = callClaudeLLM('prompt', { requestTimeoutMs: 3000 });
+      vi.advanceTimersByTime(3000);
+      // Timeout fires, taskkill runs, but child hasn't emitted close yet.
+      // Emit close now to settle the promise.
+      child.emit('close', null);
+      await expect(promise).rejects.toThrow('claude CLI timed out after 3s');
+
+      const taskkillCalls = execFileSyncSpy.mock.calls.filter(
+        (c: unknown[]) => c[0] === 'taskkill',
+      );
+      expect(taskkillCalls.length).toBe(1);
+      expect(taskkillCalls[0][1]).toEqual(['/T', '/F', '/PID', '42']);
+      expect(child.kill).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
+  });
+
+  it('falls back to child.kill() when taskkill fails on Windows', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    try {
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdin = new EventEmitter() as any;
+      child.pid = 42;
+      child.kill = vi.fn();
+      child.stdin.end = vi.fn();
+
+      vi.doMock('child_process', () => ({
+        execFileSync: vi.fn().mockImplementation((cmd: string) => {
+          if (cmd === 'taskkill') throw new Error('taskkill: process not found');
+          return 'claude 1.0.0';
+        }),
+        spawn: vi.fn(() => child),
+      }));
+      const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+      const promise = callClaudeLLM('prompt', { requestTimeoutMs: 2000 });
+      vi.advanceTimersByTime(2000);
+      child.emit('close', null);
+      await expect(promise).rejects.toThrow('claude CLI timed out after 2s');
+      expect(child.kill).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
   });
 
   it('does not set a kill timer when requestTimeoutMs is undefined', async () => {
@@ -470,5 +542,84 @@ describe('local CLI onChunk callback', () => {
     await callClaudeLLM('prompt', {}, undefined, { onChunk: (n) => chunks.push(n) });
 
     expect(chunks).toEqual([6, 12]);
+  });
+});
+
+// ─── Codex CLI flag contract snapshot ─────────────────────────────────
+
+describe('Codex CLI flag contract snapshot', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('spawn args match the exact expected contract (flag rename = test failure)', async () => {
+    const fakeChild = makeFakeChild({ stdout: 'codex output' });
+    const spawnSpy = vi.fn(() => fakeChild.child);
+
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('codex 0.1.0'),
+      spawn: spawnSpy,
+    }));
+    const { callCodexLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callCodexLLM('prompt', { workingDirectory: '/repo', model: 'o3' });
+
+    const args = spawnSpy.mock.calls[0][1] as string[];
+
+    // The contract flags start at 'exec' — skip any platform argsPrefix
+    // (e.g., ['/d', '/s', '/c', 'codex'] on Windows cmd.exe fallback)
+    const execIdx = args.indexOf('exec');
+    expect(execIdx).toBeGreaterThanOrEqual(0);
+    const contractArgs = args.slice(execIdx);
+
+    // Strip the dynamic temp path for comparison
+    const outputMsgIdx = contractArgs.indexOf('--output-last-message');
+    const normalized = [...contractArgs];
+    if (outputMsgIdx !== -1) {
+      normalized[outputMsgIdx + 1] = '<TEMP_PATH>';
+    }
+
+    expect(normalized).toEqual([
+      'exec',
+      '--cd',
+      '/repo',
+      '--sandbox',
+      'read-only',
+      '-c',
+      'approval_policy="never"',
+      '--color',
+      'never',
+      '--output-last-message',
+      '<TEMP_PATH>',
+      '--model',
+      'o3',
+      '-',
+    ]);
+  });
+
+  it('--model appears before - (stdin marker) and after --output-last-message', async () => {
+    const fakeChild = makeFakeChild({ stdout: 'codex output' });
+    const spawnSpy = vi.fn(() => fakeChild.child);
+
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('codex 0.1.0'),
+      spawn: spawnSpy,
+    }));
+    const { callCodexLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callCodexLLM('prompt', { workingDirectory: '/repo', model: 'test-model' });
+
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    const outputIdx = args.indexOf('--output-last-message');
+    const modelIdx = args.indexOf('--model');
+    const stdinIdx = args.lastIndexOf('-');
+
+    expect(outputIdx).toBeLessThan(modelIdx);
+    expect(modelIdx).toBeLessThan(stdinIdx);
+    expect(args[args.length - 1]).toBe('-');
   });
 });

--- a/gitnexus/test/unit/local-cli-subprocess.test.ts
+++ b/gitnexus/test/unit/local-cli-subprocess.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Integration-level tests for local CLI subprocess contracts.
+ *
+ * Validates the actual argv, stdin content, spawn options, and exit
+ * behavior for Claude and Codex providers — the layer that
+ * wiki-flags.test.ts mocks out. Uses a fake spawn that captures
+ * args and emits controlled events.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+function makeFakeChild(opts?: {
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+  stdinEndBehavior?: 'normal' | 'epipe';
+}) {
+  const child = new EventEmitter() as any;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = new EventEmitter() as any;
+  child.pid = 12345;
+  child.kill = vi.fn();
+
+  let stdinContent = '';
+  child.stdin.end = vi.fn((data?: string) => {
+    if (data) stdinContent += data;
+    queueMicrotask(() => {
+      if (opts?.stdinEndBehavior === 'epipe') {
+        child.stdin.emit('error', new Error('write EPIPE'));
+      }
+      if (opts?.stdout) {
+        child.stdout.emit('data', Buffer.from(opts.stdout));
+      }
+      if (opts?.stderr) {
+        child.stderr.emit('data', Buffer.from(opts.stderr));
+      }
+      child.emit('close', opts?.exitCode ?? 0);
+    });
+  });
+
+  return { child, getStdin: () => stdinContent };
+}
+
+// ─── Claude CLI argv contract ─────────────────────────────────────────
+
+describe('Claude CLI subprocess contract', () => {
+  let spawnSpy: ReturnType<typeof vi.fn>;
+  let fakeChild: ReturnType<typeof makeFakeChild>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    fakeChild = makeFakeChild({ stdout: 'Claude response text' });
+    spawnSpy = vi.fn(() => fakeChild.child);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('passes correct flags: -p --output-format text --no-session-persistence', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('claude 1.0.0'),
+      spawn: spawnSpy,
+    }));
+    const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callClaudeLLM('user prompt', {});
+
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    expect(args).toContain('-p');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('text');
+    expect(args).toContain('--no-session-persistence');
+  });
+
+  it('appends --model only when model is set', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('claude 1.0.0'),
+      spawn: spawnSpy,
+    }));
+    const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callClaudeLLM('prompt', { model: 'claude-sonnet-4-20250514' });
+
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    expect(args).toContain('--model');
+    expect(args).toContain('claude-sonnet-4-20250514');
+  });
+
+  it('does not include --model when model is empty', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('claude 1.0.0'),
+      spawn: spawnSpy,
+    }));
+    const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callClaudeLLM('prompt', {});
+
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    expect(args).not.toContain('--model');
+  });
+
+  it('sends full prompt (system + separator + user) via stdin', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('claude 1.0.0'),
+      spawn: spawnSpy,
+    }));
+    const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callClaudeLLM('user prompt', {}, 'system prompt');
+
+    const stdinText = fakeChild.getStdin();
+    expect(stdinText).toBe('system prompt\n\n---\n\nuser prompt');
+  });
+
+  it('sends only user prompt when no system prompt', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('claude 1.0.0'),
+      spawn: spawnSpy,
+    }));
+    const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callClaudeLLM('just the user prompt', {});
+
+    expect(fakeChild.getStdin()).toBe('just the user prompt');
+  });
+
+  it('sets CI=1 and windowsHide=true in spawn options', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('claude 1.0.0'),
+      spawn: spawnSpy,
+    }));
+    const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callClaudeLLM('prompt', {});
+
+    const spawnOpts = spawnSpy.mock.calls[0][2];
+    expect(spawnOpts.env.CI).toBe('1');
+    expect(spawnOpts.windowsHide).toBe(true);
+  });
+
+  it('rejects with exit code and stderr on non-zero exit', async () => {
+    fakeChild = makeFakeChild({ exitCode: 1, stderr: 'auth required' });
+    spawnSpy = vi.fn(() => fakeChild.child);
+
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('claude 1.0.0'),
+      spawn: spawnSpy,
+    }));
+    const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await expect(callClaudeLLM('prompt', {})).rejects.toThrow(
+      'claude CLI exited with code 1: auth required',
+    );
+  });
+
+  it('rejects with actionable error on empty stdout', async () => {
+    fakeChild = makeFakeChild({ stdout: '' });
+    spawnSpy = vi.fn(() => fakeChild.child);
+
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('claude 1.0.0'),
+      spawn: spawnSpy,
+    }));
+    const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await expect(callClaudeLLM('prompt', {})).rejects.toThrow('claude CLI returned empty output');
+  });
+});
+
+// ─── Codex CLI argv contract ──────────────────────────────────────────
+
+describe('Codex CLI subprocess contract', () => {
+  let spawnSpy: ReturnType<typeof vi.fn>;
+  let fakeChild: ReturnType<typeof makeFakeChild>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    fakeChild = makeFakeChild({ stdout: 'codex response' });
+    spawnSpy = vi.fn(() => fakeChild.child);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('passes correct subcommand and flags: exec --sandbox read-only -c approval_policy', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('codex 0.1.0'),
+      spawn: spawnSpy,
+    }));
+    const { callCodexLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callCodexLLM('prompt', { workingDirectory: '/repo' });
+
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    expect(args).toContain('exec');
+    expect(args).toContain('--sandbox');
+    expect(args).toContain('read-only');
+    expect(args).toContain('-c');
+    expect(args).toContain('approval_policy="never"');
+    expect(args).toContain('--color');
+    expect(args).toContain('never');
+  });
+
+  it('includes --output-last-message with a temp file path', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('codex 0.1.0'),
+      spawn: spawnSpy,
+    }));
+    const { callCodexLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callCodexLLM('prompt', { workingDirectory: '/repo' });
+
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    const outputIdx = args.indexOf('--output-last-message');
+    expect(outputIdx).toBeGreaterThan(-1);
+    const outputPath = args[outputIdx + 1];
+    expect(outputPath).toContain('gitnexus-wiki-codex-');
+    expect(outputPath).toContain('last-message.txt');
+  });
+
+  it('passes --cd with the working directory', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('codex 0.1.0'),
+      spawn: spawnSpy,
+    }));
+    const { callCodexLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callCodexLLM('prompt', { workingDirectory: '/my/repo' });
+
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    const cdIdx = args.indexOf('--cd');
+    expect(cdIdx).toBeGreaterThan(-1);
+    expect(args[cdIdx + 1]).toBe('/my/repo');
+  });
+
+  it('ends args with - (stdin marker)', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('codex 0.1.0'),
+      spawn: spawnSpy,
+    }));
+    const { callCodexLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callCodexLLM('prompt', { workingDirectory: '/repo' });
+
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    expect(args[args.length - 1]).toBe('-');
+  });
+
+  it('sends full prompt via stdin', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('codex 0.1.0'),
+      spawn: spawnSpy,
+    }));
+    const { callCodexLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callCodexLLM('user msg', { workingDirectory: '/repo' }, 'sys msg');
+
+    expect(fakeChild.getStdin()).toBe('sys msg\n\n---\n\nuser msg');
+  });
+
+  it('appends --model only when set', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('codex 0.1.0'),
+      spawn: spawnSpy,
+    }));
+    const { callCodexLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await callCodexLLM('prompt', { workingDirectory: '/repo', model: 'o3-pro' });
+
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    expect(args).toContain('--model');
+    expect(args).toContain('o3-pro');
+    const modelIdx = args.indexOf('--model');
+    const stdinIdx = args.indexOf('-');
+    expect(modelIdx).toBeLessThan(stdinIdx);
+  });
+});
+
+// ─── Timeout behavior ─────────────────────────────────────────────────
+
+describe('local CLI timeout', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('kills child process after requestTimeoutMs and rejects with timeout error', async () => {
+    const child = new EventEmitter() as any;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = new EventEmitter() as any;
+    child.pid = 99;
+    child.kill = vi.fn(() => {
+      queueMicrotask(() => child.emit('close', null));
+    });
+    child.stdin.end = vi.fn();
+
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('claude 1.0.0'),
+      spawn: vi.fn(() => child),
+    }));
+    const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    const promise = callClaudeLLM('prompt', { requestTimeoutMs: 5000 });
+
+    vi.advanceTimersByTime(5000);
+    await expect(promise).rejects.toThrow('claude CLI timed out after 5s');
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  it('does not set a kill timer when requestTimeoutMs is undefined', async () => {
+    const child = new EventEmitter() as any;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = new EventEmitter() as any;
+    child.pid = 99;
+    child.kill = vi.fn();
+    child.stdin.end = vi.fn(() => {
+      queueMicrotask(() => {
+        child.stdout.emit('data', Buffer.from('response'));
+        child.emit('close', 0);
+      });
+    });
+
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('claude 1.0.0'),
+      spawn: vi.fn(() => child),
+    }));
+    const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    const response = await callClaudeLLM('prompt', {});
+    expect(response.content).toBe('response');
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Codex output file fallback ───────────────────────────────────────
+
+describe('Codex output file fallback', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses stdout when output file is missing', async () => {
+    const fakeChild = makeFakeChild({ stdout: 'stdout content' });
+
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('codex 0.1.0'),
+      spawn: vi.fn(() => fakeChild.child),
+    }));
+    const { callCodexLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    const result = await callCodexLLM('prompt', { workingDirectory: '/repo' });
+    expect(result.content).toBe('stdout content');
+  });
+
+  it('rejects when both stdout and output file are empty', async () => {
+    const fakeChild = makeFakeChild({ stdout: '' });
+
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('codex 0.1.0'),
+      spawn: vi.fn(() => fakeChild.child),
+    }));
+    const { callCodexLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await expect(callCodexLLM('prompt', { workingDirectory: '/repo' })).rejects.toThrow(
+      'codex CLI returned empty output',
+    );
+  });
+});
+
+// ─── detectLocalCLI diagnostics ───────────────────────────────────────
+
+describe('detectLocalCLI diagnostics', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null and warns when CLI exists but --version fails (non-ENOENT)', async () => {
+    const warnSpy = vi.fn();
+    vi.doMock('../../src/core/logger.js', () => ({
+      logger: { info: vi.fn(), warn: warnSpy },
+    }));
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockImplementation(() => {
+        const err = new Error('exit code 1') as any;
+        err.status = 1;
+        throw err;
+      }),
+      spawn: vi.fn(),
+    }));
+
+    const { detectLocalCLI } = await import('../../src/core/wiki/local-cli-client.js');
+
+    const result = detectLocalCLI('claude');
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('--version failed'));
+  });
+
+  it('returns null silently when CLI is truly not found (ENOENT)', async () => {
+    const warnSpy = vi.fn();
+    vi.doMock('../../src/core/logger.js', () => ({
+      logger: { info: vi.fn(), warn: warnSpy },
+    }));
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockImplementation(() => {
+        const err = new Error('ENOENT') as any;
+        err.code = 'ENOENT';
+        throw err;
+      }),
+      spawn: vi.fn(),
+    }));
+
+    const { detectLocalCLI } = await import('../../src/core/wiki/local-cli-client.js');
+
+    const result = detectLocalCLI('claude');
+    expect(result).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ─── onChunk progress callback ────────────────────────────────────────
+
+describe('local CLI onChunk callback', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fires onChunk with cumulative stdout byte count', async () => {
+    const child = new EventEmitter() as any;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = new EventEmitter() as any;
+    child.pid = 1;
+    child.stdin.end = vi.fn(() => {
+      queueMicrotask(() => {
+        child.stdout.emit('data', Buffer.from('chunk1'));
+        child.stdout.emit('data', Buffer.from('chunk2'));
+        child.emit('close', 0);
+      });
+    });
+
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('claude 1.0.0'),
+      spawn: vi.fn(() => child),
+    }));
+    const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    const chunks: number[] = [];
+    await callClaudeLLM('prompt', {}, undefined, { onChunk: (n) => chunks.push(n) });
+
+    expect(chunks).toEqual([6, 12]);
+  });
+});

--- a/gitnexus/test/unit/rate-limit.test.ts
+++ b/gitnexus/test/unit/rate-limit.test.ts
@@ -256,6 +256,11 @@ describe('production routes — rate-limit middleware wiring', () => {
     expect(apiSource).toMatch(/app\.get\('\/api\/health',\s*\(_req,\s*res\)\s*=>/);
   });
 
+  it('does not register a bare wildcard OPTIONS route under Express 5', () => {
+    expect(apiSource).not.toContain("app.options('*'");
+    expect(apiSource).not.toMatch(/app\.options\(\s*'\/\*'/);
+  });
+
   it('createServer wires trust proxy to loopback/linklocal/uniquelocal', () => {
     expect(apiSource).toMatch(
       /app\.set\(\s*'trust proxy'\s*,\s*'loopback,\s*linklocal,\s*uniquelocal'\s*\)/,

--- a/gitnexus/test/unit/wiki-flags.test.ts
+++ b/gitnexus/test/unit/wiki-flags.test.ts
@@ -1,10 +1,11 @@
 /**
- * Unit tests for wiki CLI flags: --provider cursor, --review, --verbose
+ * Unit tests for wiki CLI flags: --provider cursor/claude/codex, --review, --verbose
  *
  * Tests the new wiki provider infrastructure without requiring an actual
- * Cursor CLI binary or LLM API key. All external dependencies are mocked.
+ * local agent CLI binary or LLM API key. All external dependencies are mocked.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
 import os from 'os';
 import path from 'path';
 import fs from 'fs/promises';
@@ -81,6 +82,51 @@ describe('resolveCursorConfig', () => {
   });
 });
 
+// ─── local agent CLI detection ───────────────────────────────────────
+
+describe('detectLocalCLI', () => {
+  let execFileSyncSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    execFileSyncSpy = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('detects and caches Claude CLI', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: execFileSyncSpy,
+      spawn: vi.fn(),
+    }));
+    const { detectLocalCLI } = await import('../../src/core/wiki/local-cli-client.js');
+
+    execFileSyncSpy.mockImplementation(() => 'claude 1.0.0');
+
+    expect(detectLocalCLI('claude')).toBe('claude');
+    const callsAfterFirstDetection = execFileSyncSpy.mock.calls.length;
+    expect(detectLocalCLI('claude')).toBe('claude');
+    expect(execFileSyncSpy).toHaveBeenCalledTimes(callsAfterFirstDetection);
+  });
+
+  it('caches null when Codex CLI is not found', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: execFileSyncSpy.mockImplementation(() => {
+        throw new Error('not found');
+      }),
+      spawn: vi.fn(),
+    }));
+    const { detectLocalCLI } = await import('../../src/core/wiki/local-cli-client.js');
+
+    expect(detectLocalCLI('codex')).toBeNull();
+    const callsAfterFirstDetection = execFileSyncSpy.mock.calls.length;
+    expect(detectLocalCLI('codex')).toBeNull();
+    expect(execFileSyncSpy).toHaveBeenCalledTimes(callsAfterFirstDetection);
+  });
+});
+
 // ─── resolveLLMConfig provider routing ───────────────────────────────
 
 describe('resolveLLMConfig', () => {
@@ -114,6 +160,51 @@ describe('resolveLLMConfig', () => {
 
     expect(config.provider).toBe('cursor');
     expect(config.model).toBe('claude-4.5-opus-high');
+  });
+
+  it('uses claudeModel when provider is claude', async () => {
+    vi.doMock('../../src/storage/repo-manager.js', () => ({
+      loadCLIConfig: vi.fn().mockResolvedValue({
+        provider: 'claude',
+        claudeModel: 'claude-sonnet-4-6',
+      }),
+    }));
+
+    const { resolveLLMConfig } = await import('../../src/core/wiki/llm-client.js');
+    const config = await resolveLLMConfig({ provider: 'claude' });
+
+    expect(config.provider).toBe('claude');
+    expect(config.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('uses codexModel when provider is codex', async () => {
+    vi.doMock('../../src/storage/repo-manager.js', () => ({
+      loadCLIConfig: vi.fn().mockResolvedValue({
+        provider: 'codex',
+        codexModel: 'gpt-5.4',
+      }),
+    }));
+
+    const { resolveLLMConfig } = await import('../../src/core/wiki/llm-client.js');
+    const config = await resolveLLMConfig({ provider: 'codex' });
+
+    expect(config.provider).toBe('codex');
+    expect(config.model).toBe('gpt-5.4');
+  });
+
+  it('does not inherit HTTP model defaults for local CLI providers', async () => {
+    vi.doMock('../../src/storage/repo-manager.js', () => ({
+      loadCLIConfig: vi.fn().mockResolvedValue({
+        provider: 'openai',
+        model: 'minimax/minimax-m2.5',
+      }),
+    }));
+
+    const { resolveLLMConfig } = await import('../../src/core/wiki/llm-client.js');
+    const config = await resolveLLMConfig({ provider: 'claude' });
+
+    expect(config.provider).toBe('claude');
+    expect(config.model).toBe('');
   });
 
   it('uses default OpenRouter model for openai provider', async () => {
@@ -720,11 +811,15 @@ describe('WikiGenerator invokeLLM routing', () => {
 
   it('routes to callCursorLLM when provider is cursor', async () => {
     const cursorClient = await import('../../src/core/wiki/cursor-client.js');
+    const localClient = await import('../../src/core/wiki/local-cli-client.js');
     const llmClient = await import('../../src/core/wiki/llm-client.js');
 
     const cursorSpy = vi
       .spyOn(cursorClient, 'callCursorLLM')
       .mockResolvedValue({ content: 'cursor response' });
+    const claudeSpy = vi
+      .spyOn(localClient, 'callClaudeLLM')
+      .mockResolvedValue({ content: 'claude response' });
     const openaiSpy = vi
       .spyOn(llmClient, 'callLLM')
       .mockResolvedValue({ content: 'openai response' });
@@ -751,17 +846,112 @@ describe('WikiGenerator invokeLLM routing', () => {
     const result = await (generator as any).invokeLLM('test prompt', 'system prompt');
 
     expect(cursorSpy).toHaveBeenCalledTimes(1);
+    expect(claudeSpy).not.toHaveBeenCalled();
     expect(openaiSpy).not.toHaveBeenCalled();
     expect(result.content).toBe('cursor response');
   });
 
-  it('routes to callLLM when provider is openai', async () => {
+  it('routes to callClaudeLLM when provider is claude', async () => {
     const cursorClient = await import('../../src/core/wiki/cursor-client.js');
+    const localClient = await import('../../src/core/wiki/local-cli-client.js');
     const llmClient = await import('../../src/core/wiki/llm-client.js');
 
     const cursorSpy = vi
       .spyOn(cursorClient, 'callCursorLLM')
       .mockResolvedValue({ content: 'cursor response' });
+    const claudeSpy = vi
+      .spyOn(localClient, 'callClaudeLLM')
+      .mockResolvedValue({ content: 'claude response' });
+    const codexSpy = vi
+      .spyOn(localClient, 'callCodexLLM')
+      .mockResolvedValue({ content: 'codex response' });
+    const openaiSpy = vi
+      .spyOn(llmClient, 'callLLM')
+      .mockResolvedValue({ content: 'openai response' });
+
+    const { WikiGenerator } = await import('../../src/core/wiki/generator.js');
+
+    const storagePath = path.join(tmpDir, 'storage');
+    const wikiDir = path.join(storagePath, 'wiki');
+    await fs.mkdir(wikiDir, { recursive: true });
+
+    const repoPath = path.join(tmpDir, 'repo');
+    await fs.mkdir(repoPath, { recursive: true });
+
+    const generator = new WikiGenerator(repoPath, storagePath, path.join(storagePath, 'lbug'), {
+      apiKey: '',
+      baseUrl: '',
+      model: 'claude-sonnet-4-6',
+      maxTokens: 1000,
+      temperature: 0,
+      provider: 'claude',
+    });
+
+    const result = await (generator as any).invokeLLM('test prompt', 'system prompt');
+
+    expect(claudeSpy).toHaveBeenCalledTimes(1);
+    expect(codexSpy).not.toHaveBeenCalled();
+    expect(cursorSpy).not.toHaveBeenCalled();
+    expect(openaiSpy).not.toHaveBeenCalled();
+    expect(result.content).toBe('claude response');
+  });
+
+  it('routes to callCodexLLM when provider is codex', async () => {
+    const cursorClient = await import('../../src/core/wiki/cursor-client.js');
+    const localClient = await import('../../src/core/wiki/local-cli-client.js');
+    const llmClient = await import('../../src/core/wiki/llm-client.js');
+
+    const cursorSpy = vi
+      .spyOn(cursorClient, 'callCursorLLM')
+      .mockResolvedValue({ content: 'cursor response' });
+    const claudeSpy = vi
+      .spyOn(localClient, 'callClaudeLLM')
+      .mockResolvedValue({ content: 'claude response' });
+    const codexSpy = vi
+      .spyOn(localClient, 'callCodexLLM')
+      .mockResolvedValue({ content: 'codex response' });
+    const openaiSpy = vi
+      .spyOn(llmClient, 'callLLM')
+      .mockResolvedValue({ content: 'openai response' });
+
+    const { WikiGenerator } = await import('../../src/core/wiki/generator.js');
+
+    const storagePath = path.join(tmpDir, 'storage');
+    const wikiDir = path.join(storagePath, 'wiki');
+    await fs.mkdir(wikiDir, { recursive: true });
+
+    const repoPath = path.join(tmpDir, 'repo');
+    await fs.mkdir(repoPath, { recursive: true });
+
+    const generator = new WikiGenerator(repoPath, storagePath, path.join(storagePath, 'lbug'), {
+      apiKey: '',
+      baseUrl: '',
+      model: 'gpt-5.4',
+      maxTokens: 1000,
+      temperature: 0,
+      provider: 'codex',
+    });
+
+    const result = await (generator as any).invokeLLM('test prompt', 'system prompt');
+
+    expect(codexSpy).toHaveBeenCalledTimes(1);
+    expect(claudeSpy).not.toHaveBeenCalled();
+    expect(cursorSpy).not.toHaveBeenCalled();
+    expect(openaiSpy).not.toHaveBeenCalled();
+    expect(result.content).toBe('codex response');
+  });
+
+  it('routes to callLLM when provider is openai', async () => {
+    const cursorClient = await import('../../src/core/wiki/cursor-client.js');
+    const localClient = await import('../../src/core/wiki/local-cli-client.js');
+    const llmClient = await import('../../src/core/wiki/llm-client.js');
+
+    const cursorSpy = vi
+      .spyOn(cursorClient, 'callCursorLLM')
+      .mockResolvedValue({ content: 'cursor response' });
+    const codexSpy = vi
+      .spyOn(localClient, 'callCodexLLM')
+      .mockResolvedValue({ content: 'codex response' });
     const openaiSpy = vi
       .spyOn(llmClient, 'callLLM')
       .mockResolvedValue({ content: 'openai response' });
@@ -788,6 +978,7 @@ describe('WikiGenerator invokeLLM routing', () => {
 
     expect(openaiSpy).toHaveBeenCalledTimes(1);
     expect(cursorSpy).not.toHaveBeenCalled();
+    expect(codexSpy).not.toHaveBeenCalled();
     expect(result.content).toBe('openai response');
   });
 });
@@ -814,6 +1005,98 @@ describe('callCursorLLM', () => {
     const { callCursorLLM } = await import('../../src/core/wiki/cursor-client.js');
 
     await expect(callCursorLLM('hello', {})).rejects.toThrow('Cursor CLI not found');
+  });
+});
+
+// ─── local CLI errors when binaries are not found ────────────────────
+
+describe('local agent CLI calls', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws when Claude CLI is not in PATH', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockImplementation(() => {
+        throw new Error('not found');
+      }),
+      spawn: vi.fn(),
+    }));
+
+    const { callClaudeLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await expect(callClaudeLLM('hello', {})).rejects.toThrow('Claude CLI not found');
+  });
+
+  it('throws when Codex CLI is not in PATH', async () => {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockImplementation(() => {
+        throw new Error('not found');
+      }),
+      spawn: vi.fn(),
+    }));
+
+    const { callCodexLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await expect(callCodexLLM('hello', {})).rejects.toThrow('Codex CLI not found');
+  });
+
+  it('uses Codex config overrides instead of removed approval flags', async () => {
+    const child = new EventEmitter() as any;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = new EventEmitter() as any;
+    child.stdin.end = vi.fn(() => {
+      queueMicrotask(() => {
+        child.stdout.emit('data', Buffer.from('codex response'));
+        child.emit('close', 0);
+      });
+    });
+
+    const spawnSpy = vi.fn(() => child);
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('codex-cli 0.132.0'),
+      spawn: spawnSpy,
+    }));
+
+    const { callCodexLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    const response = await callCodexLLM('hello', { workingDirectory: process.cwd() });
+
+    expect(response.content).toBe('codex response');
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    expect(args).toContain('-c');
+    expect(args).toContain('approval_policy="never"');
+    expect(args).not.toContain('--ask-for-approval');
+  });
+
+  it('reports Codex stderr when the process closes before stdin is fully written', async () => {
+    const child = new EventEmitter() as any;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = new EventEmitter() as any;
+    child.stdin.end = vi.fn(() => {
+      queueMicrotask(() => {
+        child.stderr.emit('data', Buffer.from("error: unexpected argument '--old-flag' found"));
+        child.stdin.emit('error', new Error('write EOF'));
+        child.emit('close', 2);
+      });
+    });
+
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn().mockReturnValue('codex-cli 0.132.0'),
+      spawn: vi.fn(() => child),
+    }));
+
+    const { callCodexLLM } = await import('../../src/core/wiki/local-cli-client.js');
+
+    await expect(callCodexLLM('hello', { workingDirectory: process.cwd() })).rejects.toThrow(
+      "codex CLI exited with code 2: error: unexpected argument '--old-flag' found",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

<!-- One or two sentences: what does this PR change? -->

## Motivation / context

<!-- Why is this change needed? Link issues, ADRs, or prior discussion. -->

## Areas touched

<!-- Check all that apply -->

- [ ] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- <!-- bullets -->

**Explicitly out of scope / not done here**

- <!-- bullets — prevents reviewers assuming missing work is an oversight -->

## Implementation notes

<!-- Optional: design choices, tradeoffs, follow-ups -->

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [ ] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [ ] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(if web changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

## Risk & rollout

<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->

## Checklist

- [ ] PR body meets repo minimum length (workflow may label short descriptions)
- [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [ ] No secrets, tokens, or machine-specific paths committed

## command
- gitnexus wiki --provider claude
- gitnexus wiki --provider claude --model claude-sonnet-4-6
- gitnexus wiki --provider codex
- gitnexus wiki --provider codex --model gpt-5.4