### PR TITLE
fix(cpp): dependent-base resolution across nested/inline namespaces (#1634)

### DIFF
--- a/gitnexus/src/core/ingestion/languages/cpp/two-phase-lookup.ts
+++ b/gitnexus/src/core/ingestion/languages/cpp/two-phase-lookup.ts
@@ -174,8 +174,8 @@ export function populateCppDependentBases(parsedFiles: readonly ParsedFile[]): v
         // syntactic qualifier (available at captures.ts:611 as
         // qualified_identifier scope) to navigate from the current scope,
         // which would resolve `detail::Inner` vs `public_api::Inner`
-        // unambiguously. Threading the qualifier is deferred to a
-        // follow-up. Until then, sibling collisions correctly suppress.
+        // unambiguously. Threading the qualifier is tracked in #1815.
+        // Until then, sibling collisions correctly suppress.
         const nsMatches = candidates.filter((c) => {
           if (c.nsPrefix === classEntry.nsPrefix) return true;
           if (classEntry.nsPrefix === '') {

--- a/gitnexus/src/core/ingestion/languages/cpp/two-phase-lookup.ts
+++ b/gitnexus/src/core/ingestion/languages/cpp/two-phase-lookup.ts
@@ -161,12 +161,33 @@ export function populateCppDependentBases(parsedFiles: readonly ParsedFile[]): v
 
         // Multiple classes share the same simple name — prefer the one
         // whose namespace matches the deriving class's namespace.
-        // V1: exact dot-prefix match only. Cross-namespace inheritance
-        // (e.g., `ns::outer::Derived` extending bare `Inner` defined in
-        // `ns::outer::inner`) and inline-namespace cases are deferred to
-        // V2; the conservative skip-on-ambiguity below avoids false
-        // associations in those edge cases.
-        const nsMatch = candidates.find((c) => c.nsPrefix === classEntry.nsPrefix);
+        // V2: filter by prefix-match capped at one level deeper, then
+        // accept only if exactly one candidate survives. This lets
+        // Derived<T> in ns::outer find Inner<T> in ns::outer::inner
+        // (or ns::v1 for inline-namespace variants) while rejecting
+        // sibling collisions (e.g. detail::Inner vs public_api::Inner).
+        //
+        // The one-segment cap limits walk depth: ns → ns.a ✓, ns → ns.a.b ✗.
+        // Global-scope deriving classes match any single-segment namespace.
+        //
+        // LIMITATION: True ISO behavior would use the base specifier's
+        // syntactic qualifier (available at captures.ts:611 as
+        // qualified_identifier scope) to navigate from the current scope,
+        // which would resolve `detail::Inner` vs `public_api::Inner`
+        // unambiguously. Threading the qualifier is deferred to a
+        // follow-up. Until then, sibling collisions correctly suppress.
+        const nsMatches = candidates.filter((c) => {
+          if (c.nsPrefix === classEntry.nsPrefix) return true;
+          if (classEntry.nsPrefix === '') {
+            return c.nsPrefix !== '' && !c.nsPrefix.includes('.');
+          }
+          if (c.nsPrefix.startsWith(classEntry.nsPrefix + '.')) {
+            const suffix = c.nsPrefix.slice(classEntry.nsPrefix.length + 1);
+            return !suffix.includes('.');
+          }
+          return false;
+        });
+        const nsMatch = nsMatches.length === 1 ? nsMatches[0] : undefined;
         if (nsMatch !== undefined) {
           bases.add(nsMatch.nodeId);
         }

--- a/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-deep/caller.cpp
+++ b/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-deep/caller.cpp
@@ -1,0 +1,6 @@
+#include "lib.h"
+
+void run() {
+  Derived<int> d;
+  d.g();
+}

--- a/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-deep/lib.h
+++ b/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-deep/lib.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace ns {
+  namespace a { namespace b {
+    template<class T>
+    struct Inner {
+      void f();
+    };
+  } }
+
+  template<class T>
+  struct Derived : a::b::Inner<T> {
+    void g() {
+      this->f();
+    }
+  };
+}
+
+// Second Inner class at global scope forces multi-candidate path
+// in populateCppDependentBases, exercising the namespace filter.
+template<class T>
+struct Inner {
+  void g2();
+};

--- a/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-inline/caller.cpp
+++ b/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-inline/caller.cpp
@@ -1,0 +1,6 @@
+#include "lib.h"
+
+void run() {
+  Derived<int> d;
+  d.g();
+}

--- a/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-inline/lib.h
+++ b/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-inline/lib.h
@@ -9,7 +9,7 @@ namespace ns {
   }
 
   template<class T>
-  struct Derived : v1::Base<T> {
+  struct Derived : Base<T> {
     void g() {
       this->f();
     }

--- a/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-inline/lib.h
+++ b/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-inline/lib.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace ns {
+  inline namespace v1 {
+    template<class T>
+    struct Base {
+      void f();
+    };
+  }
+
+  template<class T>
+  struct Derived : v1::Base<T> {
+    void g() {
+      this->f();
+    }
+  };
+}

--- a/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-neg/caller.cpp
+++ b/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-neg/caller.cpp
@@ -1,0 +1,6 @@
+#include "lib.h"
+
+void run() {
+  Derived<int> d;
+  d.g();
+}

--- a/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-neg/lib.h
+++ b/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-neg/lib.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace ns::outer {
+  namespace inner {
+    // No Inner<T> declared here
+  }
+
+  template<class T>
+  struct Derived : inner::Inner<T> {
+    void g() {
+      this->f();
+    }
+  };
+}

--- a/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-pos/caller.cpp
+++ b/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-pos/caller.cpp
@@ -1,0 +1,6 @@
+#include "lib.h"
+
+void run() {
+  Derived<int> d;
+  d.g();
+}

--- a/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-pos/lib.h
+++ b/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-pos/lib.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace ns::outer {
+  namespace inner {
+    template<class T>
+    struct Inner {
+      void f();
+    };
+  }
+
+  template<class T>
+  struct Derived : inner::Inner<T> {
+    void g() {
+      this->f();
+    }
+  };
+}

--- a/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-sibling-suppress/caller.cpp
+++ b/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-sibling-suppress/caller.cpp
@@ -1,0 +1,6 @@
+#include "lib.h"
+
+void run() {
+  Derived<int> d;
+  d.g();
+}

--- a/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-sibling-suppress/lib.h
+++ b/gitnexus/test/fixtures/lang-resolution/cpp-two-phase-dependent-base-cross-ns-sibling-suppress/lib.h
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace mylib {
+  namespace detail {
+    template<class T>
+    struct Inner {
+      void f_a();
+    };
+  }
+  namespace public_api {
+    template<class T>
+    struct Inner {
+      void f_b();
+    };
+  }
+
+  template<class T>
+  struct Derived : detail::Inner<T> {
+    void g() {
+      this->f_a();
+    }
+  };
+}

--- a/gitnexus/test/integration/resolvers/cpp.test.ts
+++ b/gitnexus/test/integration/resolvers/cpp.test.ts
@@ -2288,6 +2288,76 @@ describe('C++ two-phase template lookup — this-> name-hiding arity mismatch', 
   });
 });
 
+describe('C++ two-phase template lookup — dependent-base cross-namespace (nested ns)', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'cpp-two-phase-dependent-base-cross-ns-pos'),
+      () => {},
+    );
+  }, 60000);
+
+  it('Derived<T>::g() -> this->f() resolves to inner::Inner<T>::f when Inner is in a nested namespace (1 edge)', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const resolved = calls.filter((c) => c.source === 'g' && c.target === 'f');
+    expect(resolved.length).toBe(1);
+    expect(resolved[0].targetFilePath).toContain('lib.h');
+  });
+});
+
+describe('C++ two-phase template lookup — dependent-base cross-namespace (negative)', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'cpp-two-phase-dependent-base-cross-ns-neg'),
+      () => {},
+    );
+  }, 60000);
+
+  it('Derived<T>::g() -> this->f() emits zero CALLS when no Inner<T> exists in the nested namespace', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const leaks = calls.filter((c) => c.source === 'g' && c.target === 'f');
+    expect(leaks.length).toBe(0);
+  });
+});
+
+describe('C++ two-phase template lookup — dependent-base inline-namespace variant', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'cpp-two-phase-dependent-base-cross-ns-inline'),
+      () => {},
+    );
+  }, 60000);
+
+  it('Derived<T>::g() -> this->f() resolves to v1::Base<T>::f when Base is in an inline namespace (1 edge)', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const resolved = calls.filter((c) => c.source === 'g' && c.target === 'f');
+    expect(resolved.length).toBe(1);
+    expect(resolved[0].targetFilePath).toContain('lib.h');
+  });
+});
+
+describe('C++ two-phase template lookup — dependent-base sibling-namespace suppression', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'cpp-two-phase-dependent-base-cross-ns-sibling-suppress'),
+      () => {},
+    );
+  }, 60000);
+
+  it('Derived<T>::g() -> this->f_a() emits zero CALLS when detail::Inner and public_api::Inner are sibling namespaces (ambiguity suppressed)', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const suppressed = calls.filter((c) => c.source === 'g' && c.target === 'f_a');
+    expect(suppressed.length).toBe(0);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // U3 cross-file namespace variant: Base lives in a different file AND
 // inside a namespace. The fixture also contains a free function with the

--- a/gitnexus/test/integration/resolvers/cpp.test.ts
+++ b/gitnexus/test/integration/resolvers/cpp.test.ts
@@ -2341,6 +2341,23 @@ describe('C++ two-phase template lookup — dependent-base inline-namespace vari
   });
 });
 
+describe('C++ two-phase template lookup — dependent-base deep nesting suppression', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'cpp-two-phase-dependent-base-cross-ns-deep'),
+      () => {},
+    );
+  }, 60000);
+
+  it('Derived<T>::g() -> this->f() emits zero CALLS when Inner is two levels deep (ns.a.b) — one-level cap enforced', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const leaks = calls.filter((c) => c.source === 'g' && c.target === 'f');
+    expect(leaks.length).toBe(0);
+  });
+});
+
 describe('C++ two-phase template lookup — dependent-base sibling-namespace suppression', () => {
   let result: PipelineResult;
 

--- a/gitnexus/test/integration/resolvers/helpers.ts
+++ b/gitnexus/test/integration/resolvers/helpers.ts
@@ -358,6 +358,10 @@ const LEGACY_RESOLVER_PARITY_EXPECTED_FAILURES: Readonly<Record<string, Readonly
     'records a structured suppression reason for ADL blocker lookup',
     'swap(a,b) resolves to data::swap when inner scope has callable swap and outer has variable',
     'record(e) emits zero CALLS when a block-scope function declaration exists',
+    // PR #1634: sibling-namespace dependent-base suppression. The scope-resolver
+    // correctly suppresses when detail::Inner and public_api::Inner share the
+    // same simple name. The legacy DAG picks an arbitrary match.
+    'Derived<T>::g() -> this->f_a() emits zero CALLS when detail::Inner and public_api::Inner are sibling namespaces (ambiguity suppressed)',
   ]),
 };
 

--- a/gitnexus/test/integration/resolvers/helpers.ts
+++ b/gitnexus/test/integration/resolvers/helpers.ts
@@ -362,6 +362,9 @@ const LEGACY_RESOLVER_PARITY_EXPECTED_FAILURES: Readonly<Record<string, Readonly
     // correctly suppresses when detail::Inner and public_api::Inner share the
     // same simple name. The legacy DAG picks an arbitrary match.
     'Derived<T>::g() -> this->f_a() emits zero CALLS when detail::Inner and public_api::Inner are sibling namespaces (ambiguity suppressed)',
+    // PR #1634: deep-nesting suppression. The scope-resolver enforces a
+    // one-level cap on namespace walking. The legacy DAG picks arbitrarily.
+    'Derived<T>::g() -> this->f() emits zero CALLS when Inner is two levels deep (ns.a.b) — one-level cap enforced',
   ]),
 };
 


### PR DESCRIPTION
## Summary

Part of #1564 (LANG-cpp). Fixes  to resolve dependent bases in sibling/nested/inline namespaces by replacing the exact dot-prefix match with a prefix-contains filter capped at one level deeper.

## Change

**`two-phase-lookup.ts:169`** — Replace `candidates.find((c) => c.nsPrefix === classEntry.nsPrefix)` with a `filter` + `length === 1` guard:

- Exact namespace match (preserved existing behavior)
- Prefix-contains, one level deeper: `ns.outer → ns.outer.inner` ✓, `ns → ns.a.b` ✗
- Global-scope deriving classes match any single-segment namespace
- Multiple matches `→` undefined (conservative suppress, false negatives > false positives)

## Fixtures

| Fixture | Expected | Notes |
|---------|----------|-------|
| `pos` — `ns::outer::inner::Inner` | 1 edge | Nested namespace resolution |
| `neg` — no Inner exists | 0 edges | Correct suppression |
| `inline` — `v1::Base` in inline ns | 1 edge | Inline namespace expansion |
| `sibling-suppress` — detail vs public_api | 0 edges | Sibling collision → suppress |

## Testing

```
Default mode:  249/249 passed
Legacy mode:   196 passed, 53 skipped, 0 failed
Pre-commit:    eslint, prettier, typechecking passed
```