### PR TITLE
fix(group): Node gRPC loadPackageDefinition gate matches every member call (tree-sitter 0.21.1 alternation hazard)

### DIFF
--- a/gitnexus/src/core/group/extractors/grpc-patterns/node.ts
+++ b/gitnexus/src/core/group/extractors/grpc-patterns/node.ts
@@ -86,16 +86,33 @@ const NEW_QUALIFIED_CTOR_SPEC: PatternSpec<Record<string, never>> = {
 // proto loader). Matches either a bare call or an `obj.loadPackageDefinition(...)`
 // call. Plugin gates the qualified-constructor consumer on this —
 // structural check avoids materializing `tree.rootNode.text` for every file.
-const LOAD_PACKAGE_DEFINITION_SPEC: PatternSpec<Record<string, never>> = {
-  meta: {},
-  query: `
-    (call_expression
-      function: [
-        (identifier) @fn (#eq? @fn "loadPackageDefinition")
-        (member_expression property: (property_identifier) @fn (#eq? @fn "loadPackageDefinition"))
-      ])
-  `,
-};
+//
+// These are TWO separate specs, NOT one `function: [ (identifier) ... (member_expression) ... ]`
+// alternation. Under the pinned tree-sitter@0.21.1 binding a top-level alternation
+// whose branches reuse the same capture name (`@fn`) collapses to one pattern with
+// a shared predicate bucket; the second branch's `@fn` is left unbound and its
+// `#eq?` is never enforced, so the member-expression branch would match EVERY
+// `obj.method(...)` call (e.g. `console.log(...)`) — turning this gate always-on
+// and emitting spurious qualified-constructor consumers. Two specs compile to two
+// queries with independent predicate buckets; `runCompiledPatterns` concatenates
+// their matches, so the `.length > 0` gate still means "either form is present".
+const LOAD_PACKAGE_DEFINITION_SPECS: PatternSpec<Record<string, never>>[] = [
+  {
+    meta: {},
+    query: `
+      (call_expression
+        function: (identifier) @fn (#eq? @fn "loadPackageDefinition"))
+    `,
+  },
+  {
+    meta: {},
+    query: `
+      (call_expression
+        function: (member_expression
+          property: (property_identifier) @fn (#eq? @fn "loadPackageDefinition")))
+    `,
+  },
+];
 
 interface NodeGrpcPatternBundle {
   grpcMethod: CompiledPatterns<Record<string, never>>;
@@ -107,11 +124,14 @@ interface NodeGrpcPatternBundle {
 }
 
 function compileBundle(language: unknown, name: string): NodeGrpcPatternBundle {
-  const mk = (spec: PatternSpec<Record<string, never>>, suffix: string) =>
+  const mk = (
+    spec: PatternSpec<Record<string, never>> | PatternSpec<Record<string, never>>[],
+    suffix: string,
+  ) =>
     compilePatterns({
       name: `${name}-${suffix}`,
       language,
-      patterns: [spec],
+      patterns: Array.isArray(spec) ? spec : [spec],
     } satisfies LanguagePatterns<Record<string, never>>);
   return {
     grpcMethod: mk(GRPC_METHOD_SPEC, 'grpc-method'),
@@ -119,7 +139,7 @@ function compileBundle(language: unknown, name: string): NodeGrpcPatternBundle {
     getService: mk(GET_SERVICE_SPEC, 'get-service'),
     newSimpleCtor: mk(NEW_SIMPLE_CTOR_SPEC, 'new-simple-ctor'),
     newQualifiedCtor: mk(NEW_QUALIFIED_CTOR_SPEC, 'new-qualified-ctor'),
-    loadPackageDefinition: mk(LOAD_PACKAGE_DEFINITION_SPEC, 'load-package-definition'),
+    loadPackageDefinition: mk(LOAD_PACKAGE_DEFINITION_SPECS, 'load-package-definition'),
   };
 }
 

--- a/gitnexus/test/unit/group/grpc-extractor.test.ts
+++ b/gitnexus/test/unit/group/grpc-extractor.test.ts
@@ -1135,6 +1135,37 @@ export const authClient = new authProto.auth.v1.AuthService(
       expect(consumers[0].contractId).toBe('grpc::auth.v1.AuthService/*');
     });
 
+    it('test_extract_ts_qualified_ctor_without_loadPackageDefinition_is_ignored', async () => {
+      // Regression: an unrelated `obj.method(...)` member call must not trip the
+      // loadPackageDefinition gate. With no loadPackageDefinition call present, a
+      // qualified `new pkg...Service(...)` constructor must NOT become a consumer.
+      // Pre-fix, the gate's shared-capture `function: [...]` alternation matched
+      // every member call, so this spuriously emitted an AuthService consumer.
+      writeFile(
+        'proto/auth.proto',
+        `syntax = "proto3";
+package auth.v1;
+service AuthService {
+  rpc Login (LoginRequest) returns (LoginResponse);
+}`,
+      );
+      writeFile(
+        'src/auth.client.ts',
+        `import * as grpc from '@grpc/grpc-js';
+
+logger.info('starting up');
+export const authClient = new authProto.auth.v1.AuthService(
+  'localhost:50051',
+  grpc.credentials.createInsecure(),
+);`,
+      );
+
+      const contracts = await extractor.extract(null, tmpDir, makeRepo(tmpDir));
+      const consumers = contracts.filter((c) => c.role === 'consumer');
+
+      expect(consumers).toHaveLength(0);
+    });
+
     it('test_extract_ts_duplicate_consumer_patterns_in_one_file_dedupes_deterministically', async () => {
       writeFile(
         'proto/auth.proto',


### PR DESCRIPTION
## Problem

`LOAD_PACKAGE_DEFINITION_SPEC` (`grpc-patterns/node.ts`) detected the `loadPackageDefinition` gRPC proto-loader via a single query whose `function:` field is a **top-level alternation** sharing one capture name:

```
(call_expression function: [
  (identifier) @fn (#eq? @fn "loadPackageDefinition")
  (member_expression property: (property_identifier) @fn (#eq? @fn "loadPackageDefinition"))
])
```

Under the repo's pinned **`tree-sitter@0.21.1`** Node binding, a top-level `[...]` alternation compiles to **one** pattern whose text predicates share a single bucket keyed by capture name. The two branches reuse `@fn`, so the `member_expression` branch's `@fn` is left unbound and its `#eq?` is **never enforced** — that branch matches **every** `obj.method(...)` call (`console.log(...)`, `logger.info(...)`, …).

The result feeds `usesLoadPackage = runCompiledPatterns(bundle.loadPackageDefinition, tree).length > 0`, which gates the qualified-constructor consumer. Because virtually every TS/JS file contains *some* member call, the gate was **effectively always-open**, and `new pkg.<Capitalized>Service(...)` was emitted as a **spurious gRPC consumer** — the exact false positive the gate exists to prevent.

### Empirical confirmation (native `query.matches()`, matching `runCompiledPatterns`)

| Input | before (single alternation) | after (two specs) |
|---|---|---|
| `grpc.loadPackageDefinition(d)` (genuine) | 1 | 1 |
| `logger.info('x')` | **1** ❌ | 0 ✅ |
| `obj.doStuff(1)` | **1** ❌ | 0 ✅ |
| `notIt(y)` (bare, unrelated) | 0 | 0 |

## Fix

Split the spec into **two single-branch `PatternSpec`s**. Each compiles to its own `Parser.Query` with an independent predicate bucket, where the `#eq?` is enforced correctly. `runCompiledPatterns` concatenates matches across specs, so the `.length > 0` gate semantics are unchanged ("either form present"). `mk` now accepts a spec or a spec array.

## Tests

Adds `test_extract_ts_qualified_ctor_without_loadPackageDefinition_is_ignored` — a negative regression test **verified to fail on the pre-fix code (`origin/main`) and pass with the fix**: a file with no `loadPackageDefinition` but an unrelated member call + `new authProto.auth.v1.AuthService(...)` must emit no consumer.

- `test/unit/group/grpc-extractor.test.ts` — **65/65** (64 + 1 new) ✅
- `npx tsc --noEmit` ✅ · `npx prettier --check` ✅ · pre-commit hook (eslint + prettier + typecheck) ✅

## Context / scope

Found via an audit of all group-extractor tree-sitter queries for this 0.21.1 alternation hazard (prompted by the same class of issue surfaced while reviewing PR #1904). **The other 10 query files audited are clean** — they use either single patterns, predicate-free alternations, inner leaf alternations (`[(string) (template_string)] @x`), or separate `{meta, query}` specs. This PR fixes the one confirmed instance and is independent of #1904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
