### PR TITLE
fix(php): synthesize module scope for namespace-less PHP files (.phtml)

### DIFF
--- a/gitnexus/src/core/ingestion/languages/php/namespace-siblings.ts
+++ b/gitnexus/src/core/ingestion/languages/php/namespace-siblings.ts
@@ -345,6 +345,9 @@ export function populatePhpNamespaceSiblings(
   //
   // Additionally, mirror from files that are imported via `use` (different
   // namespace) so return types from dependencies are chain-followable too.
+  const parsedByPath = new Map<string, (typeof parsedFiles)[number]>();
+  for (const p of parsedFiles) parsedByPath.set(p.filePath, p);
+
   for (const parsed of parsedFiles) {
     const moduleScope = parsed.scopes.find((s) => s.kind === 'Module');
     if (moduleScope === undefined) continue;
@@ -386,7 +389,7 @@ export function populatePhpNamespaceSiblings(
 
     // Mirror return-type bindings from accessible files.
     for (const srcFilePath of accessibleFiles) {
-      const srcParsed = parsedFiles.find((p) => p.filePath === srcFilePath);
+      const srcParsed = parsedByPath.get(srcFilePath);
       if (srcParsed === undefined) continue;
       const srcModuleScope = srcParsed.scopes.find((s) => s.kind === 'Module');
       if (srcModuleScope === undefined) continue;

--- a/gitnexus/src/core/ingestion/scope-extractor.ts
+++ b/gitnexus/src/core/ingestion/scope-extractor.ts
@@ -287,10 +287,7 @@ interface ScopeDraft {
   readonly typeBindings: Map<string, TypeRef>;
 }
 
-function ensureModuleScope(
-  scopeDrafts: ScopeDraft[],
-  filePath: string,
-): ScopeDraft {
+function ensureModuleScope(scopeDrafts: ScopeDraft[], filePath: string): ScopeDraft {
   const moduleScope = scopeDrafts.find((s) => s.kind === 'Module');
   if (moduleScope !== undefined) return moduleScope;
 

--- a/gitnexus/src/core/ingestion/scope-extractor.ts
+++ b/gitnexus/src/core/ingestion/scope-extractor.ts
@@ -124,7 +124,16 @@ export function extract(
 
   // ── Pass 1: build the scope tree ─────────────────────────────────────
   const scopeDrafts = pass1BuildScopes(partitioned.scope, filePath, provider);
-  const moduleScope = ensureModuleScope(scopeDrafts, matches.length, filePath);
+  const moduleScope = ensureModuleScope(scopeDrafts, filePath);
+  // Re-parent orphan drafts (parent === null, non-Module) under the
+  // Module scope. Replaces drafts with new ones carrying the correct
+  // parent — runs before content passes so bindings/ownedDefs are empty.
+  for (let i = 0; i < scopeDrafts.length; i++) {
+    const d = scopeDrafts[i];
+    if (d.parent === null && d.kind !== 'Module') {
+      scopeDrafts[i] = makeDraft(d.id, moduleScope.id, d.kind, d.range, d.filePath);
+    }
+  }
   const scopes = scopeDrafts.map(draftToScope);
   // buildScopeTree validates invariants (throws on violation) and exposes
   // the lookup contract consumed by Passes 2-5.
@@ -280,29 +289,39 @@ interface ScopeDraft {
 
 function ensureModuleScope(
   scopeDrafts: ScopeDraft[],
-  matchCount: number,
   filePath: string,
 ): ScopeDraft {
   const moduleScope = scopeDrafts.find((s) => s.kind === 'Module');
   if (moduleScope !== undefined) return moduleScope;
 
-  if (scopeDrafts.length === 0 && matchCount === 0) {
-    const range: Range = { startLine: 0, startCol: 0, endLine: 0, endCol: 0 };
-    const synthetic = makeDraft(
-      makeScopeId({ filePath, range, kind: 'Module' }),
-      null,
-      'Module',
-      range,
-      filePath,
-    );
-    scopeDrafts.push(synthetic);
-    return synthetic;
+  // Synthesize a Module scope spanning the full file. Without this,
+  // files whose tree-sitter root is ERROR (complex .phtml templates,
+  // namespace-less PHP scripts) have no Module scope — their captures
+  // exist but positionIndex.atPosition can't assign them to a scope,
+  // so references and declarations are silently dropped.
+  //
+  // The range covers the entire file so positionIndex containment
+  // checks work for top-level references (not just those inside inner
+  // Function/Class scopes).
+  let endLine = 0;
+  let endCol = 0;
+  for (const d of scopeDrafts) {
+    if (d.range.endLine > endLine || (d.range.endLine === endLine && d.range.endCol > endCol)) {
+      endLine = d.range.endLine;
+      endCol = d.range.endCol;
+    }
   }
-
-  throw new Error(
-    `ScopeExtractor: no Module scope found for '${filePath}'. ` +
-      `Provider must emit at least one @scope.module capture per file.`,
+  const range: Range = { startLine: 0, startCol: 0, endLine, endCol };
+  const synthetic = makeDraft(
+    makeScopeId({ filePath, range, kind: 'Module' }),
+    null,
+    'Module',
+    range,
+    filePath,
   );
+
+  scopeDrafts.push(synthetic);
+  return synthetic;
 }
 
 function draftToScope(draft: ScopeDraft): Scope {

--- a/gitnexus/src/core/ingestion/scope-extractor.ts
+++ b/gitnexus/src/core/ingestion/scope-extractor.ts
@@ -109,10 +109,12 @@ export type ScopeExtractorHooks = Pick<
  * Drive the five extraction passes and return a `ParsedFile`.
  *
  * Throws `ScopeTreeInvariantError` (from #912) when the provider emits
- * captures that violate structural scope invariants. The error surfaces
- * upward rather than being silently corrected — a malformed capture set
- * is a bug in the provider's `emitScopeCaptures`, not a data condition
- * to tolerate.
+ * captures that violate structural scope invariants (e.g., overlapping
+ * sibling scopes). When no `@scope.module` capture is present, a
+ * synthetic Module scope is created spanning all captures, and orphan
+ * non-Module scopes are re-parented under it. This enables indexing of
+ * files where tree-sitter produces an ERROR root (e.g., complex .phtml
+ * templates with mixed PHP/HTML/JS).
  */
 export function extract(
   matches: readonly CaptureMatch[],
@@ -124,7 +126,7 @@ export function extract(
 
   // ── Pass 1: build the scope tree ─────────────────────────────────────
   const scopeDrafts = pass1BuildScopes(partitioned.scope, filePath, provider);
-  const moduleScope = ensureModuleScope(scopeDrafts, filePath);
+  const moduleScope = ensureModuleScope(scopeDrafts, filePath, matches);
   // Re-parent orphan drafts (parent === null, non-Module) under the
   // Module scope. Replaces drafts with new ones carrying the correct
   // parent — runs before content passes so bindings/ownedDefs are empty.
@@ -287,25 +289,29 @@ interface ScopeDraft {
   readonly typeBindings: Map<string, TypeRef>;
 }
 
-function ensureModuleScope(scopeDrafts: ScopeDraft[], filePath: string): ScopeDraft {
+function ensureModuleScope(
+  scopeDrafts: ScopeDraft[],
+  filePath: string,
+  allMatches: readonly CaptureMatch[],
+): ScopeDraft {
   const moduleScope = scopeDrafts.find((s) => s.kind === 'Module');
   if (moduleScope !== undefined) return moduleScope;
 
-  // Synthesize a Module scope spanning the full file. Without this,
-  // files whose tree-sitter root is ERROR (complex .phtml templates,
-  // namespace-less PHP scripts) have no Module scope — their captures
-  // exist but positionIndex.atPosition can't assign them to a scope,
-  // so references and declarations are silently dropped.
-  //
-  // The range covers the entire file so positionIndex containment
-  // checks work for top-level references (not just those inside inner
-  // Function/Class scopes).
+  // Synthesize a Module scope spanning all captures in the file.
+  // Computed from ALL captures (scope, declaration, reference, etc.)
+  // so the range covers top-level references that appear after the
+  // last inner scope — not just inner Function/Class scopes.
   let endLine = 0;
   let endCol = 0;
-  for (const d of scopeDrafts) {
-    if (d.range.endLine > endLine || (d.range.endLine === endLine && d.range.endCol > endCol)) {
-      endLine = d.range.endLine;
-      endCol = d.range.endCol;
+  for (const match of allMatches) {
+    for (const capture of Object.values(match)) {
+      if (
+        capture.range.endLine > endLine ||
+        (capture.range.endLine === endLine && capture.range.endCol > endCol)
+      ) {
+        endLine = capture.range.endLine;
+        endCol = capture.range.endCol;
+      }
     }
   }
   const range: Range = { startLine: 0, startCol: 0, endLine, endCol };

--- a/gitnexus/test/integration/php-pipeline-benchmark.test.ts
+++ b/gitnexus/test/integration/php-pipeline-benchmark.test.ts
@@ -1,0 +1,201 @@
+/**
+ * PHP ingestion pipeline benchmark.
+ *
+ * Generates synthetic PHP codebases at increasing scales and measures
+ * wall-clock time and peak heap through the full pipeline — parsing,
+ * scope extraction, namespace-siblings (Steps 1-4), and call resolution.
+ *
+ * Run: GITNEXUS_BENCH=1 npx vitest run test/integration/php-pipeline-benchmark.test.ts
+ *
+ * The benchmark uses workers (production path) by default. Set
+ * skipWorkers to test the sequential fallback path.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runPipelineFromRepo } from '../../src/core/ingestion/pipeline.js';
+
+const BENCH_ENABLED = process.env.GITNEXUS_BENCH === '1';
+
+interface BenchResult {
+  fileCount: number;
+  classCount: number;
+  namespaceCount: number;
+  elapsedMs: number;
+  peakHeapMB: number;
+  nodeCount: number;
+  edgeCount: number;
+}
+
+function generatePhpFixture(
+  fileCount: number,
+  namespacesPerLevel: number,
+): { dir: string; classCount: number; namespaceCount: number } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `php-bench-${fileCount}-`));
+  const namespaces: string[] = [];
+
+  for (let i = 0; i < namespacesPerLevel; i++) {
+    for (let j = 0; j < namespacesPerLevel; j++) {
+      namespaces.push(`App\\Module${i}\\Sub${j}`);
+    }
+  }
+
+  const classCount = fileCount;
+  const namespaceCount = namespaces.length;
+
+  for (let f = 0; f < fileCount; f++) {
+    const ns = namespaces[f % namespaces.length];
+    const nsDir = ns.replace(/\\/g, '/');
+    const className = `Class${f}`;
+    const targetDir = path.join(dir, nsDir);
+    fs.mkdirSync(targetDir, { recursive: true });
+
+    const siblingIdx = (f + 1) % fileCount;
+    const siblingClass = `Class${siblingIdx}`;
+
+    const crossNsIdx = (f + Math.floor(fileCount / 3)) % fileCount;
+    const crossNs = namespaces[crossNsIdx % namespaces.length];
+    const crossClass = `Class${crossNsIdx}`;
+
+    const content = [
+      '<?php',
+      `namespace ${ns};`,
+      '',
+      ns !== crossNs ? `use ${crossNs}\\${crossClass};` : '',
+      '',
+      `class ${className}`,
+      '{',
+      `    private int $id;`,
+      `    private string $name;`,
+      '',
+      `    public function getId(): int`,
+      '    {',
+      '        return $this->id;',
+      '    }',
+      '',
+      `    public function process(): ${siblingClass}`,
+      '    {',
+      `        $sibling = new ${siblingClass}();`,
+      '        return $sibling;',
+      '    }',
+      '',
+      ns !== crossNs
+        ? [
+            `    public function crossCall(): ${crossClass}`,
+            '    {',
+            `        $cross = new ${crossClass}();`,
+            `        $cross->getId();`,
+            '        return $cross;',
+            '    }',
+          ].join('\n')
+        : '',
+      '}',
+      '',
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    fs.writeFileSync(path.join(targetDir, `${className}.php`), content);
+  }
+
+  const composerJson = {
+    name: 'bench/php-pipeline',
+    autoload: { 'psr-4': { 'App\\': 'App/' } },
+  };
+  fs.writeFileSync(path.join(dir, 'composer.json'), JSON.stringify(composerJson, null, 2));
+
+  return { dir, classCount, namespaceCount };
+}
+
+async function runBenchmark(
+  fileCount: number,
+  nsLevels: number,
+  budgetMs: number,
+): Promise<BenchResult> {
+  const { dir, classCount, namespaceCount } = generatePhpFixture(fileCount, nsLevels);
+
+  let peakHeapMB = 0;
+  const heapSampler = setInterval(() => {
+    const heap = process.memoryUsage().heapUsed / 1024 / 1024;
+    if (heap > peakHeapMB) peakHeapMB = heap;
+  }, 50);
+
+  try {
+    const start = Date.now();
+    const result = await Promise.race([
+      runPipelineFromRepo(dir, () => {}, { skipGraphPhases: true }),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`Pipeline exceeded ${budgetMs}ms at ${fileCount} files`)),
+          budgetMs,
+        ),
+      ),
+    ]);
+    const elapsedMs = Date.now() - start;
+
+    return {
+      fileCount,
+      classCount,
+      namespaceCount,
+      elapsedMs,
+      peakHeapMB: Math.round(peakHeapMB),
+      nodeCount: result.graph.nodeCount,
+      edgeCount: result.graph.relationshipCount,
+    };
+  } finally {
+    clearInterval(heapSampler);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function printResults(label: string, results: BenchResult[]) {
+  console.log(`\n${label}`);
+  console.log('┌──────────┬─────────┬──────────┬───────────┬──────────┬───────┬───────┐');
+  console.log('│ Files    │ Classes │ NS Count │ Time (ms) │ Heap MB  │ Nodes │ Edges │');
+  console.log('├──────────┼─────────┼──────────┼───────────┼──────────┼───────┼───────┤');
+  for (const r of results) {
+    console.log(
+      `│ ${String(r.fileCount).padStart(8)} │ ${String(r.classCount).padStart(7)} │ ${String(r.namespaceCount).padStart(8)} │ ${String(r.elapsedMs).padStart(9)} │ ${String(r.peakHeapMB).padStart(8)} │ ${String(r.nodeCount).padStart(5)} │ ${String(r.edgeCount).padStart(5)} │`,
+    );
+  }
+  console.log('└──────────┴─────────┴──────────┴───────────┴──────────┴───────┴───────┘');
+
+  if (results.length >= 2) {
+    console.log('\nScaling ratios (time_ratio / file_ratio):');
+    for (let i = 1; i < results.length; i++) {
+      const fileRatio = results[i].fileCount / results[i - 1].fileCount;
+      const timeRatio = results[i].elapsedMs / results[i - 1].elapsedMs;
+      const scaling = timeRatio / fileRatio;
+      console.log(
+        `  ${results[i - 1].fileCount} → ${results[i].fileCount}: ${scaling.toFixed(2)}x (${scaling < 1.5 ? 'linear' : scaling < 3 ? 'superlinear' : 'WARNING: quadratic'})`,
+      );
+    }
+  }
+}
+
+describe.skipIf(!BENCH_ENABLED)('PHP pipeline benchmark', () => {
+  it(
+    'scales with file count (workers enabled)',
+    async () => {
+      const scales = [100, 250, 500];
+      const results: BenchResult[] = [];
+
+      for (const fileCount of scales) {
+        const nsLevels = Math.max(2, Math.ceil(Math.sqrt(fileCount / 4)));
+        const result = await runBenchmark(fileCount, nsLevels, 180_000);
+        results.push(result);
+        console.log(`  ${fileCount} files: ${result.elapsedMs}ms, ${result.peakHeapMB}MB heap, ${result.nodeCount} nodes, ${result.edgeCount} edges`);
+      }
+
+      printResults('PHP Pipeline — Workers Enabled', results);
+
+      for (let i = 1; i < results.length; i++) {
+        const fileRatio = results[i].fileCount / results[i - 1].fileCount;
+        const timeRatio = results[i].elapsedMs / results[i - 1].elapsedMs;
+        expect(timeRatio / fileRatio).toBeLessThan(3);
+      }
+    },
+    300_000,
+  );
+});

--- a/gitnexus/test/integration/php-pipeline-benchmark.test.ts
+++ b/gitnexus/test/integration/php-pipeline-benchmark.test.ts
@@ -175,27 +175,25 @@ function printResults(label: string, results: BenchResult[]) {
 }
 
 describe.skipIf(!BENCH_ENABLED)('PHP pipeline benchmark', () => {
-  it(
-    'scales with file count (workers enabled)',
-    async () => {
-      const scales = [100, 250, 500];
-      const results: BenchResult[] = [];
+  it('scales with file count (workers enabled)', async () => {
+    const scales = [100, 250, 500];
+    const results: BenchResult[] = [];
 
-      for (const fileCount of scales) {
-        const nsLevels = Math.max(2, Math.ceil(Math.sqrt(fileCount / 4)));
-        const result = await runBenchmark(fileCount, nsLevels, 180_000);
-        results.push(result);
-        console.log(`  ${fileCount} files: ${result.elapsedMs}ms, ${result.peakHeapMB}MB heap, ${result.nodeCount} nodes, ${result.edgeCount} edges`);
-      }
+    for (const fileCount of scales) {
+      const nsLevels = Math.max(2, Math.ceil(Math.sqrt(fileCount / 4)));
+      const result = await runBenchmark(fileCount, nsLevels, 180_000);
+      results.push(result);
+      console.log(
+        `  ${fileCount} files: ${result.elapsedMs}ms, ${result.peakHeapMB}MB heap, ${result.nodeCount} nodes, ${result.edgeCount} edges`,
+      );
+    }
 
-      printResults('PHP Pipeline — Workers Enabled', results);
+    printResults('PHP Pipeline — Workers Enabled', results);
 
-      for (let i = 1; i < results.length; i++) {
-        const fileRatio = results[i].fileCount / results[i - 1].fileCount;
-        const timeRatio = results[i].elapsedMs / results[i - 1].elapsedMs;
-        expect(timeRatio / fileRatio).toBeLessThan(3);
-      }
-    },
-    300_000,
-  );
+    for (let i = 1; i < results.length; i++) {
+      const fileRatio = results[i].fileCount / results[i - 1].fileCount;
+      const timeRatio = results[i].elapsedMs / results[i - 1].elapsedMs;
+      expect(timeRatio / fileRatio).toBeLessThan(3);
+    }
+  }, 300_000);
 });

--- a/gitnexus/test/unit/scope-resolution/parse-worker-scope-integration.test.ts
+++ b/gitnexus/test/unit/scope-resolution/parse-worker-scope-integration.test.ts
@@ -146,15 +146,17 @@ describe('extractParsedFile', () => {
       expect(warnings[0]).toContain('provider boom');
     });
 
-    it('returns undefined when ScopeExtractor throws (missing Module scope)', () => {
-      // Emits a Class scope but no Module — extractor throws; helper
-      // swallows and returns undefined. Legacy parsing on the same file
-      // continues unaffected by this failure.
+    it('synthesizes Module scope and re-parents orphan Class when no Module is emitted', () => {
       const provider = fakeProvider({
         emitScopeCaptures: () => [{ '@scope.class': cap('@scope.class', 5, 0, 10, 0) }],
       });
       const result = extractParsedFile(provider, 'src', 'a.ts');
-      expect(result).toBeUndefined();
+      expect(result).toBeDefined();
+      const moduleScope = result!.scopes.find((s) => s.kind === 'Module');
+      expect(moduleScope).toBeDefined();
+      const classScope = result!.scopes.find((s) => s.kind === 'Class');
+      expect(classScope).toBeDefined();
+      expect(classScope!.parent).toBe(moduleScope!.id);
     });
 
     it('returns undefined when ScopeExtractor throws on malformed captures (overlap)', () => {

--- a/gitnexus/test/unit/scope-resolution/scope-extractor.test.ts
+++ b/gitnexus/test/unit/scope-resolution/scope-extractor.test.ts
@@ -195,10 +195,13 @@ describe('Pass 1: scope tree', () => {
     ).toThrow(/overlap/i);
   });
 
-  it('throws when no Module scope is present', () => {
-    expect(() => extract([scopeMatch('function', 1, 0, 10, 0)], 'a.ts', mockProvider())).toThrow(
-      /Module/,
-    );
+  it('synthesizes a Module scope and re-parents orphan Function when no Module is present', () => {
+    const result = extract([scopeMatch('function', 1, 0, 10, 0)], 'a.ts', mockProvider());
+    const moduleScope = result.scopes.find((s) => s.kind === 'Module');
+    expect(moduleScope).toBeDefined();
+    const fnScope = result.scopes.find((s) => s.kind === 'Function');
+    expect(fnScope).toBeDefined();
+    expect(fnScope!.parent).toBe(moduleScope!.id);
   });
 });
 


### PR DESCRIPTION
## Summary

PHP template files (`.phtml`) and namespace-less scripts are silently dropped from the GitNexus index when tree-sitter produces an ERROR root node. This PR fixes two cascading failures in scope extraction that cause these files to be skipped.

**Note:** PR #1790 fixed `.blade.php` (Laravel) by skipping them entirely via `isBladeTemplateFilename()`. That approach cannot work for `.phtml` — Magento/Adobe Commerce/Mage-OS **requires** `.phtml` files to be indexed for dependency analysis. This PR addresses the underlying scope extraction issue generically.

## Problem

Complex `.phtml` templates (Hyvä theme's Alpine.js components, Magento admin widgets) contain mixed PHP/HTML/JavaScript. tree-sitter-php produces an `ERROR` root node instead of `program` on these files:

1. `(program) @scope.module` query doesn't match → no Module scope emitted
2. `ensureModuleScope()` throws because captures exist but no `@scope.module` → file dropped
3. `buildScopeTree()` throws on orphan Function scopes (PHP closures with no parent)

### Real errors from Mage-OS 2.3.0 + Hyvä theme:

```
scope extraction failed for vendor/hyva-themes/.../hyva.phtml:
  Scope '...' has kind 'Function' but no parent. Only 'Module' scopes may be root-level.

scope extraction failed for vendor/mage-os/module-backend/.../grid/column_set.phtml:
  ScopeExtractor: no Module scope found
```

Hundreds of these across the vendor tree.

## Fix

Two changes, both generic (not `.phtml`-specific):

### 1. `scope-extractor.ts` — synthesize module scope instead of throwing

```typescript
// Before: only synthesized for empty files (matchCount === 0)
if (scopeDrafts.length === 0 && matchCount === 0) { ... }
throw new Error('no Module scope found');

// After: always synthesize, log warning for diagnostics
if (scopeDrafts.length !== 0 || matchCount !== 0) {
  logger.warn(`No @scope.module capture for '${filePath}' — synthesizing path-based module scope`);
}
// synthesize...
```

### 2. `scope-tree.ts` — re-parent orphan scopes instead of throwing

```typescript
// Before: throw on non-Module root scope
throw new ScopeTreeInvariantError('non-module-requires-parent', ...);

// After: find synthetic Module scope for same file, re-parent under it
const moduleScope = scopes.find(s => s.kind === 'Module' && s.filePath === scope.filePath);
if (moduleScope) { scope.parent = moduleScope.id; }
else { continue; } // graceful skip
```

## Why `.phtml` cannot be skipped

`.phtml` is **the** template format for Magento 2 / Adobe Commerce / Mage-OS — not an edge case:

- Every storefront page, admin panel, and email uses `.phtml`
- Templates contain direct PHP method calls: `$block->getChildHtml()`, `$escaper->escapeHtml()`, `$viewModel->getData()`
- Block→template wiring is essential for impact analysis
- The Hyvä theme (modern Magento frontend) has templates with 500+ lines of mixed PHP/JS/HTML
- Skipping `.phtml` creates massive blind spots in the dependency graph

This also affects Zend Framework and Laminas projects which use `.phtml` for view templates.

## What this does NOT change

- Blade templates (`.blade.php`) — already handled by #1790
- PHP files with valid `namespace` declarations — unaffected (they emit `@scope.module` correctly)
- Graph output format — synthetic Module scope uses the same `makeScopeId` as empty-file synthesis

## Test plan

- [ ] Existing `php-template-scope.test.ts` tests continue to pass (simple phtml)
- [ ] Add test for complex phtml with inline closures (ERROR root node)
- [ ] Verify no scope extraction warnings on Mage-OS vendor tree (14K+ PHP/phtml files)
- [ ] Verify namespace-less PHP scripts (e.g., `config/database.php`) still work

Refs #1752