### PR TITLE
fix(php): prevent OOM in populatePhpNamespaceSiblings on large codebases

### DIFF
--- a/gitnexus/src/core/ingestion/languages/php/namespace-siblings.ts
+++ b/gitnexus/src/core/ingestion/languages/php/namespace-siblings.ts
@@ -240,32 +240,57 @@ export function populatePhpNamespaceSiblings(
     }
   }
 
-  // Step 3b: Inject fully-qualified-name bindings into every PHP file's
-  // Module scope. PHP `\App\Models\User` (leading-backslash FQN) and
-  // `App\Models\User` (already-qualified relative) on a parameter or
-  // typed receiver must resolve to the exact namespace-qualified class
-  // regardless of which simple-name `User` the caller's `use` imports
-  // shadowed. The shared `findClassBindingInScope` scope-chain walk
-  // consumes these augmentations via `lookupBindingsAt`, so adding the
-  // qualified key on every file's module scope routes FQN-receivers to
-  // the right def. Codex PR #1497 review, finding 1.
+  // Step 3b: Inject fully-qualified-name bindings into PHP files' Module
+  // scopes, but ONLY for FQNs each file actually references.
   //
-  // Cost: O(PHP files × class-like defs in the workspace) augmentation
-  // entries. Bounded and acceptable in practice — typical PHP projects
-  // have hundreds of files and classes, not tens of thousands.
+  // The original code injected every FQN into every file's Module scope
+  // — O(files × classDefs). For large vendor trees (16K files × 5K+
+  // classes) this creates 80M+ augmentation entries (~32GB heap).
+  // See: https://github.com/abhigyanpatwari/GitNexus/issues/1803
+  //
+  // Instead: build a FQN→def lookup once, then for each file only inject
+  // FQNs that appear in its reference sites, type bindings, or imports.
+  // This is O(files × refsPerFile) — bounded by actual code usage.
+  const fqnDefs = new Map<string, SymbolDefinition[]>();
+  for (const [ns, bucket] of buckets) {
+    if (ns === '') continue;
+    for (const def of bucket.classDefs) {
+      const q = def.qualifiedName ?? '';
+      const simpleName = q.includes('\\') ? q.slice(q.lastIndexOf('\\') + 1) : q;
+      if (simpleName === '') continue;
+      const fqn = `${ns}\\${simpleName}`;
+      let arr = fqnDefs.get(fqn);
+      if (!arr) { arr = []; fqnDefs.set(fqn, arr); }
+      arr.push(def);
+    }
+  }
+
   for (const parsed of parsedFiles) {
     const moduleScope = parsed.scopes.find((s) => s.kind === 'Module');
     if (moduleScope === undefined) continue;
     const moduleScopeId = moduleScope.id;
 
-    for (const [ns, bucket] of buckets) {
-      if (ns === '') continue; // global-namespace classes have no qualified form to register
-      for (const def of bucket.classDefs) {
-        const q = def.qualifiedName ?? '';
-        const simpleName = q.includes('\\') ? q.slice(q.lastIndexOf('\\') + 1) : q;
-        if (simpleName === '') continue;
-        const fqn = `${ns}\\${simpleName}`;
-        const arr = getAugmentationBucket(augmentations, moduleScopeId, fqn);
+    // Collect FQN-like names from reference sites and type bindings
+    const referencedFqns = new Set<string>();
+    for (const ref of parsed.referenceSites) {
+      if (ref.name && ref.name.includes('\\')) referencedFqns.add(ref.name);
+    }
+    for (const scope of parsed.scopes) {
+      for (const [name] of scope.typeBindings) {
+        if (name.includes('\\')) referencedFqns.add(name);
+      }
+    }
+    for (const imp of parsed.parsedImports) {
+      if (imp.targetRaw && imp.targetRaw.includes('\\')) referencedFqns.add(imp.targetRaw);
+    }
+
+    // Only inject augmentations for FQNs this file actually uses
+    for (const name of referencedFqns) {
+      const cleanName = name.startsWith('\\') ? name.slice(1) : name;
+      const defs = fqnDefs.get(cleanName);
+      if (!defs) continue;
+      for (const def of defs) {
+        const arr = getAugmentationBucket(augmentations, moduleScopeId, cleanName);
         if (arr.some((b) => b.def.nodeId === def.nodeId)) continue;
         arr.push({ def, origin: 'namespace' });
       }
@@ -281,6 +306,13 @@ export function populatePhpNamespaceSiblings(
   //
   // Additionally, mirror from files that are imported via `use` (different
   // namespace) so return types from dependencies are chain-followable too.
+  //
+  // Uses a Map for O(1) file lookup instead of parsedFiles.find() which
+  // was O(n) per call — O(n²) total for 16K files.
+  // See: https://github.com/abhigyanpatwari/GitNexus/issues/1803
+  const parsedByPath = new Map<string, ParsedFile>();
+  for (const p of parsedFiles) parsedByPath.set(p.filePath, p);
+
   for (const parsed of parsedFiles) {
     const moduleScope = parsed.scopes.find((s) => s.kind === 'Module');
     if (moduleScope === undefined) continue;
@@ -322,7 +354,7 @@ export function populatePhpNamespaceSiblings(
 
     // Mirror return-type bindings from accessible files.
     for (const srcFilePath of accessibleFiles) {
-      const srcParsed = parsedFiles.find((p) => p.filePath === srcFilePath);
+      const srcParsed = parsedByPath.get(srcFilePath);
       if (srcParsed === undefined) continue;
       const srcModuleScope = srcParsed.scopes.find((s) => s.kind === 'Module');
       if (srcModuleScope === undefined) continue;


### PR DESCRIPTION
## Summary

Fixes 32GB+ OOM in `populatePhpNamespaceSiblings` when processing large PHP vendor trees (16K+ files, 5K+ class definitions).

Two algorithmic fixes in `namespace-siblings.ts`:

- **Step 3b: demand-driven FQN augmentation** — original injected every FQN into every file's Module scope: O(files × classDefs) = 80M+ entries for Mage-OS. Now only injects FQNs each file actually references in its code
- **Step 4: Map-based file lookup** — replaced `parsedFiles.find()` (O(n) per call, O(n²) total) with `Map<string, ParsedFile>` for O(1) lookups

## Problem

The comment in the original code acknowledges the assumption:

> Cost: O(PHP files × class-like defs in the workspace) augmentation entries. Bounded and acceptable in practice — **typical PHP projects have hundreds of files and classes, not tens of thousands.**

Magento 2 / Mage-OS violates this: 16K files × 5K+ class defs = 80M+ augmentation entries at ~400 bytes each = ~32GB heap.

### Before

```
51% | Scope resolution (php): namespace siblings (16281 files)
Mark-Compact (reduce) 32529.0 → 32505.6 MB
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

### After

```
[scope-resolution] Phase 2c: populateNamespaceSiblings...
[scope-resolution] Phase 2c done   (68s, ~1.3GB heap)
```

## Changes

Single file: `gitnexus/src/core/ingestion/languages/php/namespace-siblings.ts`

### Step 3b fix

```typescript
// Before: inject every FQN into every file (O(files × classDefs))
for (const parsed of parsedFiles) {           // 16K
  for (const [ns, bucket] of buckets) {       // hundreds
    for (const def of bucket.classDefs) { ... } // thousands
  }
}

// After: build FQN→def map once, inject only referenced FQNs per file
const fqnDefs = new Map<string, SymbolDefinition[]>();
// ... build map once ...
for (const parsed of parsedFiles) {
  const referencedFqns = new Set<string>();
  // collect from referenceSites, typeBindings, parsedImports
  for (const name of referencedFqns) {
    const defs = fqnDefs.get(name);  // O(1) lookup
    // inject only what's needed
  }
}
```

### Step 4 fix

```typescript
// Before: O(n²) linear scan
const srcParsed = parsedFiles.find((p) => p.filePath === srcFilePath);

// After: O(1) Map lookup
const parsedByPath = new Map<string, ParsedFile>();
for (const p of parsedFiles) parsedByPath.set(p.filePath, p);
const srcParsed = parsedByPath.get(srcFilePath);
```

## Test plan

- [ ] Existing tests pass (`npm test`)
- [ ] Index Mage-OS 2.3.0 vendor (16K+ PHP files) — namespace-siblings completes without OOM at 16GB heap
- [ ] Small PHP project produces identical graph to unpatched version
- [ ] FQN-typed receivers (e.g., `\App\Models\User $user`) still resolve correctly

## Environment tested

- Mage-OS 2.3.0: vendor/mage-os/ (388 packages) + vendor/hyva-themes/ (10 packages)
- 16,306 PHP files in scope-resolution
- Linux x64, Node v24.16.0, 32GB heap limit
- Result: 189,396 nodes | 489,068 edges | completed in 93 min (namespace-siblings: 68s)

Closes #1803