### PR TITLE
fix(build): skip build.js when running outside the monorepo (#1795)

### DIFF
--- a/gitnexus/scripts/build.js
+++ b/gitnexus/scripts/build.js
@@ -35,6 +35,22 @@ function getBuildTimeoutMs() {
 
 const BUILD_TIMEOUT_MS = getBuildTimeoutMs();
 
+// Published-package guard: when installed from the npm registry the
+// monorepo sibling `gitnexus-shared` does not exist and `dist/` is
+// already pre-built. Skip the build to avoid a misleading ENOENT
+// crash (#1795).
+if (!fs.existsSync(SHARED_ROOT)) {
+  if (fs.existsSync(DIST)) {
+    console.log('[build] skipping — dist/ already present (published package).');
+    process.exit(0);
+  }
+  console.error(
+    `[build] gitnexus-shared not found at ${SHARED_ROOT} and no dist/ exists.\n` +
+      'Are you running from the monorepo checkout? Run `npm install` from the repo root first.',
+  );
+  process.exit(1);
+}
+
 // ── 1. Build gitnexus-shared ───────────────────────────────────────
 console.log('[build] compiling gitnexus-shared…');
 const tscCmd =


### PR DESCRIPTION
## Summary

- Fixes #1795 — `spawnSync /bin/sh ENOENT` when running `npm install` from a global install directory on Debian 13 (and any non-monorepo context)

`scripts/build.js` (the `prepare` lifecycle script) assumes the monorepo sibling `gitnexus-shared/` exists at `../gitnexus-shared`. When a user runs `npm install --ignore-scripts=false` from within a globally-installed package directory, `prepare` fires and `execSync(tsc, { cwd: nonExistentPath })` crashes with the misleading `spawnSync /bin/sh ENOENT` (Node reports a bad CWD as the shell not being found).

Adds an early guard in `build.js`:
- If `gitnexus-shared/` is absent **and** `dist/` already exists → skip cleanly (published package context, already pre-built)
- If `gitnexus-shared/` is absent **and** `dist/` is missing → exit with a helpful error pointing to the monorepo checkout

## Test plan

- [ ] `node --check gitnexus/scripts/build.js` — syntax valid
- [ ] From the monorepo root: `cd gitnexus && node scripts/build.js` — builds normally (guard does not fire)
- [ ] Simulate published-package context: `mkdir /tmp/gn-test && cp -r gitnexus/scripts gitnexus/dist /tmp/gn-test/ && cd /tmp/gn-test && node scripts/build.js` — prints "skipping" and exits 0
- [ ] Simulate broken install (no dist, no shared): `mkdir /tmp/gn-test2 && cp -r gitnexus/scripts /tmp/gn-test2/ && cd /tmp/gn-test2 && node scripts/build.js` — prints helpful error and exits 1