### PR TITLE
fix(lang-kotlin): interface default method dispatch via implements-split MRO (#1763)

### DIFF
--- a/gitnexus/src/core/ingestion/languages/kotlin/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/languages/kotlin/scope-resolver.ts
@@ -1,6 +1,10 @@
 import { SupportedLanguages, type ParsedFile } from 'gitnexus-shared';
+import type { KnowledgeGraph } from '../../../graph/types.js';
 import { buildMro, defaultLinearize } from '../../scope-resolution/passes/mro.js';
 import type { ScopeResolver } from '../../scope-resolution/contract/scope-resolver.js';
+import { resolveDefGraphId } from '../../scope-resolution/graph-bridge/ids.js';
+import type { GraphNodeLookup } from '../../scope-resolution/graph-bridge/node-lookup.js';
+import { isClassLike } from '../../scope-resolution/scope/walkers.js';
 import { kotlinProvider } from '../kotlin.js';
 import {
   kotlinArityCompatibility,
@@ -42,8 +46,7 @@ export const kotlinScopeResolver: ScopeResolver = {
 
   arityCompatibility: (callsite, def) => kotlinArityCompatibility(def, callsite),
 
-  buildMro: (graph, parsedFiles, nodeLookup) =>
-    buildMro(graph, parsedFiles, nodeLookup, defaultLinearize),
+  buildMro: (graph, parsedFiles, nodeLookup) => buildKotlinMro(graph, parsedFiles, nodeLookup),
 
   populateOwners: (parsed: ParsedFile) => populateKotlinOwners(parsed),
 
@@ -54,3 +57,94 @@ export const kotlinScopeResolver: ScopeResolver = {
   collapseMemberCallsByCallerTarget: false,
   hoistTypeBindingsToModule: true,
 };
+
+/**
+ * Kotlin MRO builder — extends `defaultLinearize` (EXTENDS-only) with
+ * interface ancestors discovered via `IMPLEMENTS` edges. Interface
+ * default methods (`interface Validator { fun validate(): Boolean = true }`)
+ * are inherited by implementing classes without an explicit override;
+ * the generic MRO would not surface them because the implementor has
+ * no `EXTENDS` link to the interface (#1763).
+ *
+ * Interfaces are appended after the EXTENDS chain (Kotlin resolves
+ * conflicts by requiring an explicit override, so first-seen-in-MRO
+ * ordering is a reasonable approximation for method lookup). Transitive
+ * interface inheritance (`interface A : B`) is closed via BFS.
+ */
+function buildKotlinMro(
+  graph: KnowledgeGraph,
+  parsedFiles: readonly ParsedFile[],
+  nodeLookup: GraphNodeLookup,
+): Map<string, string[]> {
+  const mro = buildMro(graph, parsedFiles, nodeLookup, defaultLinearize);
+
+  const defIdByGraphId = new Map<string, string>();
+  for (const parsed of parsedFiles) {
+    for (const def of parsed.localDefs) {
+      if (!isClassLike(def.type)) continue;
+      const graphId = resolveDefGraphId(parsed.filePath, def, nodeLookup);
+      if (graphId !== undefined) defIdByGraphId.set(graphId, def.nodeId);
+    }
+  }
+
+  // Direct IMPLEMENTS targets per class-like def.
+  const directImpls = new Map<string, string[]>();
+  for (const rel of graph.iterRelationshipsByType('IMPLEMENTS')) {
+    const source = defIdByGraphId.get(rel.sourceId);
+    const target = defIdByGraphId.get(rel.targetId);
+    if (source === undefined || target === undefined) continue;
+    let list = directImpls.get(source);
+    if (list === undefined) {
+      list = [];
+      directImpls.set(source, list);
+    }
+    if (!list.includes(target)) list.push(target);
+  }
+
+  // For each class, append the transitive closure of interfaces reachable
+  // through its own + ancestor classes' IMPLEMENTS edges. Walking
+  // ancestors picks up interfaces inherited via the EXTENDS chain
+  // (e.g. `class C : B; class B : A; interface A` — C inherits A's
+  // interface methods through B).
+  for (const [classDefId, extendsMro] of mro) {
+    const ancestorChain = [classDefId, ...extendsMro];
+    const seeds: string[] = [];
+    for (const ancestorId of ancestorChain) {
+      for (const ifaceId of directImpls.get(ancestorId) ?? []) {
+        seeds.push(ifaceId);
+      }
+    }
+    if (seeds.length === 0) continue;
+    const interfaces = closeInterfaces(seeds, directImpls);
+    mro.set(classDefId, [...extendsMro, ...interfaces.filter((i) => !extendsMro.includes(i))]);
+  }
+
+  // Classes with no EXTENDS still need an MRO entry when they implement
+  // interfaces (e.g. `class User : Validator` — no `mro` entry from the
+  // EXTENDS-only pass because no EXTENDS edges exist).
+  for (const [classDefId, ifaces] of directImpls) {
+    if (mro.has(classDefId)) continue;
+    mro.set(classDefId, closeInterfaces([...ifaces], directImpls));
+  }
+
+  return mro;
+}
+
+function closeInterfaces(
+  seeds: readonly string[],
+  directImpls: ReadonlyMap<string, readonly string[]>,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const queue: string[] = [...seeds];
+  while (queue.length > 0) {
+    const cur = queue.shift()!;
+    if (seen.has(cur)) continue;
+    seen.add(cur);
+    out.push(cur);
+    for (const next of directImpls.get(cur) ?? []) {
+      if (!seen.has(next)) queue.push(next);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Closes sub-issue #1763 of the Kotlin scope-resolution migration tracker (#1746). Final sub-issue in the set — `user.validate()` on a class implementing an interface with a default-bodied method resolved to no edge under `REGISTRY_PRIMARY_KOTLIN=1`:

```kotlin
class User(val name: String) : Validator
interface Validator { fun validate(): Boolean = true }

fun run() {
  val user = User("alice")
  user.validate()  // should resolve to Validator.validate (default method)
}
```

## Root cause

The generic `buildMro` (`scope-resolution/passes/mro.ts:49`) walks `EXTENDS` edges only. Kotlin classes link to their interfaces via `IMPLEMENTS` edges (per the parsing-processor), so the implementor's MRO never picks up the interface's default methods — `findOwnedMember(User, validate)` returns undefined and there's no fallback to walk to Validator.

## Fix

Replace `defaultLinearize` with a Kotlin-specific MRO builder modeled after PHP's `buildPhpMro` (trait composition pattern):
1. Run the generic `buildMro` (EXTENDS-only) as the base layer.
2. Collect direct `IMPLEMENTS` edges as `class → interface[]` map.
3. For each class, walk its EXTENDS-MRO ancestors AND its own IMPLEMENTS edges to seed interface candidates, then BFS-close to pick up transitive interface inheritance (`interface A : B`).
4. Append the interface closure after the EXTENDS chain. Kotlin requires explicit overrides on conflict, so first-seen-in-MRO ordering is a safe approximation for method lookup.
5. Classes with no EXTENDS but with IMPLEMENTS edges (the #1763 fixture shape) get their MRO seeded directly from their interfaces.

## Verification

| Run | Before | After |
|---|---|---|
| `REGISTRY_PRIMARY_KOTLIN=1 npx vitest run test/integration/resolvers/kotlin.test.ts` | 21 failing / 154 passing of 175 | **20 failing / 155 passing of 175** |
| `npx vitest run test/integration/resolvers/kotlin.test.ts` (default) | 175/175 | 175/175 |
| `npx vitest run test/integration/resolvers/` (full suite) | 2216/2216 | 2216/2216 |
| `npx tsc --noEmit` | clean | clean |

Test now passing under `REGISTRY_PRIMARY_KOTLIN=1`:
- `test/integration/resolvers/kotlin.test.ts:2062` — `resolves user.validate() to Validator.validate via implements-split MRO`

The 20 remaining `REGISTRY_PRIMARY_KOTLIN=1` failures are tracked by sibling sub-issues #1758, #1759, #1760, #1761, #1762 (PRs already open).

## Scope discipline

Per parent #1746 flip criteria, this PR does **not** add `SupportedLanguages.Kotlin` to `MIGRATED_LANGUAGES`. With all six failing-test sub-issues now closed (#1758–#1763), the flip is unblocked from the test-baseline angle — but issue #1746 also requires #1755 (CI-visible forced-mode baseline) and addresses #1756 (companion vs instance) and #1757 (lambda scopes) as named non-test blockers.

## Test plan

- [x] Forced-mode parity: 1 fewer failure, no regressions
- [x] Default-mode Kotlin: 175/175
- [x] Full resolver suite: 2216/2216
- [x] `npx tsc --noEmit`: clean

Closes #1763
Refs #1746