### PR TITLE
test(group): fail loud on CI when tree-sitter-kotlin grammar is unavailable

### DIFF
--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -14,6 +14,36 @@ import { HttpRouteExtractor } from '../../../src/core/group/extractors/http-rout
 import { getPluginForFile } from '../../../src/core/group/extractors/http-patterns/index.js';
 import type { RepoHandle } from '../../../src/core/group/types.js';
 
+// ─── CI tripwire: tree-sitter-kotlin grammar must be available ────────
+// The Kotlin Provider suite (PR #1849) and Consumer suite (PR #1855)
+// each guard their `it()` calls behind:
+//
+//   const kotlinAvailable = getPluginForFile('Probe.kt') !== undefined;
+//   const itKotlin = kotlinAvailable ? it : it.skip;
+//
+// This is intentional locally: contributors on platforms where the
+// optional `tree-sitter-kotlin` native binding doesn't build (or
+// haven't installed it) shouldn't be blocked by red Kotlin tests.
+//
+// On CI the same pattern becomes a silent-skip hazard: if the optional
+// dep ever fails to install (npm registry hiccup, build-toolchain
+// drift, ABI bump) all 17+ Kotlin cases would silently skip and CI
+// would still be green — the exact failure mode flagged in Claude's
+// review on PR #1855 (Finding 2). Mirrors the existing tripwire in
+// `test/integration/object-literal-owner-resolution.test.ts`.
+//
+// Module-load throw is intentional: it surfaces as a hard red, not a
+// silent zero-test pass. Contributors running on a platform without
+// the grammar can still iterate locally — only CI is gated.
+if (process.env.CI && getPluginForFile('Probe.kt') === undefined) {
+  throw new Error(
+    'tree-sitter-kotlin grammar is unavailable on CI. ' +
+      'The Kotlin Provider/Consumer test suites in this file would silently skip. ' +
+      'Check `optionalDependencies` in gitnexus/package.json and the runner build toolchain. ' +
+      'Local note: this tripwire only fires when CI=true; local runs without the grammar still skip cleanly.',
+  );
+}
+
 describe('HttpRouteExtractor', () => {
   let tmpDir: string;
   let extractor: HttpRouteExtractor;


### PR DESCRIPTION
## Summary

Follow-up to #1855, addressing the deferred Finding 2 from Claude's review (https://github.com/abhigyanpatwari/GitNexus/pull/1855#issuecomment-4552615253).

The Kotlin Provider tests (#1849) and Consumer tests (#1855) both gate their `it()` calls behind:

```ts
const kotlinAvailable = getPluginForFile('Probe.kt') !== undefined;
const itKotlin = kotlinAvailable ? it : it.skip;
```

Locally this is intentional — contributors on platforms where the optional `tree-sitter-kotlin` native binding can't build (or who haven't installed it) shouldn't be blocked by red Kotlin tests.

On CI it's a silent-skip hazard: if the optional dep ever fails to install (npm registry hiccup, build-toolchain drift on a runner image update, ABI bump in `tree-sitter-kotlin`) all 17+ Kotlin cases would silently skip and CI would still pass green.

## Fix

A module-load tripwire that throws only when **both** conditions hold:

- `process.env.CI` is set
- `getPluginForFile('Probe.kt')` returns `undefined`

Mirrors the existing CI tripwire pattern at [`test/integration/object-literal-owner-resolution.test.ts:55-66`](https://github.com/abhigyanpatwari/GitNexus/blob/main/gitnexus/test/integration/object-literal-owner-resolution.test.ts#L55-L66), which guards against silent skip on missing `dist/parse-worker.js`.

The error message states what's missing, what would otherwise happen (silent skip of Provider + Consumer), where to look (`optionalDependencies` + runner toolchain), and explicitly reassures contributors that local runs are unaffected.

## Coverage

This single tripwire protects **all** Kotlin tests in `http-route-extractor.test.ts`:

- 11 `itKotlin` cases (Provider — #1849)
- 6 `itKotlinConsumer` cases (Consumer — #1855)
- Any future Kotlin tests added under the same gating pattern

## Reverse-validated four states

| Scenario | Behavior |
|---|---|
| local + grammar present | 60 / 60 pass (unchanged) |
| local + grammar absent | 43 pass + 17 skip (unchanged) |
| `CI=true` + grammar present | 60 / 60 pass (unchanged) |
| **`CI=true` + grammar ABSENT** | **tripwire throws with clear error message** (was silently green; now hard red) |

The "grammar absent" cases were exercised locally by temporarily commenting out `Kotlin = _require('tree-sitter-kotlin')` in `kotlin.ts` and running the suite under both env settings.

## Local validation

- `http-route-extractor.test.ts` — 60 / 60 ✅
- `test/unit/group` — 540 / 540 ✅
- `npm run format:check` — clean ✅
