### PR TITLE
fix(lang-kotlin): virtual dispatch via constructor type override (#1762)

### DIFF
--- a/gitnexus/src/core/ingestion/languages/kotlin/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/kotlin/captures.ts
@@ -1,4 +1,4 @@
-import type { Capture, CaptureMatch } from 'gitnexus-shared';
+import type { Capture, CaptureMatch, Range } from 'gitnexus-shared';
 import {
   findNodeAtRange,
   nodeToCapture,
@@ -70,6 +70,30 @@ export function emitKotlinScopeCaptures(
       const anchor = grouped['@reference.read.member']!;
       const navNode = findNodeAtRange(tree.rootNode, anchor.range, 'navigation_expression');
       if (navNode === null || !shouldEmitReadMember(navNode)) continue;
+    }
+
+    // Virtual dispatch via constructor type (#1762). When a property
+    // declaration carries BOTH an explicit type annotation AND a
+    // constructor-style call value (e.g. `val animal: Animal = Dog()`),
+    // suppress the annotation capture so the constructor-inferred
+    // binding wins. This matches Kotlin's virtual dispatch semantics:
+    // `animal.speak()` should resolve to the overriding `Dog.speak`
+    // (the dynamic type), not `Animal.speak` (the static annotation).
+    //
+    // The annotation source has higher precedence than constructor-
+    // inferred in the generic scope-extractor (see
+    // `typeBindingStrength` in scope-extractor.ts), so the only way to
+    // make the constructor type prevail is to drop the annotation at
+    // emission time.
+    if (
+      grouped['@type-binding.annotation'] !== undefined &&
+      grouped['@type-binding.name'] !== undefined &&
+      grouped['@type-binding.type'] !== undefined
+    ) {
+      const annotation = grouped['@type-binding.annotation']!;
+      if (propertyDeclHasConstructorValue(tree.rootNode, annotation.range)) {
+        continue;
+      }
     }
 
     if (grouped['@scope.function'] !== undefined) {
@@ -407,6 +431,21 @@ function shouldEmitReadMember(navNode: SyntaxNode): boolean {
   if (parent.type === 'call_expression') return false;
   if (parent.type === 'directly_assignable_expression') return false;
   return true;
+}
+
+/** True when the property_declaration anchored at `range` has a
+ *  `call_expression` value sibling (i.e. `val x: T = Foo()`). Used to
+ *  suppress the explicit-annotation type-binding capture so the
+ *  constructor-inferred binding wins (#1762). */
+function propertyDeclHasConstructorValue(rootNode: SyntaxNode, range: Range): boolean {
+  const propNode = findNodeAtRange(rootNode, range, 'property_declaration');
+  if (propNode === null) return false;
+  const variable = propNode.namedChildren.find((c) => c.type === 'variable_declaration');
+  if (variable === undefined) return false;
+  const value = propNode.namedChildren.find(
+    (c) => c.id !== variable.id && c.type !== 'binding_pattern_kind',
+  );
+  return value?.type === 'call_expression';
 }
 
 function callArguments(callNode: SyntaxNode): SyntaxNode[] {


### PR DESCRIPTION
## Summary

Closes sub-issue #1762 of the Kotlin scope-resolution migration tracker (#1746). Kotlin virtual dispatch via constructor-type override didn't work under `REGISTRY_PRIMARY_KOTLIN=1`:

```kotlin
val animal: Animal = Dog()
animal.speak()  // should dispatch to Dog.speak (override), not Animal.speak
```

## Root cause

The Kotlin scope query emits both an annotation type-binding (`animal -> Animal`) AND a constructor-inferred type-binding (`animal -> Dog`). The generic scope-extractor's `typeBindingStrength` (scope-extractor.ts:874) ranks annotation sources (`2`) higher than constructor-inferred sources (`1`), so the annotation always won and `animal.speak()` dispatched against the static type — finding `Animal.speak` (not the override) or no edge at all.

Kotlin's runtime dispatch semantics expect the dynamic type: when the RHS is a constructor call, that's the class that actually runs, so its overrides should be the targets.

## Fix

In `emitKotlinScopeCaptures`, suppress the `@type-binding.annotation` capture when the underlying `property_declaration` has a `call_expression` value sibling. The constructor-inferred capture remains, becomes the sole binding for the variable, and receiver-bound resolution dispatches against the constructed class (and walks its MRO).

Intentionally Kotlin-specific. Flipping the generic precedence would change behavior for other languages whose static annotations are still the correct binding (e.g. C# with explicit interface types where the call should dispatch via the interface). Kotlin is the language where the constructor RHS is the dispatch target by design.

## Verification

| Run | Before | After |
|---|---|---|
| `REGISTRY_PRIMARY_KOTLIN=1 npx vitest run test/integration/resolvers/kotlin.test.ts` | 21 failing / 154 passing of 175 | **20 failing / 155 passing of 175** |
| `npx vitest run test/integration/resolvers/kotlin.test.ts` (default) | 175/175 | 175/175 |
| `npx vitest run test/integration/resolvers/` (full suite) | 2216/2216 | 2216/2216 |
| `npx tsc --noEmit` | clean | clean |

Test now passing under `REGISTRY_PRIMARY_KOTLIN=1`:
- `test/integration/resolvers/kotlin.test.ts:1715` — `resolves animal.speak() to models/Dog.kt via constructor type override`

The 20 remaining `REGISTRY_PRIMARY_KOTLIN=1` failures are tracked by sibling sub-issues #1758, #1759, #1760, #1761, #1763.

## Scope discipline

Per parent #1746 flip criteria, this PR does **not** add `SupportedLanguages.Kotlin` to `MIGRATED_LANGUAGES`. The flip lands once all sibling sub-issues close and the named blockers #1756 (companion vs instance) and #1757 (lambda scopes) are addressed.

## Test plan

- [x] Forced-mode parity: 1 fewer failure, no regressions
- [x] Default-mode Kotlin: 175/175
- [x] Full resolver suite: 2216/2216
- [x] `npx tsc --noEmit`: clean

Closes #1762
Refs #1746