### PR TITLE
fix(lang-kotlin): overload target-id selection by parameter types (#1761)

### DIFF
--- a/gitnexus/src/core/ingestion/languages/kotlin/owners.ts
+++ b/gitnexus/src/core/ingestion/languages/kotlin/owners.ts
@@ -4,6 +4,29 @@ import { isClassLike, populateClassOwnedMembers } from '../../scope-resolution/s
 export function populateKotlinOwners(parsed: ParsedFile): void {
   populateClassOwnedMembers(parsed);
   populateCompanionMembersOnEnclosingClass(parsed);
+  upgradeClassOwnedFunctionsToMethods(parsed);
+}
+
+/**
+ * Align scope-resolution `def.type` with the graph's node-label
+ * conventions: a `Function` def that lives inside a class body becomes
+ * a `Method`. The Kotlin extractor labels every `function_declaration`
+ * as `Function`, but the graph parsing-processor emits a `Method`
+ * graph-node label for class members. Without this realignment,
+ * `resolveDefGraphId`'s parameter-typed key lookup (gated on
+ * `def.type === 'Method'`) falls through to the simple-name fallback
+ * for class methods, collapsing same-name same-arity overloads onto
+ * the first-registered node (#1761).
+ *
+ * Only Method-bearing types are touched. Methods have a class owner
+ * (set by `populateClassOwnedMembers`) and a class-qualified name.
+ */
+function upgradeClassOwnedFunctionsToMethods(parsed: ParsedFile): void {
+  for (const def of parsed.localDefs) {
+    if (def.type !== 'Function') continue;
+    if (def.ownerId === undefined) continue;
+    (def as { type: SymbolDefinition['type'] }).type = 'Method';
+  }
 }
 
 function populateCompanionMembersOnEnclosingClass(parsed: ParsedFile): void {


### PR DESCRIPTION
## Summary

Closes sub-issue #1761 of the Kotlin scope-resolution migration tracker (#1746). Same-arity Kotlin class-method overloads collapsed onto whichever graph node was registered first — `lookup("alice")` resolved to `lookup(Int)` even though the picker correctly narrowed it to `lookup(String)`.

## Root cause

`populateKotlinOwners` (which calls `populateClassOwnedMembers`) assigns `ownerId` and qualified names to class-owned function defs but leaves `def.type === 'Function'`. The graph parsing-processor, in contrast, emits a `Method` node label for class members. `resolveDefGraphId`'s parameter-typed key lookup (`graph-bridge/ids.ts:108-116`) is gated on `def.type === 'Method'`, so it was skipped for every Kotlin class method. With the type-keyed lookup skipped, the resolver fell through to `simpleKey`, which is first-wins by registration order — and the `Int` overload always registered first in these fixtures.

Traced through to confirm: `pickImplicitThisOverload` / `narrowOverloadCandidates` already pick the correct def by type (`lookup("alice")` → `[String]` candidate). Only the graph-id lookup was broken.

## Fix

`populateKotlinOwners` upgrades `def.type` from `Function` to `Method` after `populateClassOwnedMembers` assigns `ownerId`. This aligns the scope-resolution model with the graph's node labels so parameter-typed key registration and lookup operate in the same keyspace.

23 lines, single file.

## Verification

| Run | Before | After |
|---|---|---|
| `REGISTRY_PRIMARY_KOTLIN=1 npx vitest run test/integration/resolvers/kotlin.test.ts` | 21 failing / 154 passing of 175 | **18 failing / 157 passing of 175** |
| `npx vitest run test/integration/resolvers/kotlin.test.ts` (default) | 175/175 | 175/175 |
| `npx vitest run test/integration/resolvers/` (full suite) | 2216/2216 | 2216/2216 |
| `npx tsc --noEmit` | clean | clean |

Tests now passing under `REGISTRY_PRIMARY_KOTLIN=1`:
- `test/integration/resolvers/kotlin.test.ts:1620` — `callByName() emits exactly one CALLS edge to lookup(String)` (same-file overload)
- `test/integration/resolvers/kotlin.test.ts:1659` — `crossFileByName() emits exactly one CALLS edge to find(String) in DbLookup` (cross-file overload)
- `test/integration/resolvers/kotlin.test.ts:1692` — `chainNameToFormat() resolves find("alice") → find(String) cross-file`

The 18 remaining `REGISTRY_PRIMARY_KOTLIN=1` failures are tracked by sibling sub-issues #1758, #1759, #1760, #1762, #1763.

## Scope discipline

Per parent #1746 flip criteria, this PR does **not** add `SupportedLanguages.Kotlin` to `MIGRATED_LANGUAGES`. The flip lands once all sibling sub-issues close and the named blockers #1756 (companion vs instance) and #1757 (lambda scopes) are addressed.

The fix is localized to `populateKotlinOwners` rather than the shared `populateClassOwnedMembers` — other languages may rely on the current `Function` typing for class-owned scope-resolution defs, and changing that surface needs cross-language audit.

## Test plan

- [x] Forced-mode parity: 3 fewer failures, no regressions
- [x] Default-mode Kotlin: 175/175
- [x] Full resolver suite: 2216/2216
- [x] `npx tsc --noEmit`: clean

Closes #1761
Refs #1746