### PR TITLE
fix(lang-kotlin): smart-cast type refinement for when/is and if/is (#1758)

### DIFF
--- a/gitnexus/src/core/ingestion/languages/kotlin/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/kotlin/captures.ts
@@ -35,6 +35,7 @@ export function emitKotlinScopeCaptures(
   const returnTypes = collectKotlinReturnTypeTexts(tree.rootNode);
   out.push(...synthesizeKotlinLocalAssignmentBindings(tree.rootNode, returnTypes));
   out.push(...synthesizeKotlinLoopBindings(tree.rootNode, returnTypes));
+  out.push(...synthesizeKotlinSmartCastBindings(tree.rootNode));
 
   for (const match of getKotlinScopeQuery().matches(tree.rootNode)) {
     const grouped: Record<string, Capture> = {};
@@ -184,6 +185,104 @@ function synthesizeKotlinLoopBindings(
     }
   }
   return out;
+}
+
+/**
+ * Synthesize narrowed type-bindings for Kotlin smart-cast forms — issue #1758.
+ *
+ * For each `when (x) { is T -> body }` and `if (x is T) body`, emits a
+ * `@type-binding.annotation` capture binding `x → T` anchored on the body
+ * node. The capture lands in the matching `@scope.block` scope (see query.ts
+ * smart-cast scopes), shadowing the outer parameter binding for calls inside
+ * the body without leaking across sibling arms or to `else`.
+ *
+ * Only narrows when:
+ *   - the `when` subject is a `simple_identifier` (not a call or field chain);
+ *   - the `when_entry` condition is exactly one `type_test` (skips `!is`,
+ *     compound conditions, range/`in`/value patterns);
+ *   - the `if_expression` condition is a `check_expression` of the form
+ *     `<simple_identifier> is <user_type>` and the then-branch is a
+ *     `control_structure_body`.
+ *
+ * `else` arms and non-narrowing conditions emit nothing — the fall-through to
+ * the outer scope's declared type is the correct semantic.
+ */
+function synthesizeKotlinSmartCastBindings(rootNode: SyntaxNode): CaptureMatch[] {
+  const out: CaptureMatch[] = [];
+
+  for (const whenNode of descendantsOfType(rootNode, 'when_expression')) {
+    const subjectName = extractWhenSubjectIdentifier(whenNode);
+    if (subjectName === null) continue;
+
+    for (const entry of whenNode.namedChildren) {
+      if (entry.type !== 'when_entry') continue;
+      const narrowedType = extractIsTestTargetType(entry);
+      if (narrowedType === null) continue;
+      const body = entry.namedChildren.find((child) => child.type === 'control_structure_body');
+      if (body === undefined) continue;
+      out.push(buildNarrowedTypeBindingCapture(subjectName.node, body, narrowedType));
+    }
+  }
+
+  for (const ifNode of descendantsOfType(rootNode, 'if_expression')) {
+    const check = ifNode.namedChildren.find((child) => child.type === 'check_expression');
+    if (check === undefined) continue;
+    const subject = check.namedChildren.find((child) => child.type === 'simple_identifier');
+    const typeNode = check.namedChildren.find((child) => isKotlinTypeNode(child));
+    if (subject === undefined || typeNode === undefined) continue;
+    // The first control_structure_body sibling is the then-branch; else
+    // branches (when present) appear as the second control_structure_body
+    // and are intentionally not narrowed.
+    const body = ifNode.namedChildren.find((child) => child.type === 'control_structure_body');
+    if (body === undefined) continue;
+    out.push(buildNarrowedTypeBindingCapture(subject, body, typeNode));
+  }
+
+  return out;
+}
+
+function extractWhenSubjectIdentifier(whenNode: SyntaxNode): { node: SyntaxNode } | null {
+  const subject = whenNode.namedChildren.find((child) => child.type === 'when_subject');
+  if (subject === undefined) return null;
+  const ident = subject.namedChildren.find((child) => child.type === 'simple_identifier');
+  return ident === undefined ? null : { node: ident };
+}
+
+function extractIsTestTargetType(whenEntry: SyntaxNode): SyntaxNode | null {
+  const condition = whenEntry.namedChildren.find((child) => child.type === 'when_condition');
+  if (condition === undefined) return null;
+  // Exactly one when_condition child must be a positive type_test.
+  // Compound conditions (multiple `when_condition` siblings joined with
+  // commas in some grammars) or negated `!is` are not safe to narrow.
+  if (condition.namedChildCount !== 1) return null;
+  const test = condition.namedChild(0);
+  if (test === null || test.type !== 'type_test') return null;
+  // `!is` produces a different node (`negated_type_test` in some grammars,
+  // or an extra `!` child in others) — defend by checking text prefix.
+  if (test.text.trim().startsWith('!')) return null;
+  return test.namedChildren.find((child) => isKotlinTypeNode(child)) ?? null;
+}
+
+function buildNarrowedTypeBindingCapture(
+  subject: SyntaxNode,
+  bodyAnchor: SyntaxNode,
+  typeNode: SyntaxNode,
+): CaptureMatch {
+  return {
+    '@type-binding.annotation': nodeToCapture('@type-binding.annotation', bodyAnchor),
+    '@type-binding.name': syntheticCapture('@type-binding.name', subject, subject.text),
+    '@type-binding.type': syntheticCapture(
+      '@type-binding.type',
+      typeNode,
+      normalizeKotlinType(typeNode.text),
+    ),
+    // Marker consumed by `kotlinBindingScopeFor` in simple-hooks.ts to
+    // override the scope-extractor's auto-hoist. Unbraced arm bodies
+    // (`is User -> obj.save()`) make the body anchor coincide with the
+    // Block scope's range; without this marker the binding would hoist
+    // to the enclosing function scope and lose its arm-local narrowing.
+    '@type-binding.narrowed': syntheticCapture('@type-binding.narrowed', bodyAnchor, '1'),
+  };
 }
 
 function synthesizeKotlinLocalAssignmentBindings(

--- a/gitnexus/src/core/ingestion/languages/kotlin/query.ts
+++ b/gitnexus/src/core/ingestion/languages/kotlin/query.ts
@@ -9,6 +9,19 @@ const KOTLIN_SCOPE_QUERY = `
 (companion_object) @scope.class
 (function_declaration) @scope.function
 
+;; Smart-cast narrowing scopes (RFC #909 Ring 3, issue #1758).
+;; Each is-test arm body and each if-then body becomes its own Block
+;; scope so synthesized narrowed type-bindings (see captures.ts
+;; synthesizeKotlinSmartCastBindings) shadow the outer parameter
+;; binding for calls inside the body — without leaking across arms.
+(when_entry
+  (when_condition (type_test))
+  (control_structure_body) @scope.block)
+
+(if_expression
+  (check_expression)
+  (control_structure_body) @scope.block)
+
 ;; Declarations — types
 (class_declaration
   "interface"

--- a/gitnexus/src/core/ingestion/languages/kotlin/simple-hooks.ts
+++ b/gitnexus/src/core/ingestion/languages/kotlin/simple-hooks.ts
@@ -12,6 +12,13 @@ export function kotlinBindingScopeFor(
   innermost: Scope,
   tree: ScopeTree,
 ): ScopeId | null {
+  // Smart-cast narrowed bindings (issue #1758) must stay at the innermost
+  // (Block) scope. Their anchor coincides with the Block's range for
+  // unbraced arm bodies (`is User -> obj.save()`), which would otherwise
+  // trigger scope-extractor auto-hoist into the enclosing function scope
+  // and erase the arm-local narrowing.
+  if (decl['@type-binding.narrowed'] !== undefined) return innermost.id;
+
   if (decl['@type-binding.return'] === undefined) return null;
 
   let current: Scope | undefined = innermost;


### PR DESCRIPTION
## Summary

Implements Kotlin smart-cast type narrowing for `when (x) { is T -> ... }` arms and `if (x is T) { ... }` blocks under `REGISTRY_PRIMARY_KOTLIN=1`. Closes sub-issue #1758 of the Kotlin scope-resolution migration tracker (#1746).

Today the Kotlin tree-sitter query has no captures for `when`/`if`-with-type-test, so narrowed receivers fall through to their declared type (`Any`) and `obj.member()` calls inside arms emit no `CALLS` edges. This PR adds:

- `@scope.block` captures for `when_entry` bodies (when condition is a single `is`-test) and `if_expression` then-branches (when condition is a `check_expression`).
- `synthesizeKotlinSmartCastBindings` in `captures.ts` — walks `when_expression` and `if_expression` nodes, emits a `@type-binding.annotation` capture binding the subject identifier to the tested type, anchored on the body so it lands in the matching Block scope.
- A `@type-binding.narrowed` marker + `kotlinBindingScopeFor` override so the scope-extractor's auto-hoist does not promote the narrowed binding to the enclosing function scope (which it otherwise would for unbraced arm bodies whose anchor coincides with the Block scope's range).

## Verification

| Run | Before | After |
|-----|--------|-------|
| `REGISTRY_PRIMARY_KOTLIN=1 npx vitest run test/integration/resolvers/kotlin.test.ts` | 21 failing / 154 passing of 175 | **9 failing / 166 passing of 175** |
| `npx vitest run test/integration/resolvers/kotlin.test.ts` (default) | 175/175 | 175/175 |
| `npx vitest run test/integration/resolvers/` (full suite) | 2216/2216 | 2216/2216 |
| `npx tsc --noEmit` | clean | clean |

All 12 `when/is` tests now pass (lines 957, 966, 975, 1096, 1107, 1118, 1131, 1142, 1153, 1164, 1182, 1195 in `gitnexus/test/integration/resolvers/kotlin.test.ts`), including the cross-arm-contamination guard at line 1182 (`processMultiCall` emits exactly 2 `save` edges, not 4).

The 9 remaining `REGISTRY_PRIMARY_KOTLIN=1` failures are tracked by the sibling sub-issues:
- #1759 — cross-file iterable return propagation (3 tests inc. test 487)
- #1760 — method-chain fixpoint (1 test)
- #1761 — overload target-id selection (3 tests)
- #1762 — virtual dispatch via constructor type (1 test)
- #1763 — interface default methods (1 test)

## Scope discipline

Per parent #1746 flip criteria, this PR does **not** add `SupportedLanguages.Kotlin` to `MIGRATED_LANGUAGES`. The flip lands once #1759–#1763 are green and the named blockers #1756 (companion vs instance) and #1757 (lambda scopes) are closed.

`if (x !is T) return; x.member()` (guard-then-refine, an acceptance criterion sub-bullet from #1758) is intentionally not in this PR — different control-flow shape (return-narrowing), straightforward follow-up.

## Test plan

- [x] Forced-mode parity: 12 fewer failures, no regressions
- [x] Default-mode Kotlin: 175/175
- [x] Full resolver suite: 2216/2216
- [x] `npx tsc --noEmit`: clean

Closes #1758
Refs #1746