### PR TITLE
fix(test): use retry cleanup in antigravity e2e to prevent ENOTEMPTY flake

### DIFF
--- a/gitnexus/test/helpers/test-db.ts
+++ b/gitnexus/test/helpers/test-db.ts
@@ -21,6 +21,9 @@ const cleanupBackoffMs = (attempt: number): number => 100 * (attempt + 1);
 
 const shouldSwallowCleanupError = (err: unknown): boolean => {
   const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  // ENOTEMPTY can race on any platform (macOS node-gyp cache, Linux
+  // parallel test teardown) — swallow after retries are exhausted.
+  if (code === 'ENOTEMPTY') return true;
   return process.platform === 'win32' && WINDOWS_NATIVE_LOCK_CODES.has(code ?? '');
 };
 

--- a/gitnexus/test/integration/antigravity-hook-e2e.test.ts
+++ b/gitnexus/test/integration/antigravity-hook-e2e.test.ts
@@ -18,6 +18,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawnSync } from 'child_process';
 import fs from 'fs';
+import fsp from 'fs/promises';
 import path from 'path';
 import { cleanupTempDir, cleanupTempDirSync } from '../helpers/test-db.js';
 import os from 'os';

--- a/gitnexus/test/integration/antigravity-hook-e2e.test.ts
+++ b/gitnexus/test/integration/antigravity-hook-e2e.test.ts
@@ -18,8 +18,8 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawnSync } from 'child_process';
 import fs from 'fs';
-import fsp from 'fs/promises';
 import path from 'path';
+import { cleanupTempDir, cleanupTempDirSync } from '../helpers/test-db.js';
 import os from 'os';
 import { runHook, parseHookOutput } from '../utils/hook-test-helpers.js';
 import { setupCommand } from '../../src/cli/setup.js';
@@ -84,8 +84,8 @@ beforeAll(async () => {
 afterAll(async () => {
   process.env.HOME = originalHome;
   process.env.USERPROFILE = originalUserProfile;
-  if (tempHome) await fsp.rm(tempHome, { recursive: true, force: true });
-  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  if (tempHome) await cleanupTempDir(tempHome);
+  if (tmpDir) cleanupTempDirSync(tmpDir);
 });
 
 describe('antigravity hook adapter e2e', () => {
@@ -402,7 +402,7 @@ describe('antigravity hook adapter e2e', () => {
     });
 
     afterAll(() => {
-      fs.rmSync(cleanupRoot, { recursive: true, force: true });
+      cleanupTempDirSync(cleanupRoot);
     });
 
     it('ignores AfterTool when no .gitnexus exists in cwd or any ancestor', () => {


### PR DESCRIPTION
Replace bare `fsp.rm` / `fs.rmSync` in `antigravity-hook-e2e.test.ts` afterAll with the existing `cleanupTempDir` / `cleanupTempDirSync` helpers from `test/helpers/test-db.ts` which retry with exponential backoff on transient filesystem errors.

Also extend `shouldSwallowCleanupError` to swallow `ENOTEMPTY` on **all platforms** (was Windows-only). The CI failure on macOS was `ENOTEMPTY` on a deeply nested `node-gyp` cache directory inside the temp HOME — a cleanup-time race that retries usually resolve, but the final attempt must not crash the test suite if the race persists.

## Changes

- `antigravity-hook-e2e.test.ts`: import and use `cleanupTempDir`/`cleanupTempDirSync` instead of bare `fsp.rm`/`fs.rmSync`
- `test/helpers/test-db.ts`: swallow `ENOTEMPTY` on all platforms after retry exhaustion

## Test plan

- [x] Existing antigravity e2e tests still pass locally
- [x] The `ENOTEMPTY` error from [CI run](https://github.com/abhigyanpatwari/GitNexus/actions/runs/26451154555/job/77871989280?pr=1831) would be retried then swallowed