### PR TITLE
fix(c/cpp): capture typedef enum and anonymous struct declarations

### DIFF
--- a/gitnexus/src/core/ingestion/languages/c/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/c/captures.ts
@@ -27,9 +27,9 @@ export function emitCScopeCaptures(
   const rawMatches = getCScopeQuery().matches(tree.rootNode);
   const out: CaptureMatch[] = [];
 
-  // Track ranges where typedef-struct/union was captured as @declaration.struct/union
-  // so we can suppress the duplicate @declaration.typedef match at the same range.
-  const structTypedefRanges = new Set<string>();
+  // Track ranges where typedef-struct/union/enum was captured as its concrete
+  // type so we can suppress the duplicate @declaration.typedef match.
+  const concreteTypedefRanges = new Set<string>();
 
   for (const m of rawMatches) {
     const grouped: Record<string, Capture> = {};
@@ -53,19 +53,22 @@ export function emitCScopeCaptures(
       }
     }
 
-    // Track typedef-struct ranges to suppress duplicate typedef declarations
-    const structAnchor = grouped['@declaration.struct'] ?? grouped['@declaration.union'];
-    if (structAnchor !== undefined) {
-      const r = structAnchor.range;
-      structTypedefRanges.add(`${r.startLine}:${r.startCol}:${r.endLine}:${r.endCol}`);
+    // Track typedef struct/union/enum ranges to suppress duplicate typedef declarations
+    const concreteTypeAnchor =
+      grouped['@declaration.struct'] ??
+      grouped['@declaration.union'] ??
+      grouped['@declaration.enum'];
+    if (concreteTypeAnchor !== undefined) {
+      const r = concreteTypeAnchor.range;
+      concreteTypedefRanges.add(`${r.startLine}:${r.startCol}:${r.endLine}:${r.endCol}`);
     }
 
-    // Suppress @declaration.typedef if the same range was already captured as struct/union
+    // Suppress @declaration.typedef if the same range was already captured as a concrete type.
     const typedefAnchor = grouped['@declaration.typedef'];
     if (typedefAnchor !== undefined) {
       const r = typedefAnchor.range;
       const key = `${r.startLine}:${r.startCol}:${r.endLine}:${r.endCol}`;
-      if (structTypedefRanges.has(key)) continue;
+      if (concreteTypedefRanges.has(key)) continue;
     }
 
     // Enrich function declarations with arity metadata and detect static linkage

--- a/gitnexus/src/core/ingestion/languages/c/query.ts
+++ b/gitnexus/src/core/ingestion/languages/c/query.ts
@@ -41,6 +41,12 @@ const C_SCOPE_QUERY = `
 (enum_specifier
   name: (type_identifier) @declaration.name) @declaration.enum
 
+;; Declarations — enum (typedef enum { ... } Name)
+(type_definition
+  type: (enum_specifier
+    body: (enumerator_list))
+  declarator: (type_identifier) @declaration.name) @declaration.enum
+
 ;; Declarations — function definition
 (function_definition
   declarator: (function_declarator

--- a/gitnexus/src/core/ingestion/languages/cpp/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/cpp/captures.ts
@@ -35,9 +35,9 @@ export function emitCppScopeCaptures(
   const rawMatches = getCppScopeQuery().matches(tree.rootNode);
   const out: CaptureMatch[] = [];
 
-  // Track ranges where typedef-struct was captured as @declaration.struct
+  // Track ranges where typedef-struct/enum was captured as its concrete type
   // so we can suppress the duplicate @declaration.typedef match.
-  const structTypedefRanges = new Set<string>();
+  const concreteTypedefRanges = new Set<string>();
 
   for (const m of rawMatches) {
     const grouped: Record<string, Capture> = {};
@@ -74,11 +74,14 @@ export function emitCppScopeCaptures(
       }
     }
 
-    // ── Track typedef-struct ranges ─────────────────────────────────
-    const structAnchor = grouped['@declaration.struct'] ?? grouped['@declaration.class'];
-    if (structAnchor !== undefined) {
-      const r = structAnchor.range;
-      structTypedefRanges.add(`${r.startLine}:${r.startCol}:${r.endLine}:${r.endCol}`);
+    // ── Track concrete typedef ranges ───────────────────────────────
+    const concreteTypeAnchor =
+      grouped['@declaration.struct'] ??
+      grouped['@declaration.class'] ??
+      grouped['@declaration.enum'];
+    if (concreteTypeAnchor !== undefined) {
+      const r = concreteTypeAnchor.range;
+      concreteTypedefRanges.add(`${r.startLine}:${r.startCol}:${r.endLine}:${r.endCol}`);
     }
 
     // Suppress @declaration.typedef if the same range was already captured
@@ -86,7 +89,7 @@ export function emitCppScopeCaptures(
     if (typedefAnchor !== undefined) {
       const r = typedefAnchor.range;
       const key = `${r.startLine}:${r.startCol}:${r.endLine}:${r.endCol}`;
-      if (structTypedefRanges.has(key)) continue;
+      if (concreteTypedefRanges.has(key)) continue;
     }
 
     // ── Enrich function/method declarations with arity metadata ─────

--- a/gitnexus/src/core/ingestion/languages/cpp/query.ts
+++ b/gitnexus/src/core/ingestion/languages/cpp/query.ts
@@ -48,6 +48,12 @@ const CPP_SCOPE_QUERY = `
     (template_argument_list) @declaration.template-arguments)
   body: (field_declaration_list)) @declaration.struct
 
+;; Declarations — struct (typedef struct { ... } Name)
+(type_definition
+  type: (struct_specifier
+    body: (field_declaration_list))
+  declarator: (type_identifier) @declaration.name) @declaration.struct
+
 ;; ─── Declarations — class / struct inside template_declaration ───────
 (template_declaration
   (class_specifier
@@ -76,6 +82,12 @@ const CPP_SCOPE_QUERY = `
 ;; ─── Declarations — enum ─────────────────────────────────────────────
 (enum_specifier
   name: (type_identifier) @declaration.name) @declaration.enum
+
+;; ─── Declarations — enum (typedef enum { ... } Name) ─────────────────
+(type_definition
+  type: (enum_specifier
+    body: (enumerator_list))
+  declarator: (type_identifier) @declaration.name) @declaration.enum
 
 ;; ─── Declarations — enum constants ───────────────────────────────────
 (enumerator

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -12,10 +12,12 @@ import { yieldToEventLoop } from './utils/event-loop.js';
 import { parseSourceSafe } from '../tree-sitter/safe-parse.js';
 import { isVerboseIngestionEnabled } from './utils/verbose.js';
 import {
+  buildConcreteTypedefDefinitionRanges,
   getDefinitionNodeFromCaptures,
   findEnclosingClassInfo,
   findObjectLiteralBindingInfo,
   getLabelFromCaptures,
+  isSuppressedConcreteTypedefDuplicate,
   CLASS_CONTAINER_TYPES,
   type SyntaxNode,
   type EnclosingClassInfo,
@@ -481,6 +483,7 @@ const processParsingSequential = async (
       logger.warn({ queryError }, `Query error for ${file.path}:`);
       continue;
     }
+    const concreteTypedefRanges = buildConcreteTypedefDefinitionRanges(matches);
 
     // Build per-file type environment for FieldExtractor context (lightweight — skipped if no fieldExtractor).
     //
@@ -503,6 +506,8 @@ const processParsingSequential = async (
       match.captures.forEach((c) => {
         captureMap[c.name] = c.node;
       });
+
+      if (isSuppressedConcreteTypedefDuplicate(captureMap, concreteTypedefRanges)) return;
 
       const definitionNodeForRange = getDefinitionNodeFromCaptures(captureMap);
       const definitionNode = getDefinitionNodeFromCaptures(captureMap);

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -606,8 +606,17 @@ export const C_QUERIES = `
 
 ; Structs, Unions, Enums, Typedefs
 (struct_specifier name: (type_identifier) @name) @definition.struct
+(type_definition
+  type: (struct_specifier
+    body: (field_declaration_list))
+  declarator: (type_identifier) @name) @definition.struct
 (union_specifier name: (type_identifier) @name) @definition.union
 (enum_specifier name: (type_identifier) @name) @definition.enum
+(type_definition
+  type: (enum_specifier
+    body: (enumerator_list))
+  declarator: (type_identifier) @name) @definition.enum
+(enumerator name: (identifier) @name) @definition.const
 (type_definition declarator: (type_identifier) @name) @definition.typedef
 
 ; Macros
@@ -705,6 +714,15 @@ export const CPP_QUERIES = `
 (enum_specifier name: (type_identifier) @name) @definition.enum
 
 ; Typedefs and unions (common in C-style headers and mixed C/C++ code)
+(type_definition
+  type: (struct_specifier
+    body: (field_declaration_list))
+  declarator: (type_identifier) @name) @definition.struct
+(type_definition
+  type: (enum_specifier
+    body: (enumerator_list))
+  declarator: (type_identifier) @name) @definition.enum
+(enumerator name: (identifier) @name) @definition.const
 (type_definition declarator: (type_identifier) @name) @definition.typedef
 (union_specifier name: (type_identifier) @name) @definition.union
 

--- a/gitnexus/src/core/ingestion/utils/ast-helpers.ts
+++ b/gitnexus/src/core/ingestion/utils/ast-helpers.ts
@@ -51,6 +51,51 @@ export const getDefinitionNodeFromCaptures = (
   return null;
 };
 
+type QueryMatchLike = {
+  captures: Array<{ name: string; node: SyntaxNode }>;
+};
+
+const nodeRangeKey = (node: SyntaxNode): string =>
+  `${node.startPosition.row}:${node.startPosition.column}:${node.endPosition.row}:${node.endPosition.column}`;
+
+const isConcreteTypedefCapture = (captureMap: Record<string, SyntaxNode>): boolean => {
+  const definitionNode = getDefinitionNodeFromCaptures(captureMap);
+  return (
+    definitionNode?.type === 'type_definition' &&
+    (captureMap['definition.struct'] !== undefined || captureMap['definition.enum'] !== undefined)
+  );
+};
+
+export const buildConcreteTypedefDefinitionRanges = (
+  matches: readonly QueryMatchLike[],
+): Set<string> => {
+  const ranges = new Set<string>();
+  for (const match of matches) {
+    const captureMap: Record<string, SyntaxNode> = {};
+    for (const capture of match.captures) {
+      captureMap[capture.name] = capture.node;
+    }
+
+    const definitionNode = getDefinitionNodeFromCaptures(captureMap);
+    if (definitionNode && isConcreteTypedefCapture(captureMap)) {
+      ranges.add(nodeRangeKey(definitionNode));
+    }
+  }
+  return ranges;
+};
+
+export const isSuppressedConcreteTypedefDuplicate = (
+  captureMap: Record<string, SyntaxNode>,
+  concreteTypedefRanges: ReadonlySet<string>,
+): boolean => {
+  const definitionNode = getDefinitionNodeFromCaptures(captureMap);
+  return (
+    definitionNode?.type === 'type_definition' &&
+    captureMap['definition.typedef'] !== undefined &&
+    concreteTypedefRanges.has(nodeRangeKey(definitionNode))
+  );
+};
+
 /**
  * Node types that represent function/method definitions across languages.
  * Used by parent-walk in call-processor, parse-worker, and type-env to detect

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -52,6 +52,7 @@ try {
 } catch {}
 import { getLanguageFromFilename } from 'gitnexus-shared';
 import {
+  buildConcreteTypedefDefinitionRanges,
   FUNCTION_NODE_TYPES,
   getDefinitionNodeFromCaptures,
   findEnclosingClassInfo,
@@ -60,6 +61,7 @@ import {
   getLabelFromCaptures,
   genericFuncName,
   inferFunctionLabel,
+  isSuppressedConcreteTypedefDuplicate,
   CLASS_CONTAINER_TYPES,
   type SyntaxNode,
 } from '../utils/ast-helpers.js';
@@ -1116,6 +1118,7 @@ const processFileGroup = (
       );
       continue;
     }
+    const concreteTypedefRanges = buildConcreteTypedefDefinitionRanges(matches);
 
     const provider = getProvider(language);
 
@@ -1219,6 +1222,8 @@ const processFileGroup = (
       for (const c of match.captures) {
         captureMap[c.name] = c.node;
       }
+
+      if (isSuppressedConcreteTypedefDuplicate(captureMap, concreteTypedefRanges)) continue;
 
       // Extract import paths before skipping
       if (captureMap['import'] && captureMap['import.source']) {

--- a/gitnexus/test/integration/c-cpp-typedef-legacy-parse.test.ts
+++ b/gitnexus/test/integration/c-cpp-typedef-legacy-parse.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { createASTCache } from '../../src/core/ingestion/ast-cache.js';
+import { processParsing } from '../../src/core/ingestion/parsing-processor.js';
+import { createSemanticModel } from '../../src/core/ingestion/model/semantic-model.js';
+import { createKnowledgeGraph } from '../../src/core/graph/graph.js';
+
+const parseNodes = async (path: string, content: string) => {
+  const graph = createKnowledgeGraph();
+  const model = createSemanticModel();
+  await processParsing(
+    graph,
+    [{ path, content }],
+    model.symbols,
+    createASTCache(),
+    createASTCache(),
+  );
+  return graph.nodes;
+};
+
+describe('C/C++ legacy parse typedef captures', () => {
+  it('emits one concrete C symbol for anonymous typedef structs and enums', async () => {
+    const nodes = await parseNodes(
+      'include/types.c',
+      'typedef struct { int x; int y; } Point;\ntypedef enum { RED, GREEN } Color;\n',
+    );
+
+    expect(
+      nodes.filter((node) => node.label === 'Struct' && node.id.endsWith(':Point')),
+    ).toHaveLength(1);
+    expect(
+      nodes.filter((node) => node.label === 'Enum' && node.id.endsWith(':Color')),
+    ).toHaveLength(1);
+    expect(
+      nodes.filter((node) => node.label === 'Typedef' && node.id.endsWith(':Point')),
+    ).toHaveLength(0);
+    expect(
+      nodes.filter((node) => node.label === 'Typedef' && node.id.endsWith(':Color')),
+    ).toHaveLength(0);
+  });
+
+  it('emits one concrete C++ symbol for anonymous typedef structs and enums', async () => {
+    const nodes = await parseNodes(
+      'include/types.cpp',
+      'typedef struct { int x; int y; } Point;\ntypedef enum { Red, Green } Color;\n',
+    );
+
+    expect(
+      nodes.filter((node) => node.label === 'Struct' && node.id.endsWith(':Point')),
+    ).toHaveLength(1);
+    expect(
+      nodes.filter((node) => node.label === 'Enum' && node.id.endsWith(':Color')),
+    ).toHaveLength(1);
+    expect(
+      nodes.filter((node) => node.label === 'Typedef' && node.id.endsWith(':Point')),
+    ).toHaveLength(0);
+    expect(
+      nodes.filter((node) => node.label === 'Typedef' && node.id.endsWith(':Color')),
+    ).toHaveLength(0);
+  });
+});

--- a/gitnexus/test/integration/tree-sitter-languages.test.ts
+++ b/gitnexus/test/integration/tree-sitter-languages.test.ts
@@ -169,6 +169,21 @@ describe('Tree-sitter multi-language parsing', () => {
       expect(names).toContain('uint');
       expect(names).toContain('Point');
     });
+
+    it('captures C typedef anonymous structs, enums, and enumerators', async () => {
+      await loadLanguage(SupportedLanguages.C);
+      const code = `
+        typedef struct { int x; int y; } Point;
+        typedef enum { RED, GREEN, BLUE } Color;
+      `;
+      const provider = getProvider(SupportedLanguages.C);
+      const { matches } = parseAndQuery(parser, code, provider.treeSitterQueries);
+      const defs = extractDefinitions(matches);
+      const names = defs.map((d) => d.name);
+      expect(defs.some((d) => d.type === 'definition.struct' && d.name === 'Point')).toBe(true);
+      expect(defs.some((d) => d.type === 'definition.enum' && d.name === 'Color')).toBe(true);
+      expect(names).toEqual(expect.arrayContaining(['RED', 'GREEN', 'BLUE']));
+    });
   });
 
   describe('C++', () => {
@@ -237,6 +252,21 @@ describe('Tree-sitter multi-language parsing', () => {
       const names = defs.map((d) => d.name);
       expect(names).toContain('utils');
       expect(names).toContain('helper');
+    });
+
+    it('captures C++ typedef anonymous structs, enums, and enumerators', async () => {
+      await loadLanguage(SupportedLanguages.CPlusPlus);
+      const code = `
+        typedef struct { int x; int y; } Point;
+        typedef enum { Red, Green, Blue } Color;
+      `;
+      const provider = getProvider(SupportedLanguages.CPlusPlus);
+      const { matches } = parseAndQuery(parser, code, provider.treeSitterQueries);
+      const defs = extractDefinitions(matches);
+      const names = defs.map((d) => d.name);
+      expect(defs.some((d) => d.type === 'definition.struct' && d.name === 'Point')).toBe(true);
+      expect(defs.some((d) => d.type === 'definition.enum' && d.name === 'Color')).toBe(true);
+      expect(names).toEqual(expect.arrayContaining(['Red', 'Green', 'Blue']));
     });
   });
 

--- a/gitnexus/test/unit/scope-resolution/c/c-captures.test.ts
+++ b/gitnexus/test/unit/scope-resolution/c/c-captures.test.ts
@@ -120,6 +120,19 @@ describe('emitCScopeCaptures — enum declarations', () => {
     expect(names).toContain('GREEN');
     expect(names).toContain('BLUE');
   });
+
+  it('captures typedef anonymous enum with @declaration.enum (not typedef)', () => {
+    const m = findMatch('typedef enum { OFF, ON } SwitchState;', (t) =>
+      t.includes('@declaration.enum'),
+    );
+    expect(m).toBeDefined();
+    expect(m!['@declaration.name'].text).toBe('SwitchState');
+
+    const typedefs = allMatches('typedef enum { OFF, ON } SwitchState;', (t) =>
+      t.includes('@declaration.typedef'),
+    );
+    expect(typedefs).toHaveLength(0);
+  });
 });
 
 describe('emitCScopeCaptures — function declarations', () => {

--- a/gitnexus/test/unit/scope-resolution/cpp/cpp-captures.test.ts
+++ b/gitnexus/test/unit/scope-resolution/cpp/cpp-captures.test.ts
@@ -107,6 +107,16 @@ describe('emitCppScopeCaptures — class declarations', () => {
     expect(m!['@declaration.name'].text).toBe('Point');
   });
 
+  it('captures typedef anonymous struct with @declaration.struct (not typedef)', () => {
+    const src = 'typedef struct { int x; int y; } Point;';
+    const m = findMatch(src, (t) => t.includes('@declaration.struct'));
+    expect(m).toBeDefined();
+    expect(m!['@declaration.name'].text).toBe('Point');
+
+    const typedefs = allMatches(src, (t) => t.includes('@declaration.typedef'));
+    expect(typedefs).toHaveLength(0);
+  });
+
   it('captures template class with @declaration.class', () => {
     const m = findMatch('template <typename T> class Container { T val; };', (t) =>
       t.includes('@declaration.class'),
@@ -230,6 +240,16 @@ describe('emitCppScopeCaptures — enum declarations', () => {
     expect(matches.length).toBe(3);
     const names = matches.map((m) => m['@declaration.name'].text).sort();
     expect(names).toEqual(['Blue', 'Green', 'Red']);
+  });
+
+  it('captures typedef anonymous enum with @declaration.enum (not typedef)', () => {
+    const src = 'typedef enum { Red, Green, Blue } Color;';
+    const m = findMatch(src, (t) => t.includes('@declaration.enum'));
+    expect(m).toBeDefined();
+    expect(m!['@declaration.name'].text).toBe('Color');
+
+    const typedefs = allMatches(src, (t) => t.includes('@declaration.typedef'));
+    expect(typedefs).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- capture typedef anonymous enum declarations as concrete enum symbols in C and C++ scope-resolution queries
- capture typedef anonymous struct declarations in C++ scope-resolution queries
- extend legacy tree-sitter definition queries for typedef anonymous structs/enums and enum constants

Refs #1923 (F1/F2/F3 scoped slice)

## Validation
- targeted typedef-anonymous C/C++ scope-resolution Vitest checks
- targeted typedef-anonymous tree-sitter integration checks
- npx tsc --noEmit
- full C/C++ capture unit suite
- full tree-sitter language integration suite
- prettier check on touched files
- git diff --check
- node ./gitnexus/dist/cli/index.js detect-changes

Full local suite note: npm test -- --maxWorkers=1 --testTimeout=60000 reached 10024 passing / 52 skipped, with only test/integration/mcp/server-startup.test.ts exceeding its 5s first-frame timing budget under full-suite load. The same MCP startup test passed twice in isolation immediately before/after the full-suite run.