### PR TITLE
Add support for Julia

### DIFF
--- a/gitnexus-shared/src/language-detection.ts
+++ b/gitnexus-shared/src/language-detection.ts
@@ -43,6 +43,7 @@ const EXTENSION_MAP: Record<SupportedLanguages, readonly string[]> = {
   [SupportedLanguages.Dart]: ['.dart'],
   [SupportedLanguages.Vue]: ['.vue'],
   [SupportedLanguages.Cobol]: ['.cbl', '.cob', '.cpy', '.cobol'],
+  [SupportedLanguages.Julia]: ['.jl'],
 } satisfies Record<SupportedLanguages, readonly string[]>; // Ensure exhaustiveness
 
 /** Pre-built reverse lookup: extension → language (built once at module load). */
@@ -111,6 +112,7 @@ const SYNTAX_MAP: Record<SupportedLanguages, string> = {
   [SupportedLanguages.Dart]: 'dart',
   [SupportedLanguages.Vue]: 'typescript',
   [SupportedLanguages.Cobol]: 'cobol',
+  [SupportedLanguages.Julia]: 'julia',
 } satisfies Record<SupportedLanguages, string>; // Ensure exhaustiveness
 
 /** Non-code file extensions → Prism-compatible syntax identifiers */

--- a/gitnexus-shared/src/languages.ts
+++ b/gitnexus-shared/src/languages.ts
@@ -22,4 +22,5 @@ export enum SupportedLanguages {
   Vue = 'vue',
   /** Standalone regex processor — no tree-sitter, no LanguageProvider. */
   Cobol = 'cobol',
+  Julia = 'julia',
 }

--- a/gitnexus-shared/src/scope-resolution/language-classification.ts
+++ b/gitnexus-shared/src/scope-resolution/language-classification.ts
@@ -41,6 +41,7 @@ export const LanguageClassifications: Readonly<Record<SupportedLanguages, Langua
     [SupportedLanguages.Dart]: 'production',
     [SupportedLanguages.Vue]: 'experimental',
     [SupportedLanguages.Cobol]: 'experimental',
+    [SupportedLanguages.Julia]: 'experimental',
   };
 
 /** Convenience predicate: is this language gating Ring 4 retirement? */

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -39,6 +39,7 @@
         "tree-sitter-go": "^0.23.0",
         "tree-sitter-java": "^0.23.5",
         "tree-sitter-javascript": "^0.23.0",
+        "tree-sitter-julia": "^0.23.1",
         "tree-sitter-php": "^0.23.0",
         "tree-sitter-python": "0.23.4",
         "tree-sitter-ruby": "^0.23.1",
@@ -4893,6 +4894,25 @@
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
       "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-julia": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmmirror.com/tree-sitter-julia/-/tree-sitter-julia-0.23.1.tgz",
+      "integrity": "sha512-3vShY0GIu8ajR6hXzE0pyUk6kkfg4pGx3Bfzm6lGmR9aC3fe+LgoBMlaFJ7JY+t0fNFccc77J8HVP67ukuDMxQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -82,6 +82,7 @@
     "tree-sitter-go": "^0.23.0",
     "tree-sitter-java": "^0.23.5",
     "tree-sitter-javascript": "^0.23.0",
+    "tree-sitter-julia": "^0.23.1",
     "tree-sitter-php": "^0.23.0",
     "tree-sitter-python": "0.23.4",
     "tree-sitter-ruby": "^0.23.1",

--- a/gitnexus/src/core/ingestion/call-extractors/configs/julia.ts
+++ b/gitnexus/src/core/ingestion/call-extractors/configs/julia.ts
@@ -1,0 +1,6 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { CallExtractionConfig } from '../../call-types.js';
+
+export const juliaCallConfig: CallExtractionConfig = {
+  language: SupportedLanguages.Julia,
+};

--- a/gitnexus/src/core/ingestion/class-extractors/configs/julia.ts
+++ b/gitnexus/src/core/ingestion/class-extractors/configs/julia.ts
@@ -1,0 +1,8 @@
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { ClassExtractionConfig } from '../../class-types.js';
+
+export const juliaClassConfig: ClassExtractionConfig = {
+  language: SupportedLanguages.Julia,
+  typeDeclarationNodes: ['struct_definition', 'abstract_definition'],
+  ancestorScopeNodeTypes: ['struct_definition', 'abstract_definition', 'module_definition'],
+};

--- a/gitnexus/src/core/ingestion/export-detection.ts
+++ b/gitnexus/src/core/ingestion/export-detection.ts
@@ -246,3 +246,31 @@ export const rubyExportChecker: ExportChecker = (_node, _name) => true;
 
 /** Dart: public if no leading underscore (convention, same as Python). */
 export const dartExportChecker: ExportChecker = (_node, name) => !name.startsWith('_');
+
+/**
+ * Julia: walk ancestors looking for an export_statement.
+ * Julia uses explicit `export` keyword to mark public symbols.
+ * Symbols not in an export list are still accessible via qualified names
+ * but are not exported — we treat un-exported symbols as non-public.
+ * Fallback: if no export statement is found in the module, treat all
+ * non-underscore names as public (common for scripts without explicit exports).
+ */
+export const juliaExportChecker: ExportChecker = (node, name) => {
+  if (name.startsWith('_')) return false;
+  let current: SyntaxNode | null = node;
+  while (current) {
+    if (current.type === 'module_definition') {
+      // Check siblings inside module body for export_statement listing this name
+      const body = current.childForFieldName('body') ?? current;
+      for (let i = 0; i < body.childCount; i++) {
+        const child = body.child(i);
+        if (child?.type === 'export_statement' && child.text?.includes(name)) return true;
+      }
+      // Module found but name not in any export — treat as internal
+      return false;
+    }
+    current = current.parent;
+  }
+  // Top-level (script) — treat all non-underscore names as public
+  return true;
+};

--- a/gitnexus/src/core/ingestion/field-extractors/configs/julia.ts
+++ b/gitnexus/src/core/ingestion/field-extractors/configs/julia.ts
@@ -1,0 +1,58 @@
+// gitnexus/src/core/ingestion/field-extractors/configs/julia.ts
+// Verified against tree-sitter-julia grammar
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { FieldExtractionConfig } from '../generic.js';
+
+/**
+ * Julia field extraction config.
+ *
+ * Julia struct fields appear as typed or untyped identifiers inside struct bodies:
+ *   struct Point
+ *     x::Float64
+ *     y::Float64
+ *   end
+ *
+ * In tree-sitter-julia the struct body contains field declarations.
+ * Each field is either an identifier or a typed_parameter node.
+ */
+export const juliaConfig: FieldExtractionConfig = {
+  language: SupportedLanguages.Julia,
+  typeDeclarationNodes: ['struct_definition'],
+  fieldNodeTypes: ['identifier', 'typed_parameter'],
+  bodyNodeTypes: ['field_declaration_list'],
+  defaultVisibility: 'public',
+
+  extractName(node) {
+    if (node.type === 'identifier') return node.text;
+    if (node.type === 'typed_parameter') {
+      const nameNode = node.childForFieldName('name') ?? node.firstNamedChild;
+      return nameNode?.type === 'identifier' ? nameNode.text : undefined;
+    }
+    return undefined;
+  },
+
+  extractType(node) {
+    if (node.type === 'typed_parameter') {
+      const typeNode = node.childForFieldName('type') ?? node.namedChild(1);
+      return typeNode?.text?.trim();
+    }
+    return undefined;
+  },
+
+  extractVisibility(_node) {
+    // Julia struct fields are always public (no access modifiers)
+    return 'public';
+  },
+
+  isStatic(_node) {
+    return false;
+  },
+
+  isReadonly(_node) {
+    // Immutable structs (struct, not mutable struct) have readonly fields.
+    // The mutable keyword is on the parent struct_definition, not on individual fields.
+    // We return false here; the struct-level immutability is handled elsewhere.
+    return false;
+  },
+};

--- a/gitnexus/src/core/ingestion/field-extractors/configs/julia.ts
+++ b/gitnexus/src/core/ingestion/field-extractors/configs/julia.ts
@@ -1,47 +1,71 @@
 // gitnexus/src/core/ingestion/field-extractors/configs/julia.ts
-// Verified against tree-sitter-julia grammar
 
 import { SupportedLanguages } from 'gitnexus-shared';
 import type { FieldExtractionConfig } from '../generic.js';
+import type { SyntaxNode } from '../../utils/ast-helpers.js';
 
 /**
- * Julia field extraction config.
+ * Extract the struct name from a struct_definition node.
  *
- * Julia struct fields appear as typed or untyped identifiers inside struct bodies:
- *   struct Point
- *     x::Float64
- *     y::Float64
- *   end
- *
- * In tree-sitter-julia the struct body contains field declarations.
- * Each field is either an identifier or a typed_parameter node.
+ * Julia grammar has no named fields on struct_definition, so
+ * childForFieldName('name') always returns null. The name lives at:
+ *   struct_definition > type_head > identifier          (simple)
+ *   struct_definition > type_head > binary_expression > identifier  (with <: supertype)
  */
+function extractStructOwnerName(node: SyntaxNode): string | undefined {
+  const typeHead = node.namedChild(0);
+  if (typeHead?.type !== 'type_head') return undefined;
+  const first = typeHead.firstNamedChild;
+  if (first?.type === 'identifier') return first.text;
+  // struct Foo <: Bar  →  binary_expression first child is the name identifier
+  if (first?.type === 'binary_expression') return first.firstNamedChild?.text;
+  return undefined;
+}
+
+/**
+ * Extract field name + type from a struct field node.
+ *
+ * Handles three shapes that appear as direct children of struct_definition:
+ *   identifier          →  plain untyped field:        `label`
+ *   typed_expression    →  typed field:                `x::Float64`
+ *   assignment          →  field with default (@with_kw): `x::Int = 1` or `flag = false`
+ *
+ * The `type_head` child (struct name / supertype) is excluded via fieldNodeTypes.
+ */
+function extractFieldName(node: SyntaxNode): string | undefined {
+  if (node.type === 'identifier') return node.text;
+  if (node.type === 'typed_expression') return node.firstNamedChild?.text;
+  if (node.type === 'assignment') {
+    const lhs = node.firstNamedChild;
+    if (lhs?.type === 'typed_expression') return lhs.firstNamedChild?.text;
+    if (lhs?.type === 'identifier') return lhs.text;
+  }
+  return undefined;
+}
+
+function extractFieldType(node: SyntaxNode): string | undefined {
+  if (node.type === 'typed_expression') return node.namedChild(1)?.text?.trim();
+  if (node.type === 'assignment') {
+    const lhs = node.firstNamedChild;
+    if (lhs?.type === 'typed_expression') return lhs.namedChild(1)?.text?.trim();
+  }
+  return undefined;
+}
+
 export const juliaConfig: FieldExtractionConfig = {
   language: SupportedLanguages.Julia,
   typeDeclarationNodes: ['struct_definition'],
-  fieldNodeTypes: ['identifier', 'typed_parameter'],
-  bodyNodeTypes: ['field_declaration_list'],
+  // Fields are direct children of struct_definition (no wrapper body node).
+  // type_head holds the struct name and is excluded by listing only field shapes.
+  fieldNodeTypes: ['identifier', 'typed_expression', 'assignment'],
+  bodyNodeTypes: [],
+  useOwnerAsBody: true,
+  extractOwnerName: extractStructOwnerName,
   defaultVisibility: 'public',
-
-  extractName(node) {
-    if (node.type === 'identifier') return node.text;
-    if (node.type === 'typed_parameter') {
-      const nameNode = node.childForFieldName('name') ?? node.firstNamedChild;
-      return nameNode?.type === 'identifier' ? nameNode.text : undefined;
-    }
-    return undefined;
-  },
-
-  extractType(node) {
-    if (node.type === 'typed_parameter') {
-      const typeNode = node.childForFieldName('type') ?? node.namedChild(1);
-      return typeNode?.text?.trim();
-    }
-    return undefined;
-  },
+  extractName: extractFieldName,
+  extractType: extractFieldType,
 
   extractVisibility(_node) {
-    // Julia struct fields are always public (no access modifiers)
     return 'public';
   },
 
@@ -50,9 +74,6 @@ export const juliaConfig: FieldExtractionConfig = {
   },
 
   isReadonly(_node) {
-    // Immutable structs (struct, not mutable struct) have readonly fields.
-    // The mutable keyword is on the parent struct_definition, not on individual fields.
-    // We return false here; the struct-level immutability is handled elsewhere.
     return false;
   },
 };

--- a/gitnexus/src/core/ingestion/field-extractors/generic.ts
+++ b/gitnexus/src/core/ingestion/field-extractors/generic.ts
@@ -56,6 +56,18 @@ export interface FieldExtractionConfig {
   /** Extract fields from primary constructor parameters on the owner node itself
    *  (e.g. C# record positional parameters, C# 12 class primary constructors). */
   extractPrimaryFields?: (ownerNode: SyntaxNode, context: FieldExtractorContext) => FieldInfo[];
+  /**
+   * Custom owner name extractor for grammars where `childForFieldName('name')` does not work
+   * (e.g. Julia, where struct_definition has no named grammar fields).
+   * When provided, used instead of `node.childForFieldName('name')?.text`.
+   */
+  extractOwnerName?: (node: SyntaxNode) => string | undefined;
+  /**
+   * When true, use the owner node itself as the field body (fields are direct children).
+   * For grammars like Julia where struct fields live directly under the type-declaration node
+   * rather than inside a separate body wrapper node.
+   */
+  useOwnerAsBody?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -85,9 +97,8 @@ export function createFieldExtractor(config: FieldExtractionConfig): FieldExtrac
       if (!this.isTypeDeclaration(node)) return null;
 
       const nameNode = node.childForFieldName('name');
-      if (!nameNode) return null;
-
-      const ownerFqn = nameNode.text;
+      const ownerFqn = config.extractOwnerName?.(node) ?? nameNode?.text;
+      if (!ownerFqn) return null;
       const fields: FieldInfo[] = [];
 
       // Find body container(s)
@@ -110,6 +121,7 @@ export function createFieldExtractor(config: FieldExtractionConfig): FieldExtrac
     // ------------------------------------------------------------------
 
     private findBodies(node: SyntaxNode): SyntaxNode[] {
+      if (config.useOwnerAsBody) return [node];
       const result: SyntaxNode[] = [];
       // Try named 'body' field first
       const bodyField = node.childForFieldName('body');

--- a/gitnexus/src/core/ingestion/import-resolvers/configs/julia.ts
+++ b/gitnexus/src/core/ingestion/import-resolvers/configs/julia.ts
@@ -1,0 +1,33 @@
+/**
+ * Julia import resolution config.
+ *
+ * Julia supports two import forms:
+ *   import Foo         → namespace import (Foo.bar access)
+ *   using Foo          → wildcard import (all exported names in scope)
+ *   using Foo: bar     → named import
+ *   import Foo: bar    → named import
+ *
+ * Within a package, `include("file.jl")` is used for relative file inclusion.
+ * We handle include() as a special import form resolved via suffix matching.
+ */
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { ImportResolutionConfig, ImportResolverStrategy } from '../types.js';
+import { suffixResolve } from '../utils.js';
+import { createStandardStrategy } from '../standard.js';
+
+/** Julia include("file.jl") resolution strategy. */
+export const juliaIncludeStrategy: ImportResolverStrategy = (rawImportPath, _filePath, ctx) => {
+  // Strip quotes and resolve as relative .jl path
+  const cleaned = rawImportPath.replace(/^["']|["']$/g, '');
+  if (!cleaned.endsWith('.jl')) return null;
+
+  const pathParts = cleaned.replace(/^\.\//, '').split('/').filter(Boolean);
+  const resolved = suffixResolve(pathParts, ctx.normalizedFileList, ctx.allFileList, ctx.index);
+  return resolved ? { kind: 'files', files: [resolved] } : null;
+};
+
+export const juliaImportConfig: ImportResolutionConfig = {
+  language: SupportedLanguages.Julia,
+  strategies: [juliaIncludeStrategy, createStandardStrategy(SupportedLanguages.Julia)],
+};

--- a/gitnexus/src/core/ingestion/languages/index.ts
+++ b/gitnexus/src/core/ingestion/languages/index.ts
@@ -25,6 +25,7 @@ import { swiftProvider } from './swift.js';
 import { dartProvider } from './dart.js';
 import { vueProvider } from './vue.js';
 import { cobolProvider } from './cobol.js';
+import { juliaProvider } from './julia.js';
 
 export const providers = {
   [SupportedLanguages.JavaScript]: javascriptProvider,
@@ -43,6 +44,7 @@ export const providers = {
   [SupportedLanguages.Dart]: dartProvider,
   [SupportedLanguages.Vue]: vueProvider,
   [SupportedLanguages.Cobol]: cobolProvider,
+  [SupportedLanguages.Julia]: juliaProvider,
 } satisfies Record<SupportedLanguages, LanguageProvider>;
 
 /** Get provider by language enum (always succeeds for SupportedLanguages). */

--- a/gitnexus/src/core/ingestion/languages/julia.ts
+++ b/gitnexus/src/core/ingestion/languages/julia.ts
@@ -1,0 +1,108 @@
+/**
+ * Julia language provider.
+ *
+ * Julia uses wildcard-leaf import semantics: `using Foo` brings all exported
+ * names into scope in one hop. `import Foo` uses namespace access (Foo.bar).
+ * Within packages, `include("file.jl")` handles relative file inclusion.
+ *
+ * Key Julia traits:
+ *   - importSemantics: 'wildcard-leaf' (using Foo / import Foo)
+ *   - No mandatory visibility modifiers — export list controls public API
+ *   - Multiple dispatch: functions specialize on argument types
+ *   - Structs are class-like (no methods in body; methods defined externally)
+ */
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import { createClassExtractor } from '../class-extractors/generic.js';
+import { juliaClassConfig } from '../class-extractors/configs/julia.js';
+import { defineLanguage } from '../language-provider.js';
+import { typeConfig as juliaTypeConfig } from '../type-extractors/julia.js';
+import { juliaExportChecker } from '../export-detection.js';
+import { createImportResolver } from '../import-resolvers/resolver-factory.js';
+import { juliaImportConfig } from '../import-resolvers/configs/julia.js';
+import { JULIA_QUERIES } from '../tree-sitter-queries.js';
+import { createFieldExtractor } from '../field-extractors/generic.js';
+import { juliaConfig as juliaFieldConfig } from '../field-extractors/configs/julia.js';
+import { createMethodExtractor } from '../method-extractors/generic.js';
+import { juliaMethodConfig } from '../method-extractors/configs/julia.js';
+import { createVariableExtractor } from '../variable-extractors/generic.js';
+import { juliaVariableConfig } from '../variable-extractors/configs/julia.js';
+import { createCallExtractor } from '../call-extractors/generic.js';
+import { juliaCallConfig } from '../call-extractors/configs/julia.js';
+import { createHeritageExtractor } from '../heritage-extractors/generic.js';
+
+const BUILT_INS: ReadonlySet<string> = new Set([
+  'print',
+  'println',
+  'typeof',
+  'length',
+  'size',
+  'push!',
+  'pop!',
+  'append!',
+  'map',
+  'filter',
+  'reduce',
+  'sum',
+  'prod',
+  'minimum',
+  'maximum',
+  'sort',
+  'sort!',
+  'collect',
+  'enumerate',
+  'zip',
+  'keys',
+  'values',
+  'haskey',
+  'get',
+  'getindex',
+  'setindex!',
+  'error',
+  'throw',
+  'isa',
+  'isdefined',
+  'isnothing',
+  'ismissing',
+  'eltype',
+  'zeros',
+  'ones',
+  'rand',
+  'randn',
+  'copy',
+  'deepcopy',
+  'string',
+  'Symbol',
+  'parse',
+  'convert',
+  'promote',
+  'similar',
+  'fill',
+  'repeat',
+  'reshape',
+  'hcat',
+  'vcat',
+  'cat',
+  'tuple',
+  'nameof',
+  'supertype',
+  'subtypes',
+]);
+
+export const juliaProvider = defineLanguage({
+  id: SupportedLanguages.Julia,
+  extensions: ['.jl'],
+  entryPointPatterns: [/^main$/, /^run$/, /^execute$/],
+  treeSitterQueries: JULIA_QUERIES,
+  typeConfig: juliaTypeConfig,
+  exportChecker: juliaExportChecker,
+  importResolver: createImportResolver(juliaImportConfig),
+  importSemantics: 'wildcard-leaf',
+  callExtractor: createCallExtractor(juliaCallConfig),
+  fieldExtractor: createFieldExtractor(juliaFieldConfig),
+  methodExtractor: createMethodExtractor(juliaMethodConfig),
+  variableExtractor: createVariableExtractor(juliaVariableConfig),
+  classExtractor: createClassExtractor(juliaClassConfig),
+  heritageExtractor: createHeritageExtractor(SupportedLanguages.Julia),
+  builtInNames: BUILT_INS,
+});

--- a/gitnexus/src/core/ingestion/languages/julia.ts
+++ b/gitnexus/src/core/ingestion/languages/julia.ts
@@ -30,6 +30,30 @@ import { juliaVariableConfig } from '../variable-extractors/configs/julia.js';
 import { createCallExtractor } from '../call-extractors/generic.js';
 import { juliaCallConfig } from '../call-extractors/configs/julia.js';
 import { createHeritageExtractor } from '../heritage-extractors/generic.js';
+import type { SyntaxNode } from '../utils/ast-helpers.js';
+
+const JULIA_CALL_RESULT = { kind: 'call' } as const;
+const JULIA_SKIP_RESULT = { kind: 'skip' } as const;
+
+function routeJuliaCall(calledName: string, callNode: SyntaxNode) {
+  // Skip signature-shape calls (e.g., `function run()` parsed as call_expression in signature).
+  if (callNode.parent?.type === 'signature') return JULIA_SKIP_RESULT;
+
+  if (calledName === 'include') {
+    const args =
+      callNode.childForFieldName('arguments') ??
+      callNode.namedChildren.find((n) => n.type === 'argument_list');
+    const literal = args?.namedChildren.find((n) => n.type === 'string_literal');
+    const content = literal?.namedChildren.find((n) => n.type === 'content');
+    const importPath = content?.text?.trim();
+    if (!importPath || importPath.length > 1024 || /[\x00-\x1f]/.test(importPath)) {
+      return JULIA_SKIP_RESULT;
+    }
+    return { kind: 'import', importPath, isRelative: true } as const;
+  }
+
+  return JULIA_CALL_RESULT;
+}
 
 const BUILT_INS: ReadonlySet<string> = new Set([
   'print',
@@ -97,6 +121,7 @@ export const juliaProvider = defineLanguage({
   typeConfig: juliaTypeConfig,
   exportChecker: juliaExportChecker,
   importResolver: createImportResolver(juliaImportConfig),
+  callRouter: routeJuliaCall,
   importSemantics: 'wildcard-leaf',
   callExtractor: createCallExtractor(juliaCallConfig),
   fieldExtractor: createFieldExtractor(juliaFieldConfig),

--- a/gitnexus/src/core/ingestion/method-extractors/configs/julia.ts
+++ b/gitnexus/src/core/ingestion/method-extractors/configs/julia.ts
@@ -1,0 +1,119 @@
+// gitnexus/src/core/ingestion/method-extractors/configs/julia.ts
+// Verified against tree-sitter-julia grammar
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { MethodExtractionConfig, ParameterInfo } from '../../method-types.js';
+import type { SyntaxNode } from '../../utils/ast-helpers.js';
+
+/**
+ * Extract parameters from a Julia function definition.
+ *
+ * Julia parameters can be:
+ *   - Plain identifier: `x`
+ *   - Typed: `x::Int`
+ *   - With default: `x=1`
+ *   - Typed with default: `x::Int=1`
+ *   - Splat: `args...`
+ *   - Keyword: `; kw=default`
+ */
+function extractJuliaParameters(node: SyntaxNode): ParameterInfo[] {
+  const paramList = node.childForFieldName('parameters');
+  if (!paramList) return [];
+
+  const params: ParameterInfo[] = [];
+
+  for (let i = 0; i < paramList.namedChildCount; i++) {
+    const param = paramList.namedChild(i);
+    if (!param) continue;
+
+    switch (param.type) {
+      case 'identifier': {
+        params.push({ name: param.text, type: null, rawType: null, isOptional: false, isVariadic: false });
+        break;
+      }
+      case 'typed_parameter': {
+        const nameNode = param.childForFieldName('name') ?? param.firstNamedChild;
+        const typeNode = param.childForFieldName('type') ?? param.namedChild(1);
+        if (nameNode) {
+          params.push({
+            name: nameNode.text,
+            type: typeNode?.text?.trim() ?? null,
+            rawType: typeNode?.text?.trim() ?? null,
+            isOptional: false,
+            isVariadic: false,
+          });
+        }
+        break;
+      }
+      case 'optional_parameter': {
+        const nameNode = param.childForFieldName('name') ?? param.firstNamedChild;
+        const typeNode = param.childForFieldName('type');
+        if (nameNode) {
+          params.push({
+            name: nameNode.text,
+            type: typeNode?.text?.trim() ?? null,
+            rawType: typeNode?.text?.trim() ?? null,
+            isOptional: true,
+            isVariadic: false,
+          });
+        }
+        break;
+      }
+      case 'splat_parameter': {
+        const nameNode = param.firstNamedChild;
+        if (nameNode) {
+          params.push({ name: nameNode.text, type: null, rawType: null, isOptional: false, isVariadic: true });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return params;
+}
+
+function extractJuliaReturnType(node: SyntaxNode): string | undefined {
+  const retType = node.childForFieldName('return_type');
+  return retType?.text?.trim();
+}
+
+export const juliaMethodConfig: MethodExtractionConfig = {
+  language: SupportedLanguages.Julia,
+  // Julia methods are defined outside structs — no struct body method extraction
+  typeDeclarationNodes: ['struct_definition'],
+  methodNodeTypes: ['function_definition', 'short_function_definition'],
+  bodyNodeTypes: ['field_declaration_list'],
+
+  extractName(node) {
+    const nameNode = node.childForFieldName('name');
+    return nameNode?.text;
+  },
+
+  extractReturnType: extractJuliaReturnType,
+  extractParameters: extractJuliaParameters,
+
+  extractVisibility(_node) {
+    return 'public';
+  },
+
+  isStatic(_node) {
+    return false;
+  },
+
+  isAbstract(_node) {
+    return false;
+  },
+
+  isFinal(_node) {
+    return false;
+  },
+
+  extractAnnotations(_node) {
+    return [];
+  },
+
+  isAsync(_node) {
+    return false;
+  },
+};

--- a/gitnexus/src/core/ingestion/method-extractors/configs/julia.ts
+++ b/gitnexus/src/core/ingestion/method-extractors/configs/julia.ts
@@ -2,8 +2,23 @@
 // Verified against tree-sitter-julia grammar
 
 import { SupportedLanguages } from 'gitnexus-shared';
+import type { NodeLabel } from 'gitnexus-shared';
 import type { MethodExtractionConfig, ParameterInfo } from '../../method-types.js';
 import type { SyntaxNode } from '../../utils/ast-helpers.js';
+
+function getJuliaParameterList(node: SyntaxNode): SyntaxNode | undefined {
+  const direct = node.childForFieldName('parameters');
+  if (direct) return direct;
+
+  const signature =
+    node.childForFieldName('signature') ?? node.namedChildren.find((n) => n.type === 'signature');
+  if (!signature) return undefined;
+  const headerCall = signature.namedChildren.find((n) => n.type === 'call_expression');
+  if (!headerCall) return undefined;
+  const args = headerCall.childForFieldName('arguments');
+  if (args) return args;
+  return headerCall.namedChildren.find((n) => n.type === 'argument_list');
+}
 
 /**
  * Extract parameters from a Julia function definition.
@@ -17,7 +32,7 @@ import type { SyntaxNode } from '../../utils/ast-helpers.js';
  *   - Keyword: `; kw=default`
  */
 function extractJuliaParameters(node: SyntaxNode): ParameterInfo[] {
-  const paramList = node.childForFieldName('parameters');
+  const paramList = getJuliaParameterList(node);
   if (!paramList) return [];
 
   const params: ParameterInfo[] = [];
@@ -28,7 +43,13 @@ function extractJuliaParameters(node: SyntaxNode): ParameterInfo[] {
 
     switch (param.type) {
       case 'identifier': {
-        params.push({ name: param.text, type: null, rawType: null, isOptional: false, isVariadic: false });
+        params.push({
+          name: param.text,
+          type: null,
+          rawType: null,
+          isOptional: false,
+          isVariadic: false,
+        });
         break;
       }
       case 'typed_parameter': {
@@ -62,7 +83,13 @@ function extractJuliaParameters(node: SyntaxNode): ParameterInfo[] {
       case 'splat_parameter': {
         const nameNode = param.firstNamedChild;
         if (nameNode) {
-          params.push({ name: nameNode.text, type: null, rawType: null, isOptional: false, isVariadic: true });
+          params.push({
+            name: nameNode.text,
+            type: null,
+            rawType: null,
+            isOptional: false,
+            isVariadic: true,
+          });
         }
         break;
       }
@@ -78,17 +105,55 @@ function extractJuliaReturnType(node: SyntaxNode): string | undefined {
   return retType?.text?.trim();
 }
 
+/**
+ * Extract function name from a Julia function node during parent-walk.
+ *
+ * Julia function_definition stores the name inside signature → call_expression:
+ *   function run(x) ... end
+ *   → (function_definition (signature (call_expression (identifier "run") ...)) ...)
+ *
+ * Short-form assignment functions are handled separately (assignment is not in
+ * FUNCTION_NODE_TYPES, so they don't appear in the parent-walk).
+ */
+function juliaExtractFunctionName(
+  node: SyntaxNode,
+): { funcName: string | null; label: NodeLabel } | null {
+  if (node.type !== 'function_definition' && node.type !== 'macro_definition') return null;
+
+  // Navigate: function_definition → signature (first named child) → call_expression → identifier
+  const sig = node.namedChild(0);
+  if (sig?.type !== 'signature') return { funcName: null, label: 'Function' };
+
+  const callExpr = sig.namedChild(0);
+  if (callExpr?.type !== 'call_expression') return { funcName: null, label: 'Function' };
+
+  // The function name is the first child of the call_expression (an identifier)
+  const nameNode = callExpr.child(0);
+  const funcName = nameNode?.type === 'identifier' ? nameNode.text : null;
+  return { funcName, label: 'Function' };
+}
+
 export const juliaMethodConfig: MethodExtractionConfig = {
   language: SupportedLanguages.Julia,
   // Julia methods are defined outside structs — no struct body method extraction
   typeDeclarationNodes: ['struct_definition'],
-  methodNodeTypes: ['function_definition', 'short_function_definition'],
+  methodNodeTypes: ['function_definition'],
   bodyNodeTypes: ['field_declaration_list'],
 
   extractName(node) {
-    const nameNode = node.childForFieldName('name');
-    return nameNode?.text;
+    // Navigate: function_definition → signature → call_expression → identifier
+    const sig = node.namedChild(0);
+    if (sig?.type === 'signature') {
+      const callExpr = sig.namedChild(0);
+      if (callExpr?.type === 'call_expression') {
+        const nameNode = callExpr.child(0);
+        if (nameNode?.type === 'identifier') return nameNode.text;
+      }
+    }
+    return undefined;
   },
+
+  extractFunctionName: juliaExtractFunctionName,
 
   extractReturnType: extractJuliaReturnType,
   extractParameters: extractJuliaParameters,

--- a/gitnexus/src/core/ingestion/method-extractors/configs/julia.ts
+++ b/gitnexus/src/core/ingestion/method-extractors/configs/julia.ts
@@ -52,7 +52,8 @@ function extractJuliaParameters(node: SyntaxNode): ParameterInfo[] {
         });
         break;
       }
-      case 'typed_parameter': {
+      case 'typed_parameter':
+      case 'typed_expression': {
         const nameNode = param.childForFieldName('name') ?? param.firstNamedChild;
         const typeNode = param.childForFieldName('type') ?? param.namedChild(1);
         if (nameNode) {
@@ -61,6 +62,33 @@ function extractJuliaParameters(node: SyntaxNode): ParameterInfo[] {
             type: typeNode?.text?.trim() ?? null,
             rawType: typeNode?.text?.trim() ?? null,
             isOptional: false,
+            isVariadic: false,
+          });
+        }
+        break;
+      }
+      case 'named_argument': {
+        // Default positional (x::Int=1) or keyword (; kw::String="hello") parameter.
+        // First named child is typed_expression (typed) or identifier (untyped).
+        const first = param.firstNamedChild;
+        if (first?.type === 'typed_expression') {
+          const nameNode = first.firstNamedChild;
+          const typeNode = first.namedChild(1);
+          if (nameNode) {
+            params.push({
+              name: nameNode.text,
+              type: typeNode?.text?.trim() ?? null,
+              rawType: typeNode?.text?.trim() ?? null,
+              isOptional: true,
+              isVariadic: false,
+            });
+          }
+        } else if (first?.type === 'identifier') {
+          params.push({
+            name: first.text,
+            type: null,
+            rawType: null,
+            isOptional: true,
             isVariadic: false,
           });
         }

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -1512,6 +1512,61 @@ export const DART_QUERIES = `
       (type_identifier) @heritage.trait))) @heritage
 `;
 
+// Julia queries - works with tree-sitter-julia
+export const JULIA_QUERIES = `
+; ── Structs (class-like types) ───────────────────────────────────────────────
+(struct_definition
+  name: (identifier) @name) @definition.class
+
+; ── Abstract types ────────────────────────────────────────────────────────────
+(abstract_definition
+  name: (identifier) @name) @definition.class
+
+; ── Modules ───────────────────────────────────────────────────────────────────
+(module_definition
+  name: (identifier) @name) @definition.module
+
+; ── Function definitions ──────────────────────────────────────────────────────
+(function_definition
+  name: (identifier) @name) @definition.function
+
+; ── Short-form function definitions: f(x) = expr ─────────────────────────────
+(short_function_definition
+  name: (identifier) @name) @definition.function
+
+; ── Macro definitions ─────────────────────────────────────────────────────────
+(macro_definition
+  name: (identifier) @name) @definition.function
+
+; ── Import statements ─────────────────────────────────────────────────────────
+(import_statement) @import
+
+(using_statement) @import
+
+; ── Call expressions ──────────────────────────────────────────────────────────
+(call_expression
+  (identifier) @call.name) @call
+
+(call_expression
+  (field_expression
+    (identifier) @call.name)) @call
+
+; ── Heritage: struct Foo <: Bar ───────────────────────────────────────────────
+(struct_definition
+  name: (identifier) @heritage.class
+  supertype: (type_clause
+    (identifier) @heritage.extends)) @heritage
+
+(abstract_definition
+  name: (identifier) @heritage.class
+  supertype: (type_clause
+    (identifier) @heritage.extends)) @heritage
+
+; ── Variable assignments at module scope ──────────────────────────────────────
+(assignment
+  left: (identifier) @name) @definition.variable
+`;
+
 import { SupportedLanguages } from 'gitnexus-shared';
 
 export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
@@ -1531,4 +1586,5 @@ export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.Dart]: DART_QUERIES,
   [SupportedLanguages.Vue]: TYPESCRIPT_QUERIES, // Vue <script> blocks are parsed as TypeScript
   [SupportedLanguages.Cobol]: '', // Standalone regex processor — no tree-sitter queries
+  [SupportedLanguages.Julia]: JULIA_QUERIES,
 };

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -1512,59 +1512,81 @@ export const DART_QUERIES = `
       (type_identifier) @heritage.trait))) @heritage
 `;
 
-// Julia queries - works with tree-sitter-julia
+// Julia queries — verified against tree-sitter-julia grammar.
+//
+// Key structural facts (no named fields for struct/abstract type children):
+//   struct Foo <: Bar     → (struct_definition (type_head (binary_expression (identifier "Foo") ...)))
+//   struct Simple         → (struct_definition (type_head (identifier "Simple")))
+//   abstract type A <: B  → (abstract_definition (type_head (binary_expression ...)))
+//   module M              → (module_definition name: (identifier "M"))  ← has named field
+//   function f(x)         → (function_definition (signature (call_expression . (identifier "f") ...)))
+//   f(x) = expr           → (assignment . (call_expression . (identifier "f") ...) ...)
+//   macro @m(x)           → (macro_definition (signature (call_expression . (identifier "m") ...)))
 export const JULIA_QUERIES = `
 ; ── Structs (class-like types) ───────────────────────────────────────────────
+; Simple struct (no supertype): (type_head (identifier))
 (struct_definition
-  name: (identifier) @name) @definition.class
+  (type_head (identifier) @name)) @definition.class
+
+; Struct with supertype: (type_head (binary_expression . identifier <: identifier))
+(struct_definition
+  (type_head (binary_expression . (identifier) @name))) @definition.class
 
 ; ── Abstract types ────────────────────────────────────────────────────────────
 (abstract_definition
-  name: (identifier) @name) @definition.class
+  (type_head (identifier) @name)) @definition.class
+
+(abstract_definition
+  (type_head (binary_expression . (identifier) @name))) @definition.class
 
 ; ── Modules ───────────────────────────────────────────────────────────────────
 (module_definition
   name: (identifier) @name) @definition.module
 
 ; ── Function definitions ──────────────────────────────────────────────────────
+; Full form: function f(args...) ... end
 (function_definition
-  name: (identifier) @name) @definition.function
+  (signature (call_expression . (identifier) @name))) @definition.function
 
-; ── Short-form function definitions: f(x) = expr ─────────────────────────────
-(short_function_definition
-  name: (identifier) @name) @definition.function
+; Short form: f(args...) = expr
+; The leading . anchors call_expression as the first child (LHS), preventing
+; false matches on the RHS call expression in the assignment.
+(assignment .
+  (call_expression . (identifier) @name)) @definition.function
 
 ; ── Macro definitions ─────────────────────────────────────────────────────────
 (macro_definition
-  name: (identifier) @name) @definition.function
+  (signature (call_expression . (identifier) @name))) @definition.function
 
 ; ── Import statements ─────────────────────────────────────────────────────────
-(import_statement) @import
+(import_statement (identifier) @import.source) @import
 
-(using_statement) @import
+(using_statement (identifier) @import.source) @import
 
 ; ── Call expressions ──────────────────────────────────────────────────────────
-(call_expression
-  (identifier) @call.name) @call
+; Free calls: f(args...)
+(call_expression . (identifier) @call.name) @call
 
+; Member calls: obj.method(args...) — (field_expression value: receiver (identifier method))
 (call_expression
-  (field_expression
-    (identifier) @call.name)) @call
+  (field_expression value: (_) (identifier) @call.name)) @call
 
-; ── Heritage: struct Foo <: Bar ───────────────────────────────────────────────
+; ── Heritage: struct/abstract Foo <: Bar ──────────────────────────────────────
 (struct_definition
-  name: (identifier) @heritage.class
-  supertype: (type_clause
-    (identifier) @heritage.extends)) @heritage
+  (type_head
+    (binary_expression
+      (identifier) @heritage.class
+      (identifier) @heritage.extends))) @heritage
 
 (abstract_definition
-  name: (identifier) @heritage.class
-  supertype: (type_clause
-    (identifier) @heritage.extends)) @heritage
+  (type_head
+    (binary_expression
+      (identifier) @heritage.class
+      (identifier) @heritage.extends))) @heritage
 
-; ── Variable assignments at module scope ──────────────────────────────────────
-(assignment
-  left: (identifier) @name) @definition.variable
+; ── Variable assignments ──────────────────────────────────────────────────────
+; Simple assignment: x = expr (LHS is a plain identifier, not a call)
+(assignment . (identifier) @name) @definition.variable
 `;
 
 import { SupportedLanguages } from 'gitnexus-shared';

--- a/gitnexus/src/core/ingestion/type-extractors/julia.ts
+++ b/gitnexus/src/core/ingestion/type-extractors/julia.ts
@@ -1,0 +1,123 @@
+import type {
+  LanguageTypeConfig,
+  ParameterExtractor,
+  TypeBindingExtractor,
+  InitializerExtractor,
+  ConstructorBindingScanner,
+  PendingAssignmentExtractor,
+} from './types.js';
+import { extractSimpleTypeName, extractVarName } from './shared.js';
+import type { SyntaxNode } from '../utils/ast-helpers.js';
+
+/**
+ * Julia type extractor.
+ *
+ * Julia uses `::` for type annotations:
+ *   x::Int
+ *   function foo(x::Int, y::String)::Bool
+ *
+ * Constructor inference: `obj = MyType(args...)` binds `obj` → `MyType`.
+ */
+
+const DECLARATION_NODE_TYPES: ReadonlySet<string> = new Set([
+  'function_definition',
+  'short_function_definition',
+  'assignment',
+]);
+
+/**
+ * Extract type annotations from function parameter lists into env.
+ * Julia: `function foo(x::Int, y::String)` → env.set("x", "Int")
+ */
+const extractDeclaration: TypeBindingExtractor = (node: SyntaxNode, env: Map<string, string>): void => {
+  if (node.type !== 'function_definition' && node.type !== 'short_function_definition') return;
+
+  const paramList = node.childForFieldName('parameters');
+  if (!paramList) return;
+
+  for (let i = 0; i < paramList.namedChildCount; i++) {
+    const param = paramList.namedChild(i);
+    if (!param) continue;
+
+    if (param.type === 'typed_parameter') {
+      const nameNode = param.childForFieldName('name') ?? param.firstNamedChild;
+      const typeNode = param.childForFieldName('type') ?? param.namedChild(1);
+      if (nameNode && typeNode) {
+        const varName = extractVarName(nameNode);
+        const typeName = extractSimpleTypeName(typeNode) ?? typeNode.text?.trim();
+        if (varName && typeName) env.set(varName, typeName);
+      }
+    }
+  }
+};
+
+const extractParameter: ParameterExtractor = (_node: SyntaxNode, _env: Map<string, string>): void => {
+  // Parameter types are handled by extractDeclaration above
+};
+
+/**
+ * Julia constructor inference: obj = MyType(args...)
+ * MyType() is a constructor call when MyType matches a known type name.
+ */
+const extractInitializer: InitializerExtractor = (node, env, classNames): void => {
+  if (node.type !== 'assignment') return;
+  const left = node.childForFieldName('left');
+  const right = node.childForFieldName('right');
+  if (!left || !right) return;
+
+  const varName = extractVarName(left);
+  if (!varName || env.has(varName)) return;
+
+  // call_expression where the callee is an identifier matching a known type
+  if (right.type === 'call_expression') {
+    const callee = right.firstNamedChild ?? right.child(0);
+    if (callee?.type === 'identifier' && classNames.has(callee.text)) {
+      env.set(varName, callee.text);
+    }
+  }
+};
+
+const scanConstructorBinding: ConstructorBindingScanner = (node) => {
+  if (node.type !== 'assignment') return undefined;
+  const left = node.childForFieldName('left');
+  const right = node.childForFieldName('right');
+  if (!left || !right) return undefined;
+
+  const varName = extractVarName(left);
+  if (!varName) return undefined;
+
+  if (right.type === 'call_expression') {
+    const callee = right.firstNamedChild ?? right.child(0);
+    if (callee?.type === 'identifier') {
+      return { varName, calleeName: callee.text };
+    }
+  }
+  return undefined;
+};
+
+const extractPendingAssignment: PendingAssignmentExtractor = (node, scopeEnv) => {
+  if (node.type !== 'assignment') return undefined;
+  const lhsNode = node.childForFieldName('left');
+  if (!lhsNode || lhsNode.type !== 'identifier') return undefined;
+  const varName = lhsNode.text;
+  if (scopeEnv.has(varName)) return undefined;
+  const rhsNode = node.childForFieldName('right');
+  if (!rhsNode) return undefined;
+  if (rhsNode.type === 'identifier') return { kind: 'copy', lhs: varName, rhs: rhsNode.text };
+  if (rhsNode.type === 'call_expression') {
+    const callee = rhsNode.firstNamedChild ?? rhsNode.child(0);
+    if (callee?.type === 'identifier') {
+      return { kind: 'callResult', lhs: varName, callee: callee.text };
+    }
+  }
+  return undefined;
+};
+
+export const typeConfig: LanguageTypeConfig = {
+  declarationNodeTypes: DECLARATION_NODE_TYPES,
+  extractDeclaration,
+  extractParameter,
+  extractInitializer,
+  scanConstructorBinding,
+  extractPendingAssignment,
+};

--- a/gitnexus/src/core/ingestion/type-extractors/julia.ts
+++ b/gitnexus/src/core/ingestion/type-extractors/julia.ts
@@ -25,14 +25,31 @@ const DECLARATION_NODE_TYPES: ReadonlySet<string> = new Set([
   'assignment',
 ]);
 
+function getJuliaParameterList(node: SyntaxNode): SyntaxNode | undefined {
+  const direct = node.childForFieldName('parameters');
+  if (direct) return direct;
+
+  const signature =
+    node.childForFieldName('signature') ?? node.namedChildren.find((n) => n.type === 'signature');
+  if (!signature) return undefined;
+  const headerCall = signature.namedChildren.find((n) => n.type === 'call_expression');
+  if (!headerCall) return undefined;
+  const args = headerCall.childForFieldName('arguments');
+  if (args) return args;
+  return headerCall.namedChildren.find((n) => n.type === 'argument_list');
+}
+
 /**
  * Extract type annotations from function parameter lists into env.
  * Julia: `function foo(x::Int, y::String)` → env.set("x", "Int")
  */
-const extractDeclaration: TypeBindingExtractor = (node: SyntaxNode, env: Map<string, string>): void => {
+const extractDeclaration: TypeBindingExtractor = (
+  node: SyntaxNode,
+  env: Map<string, string>,
+): void => {
   if (node.type !== 'function_definition' && node.type !== 'short_function_definition') return;
 
-  const paramList = node.childForFieldName('parameters');
+  const paramList = getJuliaParameterList(node);
   if (!paramList) return;
 
   for (let i = 0; i < paramList.namedChildCount; i++) {
@@ -51,7 +68,10 @@ const extractDeclaration: TypeBindingExtractor = (node: SyntaxNode, env: Map<str
   }
 };
 
-const extractParameter: ParameterExtractor = (_node: SyntaxNode, _env: Map<string, string>): void => {
+const extractParameter: ParameterExtractor = (
+  _node: SyntaxNode,
+  _env: Map<string, string>,
+): void => {
   // Parameter types are handled by extractDeclaration above
 };
 

--- a/gitnexus/src/core/ingestion/utils/method-props.ts
+++ b/gitnexus/src/core/ingestion/utils/method-props.ts
@@ -151,9 +151,7 @@ export function buildMethodProps(info: MethodInfo): Record<string, unknown> {
   }
   return {
     parameterCount: hasVariadic ? undefined : info.parameters.length,
-    ...(!hasVariadic && optionalCount > 0
-      ? { requiredParameterCount: info.parameters.length - optionalCount }
-      : {}),
+    ...(!hasVariadic ? { requiredParameterCount: info.parameters.length - optionalCount } : {}),
     ...(types.length > 0 ? { parameterTypes: types } : {}),
     returnType: info.returnType ?? undefined,
     visibility: info.visibility,

--- a/gitnexus/src/core/ingestion/variable-extractors/configs/julia.ts
+++ b/gitnexus/src/core/ingestion/variable-extractors/configs/julia.ts
@@ -1,0 +1,62 @@
+// gitnexus/src/core/ingestion/variable-extractors/configs/julia.ts
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import type { VariableExtractionConfig, VariableVisibility } from '../../variable-types.js';
+import type { SyntaxNode } from '../../utils/ast-helpers.js';
+
+function extractNameFromJulia(node: SyntaxNode): string | undefined {
+  // assignment: x = value
+  if (node.type === 'assignment') {
+    const left = node.childForFieldName('left');
+    if (left?.type === 'identifier') return left.text;
+  }
+  return undefined;
+}
+
+function extractTypeFromJulia(node: SyntaxNode): string | undefined {
+  // Julia module-level assignments rarely carry inline type annotations.
+  // Typed declarations would be `x::Int = 5` via typed_parameter, but that's uncommon at module scope.
+  if (node.type === 'assignment') {
+    const left = node.childForFieldName('left');
+    if (left?.type === 'typed_parameter') {
+      const typeNode = left.childForFieldName('type') ?? left.namedChild(1);
+      return typeNode?.text?.trim();
+    }
+  }
+  return undefined;
+}
+
+function extractVisFromJulia(node: SyntaxNode): VariableVisibility {
+  const name = extractNameFromJulia(node);
+  if (!name) return 'public';
+  if (name.startsWith('_')) return 'private';
+  return 'public';
+}
+
+export const juliaVariableConfig: VariableExtractionConfig = {
+  language: SupportedLanguages.Julia,
+  constNodeTypes: [],
+  staticNodeTypes: [],
+  variableNodeTypes: ['assignment'],
+
+  extractName: extractNameFromJulia,
+  extractType: extractTypeFromJulia,
+  extractVisibility: extractVisFromJulia,
+
+  isConst(node) {
+    // Julia convention: SCREAMING_SNAKE_CASE names are constants
+    const name = extractNameFromJulia(node);
+    if (!name) return false;
+    return name === name.toUpperCase() && /^[A-Z][A-Z0-9_]*$/.test(name);
+  },
+
+  isStatic(_node) {
+    return false;
+  },
+
+  isMutable(node) {
+    const name = extractNameFromJulia(node);
+    if (!name) return true;
+    return !(name === name.toUpperCase() && /^[A-Z][A-Z0-9_]*$/.test(name));
+  },
+};

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -12,6 +12,7 @@ import Go from 'tree-sitter-go';
 import Rust from 'tree-sitter-rust';
 import PHP from 'tree-sitter-php';
 import Ruby from 'tree-sitter-ruby';
+import Julia from 'tree-sitter-julia';
 import { createRequire } from 'node:module';
 import { SupportedLanguages } from 'gitnexus-shared';
 import { getProvider } from '../languages/index.js';
@@ -313,6 +314,7 @@ const languageMap: Record<string, TreeSitterLanguage> = {
   ...(Kotlin ? { [SupportedLanguages.Kotlin]: Kotlin } : {}),
   [SupportedLanguages.PHP]: PHP.php_only,
   [SupportedLanguages.Ruby]: Ruby,
+  [SupportedLanguages.Julia]: Julia,
   [SupportedLanguages.Vue]: TypeScript.typescript,
   ...(Dart ? { [SupportedLanguages.Dart]: Dart } : {}),
   ...(Swift ? { [SupportedLanguages.Swift]: Swift } : {}),

--- a/gitnexus/src/core/lbug/sidecar-recovery.ts
+++ b/gitnexus/src/core/lbug/sidecar-recovery.ts
@@ -113,7 +113,9 @@ const warnOnce = (logger: SidecarRecoveryLogger, key: string, message: string): 
 // — `git grep "LADYBUGDB-CONTRACT"` enumerates every version-coupled spot.
 export const isMissingShadowSidecarError = (err: unknown): boolean => {
   const msg = err instanceof Error ? err.message : String(err);
-  return /Cannot open file .*\.shadow: No such file or directory/i.test(msg);
+  return /Cannot open file(?:\. path:)? .*\.shadow(?:: No such file or directory| - Error 2: The system cannot find the file specified\.?)/i.test(
+    msg,
+  );
 };
 
 // LADYBUGDB-CONTRACT: matches @ladybugdb/core ^0.16.1 native error text.

--- a/gitnexus/src/core/tree-sitter/parser-loader.ts
+++ b/gitnexus/src/core/tree-sitter/parser-loader.ts
@@ -161,6 +161,11 @@ const SOURCES: Record<string, GrammarSource> = {
       'Kotlin parsing disabled: `tree-sitter-kotlin` is an optionalDependency ' +
       'and is not installed (or its native binding failed to build).',
   },
+  [SupportedLanguages.Julia]: {
+    load: () => _require('tree-sitter-julia'),
+    unavailableNote:
+      'Julia parsing requires `tree-sitter-julia`. Check that the package and its native binding installed cleanly (`npm ci`).',
+  },
 };
 
 type LoadResult =

--- a/gitnexus/test/fixtures/lang-resolution/julia-calls/app.jl
+++ b/gitnexus/test/fixtures/lang-resolution/julia-calls/app.jl
@@ -1,0 +1,7 @@
+function write_audit(x)
+    return x
+end
+
+function run()
+    write_audit(42)
+end

--- a/gitnexus/test/fixtures/lang-resolution/julia-export-visibility/app.jl
+++ b/gitnexus/test/fixtures/lang-resolution/julia-export-visibility/app.jl
@@ -1,0 +1,7 @@
+function _internal()
+    return 1
+end
+
+function public_api()
+    return _internal()
+end

--- a/gitnexus/test/fixtures/lang-resolution/julia-heritage/types.jl
+++ b/gitnexus/test/fixtures/lang-resolution/julia-heritage/types.jl
@@ -1,0 +1,15 @@
+abstract type AbstractAnimal end
+
+abstract type Animal <: AbstractAnimal end
+
+struct Dog <: Animal
+    name::String
+end
+
+struct Cat <: Animal
+    name::String
+end
+
+function speak(a::Animal)
+    println("...")
+end

--- a/gitnexus/test/fixtures/lang-resolution/julia-include-import/app.jl
+++ b/gitnexus/test/fixtures/lang-resolution/julia-include-import/app.jl
@@ -1,0 +1,5 @@
+include("utils.jl")
+
+function run()
+    write_audit(42)
+end

--- a/gitnexus/test/fixtures/lang-resolution/julia-include-import/utils.jl
+++ b/gitnexus/test/fixtures/lang-resolution/julia-include-import/utils.jl
@@ -1,0 +1,3 @@
+function write_audit(x)
+    return x
+end

--- a/gitnexus/test/fixtures/lang-resolution/julia-typed-params/app.jl
+++ b/gitnexus/test/fixtures/lang-resolution/julia-typed-params/app.jl
@@ -1,0 +1,7 @@
+struct User
+    id::Int
+end
+
+function process(user::User, limit::Int)
+    return limit
+end

--- a/gitnexus/test/fixtures/lang-resolution/julia-with-kw/app.jl
+++ b/gitnexus/test/fixtures/lang-resolution/julia-with-kw/app.jl
@@ -1,0 +1,21 @@
+using Parameters
+
+@with_kw struct ModelConfig
+    hidden_size::Int = 256
+    dropout::Float64 = 0.1
+    label::String = "default"
+    verbose = false
+end
+
+struct Point
+    x::Float64
+    y::Float64
+end
+
+function train(cfg::ModelConfig; epochs::Int=10, lr::Float64=0.001)
+    return cfg.hidden_size
+end
+
+function distance(a::Point, b::Point)
+    return a.x - b.x
+end

--- a/gitnexus/test/integration/resolvers/julia-debug.test.ts
+++ b/gitnexus/test/integration/resolvers/julia-debug.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, beforeAll } from 'vitest';
+import path from 'path';
+import {
+  FIXTURES,
+  getRelationships,
+  getNodesByLabel,
+  runPipelineFromRepo,
+  type PipelineResult,
+} from './helpers.js';
+
+describe('Julia debug', () => {
+  let result: PipelineResult;
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'julia-calls'), () => {});
+  }, 60000);
+
+  it('shows all edges', () => {
+    const calls = getRelationships(result, 'CALLS');
+    console.log(
+      'CALLS:',
+      calls.map((c) => `${c.source} → ${c.target}`),
+    );
+    const fns = getNodesByLabel(result, 'Function');
+    console.log('Functions:', fns);
+  });
+});

--- a/gitnexus/test/integration/resolvers/julia.test.ts
+++ b/gitnexus/test/integration/resolvers/julia.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Julia: function definitions, struct/abstract type detection, heritage (<:),
+ *        and function call resolution.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'path';
+import {
+  FIXTURES,
+  getRelationships,
+  getNodesByLabel,
+  getNodesByLabelFull,
+  edgeSet,
+  runPipelineFromRepo,
+  type PipelineResult,
+} from './helpers.js';
+
+// ---------------------------------------------------------------------------
+// Function definitions and call resolution (single file)
+// ---------------------------------------------------------------------------
+
+describe('Julia function detection and call resolution', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'julia-calls'), () => {});
+  }, 60000);
+
+  it('detects both functions', () => {
+    const fns = getNodesByLabel(result, 'Function');
+    expect(fns).toContain('write_audit');
+    expect(fns).toContain('run');
+  });
+
+  it('emits CALLS edge: run → write_audit', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const edge = calls.find((c) => c.source === 'run' && c.target === 'write_audit');
+    expect(edge).toBeDefined();
+  });
+
+  it('does not emit signature self-call edges', () => {
+    const calls = getRelationships(result, 'CALLS');
+    expect(calls.find((c) => c.source === 'run' && c.target === 'run')).toBeUndefined();
+    expect(
+      calls.find((c) => c.source === 'write_audit' && c.target === 'write_audit'),
+    ).toBeUndefined();
+  });
+
+  it('does not emit spurious CALLS edges from built-in calls', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const builtinCalls = calls.filter((c) => c.target === 'println');
+    expect(builtinCalls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Struct and abstract type detection + heritage (<:)
+// ---------------------------------------------------------------------------
+
+describe('Julia struct and abstract type detection with heritage', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'julia-heritage'), () => {});
+  }, 60000);
+
+  it('detects all class-like types (structs and abstract types)', () => {
+    const classes = getNodesByLabel(result, 'Class');
+    expect(classes).toContain('AbstractAnimal');
+    expect(classes).toContain('Animal');
+    expect(classes).toContain('Dog');
+    expect(classes).toContain('Cat');
+  });
+
+  it('detects the speak function', () => {
+    const fns = getNodesByLabel(result, 'Function');
+    expect(fns).toContain('speak');
+  });
+
+  it('emits EXTENDS edge: Animal <: AbstractAnimal', () => {
+    const extends_ = getRelationships(result, 'EXTENDS');
+    const edge = extends_.find((e) => e.source === 'Animal' && e.target === 'AbstractAnimal');
+    expect(edge).toBeDefined();
+  });
+
+  it('emits EXTENDS edge: Dog <: Animal', () => {
+    const extends_ = getRelationships(result, 'EXTENDS');
+    const edge = extends_.find((e) => e.source === 'Dog' && e.target === 'Animal');
+    expect(edge).toBeDefined();
+  });
+
+  it('emits EXTENDS edge: Cat <: Animal', () => {
+    const extends_ = getRelationships(result, 'EXTENDS');
+    const edge = extends_.find((e) => e.source === 'Cat' && e.target === 'Animal');
+    expect(edge).toBeDefined();
+  });
+
+  it('emits exactly 3 EXTENDS edges', () => {
+    const extends_ = getRelationships(result, 'EXTENDS');
+    expect(edgeSet(extends_).sort()).toEqual([
+      'Animal → AbstractAnimal',
+      'Cat → Animal',
+      'Dog → Animal',
+    ]);
+  });
+
+  it('all heritage edges point to real graph nodes', () => {
+    for (const edge of getRelationships(result, 'EXTENDS')) {
+      const target = result.graph.getNode(edge.rel.targetId);
+      expect(target).toBeDefined();
+    }
+  });
+});
+
+describe('Julia include() import routing', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'julia-include-import'), () => {});
+  }, 60000);
+
+  it('emits IMPORTS edge: app.jl → utils.jl from include()', () => {
+    const imports = getRelationships(result, 'IMPORTS');
+    const includeEdge = imports.find(
+      (e) => e.sourceFilePath === 'app.jl' && e.targetFilePath === 'utils.jl',
+    );
+    expect(includeEdge).toBeDefined();
+  });
+
+  it('resolves run → write_audit across include target', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const edge = calls.find(
+      (c) => c.source === 'run' && c.target === 'write_audit' && c.targetFilePath === 'utils.jl',
+    );
+    expect(edge).toBeDefined();
+  });
+});
+
+describe('Julia typed parameter extraction', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'julia-typed-params'), () => {});
+  }, 60000);
+
+  it('extracts parameter metadata for process(user::User, limit::Int)', () => {
+    const fns = getNodesByLabelFull(result, 'Function');
+    const process = fns.find((n) => n.name === 'process');
+    expect(process).toBeDefined();
+    expect(process?.properties.parameterCount).toBe(2);
+    expect(process?.properties.requiredParameterCount).toBe(2);
+    expect(process?.properties.parameterTypes).toEqual(['User', 'Int']);
+  });
+});
+
+describe('Julia export visibility in top-level scripts', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'julia-export-visibility'), () => {});
+  }, 60000);
+
+  it('marks underscore-prefixed function as internal', () => {
+    const fns = getNodesByLabelFull(result, 'Function');
+    const internal = fns.find((n) => n.name === '_internal');
+    expect(internal).toBeDefined();
+    expect(internal?.properties.isExported).toBe(false);
+  });
+
+  it('marks non-underscore function as exported', () => {
+    const fns = getNodesByLabelFull(result, 'Function');
+    const api = fns.find((n) => n.name === 'public_api');
+    expect(api).toBeDefined();
+    expect(api?.properties.isExported).toBe(true);
+  });
+});

--- a/gitnexus/test/integration/resolvers/julia.test.ts
+++ b/gitnexus/test/integration/resolvers/julia.test.ts
@@ -173,3 +173,43 @@ describe('Julia export visibility in top-level scripts', () => {
     expect(api?.properties.isExported).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Parameters.jl @with_kw — struct field extraction + keyword/default params
+// ---------------------------------------------------------------------------
+
+describe('Julia @with_kw struct and keyword parameter extraction', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'julia-with-kw'), () => {});
+  }, 60000);
+
+  it('detects @with_kw struct as a Class node', () => {
+    const classes = getNodesByLabel(result, 'Class');
+    expect(classes).toContain('ModelConfig');
+  });
+
+  it('detects plain struct as a Class node', () => {
+    const classes = getNodesByLabel(result, 'Class');
+    expect(classes).toContain('Point');
+  });
+
+  it('extracts keyword/default parameters for train(cfg; epochs, lr)', () => {
+    const fns = getNodesByLabelFull(result, 'Function');
+    const train = fns.find((n) => n.name === 'train');
+    expect(train).toBeDefined();
+    expect(train?.properties.parameterCount).toBe(3);
+    expect(train?.properties.requiredParameterCount).toBe(1);
+    expect(train?.properties.parameterTypes).toEqual(['ModelConfig', 'Int', 'Float64']);
+  });
+
+  it('extracts required-only parameters for distance(a, b)', () => {
+    const fns = getNodesByLabelFull(result, 'Function');
+    const dist = fns.find((n) => n.name === 'distance');
+    expect(dist).toBeDefined();
+    expect(dist?.properties.parameterCount).toBe(2);
+    expect(dist?.properties.requiredParameterCount).toBe(2);
+    expect(dist?.properties.parameterTypes).toEqual(['Point', 'Point']);
+  });
+});

--- a/gitnexus/test/unit/sidecar-recovery.test.ts
+++ b/gitnexus/test/unit/sidecar-recovery.test.ts
@@ -7,6 +7,7 @@ import {
   _resetSidecarRecoveryWarningsForTest,
   finalizeLbugSidecarsAfterClose,
   inspectLbugSidecars,
+  isMissingShadowSidecarError,
   isPermissionRenameError,
   isReadOnlyShadowReplayError,
   listQuarantinedMissingShadowWals,
@@ -184,6 +185,24 @@ describe('LadybugDB sidecar recovery', () => {
   });
 
   describe('Centralized isReadOnlyShadowReplayError (PR #1747 review, F4 dedup)', () => {
+    it('matches LadybugDB missing-shadow errors on both Unix and Windows formats', () => {
+      const unixErr = new Error(
+        'IO exception: Cannot open file /tmp/lbug.shadow: No such file or directory',
+      );
+      const winErr = new Error(
+        'IO exception: Cannot open file. path: D:\\repo\\.gitnexus\\lbug.shadow - Error 2: The system cannot find the file specified.',
+      );
+      expect(isMissingShadowSidecarError(unixErr)).toBe(true);
+      expect(isMissingShadowSidecarError(winErr)).toBe(true);
+    });
+
+    it('false-positive guard: missing-shadow matcher rejects unrelated errors', () => {
+      expect(isMissingShadowSidecarError(new Error('file not found'))).toBe(false);
+      expect(
+        isMissingShadowSidecarError(new Error('Cannot open file /tmp/lbug.wal: lock conflict')),
+      ).toBe(false);
+    });
+
     it('matches LadybugDB read-only shadow-replay error', () => {
       const err = new Error(
         "Runtime exception: Couldn't replay shadow pages under read-only mode. Please re-open the database with read-write mode to replay shadow pages.",


### PR DESCRIPTION
## Summary

Add Julia support and then hardened it with integration fixtures/tests and parser-extraction fixes.
Overall outcome: Julia ingestion path, resolver behavior, and coverage for call/heritage/include/export/keyword-params scenarios were added and verified.

## Motivation / context

GitNexus needed end-to-end Julia support for `.jl` repositories instead of treating Julia files as unsupported.
After initial language wiring, tests exposed gaps in extraction behavior, so follow-up commits added focused fixtures and fixes.

## Areas touched

- [X] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

Note: `gitnexus-shared/` was also updated for language detection/classification.

## Scope & constraints

**In scope**

- Add `SupportedLanguages.Julia` and `.jl` detection/classification wiring (`gitnexus-shared`).
- Register Julia parser loading via `tree-sitter-julia` and language provider integration.
- Add Julia extractor/resolver/query configs across calls/classes/fields/methods/variables/types/imports/exports.
- Add comprehensive Julia integration fixtures and resolver tests:
  `julia-calls`, `julia-heritage`, `julia-include-import`, `julia-typed-params`, `julia-export-visibility`, `julia-with-kw`.
- Fix extraction issues found by tests (field/method/parameter handling, incl. keyword/default parameter cases).

**Explicitly out of scope / not done here**

- No `gitnexus-web/` UI changes.
- No CI/workflow changes.
- No unrelated refactors outside Julia support and its test validation path.

## Implementation notes

Commits included in this summary:
- `56065ef` (2026-05-24): add support for julia
- `0444e41` (2026-05-24): add test for Julia
- `8703bfe` (2026-05-24): fix Julia tests

Behavior covered by fixtures/tests includes:
- function discovery and `CALLS` edges
- struct/abstract type detection and `EXTENDS` edges
- `include()` import routing
- typed parameter extraction
- export visibility heuristics
- `@with_kw` struct and keyword/default parameter extraction

## Testing & verification

- [x] `cd gitnexus && npm test`
Executed for this summary:
- [x] `cd gitnexus && npx vitest run --reporter=verbose test/integration/resolvers/julia.test.ts test/integration/resolvers/julia-debug.test.ts`
  - Result: `2` files passed, `21` tests passed.

## Risk & rollout

- Dependency/runtime risk: requires successful `tree-sitter-julia` availability in runtime environment.
- Rollout: run `npx gitnexus analyze` on Julia repos to validate indexing outputs in real projects.
- No explicit breaking API contract change declared in these commits.

## Checklist

- [X] PR body meets repo minimum length (workflow may label short descriptions)
- [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project
  conventions
- [X] No secrets, tokens, or machine-specific paths committed
