### PR TITLE
docs(lang-kotlin): refresh scope-resolver JSDoc after #1758-#1763 landed

### DIFF
--- a/gitnexus/src/core/ingestion/languages/kotlin/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/languages/kotlin/scope-resolver.ts
@@ -20,14 +20,26 @@ import {
  * Kotlin is intentionally registered but not yet listed in
  * `MIGRATED_LANGUAGES`, matching the Java migration pattern from #1482:
  * the resolver can run in shadow/forced mode, while production default
- * stays on the legacy DAG until registry-primary parity reaches the
- * RFC threshold. Forced mode currently passes 154/175 fixtures (88%),
- * including core import, receiver, companion, default-param, vararg,
- * constructor, local assignment-chain, and collection-iteration fixtures.
- * Remaining gaps are advanced TypeEnv behaviors such as smart casts,
- * cross-file iterable return propagation, method-chain fixpoint cases,
- * overload target-id selection, virtual dispatch, and interface default
- * method dispatch.
+ * stays on the legacy DAG until the RFC flip criteria in #1746 are met.
+ *
+ * **Forced-mode parity (`REGISTRY_PRIMARY_KOTLIN=1`):** 175/175 fixtures
+ * after the migration sub-issues #1758–#1763 closed. Covers core
+ * import, receiver, companion, default-param, vararg, constructor,
+ * local assignment-chain, collection-iteration, smart casts
+ * (`when (x) { is T -> … }` and `if (x is T)` — #1758), cross-file
+ * iterable return propagation (#1759), single-level method-chain
+ * fixpoint receiver types (#1760), parameter-type-narrowed overload
+ * target-id selection (#1761), virtual dispatch via constructor RHS
+ * (`val x: Animal = Dog()` — #1762), and interface default-method
+ * dispatch via implements-split MRO (#1763).
+ *
+ * **Remaining pre-flip blockers (#1746):** #1755 (forced-mode preview
+ * CI workflow — obviated once Kotlin lands in `MIGRATED_LANGUAGES`
+ * because the existing scope-parity matrix auto-discovers it), #1756
+ * (companion vs instance member dispatch), and #1757 (lambda scopes
+ * and lambda-parameter bindings). The flip PR adds
+ * `SupportedLanguages.Kotlin` to `MIGRATED_LANGUAGES` after the named
+ * blockers close.
  */
 export const kotlinScopeResolver: ScopeResolver = {
   language: SupportedLanguages.Kotlin,


### PR DESCRIPTION
## Summary

Docs-only follow-up to the Kotlin migration. `scope-resolver.ts:17-30` claimed forced-mode passed 154/175 (88%) and listed exactly the features that closed in PRs #1774-#1779 as \"remaining gaps\". With those six sub-issues now merged on \`main\`, forced mode passes 175/175 — verified locally on a fresh main checkout:

\`\`\`
REGISTRY_PRIMARY_KOTLIN=true npx vitest run test/integration/resolvers/kotlin.test.ts
Tests  175 passed (175)

npx vitest run test/integration/resolvers/kotlin.test.ts  # default mode
Tests  175 passed (175)

npx vitest run test/integration/resolvers/  # full suite
Tests  2216 passed (2216)
\`\`\`

## Changes

- State the current forced-mode result (175/175) instead of the stale 154/175.
- Enumerate the closed sub-issues with their PR references so future readers can trace each capability back to where it landed:
  - #1758 — smart casts (\`when (x) { is T -> … }\`, \`if (x is T)\`)
  - #1759 — cross-file iterable return propagation
  - #1760 — single-level method-chain fixpoint receiver types
  - #1761 — parameter-type-narrowed overload target-id selection
  - #1762 — virtual dispatch via constructor RHS
  - #1763 — interface default-method dispatch via implements-split MRO
- Explicitly name the remaining flip blockers (#1755 preview CI, #1756 companion vs instance, #1757 lambda scopes) so the next maintainer touching this file knows exactly what's required before adding \`SupportedLanguages.Kotlin\` to \`MIGRATED_LANGUAGES\` (per #1746).

## Test plan

- [x] Docs-only — no code changes
- [x] \`npx tsc --noEmit\`: clean
- [x] Default + forced-mode Kotlin tests: 175/175 each
- [x] Full resolver suite: 2216/2216

Refs #1746