### PR TITLE
feat: add Objective-C ingestion support (phase 1)

### DIFF
--- a/gitnexus-shared/src/language-detection.ts
+++ b/gitnexus-shared/src/language-detection.ts
@@ -43,6 +43,7 @@ const EXTENSION_MAP: Record<SupportedLanguages, readonly string[]> = {
   [SupportedLanguages.Dart]: ['.dart'],
   [SupportedLanguages.Vue]: ['.vue'],
   [SupportedLanguages.Cobol]: ['.cbl', '.cob', '.cpy', '.cobol'],
+  [SupportedLanguages.ObjectiveC]: ['.m', '.mm'],
 } satisfies Record<SupportedLanguages, readonly string[]>; // Ensure exhaustiveness
 
 /** Pre-built reverse lookup: extension → language (built once at module load). */
@@ -111,6 +112,7 @@ const SYNTAX_MAP: Record<SupportedLanguages, string> = {
   [SupportedLanguages.Dart]: 'dart',
   [SupportedLanguages.Vue]: 'typescript',
   [SupportedLanguages.Cobol]: 'cobol',
+  [SupportedLanguages.ObjectiveC]: 'objc',
 } satisfies Record<SupportedLanguages, string>; // Ensure exhaustiveness
 
 /** Non-code file extensions → Prism-compatible syntax identifiers */

--- a/gitnexus-shared/src/languages.ts
+++ b/gitnexus-shared/src/languages.ts
@@ -22,4 +22,6 @@ export enum SupportedLanguages {
   Vue = 'vue',
   /** Standalone regex processor — no tree-sitter, no LanguageProvider. */
   Cobol = 'cobol',
+  /** Objective-C: uses tree-sitter-objc for .m/.mm implementation files. */
+  ObjectiveC = 'objectivec',
 }

--- a/gitnexus-shared/src/scope-resolution/language-classification.ts
+++ b/gitnexus-shared/src/scope-resolution/language-classification.ts
@@ -39,6 +39,7 @@ export const LanguageClassifications: Readonly<Record<SupportedLanguages, Langua
     [SupportedLanguages.Kotlin]: 'production',
     [SupportedLanguages.Swift]: 'production',
     [SupportedLanguages.Dart]: 'production',
+    [SupportedLanguages.ObjectiveC]: 'experimental',
     [SupportedLanguages.Vue]: 'experimental',
     [SupportedLanguages.Cobol]: 'experimental',
   };

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -39,7 +39,7 @@
         "tree-sitter-go": "^0.23.0",
         "tree-sitter-java": "^0.23.5",
         "tree-sitter-javascript": "^0.23.0",
-        "tree-sitter-objc": "^2.1.0",
+        "tree-sitter-objc": "^3.0.2",
         "tree-sitter-php": "^0.23.0",
         "tree-sitter-python": "0.23.4",
         "tree-sitter-ruby": "^0.23.1",
@@ -59,6 +59,7 @@
         "@types/uuid": "^11.0.0",
         "@vitest/coverage-v8": "^4.0.18",
         "gitnexus-shared": "file:../gitnexus-shared",
+        "graphology-types": "^0.24.8",
         "tsx": "^4.0.0",
         "typescript": "^5.4.5",
         "vitest": "^4.0.18"
@@ -3036,8 +3037,8 @@
       "version": "0.24.8",
       "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
       "integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
-      "license": "MIT",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/graphology-utils": {
       "version": "2.5.2",
@@ -3769,12 +3770,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/nan": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
-      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4943,13 +4938,42 @@
       "optional": true
     },
     "node_modules/tree-sitter-objc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-objc/-/tree-sitter-objc-2.1.0.tgz",
-      "integrity": "sha512-qAeeaZS5sYSB8JYoKpE8GbvtUQFZqDckegU4ntVtpdQPLffjF/6ANgzqbXPWl9YaK2WBZtBFeRF7OPvh7nIErA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-objc/-/tree-sitter-objc-3.0.2.tgz",
+      "integrity": "sha512-Hs0ohmx1u5M+0K7efoW+dv/corhBsfjftfIYLtp7dSGeJ+Zj4c33tDIboBYLs6qijRlz6wtHFxa0YX+FibLulA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "nan": "^2.17.0"
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4",
+        "tree-sitter-c": "^0.23.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-objc/node_modules/tree-sitter-c": {
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-c/-/tree-sitter-c-0.23.6.tgz",
+      "integrity": "sha512-0dxXKznVyUA0s6PjNolJNs2yF87O5aL538A/eR6njA5oqX3C3vH4vnx3QdOKwuUdpKEcFdHuiDpRKLLCA/tjvQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
       }
     },
     "node_modules/tree-sitter-php": {

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -39,6 +39,7 @@
         "tree-sitter-go": "^0.23.0",
         "tree-sitter-java": "^0.23.5",
         "tree-sitter-javascript": "^0.23.0",
+        "tree-sitter-objc": "^2.1.0",
         "tree-sitter-php": "^0.23.0",
         "tree-sitter-python": "0.23.4",
         "tree-sitter-ruby": "^0.23.1",
@@ -3770,6 +3771,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nan": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -4934,6 +4941,16 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/tree-sitter-objc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-objc/-/tree-sitter-objc-2.1.0.tgz",
+      "integrity": "sha512-qAeeaZS5sYSB8JYoKpE8GbvtUQFZqDckegU4ntVtpdQPLffjF/6ANgzqbXPWl9YaK2WBZtBFeRF7OPvh7nIErA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.17.0"
+      }
     },
     "node_modules/tree-sitter-php": {
       "version": "0.23.12",

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -84,7 +84,7 @@
     "tree-sitter-go": "^0.23.0",
     "tree-sitter-java": "^0.23.5",
     "tree-sitter-javascript": "^0.23.0",
-    "tree-sitter-objc": "^2.1.0",
+    "tree-sitter-objc": "^3.0.2",
     "tree-sitter-php": "^0.23.0",
     "tree-sitter-python": "0.23.4",
     "tree-sitter-ruby": "^0.23.1",
@@ -106,6 +106,7 @@
     "@types/uuid": "^11.0.0",
     "@vitest/coverage-v8": "^4.0.18",
     "gitnexus-shared": "file:../gitnexus-shared",
+    "graphology-types": "^0.24.8",
     "tsx": "^4.0.0",
     "typescript": "^5.4.5",
     "vitest": "^4.0.18"

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -84,6 +84,7 @@
     "tree-sitter-go": "^0.23.0",
     "tree-sitter-java": "^0.23.5",
     "tree-sitter-javascript": "^0.23.0",
+    "tree-sitter-objc": "^2.1.0",
     "tree-sitter-php": "^0.23.0",
     "tree-sitter-python": "0.23.4",
     "tree-sitter-ruby": "^0.23.1",

--- a/gitnexus/src/core/ingestion/languages/index.ts
+++ b/gitnexus/src/core/ingestion/languages/index.ts
@@ -25,6 +25,7 @@ import { swiftProvider } from './swift.js';
 import { dartProvider } from './dart.js';
 import { vueProvider } from './vue.js';
 import { cobolProvider } from './cobol.js';
+import { objcProvider } from './objc.js';
 
 export const providers = {
   [SupportedLanguages.JavaScript]: javascriptProvider,
@@ -43,6 +44,7 @@ export const providers = {
   [SupportedLanguages.Dart]: dartProvider,
   [SupportedLanguages.Vue]: vueProvider,
   [SupportedLanguages.Cobol]: cobolProvider,
+  [SupportedLanguages.ObjectiveC]: objcProvider,
 } satisfies Record<SupportedLanguages, LanguageProvider>;
 
 /** Get provider by language enum (always succeeds for SupportedLanguages). */

--- a/gitnexus/src/core/ingestion/languages/objc.ts
+++ b/gitnexus/src/core/ingestion/languages/objc.ts
@@ -1,0 +1,106 @@
+/**
+ * Objective-C Language Provider
+ *
+ * Assembles all Objective-C-specific ingestion capabilities into a single
+ * LanguageProvider, following the Strategy pattern used by the pipeline.
+ *
+ * Key Objective-C traits:
+ *   - importSemantics: 'wildcard' (ObjC imports entire modules via #import)
+ *   - heritageDefaultEdge: 'EXTENDS' (single class inheritance, multiple protocol adoption)
+ *   - ObjC uses the same type config and export checker as C++ since they share
+ *     similar declaration patterns for functions and global state.
+ *   - message_expression nodes are captured as CALLS (e.g., [self doSomething])
+ *   - class_interface / class_implementation / protocol_declaration captured as definitions.
+ */
+
+import { SupportedLanguages } from 'gitnexus-shared';
+import { defineLanguage } from '../language-provider.js';
+import { typeConfig as cCppConfig } from '../type-extractors/c-cpp.js';
+import { cCppExportChecker } from '../export-detection.js';
+import { createImportResolver } from '../import-resolvers/resolver-factory.js';
+import { createStandardStrategy } from '../import-resolvers/standard.js';
+import { OBJ_C_QUERIES } from '../tree-sitter-queries.js';
+import { createFieldExtractor } from '../field-extractors/generic.js';
+import { cConfig as cFieldConfig } from '../field-extractors/configs/c-cpp.js';
+import { createMethodExtractor } from '../method-extractors/generic.js';
+import { cMethodConfig } from '../method-extractors/configs/c-cpp.js';
+import { createCallExtractor } from '../call-extractors/generic.js';
+import { cCallConfig } from '../call-extractors/configs/c-cpp.js';
+import { createHeritageExtractor } from '../heritage-extractors/generic.js';
+
+const OBJC_BUILT_INS: ReadonlySet<string> = new Set([
+  'NSLog',
+  'NSLogv',
+  'dispatch_async',
+  'dispatch_sync',
+  'dispatch_once',
+  'dispatch_after',
+  'dispatch_group_async',
+  'objc_getClass',
+  'objc_getMetaClass',
+  'objc_msgSend',
+  'objc_msgSendSuper',
+  'objc_msgSend_stret',
+  'objc_msgSendSuper_stret',
+  'sel_registerName',
+  'protocol_getName',
+  'class_getName',
+  'class_getSuperclass',
+  'object_getClass',
+  'object_getInstanceSize',
+  'class_addMethod',
+  'class_replaceMethod',
+  'class_getInstanceMethod',
+  'class_getClassMethod',
+  'method_exchangeImplementations',
+  'imp_implementationWithBlock',
+  'imp_getBlock',
+  'imp_removeBlock',
+  'objc_setAssociatedObject',
+  'objc_getAssociatedObject',
+  'objc_removeAssociatedObjects',
+  'class_copyPropertyList',
+  'class_copyMethodList',
+  'class_copyIvarList',
+  'property_getName',
+  'ivar_getName',
+  'ivar_getTypeEncoding',
+  'method_getName',
+  'method_getTypeEncoding',
+  'method_getReturnType',
+  'method_getNumberOfArguments',
+  'method_getArgumentType',
+  'class_isMetaClass',
+  'object_isClass',
+  'class_respondsToSelector',
+  'instancesRespondToSelector',
+  'conformsToProtocol',
+  'CFRetain',
+  'CFRelease',
+  'CFAutorelease',
+]);
+
+const stripObjcNullabilityMacros = (sourceText: string): string =>
+  sourceText
+    .replace(/NS_ASSUME_NONNULL_BEGIN/g, (m) => ' '.repeat(m.length))
+    .replace(/NS_ASSUME_NONNULL_END/g, (m) => ' '.repeat(m.length));
+
+export const objcProvider = defineLanguage({
+  id: SupportedLanguages.ObjectiveC,
+  extensions: ['.m', '.mm'],
+  treeSitterQueries: OBJ_C_QUERIES,
+  preprocessSource: stripObjcNullabilityMacros,
+  typeConfig: cCppConfig,
+  exportChecker: cCppExportChecker,
+  importResolver: createImportResolver({
+    language: SupportedLanguages.ObjectiveC,
+    strategies: [createStandardStrategy(SupportedLanguages.C)],
+  }),
+  importSemantics: 'wildcard-transitive',
+  heritageDefaultEdge: 'EXTENDS',
+  callExtractor: createCallExtractor(cCallConfig),
+  fieldExtractor: createFieldExtractor(cFieldConfig),
+  methodExtractor: createMethodExtractor(cMethodConfig),
+  heritageExtractor: createHeritageExtractor(SupportedLanguages.ObjectiveC),
+  builtInNames: OBJC_BUILT_INS,
+});

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -1242,6 +1242,82 @@ export const KOTLIN_QUERIES = `
 
 `;
 
+// Objective-C queries - works with tree-sitter-objc
+export const OBJ_C_QUERIES = `
+; Class declarations - use anchor to capture only the first identifier (class name)
+; . anchor ensures we get the FIRST identifier (class name), not superclass or others
+(class_interface
+  .
+  (identifier) @name) @definition.class
+
+; Class implementations - @implementation MyClass (methods only, no heritage)
+(class_implementation
+  .
+  (identifier) @name) @definition.class
+
+; Protocol declarations - anchor to first identifier (protocol name)
+(protocol_declaration
+  .
+  (identifier) @name) @definition.interface
+
+; Categories - class extension (anonymous category = extension)
+(class_interface
+  .
+  (identifier) @name
+  category: (identifier) @category) @definition.class
+
+; Heritage - superclass (e.g., @interface Foo : Bar)
+; . matches the FIRST identifier (Foo = class name); then explicit superclass identifier
+(class_interface
+  .
+  (identifier) @heritage.class
+  (identifier) @heritage.extends) @heritage
+
+; Heritage - protocol adoptions (e.g., @interface Foo <Proto1, Proto2>)
+; . anchors to class name identifier; parameterized_arguments follows as sibling
+(class_interface
+  .
+  (identifier) @heritage.class
+  (parameterized_arguments
+    (type_name
+      (type_identifier) @heritage.implements))) @heritage.impl
+
+; Method definitions - capture only the first identifier after +/- and method_type
+; Use ["+" "-"] to match both class (+) and instance (-) methods
+(method_declaration
+  ["+" "-"]
+  (method_type)
+  (identifier) @name) @definition.method
+
+; Calls - ObjC message expressions (e.g., [self doSomething], [calc add:5 to:3])
+; Use method: field to capture the method selector name(s)
+(message_expression
+  method: (identifier) @call.name) @call
+
+; Calls - C-style function calls (e.g., NSLog(...))
+(call_expression
+  (identifier) @call.name) @call
+
+; Property declarations (e.g., @property (nonatomic, strong) NSString *name)
+(property_declaration
+  (struct_declaration
+    (_)
+    (struct_declarator
+      (pointer_declarator
+        declarator: (identifier) @name)))) @definition.property
+
+; Instance variable declarations inside @interface { } block
+(instance_variable
+  (struct_declaration
+    (_)
+    (struct_declarator
+      (pointer_declarator
+        declarator: (identifier) @name)))) @definition.property
+
+; Imports - #import "path" or #import <path> (preproc_include is used by tree-sitter-objc for #import)
+(preproc_include path: (_) @import.source) @import
+`;
+
 // Swift queries - works with tree-sitter-swift
 export const SWIFT_QUERIES = `
 ; Classes
@@ -1543,4 +1619,5 @@ export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.Dart]: DART_QUERIES,
   [SupportedLanguages.Vue]: TYPESCRIPT_QUERIES, // Vue <script> blocks are parsed as TypeScript
   [SupportedLanguages.Cobol]: '', // Standalone regex processor — no tree-sitter queries
+  [SupportedLanguages.ObjectiveC]: OBJ_C_QUERIES,
 };

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -12,6 +12,7 @@ import Go from 'tree-sitter-go';
 import Rust from 'tree-sitter-rust';
 import PHP from 'tree-sitter-php';
 import Ruby from 'tree-sitter-ruby';
+import ObjectiveC from 'tree-sitter-objc';
 import { createRequire } from 'node:module';
 import { SupportedLanguages } from 'gitnexus-shared';
 import { getProvider } from '../languages/index.js';
@@ -319,6 +320,7 @@ const languageMap: Record<string, TreeSitterLanguage> = {
   ...(Kotlin ? { [SupportedLanguages.Kotlin]: Kotlin } : {}),
   [SupportedLanguages.PHP]: PHP.php_only,
   [SupportedLanguages.Ruby]: Ruby,
+  [SupportedLanguages.ObjectiveC]: ObjectiveC,
   [SupportedLanguages.Vue]: TypeScript.typescript,
   ...(Dart ? { [SupportedLanguages.Dart]: Dart } : {}),
   ...(Swift ? { [SupportedLanguages.Swift]: Swift } : {}),

--- a/gitnexus/src/core/tree-sitter/parser-loader.ts
+++ b/gitnexus/src/core/tree-sitter/parser-loader.ts
@@ -111,6 +111,12 @@ const SOURCES: Record<string, GrammarSource> = {
     unavailableNote:
       'Vue parsing piggybacks on `tree-sitter-typescript`. Check the install and native binding.',
   },
+  [SupportedLanguages.ObjectiveC]: {
+    load: () => _require('tree-sitter-objc'),
+    unavailableNote:
+      'Objective-C parsing requires `tree-sitter-objc`. ' +
+      'Check that the package and its native binding installed cleanly (`npm ci`).',
+  },
 
   // tree-sitter-c is a required dependency, but its native binding has
   // historically been ABI-incompatible with the bundled tree-sitter@0.21.1

--- a/gitnexus/test/fixtures/sample-code/simple.m
+++ b/gitnexus/test/fixtures/sample-code/simple.m
@@ -1,0 +1,34 @@
+#import <Foundation/Foundation.h>
+@interface Calculator : NSObject
+@property (nonatomic, strong) NSString *name;
+- (void)reset;
+- (NSInteger)add:(NSInteger)a to:(NSInteger)b;
+- (NSInteger)multiply:(NSInteger)a with:(NSInteger)b;
++ (instancetype)sharedCalculator;
+@end
+
+@implementation Calculator
+- (void)reset {
+    NSLog(@"reset");
+}
+
+- (NSInteger)add:(NSInteger)a to:(NSInteger)b {
+    return a + b;
+}
+
+- (NSInteger)multiply:(NSInteger)a with:(NSInteger)b {
+    return a * b;
+}
+
++ (instancetype)sharedCalculator {
+    Calculator *calc = [Calculator alloc];
+    return [calc init];
+}
+@end
+
+void runCalculatorSample(void) {
+    Calculator *calc = [Calculator sharedCalculator];
+    [calc reset];
+    [calc add:5 to:3];
+    [calc multiply:2 with:4];
+}

--- a/gitnexus/test/integration/tree-sitter-languages.test.ts
+++ b/gitnexus/test/integration/tree-sitter-languages.test.ts
@@ -378,6 +378,76 @@ describe('Tree-sitter multi-language parsing', () => {
     });
   });
 
+  describe('Objective-C', () => {
+    it('parses class, method declarations if tree-sitter-objc is available', async () => {
+      try {
+        await loadLanguage(SupportedLanguages.ObjectiveC, 'simple.m');
+      } catch {
+        // tree-sitter-objc not installed — skip
+        return;
+      }
+
+      const content = readFixture('simple.m');
+      const provider = getProvider(SupportedLanguages.ObjectiveC);
+      const { matches } = parseAndQuery(parser, content, provider.treeSitterQueries);
+      const defs = extractDefinitions(matches);
+
+      expect(defs.length).toBeGreaterThan(0);
+      const names = defs.map((d) => d.name);
+      // Class names
+      expect(names).toContain('Calculator');
+      // Method names (keyword selectors captured as separate identifiers: add, to, multiply, with)
+      expect(names).toContain('reset');
+      expect(names).toContain('add');
+      expect(names).toContain('to');
+      expect(names).toContain('multiply');
+      expect(names).toContain('with');
+      expect(names).toContain('sharedCalculator');
+    });
+
+    it('captures class interface and implementation', async () => {
+      try {
+        await loadLanguage(SupportedLanguages.ObjectiveC, 'simple.m');
+      } catch {
+        return;
+      }
+
+      const content = readFixture('simple.m');
+      const provider = getProvider(SupportedLanguages.ObjectiveC);
+      const { matches } = parseAndQuery(parser, content, provider.treeSitterQueries);
+      const defs = extractDefinitions(matches);
+      const defTypes = defs.map((d) => d.type);
+      expect(defTypes).toContain('definition.class');
+    });
+
+    it('captures ObjC message expressions as calls', async () => {
+      try {
+        await loadLanguage(SupportedLanguages.ObjectiveC, 'simple.m');
+      } catch {
+        return;
+      }
+
+      const content = readFixture('simple.m');
+      const provider = getProvider(SupportedLanguages.ObjectiveC);
+      const { matches } = parseAndQuery(parser, content, provider.treeSitterQueries);
+
+      const calls: string[] = [];
+      for (const match of matches) {
+        for (const capture of match.captures) {
+          if (capture.name === 'call.name') calls.push(capture.node.text);
+        }
+      }
+      // ObjC message calls capture method names (selectors), not receivers
+      // [calc reset] -> reset, [calc add:5 to:3] -> add, to, [Calculator sharedCalculator] -> sharedCalculator
+      // C function calls like NSLog() are also captured
+      expect(calls).toContain('reset');
+      expect(calls).toContain('sharedCalculator');
+      expect(calls).toContain('NSLog');
+      expect(calls).toContain('alloc');
+      expect(calls).toContain('init');
+    });
+  });
+
   describe('Swift', () => {
     it('parses class, struct, protocol, and function if tree-sitter-swift is available', async () => {
       try {

--- a/gitnexus/test/integration/worker-pool.test.ts
+++ b/gitnexus/test/integration/worker-pool.test.ts
@@ -135,6 +135,24 @@ describe('worker pool integration', () => {
     expect(names).toContain('validateInput');
   });
 
+  it.skipIf(!hasDistWorker)('parses Objective-C file through worker', async () => {
+    const workerUrl = pathToFileURL(DIST_WORKER) as URL;
+    pool = createWorkerPool(workerUrl, 1);
+
+    const fixtureFile = path.resolve(__dirname, '..', 'fixtures', 'sample-code', 'simple.m');
+    const content = fs.readFileSync(fixtureFile, 'utf-8');
+
+    const results = await pool.dispatch<any, any>([{ path: 'sample-code/simple.m', content }]);
+
+    expect(results).toHaveLength(1);
+    const result = results[0];
+    expect(result.fileCount).toBe(1);
+
+    const names = result.nodes.map((n: any) => n.properties.name);
+    expect(names).toContain('Calculator');
+    expect(names).toContain('sharedCalculator');
+  });
+
   it.skipIf(!hasDistWorker)('parses multiple files across workers', async () => {
     const workerUrl = pathToFileURL(DIST_WORKER) as URL;
     pool = createWorkerPool(workerUrl, 2);


### PR DESCRIPTION
## Summary
- add Objective-C language support to ingestion pipeline (provider + parser wiring)
- add Objective-C tree-sitter queries and fixture coverage
- add integration tests for Objective-C parsing/definitions/calls
- extend shared language detection/types for Objective-C

## Implementation details
- new provider: `gitnexus/src/core/ingestion/languages/objc.ts`
  - language id: `SupportedLanguages.ObjectiveC`
  - extensions: `.m`, `.mm`
  - import semantics: wildcard-transitive
  - built-in filtering for common ObjC/runtime symbols
  - preprocess nullability macros (`NS_ASSUME_NONNULL_BEGIN/END`) to preserve parser stability
- parser registration: `tree-sitter-objc` wired in `parser-loader.ts`
- queries: Objective-C captures in `tree-sitter-queries.ts`
- tests:
  - fixture: `test/fixtures/sample-code/simple.m`
  - integration: Objective-C cases in `test/integration/tree-sitter-languages.test.ts`

## Dependency note
- use `tree-sitter-objc@^2.1.0`
- reason: current repo uses `tree-sitter@0.21.x`; `tree-sitter-objc@3.x` pulls peerOptional `tree-sitter@^0.22.1`, causing install conflict in this branch setup

## Validation
- full integration suite passed locally after merge/conflict resolution:
  - Test Files: 91 passed, 5 skipped
  - Tests: 3049 passed, 133 skipped

## Follow-ups (separate phase)
- Objective-C++ specific semantics and query refinements
- broader Apple framework/runtime heuristics for ObjC projects


## Incremental update

Additional follow-up has now been pushed on branch `feat/objcxx-p2-02-header-classification`:

- commit: `f3ad5c21`
- title: `fix(objcxx): honor guarded ObjC and C++ header signals`

What this follow-up fixes:
- content-aware `.h/.pch` classification now inspects compatibility-guarded branches
- `__OBJC__` sections contribute Objective-C signals
- `__cplusplus` sections contribute C++ signals
- guarded diagnostics were added for exact test assertions:
  - `objcGuardedSignals`
  - `cppGuardedSignals`

Why it matters:
- Apple-style compatibility headers often hide ObjC or C++ declarations behind preprocessor guards
- without scanning those guarded regions, mixed headers could be routed through the wrong language path during ingestion
- this preserves Objective-C routing for guarded ObjC declarations and correctly classifies guarded C/C++ compatibility headers

Validation:
- `node gitnexus/scripts/build.js`
- `cd gitnexus && npx vitest run test/unit/ingestion-utils.test.ts test/unit/sequential-language-availability.test.ts`
- result: **126 tests passed**
