### PR TITLE
fix(lang-kotlin): cross-file iterable return propagation (#1759)

### DIFF
--- a/gitnexus/src/core/ingestion/languages/kotlin/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/kotlin/captures.ts
@@ -312,7 +312,16 @@ function inferKotlinIterableElementType(
     const callee = iterable.namedChildren.find((child) => child.type === 'simple_identifier');
     if (callee === undefined) return null;
     const raw = returnTypes.get(callee.text);
-    return raw === undefined ? null : kotlinContainerElementType(raw, 'values');
+    if (raw !== undefined) return kotlinContainerElementType(raw, 'values');
+    // Cross-file fallback (#1759): the callee's return type is unknown
+    // locally because the function lives in another file. Emit the
+    // callee name itself as the binding's rawName; `propagateImported
+    // ReturnTypes` will chain-follow `loopvar → callee → <ElementType>`
+    // once the imported module's `callee → ElementType` mirror lands at
+    // module scope. If `callee` isn't actually an imported callable
+    // (e.g. a local lambda or unrelated symbol), chain-follow fails
+    // safely and no edge is emitted.
+    return callee.text;
   }
 
   return null;

--- a/gitnexus/src/core/ingestion/languages/kotlin/import-target.ts
+++ b/gitnexus/src/core/ingestion/languages/kotlin/import-target.ts
@@ -8,7 +8,7 @@ export interface KotlinResolveContext {
 export function resolveKotlinImportTarget(
   parsedImport: ParsedImport,
   workspaceIndex: WorkspaceIndex,
-): string | null {
+): string | readonly string[] | null {
   const ctx = workspaceIndex as KotlinResolveContext | undefined;
   if (
     ctx === undefined ||
@@ -25,22 +25,49 @@ export function resolveKotlinImportTarget(
     : parsedImport.targetRaw;
   const pathLike = target.replace(/\./g, '/');
 
+  // Resolution tiers, most-specific first:
+  //  1. The full `pathLike` matches a `.kt`/`.kts` file directly
+  //     (`import util.User` → `util/User.kt`).
+  //  2. Stripped (last-segment removed) `pathLike` matches a file
+  //     directly (`import util.OneArg.writeAudit` → `util/OneArg.kt`,
+  //     a class-or-object holding `writeAudit`).
+  //  3. Stripped `pathLike` matches a *package directory* — fan out to
+  //     every `.kt`/`.kts` file inside it (`import models.getRepo` →
+  //     `[models/User.kt, models/Repo.kt]`). The finalize pass walks
+  //     each candidate and picks the one whose `localDefs` actually
+  //     export the imported name (#1759).
+  //  4. Progressive prefix strip for deeper namespace aliases that
+  //     don't map 1:1 to directories.
+  const stripped = pathLike.split('/').slice(0, -1).join('/');
   return (
     findKotlinFile(ctx.allFilePaths, pathLike) ??
-    findKotlinFile(ctx.allFilePaths, pathLike.split('/').slice(0, -1).join('/')) ??
+    findKotlinExactOrSuffix(ctx.allFilePaths, stripped) ??
+    findKotlinPackageFiles(ctx.allFilePaths, stripped) ??
     findByProgressivePrefixStrip(ctx.allFilePaths, pathLike)
   );
 }
 
 function findKotlinFile(allFilePaths: ReadonlySet<string>, pathLike: string): string | null {
+  return (
+    findKotlinExactOrSuffix(allFilePaths, pathLike) ??
+    findKotlinDirectoryChild(allFilePaths, pathLike)
+  );
+}
+
+/** Exact (`file === pathLike+ext`) or suffix (`file ends with /pathLike+ext`)
+ *  match — does NOT fall back to picking an arbitrary file inside a
+ *  `pathLike/` directory. Used by the stripped-path tier in
+ *  `resolveKotlinImportTarget` so a package import like `models.getRepo`
+ *  delegates to `findKotlinPackageFiles` (multi-file fan-out) instead of
+ *  silently committing to the first directory child. */
+function findKotlinExactOrSuffix(
+  allFilePaths: ReadonlySet<string>,
+  pathLike: string,
+): string | null {
   if (pathLike === '') return null;
   const extensions = ['.kt', '.kts'];
   const suffix = `/${pathLike}`;
-  const dirPrefix = `${pathLike}/`;
-  const suffixDirPrefix = `/${dirPrefix}`;
-
   let suffixFile: string | null = null;
-  let directoryChild: string | null = null;
 
   for (const raw of allFilePaths) {
     const file = raw.replace(/\\/g, '/');
@@ -49,18 +76,73 @@ function findKotlinFile(allFilePaths: ReadonlySet<string>, pathLike: string): st
       if (file === `${pathLike}${ext}`) return raw;
       if (suffixFile === null && file.endsWith(`${suffix}${ext}`)) suffixFile = raw;
     }
-    if (directoryChild === null) {
-      const atRoot = file.startsWith(dirPrefix);
-      const atNested = file.includes(suffixDirPrefix);
-      if (atRoot || atNested) {
-        const idx = atRoot ? 0 : file.indexOf(suffixDirPrefix) + 1;
-        const after = file.slice(idx + dirPrefix.length);
-        if (after.length > 0 && !after.includes('/')) directoryChild = raw;
-      }
-    }
   }
 
-  return suffixFile ?? directoryChild;
+  return suffixFile;
+}
+
+/** First directory child of `pathLike/` — preserves the legacy single-
+ *  file fallback for cases where `pathLike` itself is an unqualified
+ *  package reference (rare in real Kotlin code; some fixtures rely on
+ *  it). Multi-file package fan-out goes through
+ *  `findKotlinPackageFiles` instead. */
+function findKotlinDirectoryChild(
+  allFilePaths: ReadonlySet<string>,
+  pathLike: string,
+): string | null {
+  if (pathLike === '') return null;
+  const extensions = ['.kt', '.kts'];
+  const dirPrefix = `${pathLike}/`;
+  const suffixDirPrefix = `/${dirPrefix}`;
+
+  for (const raw of allFilePaths) {
+    const file = raw.replace(/\\/g, '/');
+    if (!extensions.some((ext) => file.endsWith(ext))) continue;
+    const atRoot = file.startsWith(dirPrefix);
+    const atNested = file.includes(suffixDirPrefix);
+    if (!atRoot && !atNested) continue;
+    const idx = atRoot ? 0 : file.indexOf(suffixDirPrefix) + 1;
+    const after = file.slice(idx + dirPrefix.length);
+    if (after.length > 0 && !after.includes('/')) return raw;
+  }
+
+  return null;
+}
+
+/**
+ * Return every `.kt`/`.kts` file inside the package directory `dirPath`
+ * (e.g. `models` → `['models/User.kt', 'models/Repo.kt']`). Used as a
+ * fallback when an import like `models.getRepo` does not resolve to a
+ * file named after the symbol — in Kotlin the symbol can live in any
+ * file inside the package directory. The finalize pass walks each
+ * candidate and picks the one whose `localDefs` actually export the
+ * imported name (#1759).
+ */
+function findKotlinPackageFiles(
+  allFilePaths: ReadonlySet<string>,
+  dirPath: string,
+): readonly string[] | null {
+  if (dirPath === '') return null;
+  const extensions = ['.kt', '.kts'];
+  const dirPrefix = `${dirPath}/`;
+  const suffixDirPrefix = `/${dirPrefix}`;
+  const out: string[] = [];
+
+  for (const raw of allFilePaths) {
+    const file = raw.replace(/\\/g, '/');
+    if (!extensions.some((ext) => file.endsWith(ext))) continue;
+    const atRoot = file.startsWith(dirPrefix);
+    const atNested = file.includes(suffixDirPrefix);
+    if (!atRoot && !atNested) continue;
+    const idx = atRoot ? 0 : file.indexOf(suffixDirPrefix) + 1;
+    const after = file.slice(idx + dirPrefix.length);
+    // Direct children only — `models/sub/Util.kt` is a different package
+    // (`models.sub`) and must not be merged with `models`.
+    if (after.length === 0 || after.includes('/')) continue;
+    out.push(raw);
+  }
+
+  return out.length === 0 ? null : out;
 }
 
 function findByProgressivePrefixStrip(


### PR DESCRIPTION
## Summary

Closes sub-issue #1759 of the Kotlin scope-resolution migration tracker (#1746). Fixes two related cross-file return-type propagation gaps under `REGISTRY_PRIMARY_KOTLIN=1`:

1. **Package-scoped imports silently committed to the wrong file.** `import models.getRepo` resolved to `models/User.kt` (the first `.kt` file inside `models/` by iteration order) because `findKotlinFile` returned a single directory child as a fallback. The importer's module-scope mirror therefore only picked up `getUser → User` — `getRepo → Repo` was never mirrored, and `repo.save()` inside `processRepo()` fell through to no edge. This is why the test 487 \"identical fixture\" mystery existed: `processUser` worked by coincidence (first file alphabetically held `getUser`), `processRepo` failed because `getRepo` lived in a *different* file.

2. **For-loops over cross-file callables produced no element-type binding.** `for (x in getUsers())` did not produce a `x → User` binding when `getUsers()` was imported from another file, because `inferKotlinIterableElementType`'s call-expression arm consulted only the local file's `returnTypes` map.

## Implementation

- **`import-target.ts`** — split the legacy `findKotlinFile` into `findKotlinExactOrSuffix` (no directory-child fallback) and `findKotlinDirectoryChild` (legacy single-child preserved for compatibility). Added `findKotlinPackageFiles` returning `readonly string[]` — every `.kt`/`.kts` file inside a package directory. The resolver now fans out the stripped path through `findKotlinExactOrSuffix → findKotlinPackageFiles`, and the finalize pass picks whichever candidate's `localDefs` actually exports the imported name. This uses the existing `FinalizeHooks.resolveImportTarget: string | readonly string[] | null` contract — no shared-types changes.
- **`captures.ts`** — `inferKotlinIterableElementType` for `call_expression` now falls back to the callee identifier text when local return-types miss. `propagateImportedReturnTypes` chain-follows `loopvar → callee → ElementType` once the imported `callee → ElementType` mirror lands at module scope (which now works thanks to fix #1).

## Verification

| Run | Before | After |
|---|---|---|
| `REGISTRY_PRIMARY_KOTLIN=1 npx vitest run test/integration/resolvers/kotlin.test.ts` | 21 failing / 154 passing of 175 | **18 failing / 157 passing of 175** |
| `npx vitest run test/integration/resolvers/kotlin.test.ts` (default) | 175/175 | 175/175 |
| `npx vitest run test/integration/resolvers/` (full suite) | 2216/2216 | 2216/2216 |
| `npx tsc --noEmit` | clean | clean |

Tests now passing under `REGISTRY_PRIMARY_KOTLIN=1`:
- `test/integration/resolvers/kotlin.test.ts:487` — `resolves repo.save() to Repo#save via return type inference`
- `test/integration/resolvers/kotlin.test.ts:1242` — `resolves user.save() in for-loop over getUsers() to User#save`
- `test/integration/resolvers/kotlin.test.ts:1251` — `resolves repo.save() in for-loop over getRepos() to Repo#save`

The 18 remaining `REGISTRY_PRIMARY_KOTLIN=1` failures are tracked by sibling sub-issues #1758, #1760, #1761, #1762, #1763.

Regression check: the `import util.OneArg.writeAudit` case in `kotlin-calls` (line 176, arity narrowing) still resolves correctly — the stripped-path tier still uses `findKotlinExactOrSuffix` and matches `util/OneArg.kt` exactly.

## Scope discipline

Per parent #1746 flip criteria, this PR does **not** add `SupportedLanguages.Kotlin` to `MIGRATED_LANGUAGES`. The flip lands once all sibling sub-issues close and the named blockers #1756 (companion vs instance) and #1757 (lambda scopes) are addressed.

## Test plan

- [x] Forced-mode parity: 3 fewer failures, no regressions
- [x] Default-mode Kotlin: 175/175
- [x] Full resolver suite: 2216/2216
- [x] `npx tsc --noEmit`: clean
- [x] `kotlin-calls` arity narrowing regression check (line 176) — still green

Closes #1759
Refs #1746