### PR TITLE
feat(group): make HTTP consumer client identifiers configurable

### DIFF
--- a/gitnexus/src/core/group/config-parser.ts
+++ b/gitnexus/src/core/group/config-parser.ts
@@ -33,6 +33,10 @@ const DEFAULT_DETECT = {
   embedding_fallback: true,
   includes: false,
   workspace_deps: false,
+  // Extra HTTP client identifiers (besides built-in defaults like `axios`)
+  // recognized for member-style consumer calls (`client.get(url)`).
+  // Opt-in per group via `detect.http_client_aliases: [request, http]`.
+  http_client_aliases: [] as string[],
 };
 
 const DEFAULT_MATCHING = {
@@ -96,6 +100,15 @@ export function parseGroupConfig(yamlContent: string): GroupConfig {
   });
 
   const detect = { ...DEFAULT_DETECT, ...((raw.detect as object) || {}) };
+  if (!Array.isArray(detect.http_client_aliases)) {
+    throw new Error('detect.http_client_aliases must be an array of strings');
+  }
+  detect.http_client_aliases = detect.http_client_aliases.map((a, i) => {
+    if (typeof a !== 'string') {
+      throw new Error(`detect.http_client_aliases[${i}] must be a string`);
+    }
+    return a;
+  });
   const matching = { ...DEFAULT_MATCHING, ...((raw.matching as object) || {}) };
   const packages = (raw.packages as Record<string, Record<string, string>>) || {};
 

--- a/gitnexus/src/core/group/extractors/http-patterns/node.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/node.ts
@@ -94,13 +94,20 @@ const FETCH_WITH_OPTIONS_SPEC: PatternSpec<Record<string, never>> = {
   `,
 };
 
-// ─── Consumer: axios.get/post/... ────────────────────────────────────
+// ─── Consumer: axios.get/post/... (and configured client aliases) ────
+// The `@obj` identifier is captured but NOT pinned to "axios" in the
+// query: the plugin filters it against a configurable client-identifier
+// set in `scanBundle` (default {"axios"}). This lets projects that wrap
+// their HTTP client behind a helper — e.g. uni-app / luch-request style
+// `import request from "@/utils/request"; request.get("/x")` — opt that
+// wrapper name in via `detect.http_client_aliases` in group.yaml without
+// recompiling the tree-sitter query per config.
 const AXIOS_SPEC: PatternSpec<Record<string, never>> = {
   meta: {},
   query: `
     (call_expression
       function: (member_expression
-        object: (identifier) @obj (#eq? @obj "axios")
+        object: (identifier) @obj
         property: (property_identifier) @http_method (#match? @http_method "^(get|post|put|delete|patch)$"))
       arguments: (arguments . [(string) (template_string)] @path))
   `,
@@ -295,7 +302,16 @@ function findDecoratedMethod(decoratorNode: Parser.SyntaxNode): Parser.SyntaxNod
   return null;
 }
 
-function scanBundle(bundle: NodePatternBundle, tree: Parser.Tree): HttpDetection[] {
+/** Built-in HTTP client identifier recognized for member-style calls
+ *  (`axios.get(url)`). Extra identifiers are opted in per group via
+ *  `detect.http_client_aliases`. */
+const DEFAULT_HTTP_CLIENTS = ['axios'] as const;
+
+function scanBundle(
+  bundle: NodePatternBundle,
+  tree: Parser.Tree,
+  clientIds: ReadonlySet<string> = new Set(DEFAULT_HTTP_CLIENTS),
+): HttpDetection[] {
   const out: HttpDetection[] = [];
 
   // NestJS: collect `@Controller('prefix')` class decorators, keyed by
@@ -407,16 +423,22 @@ function scanBundle(bundle: NodePatternBundle, tree: Parser.Tree): HttpDetection
     });
   }
 
-  // Consumer: axios.<verb>(url)
+  // Consumer: <client>.<verb>(url) — axios by default, plus any client
+  // identifiers opted in via `detect.http_client_aliases`. The query
+  // matches any `ident.<verb>(string)`; we filter the object identifier
+  // against `clientIds` here so the recognized-client set is config-driven
+  // without recompiling the tree-sitter query.
   for (const match of runCompiledPatterns(bundle.axios, tree)) {
+    const objNode = match.captures.obj;
     const methodNode = match.captures.http_method;
     const pathNode = match.captures.path;
-    if (!methodNode || !pathNode) continue;
+    if (!objNode || !methodNode || !pathNode) continue;
+    if (!clientIds.has(objNode.text)) continue;
     const path = unquoteLiteral(pathNode.text);
     if (path === null) continue;
     out.push({
       role: 'consumer',
-      framework: 'axios',
+      framework: objNode.text,
       method: methodNode.text.toUpperCase(),
       path,
       name: null,
@@ -483,20 +505,48 @@ function scanBundle(bundle: NodePatternBundle, tree: Parser.Tree): HttpDetection
   return out;
 }
 
+/** Opaque per-repo context this plugin builds in `prepareRepo`: the set
+ *  of HTTP client identifiers recognized for member-style consumer calls. */
+interface NodeHttpRepoContext {
+  clientIds: ReadonlySet<string>;
+}
+
+/** Build the recognized-client set from the orchestrator-supplied aliases.
+ *  Never throws (the orchestrator already guards prepareRepo). */
+function prepareNodeRepoContext(args: {
+  httpClientAliases?: readonly string[];
+}): NodeHttpRepoContext {
+  const ids = new Set<string>(DEFAULT_HTTP_CLIENTS);
+  for (const alias of args.httpClientAliases ?? []) {
+    if (typeof alias === 'string' && alias.trim()) ids.add(alias.trim());
+  }
+  return { clientIds: ids };
+}
+
+/** Resolve the client set from whatever `prepareRepo` produced, falling
+ *  back to the built-in default when context is absent. */
+function resolveClientIds(repoContext?: unknown): ReadonlySet<string> {
+  const ctx = repoContext as NodeHttpRepoContext | undefined;
+  return ctx?.clientIds ?? new Set(DEFAULT_HTTP_CLIENTS);
+}
+
 export const JAVASCRIPT_HTTP_PLUGIN: HttpLanguagePlugin = {
   name: 'javascript-http',
   language: JavaScript,
-  scan: (tree) => scanBundle(JAVASCRIPT_BUNDLE, tree),
+  prepareRepo: (args) => prepareNodeRepoContext(args),
+  scan: (tree, repoContext) => scanBundle(JAVASCRIPT_BUNDLE, tree, resolveClientIds(repoContext)),
 };
 
 export const TYPESCRIPT_HTTP_PLUGIN: HttpLanguagePlugin = {
   name: 'typescript-http',
   language: TypeScript.typescript,
-  scan: (tree) => scanBundle(TYPESCRIPT_BUNDLE, tree),
+  prepareRepo: (args) => prepareNodeRepoContext(args),
+  scan: (tree, repoContext) => scanBundle(TYPESCRIPT_BUNDLE, tree, resolveClientIds(repoContext)),
 };
 
 export const TSX_HTTP_PLUGIN: HttpLanguagePlugin = {
   name: 'tsx-http',
   language: TypeScript.tsx,
-  scan: (tree) => scanBundle(TSX_BUNDLE, tree),
+  prepareRepo: (args) => prepareNodeRepoContext(args),
+  scan: (tree, repoContext) => scanBundle(TSX_BUNDLE, tree, resolveClientIds(repoContext)),
 };

--- a/gitnexus/src/core/group/extractors/http-patterns/types.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/types.ts
@@ -90,6 +90,13 @@ export interface HttpLanguagePlugin {
     parser: Parser;
     readFile: (rel: string) => string | null;
     parseSource: (parser: Parser, src: string) => Parser.Tree | null;
+    /**
+     * Extra HTTP client identifiers (besides built-in defaults like
+     * `axios`) opted in via `detect.http_client_aliases` in group.yaml.
+     * Plugins that recognize wrapped HTTP clients (e.g. a project's
+     * `request` helper) use these to widen consumer detection.
+     */
+    httpClientAliases?: readonly string[];
   }): RepoContext | undefined;
   /**
    * Scan a parsed tree and return zero or more HTTP detections. Plugins

--- a/gitnexus/src/core/group/extractors/http-route-extractor.ts
+++ b/gitnexus/src/core/group/extractors/http-route-extractor.ts
@@ -153,6 +153,15 @@ function pickSymbolUid(
 export class HttpRouteExtractor implements ContractExtractor {
   type = 'http' as const;
 
+  /**
+   * @param httpClientAliases extra HTTP client identifiers (besides each
+   *   language plugin's built-in defaults) opted in via
+   *   `detect.http_client_aliases` in group.yaml. Threaded into each
+   *   plugin's `prepareRepo` so wrapped clients (e.g. a `request` helper)
+   *   are recognized as consumers.
+   */
+  constructor(private readonly httpClientAliases: readonly string[] = []) {}
+
   async canExtract(_repo: RepoHandle): Promise<boolean> {
     return true;
   }
@@ -192,6 +201,7 @@ export class HttpRouteExtractor implements ContractExtractor {
           parser,
           readFile: (rel) => readSafe(repoPath, rel),
           parseSource: (p, src) => parseSourceSafe(p, src),
+          httpClientAliases: this.httpClientAliases,
         });
         repoContextByPlugin.set(plugin.name, ctx);
         return ctx;

--- a/gitnexus/src/core/group/sync.ts
+++ b/gitnexus/src/core/group/sync.ts
@@ -101,7 +101,7 @@ export async function syncGroup(config: GroupConfig, opts?: SyncOptions): Promis
       registryEntries = await readRegistry();
       const entries = registryEntries;
       const resolve = opts?.resolveRepoHandle ?? defaultResolveHandle(entries);
-      const httpEx = new HttpRouteExtractor();
+      const httpEx = new HttpRouteExtractor(config.detect.http_client_aliases);
       const grpcEx = new GrpcExtractor();
       const thriftEx = new ThriftExtractor();
       const topicEx = new TopicExtractor();

--- a/gitnexus/src/core/group/types.ts
+++ b/gitnexus/src/core/group/types.ts
@@ -30,6 +30,15 @@ export interface DetectConfig {
   embedding_fallback: boolean;
   includes: boolean;
   workspace_deps: boolean;
+  /**
+   * Extra HTTP client identifiers (besides each language plugin's
+   * built-in defaults, e.g. `axios`) recognized for member-style consumer
+   * calls like `client.get(url)`. Lets projects that wrap their HTTP
+   * client behind a helper — e.g. uni-app / luch-request style
+   * `import request from "@/utils/request"; request.get("/x")` — opt the
+   * wrapper name in. Default: [].
+   */
+  http_client_aliases: string[];
 }
 
 export interface MatchingConfig {

--- a/gitnexus/test/unit/group/config-parser.test.ts
+++ b/gitnexus/test/unit/group/config-parser.test.ts
@@ -131,6 +131,59 @@ detect:
     });
   });
 
+  describe('detect.http_client_aliases', () => {
+    it('defaults to an empty array when omitted', () => {
+      const config = parseGroupConfig(`
+version: 1
+name: test
+repos:
+  app: my-app
+`);
+      expect(config.detect.http_client_aliases).toEqual([]);
+    });
+
+    it('parses an explicit list of client aliases', () => {
+      const config = parseGroupConfig(`
+version: 1
+name: test
+repos:
+  app: my-app
+detect:
+  http_client_aliases:
+    - request
+    - http
+`);
+      expect(config.detect.http_client_aliases).toEqual(['request', 'http']);
+    });
+
+    it('throws when http_client_aliases is not an array', () => {
+      expect(() =>
+        parseGroupConfig(`
+version: 1
+name: test
+repos:
+  app: my-app
+detect:
+  http_client_aliases: request
+`),
+      ).toThrow(/http_client_aliases.*array/i);
+    });
+
+    it('throws when an alias entry is not a string', () => {
+      expect(() =>
+        parseGroupConfig(`
+version: 1
+name: test
+repos:
+  app: my-app
+detect:
+  http_client_aliases:
+    - 123
+`),
+      ).toThrow(/http_client_aliases\[0\].*string/i);
+    });
+  });
+
   it('parses thrift manifest links', () => {
     const yaml = `
 version: 1

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -1193,6 +1193,50 @@ export const deleteUser = (id: string) => axios.delete(\`/api/users/\${id}\`);
       ).toBeDefined();
     });
 
+    it('does NOT detect a wrapped client (request.get) without configured aliases', async () => {
+      const dir = path.join(tmpDir, 'wrapped-no-alias');
+      fs.mkdirSync(path.join(dir, 'api'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'api/user.js'),
+        `
+import request from '@/utils/request.js';
+export function getUsers() { return request.get('/api/users'); }
+`,
+      );
+
+      // Default extractor (no aliases): only built-in clients (axios) are
+      // recognized, so the wrapped \`request.get\` must NOT become a consumer.
+      const contracts = await extractor.extract(null, dir, makeRepo(dir));
+      const consumers = contracts.filter((c) => c.role === 'consumer');
+      expect(consumers.find((c) => c.contractId === 'http::GET::/api/users')).toBeUndefined();
+    });
+
+    it('detects a wrapped client (request.get) when opted in via http_client_aliases', async () => {
+      const dir = path.join(tmpDir, 'wrapped-with-alias');
+      fs.mkdirSync(path.join(dir, 'api'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'api/user.js'),
+        `
+import request from '@/utils/request.js';
+export function getUsers() { return request.get('/api/users'); }
+export function removeUser(id) { return request.delete(\`/api/users/\${id}\`); }
+`,
+      );
+
+      // Extractor configured with the wrapper name (mirrors group.yaml
+      // \`detect.http_client_aliases: [request]\`).
+      const aliasExtractor = new HttpRouteExtractor(['request']);
+      const contracts = await aliasExtractor.extract(null, dir, makeRepo(dir));
+      const consumers = contracts.filter((c) => c.role === 'consumer');
+
+      const getRoute = consumers.find((c) => c.contractId === 'http::GET::/api/users');
+      expect(getRoute).toBeDefined();
+      expect(getRoute?.meta.framework).toBe('request');
+      expect(
+        consumers.find((c) => c.contractId === 'http::DELETE::/api/users/{param}'),
+      ).toBeDefined();
+    });
+
     it('extracts jQuery $.get and $.post shorthand', async () => {
       const dir = path.join(tmpDir, 'jquery-shorthand');
       fs.mkdirSync(path.join(dir, 'public/js'), { recursive: true });


### PR DESCRIPTION
## What

Adds a `detect.http_client_aliases` option to `group.yaml` so the JS/TS HTTP
consumer extractor recognizes member-style calls (`client.get(url)`,
`client.post(url)`, …) made through a **wrapped HTTP client**, not just the
built-in `axios`.

```yaml
# group.yaml
detect:
  http_client_aliases: [request, http]   # default: []
```

With the example above, calls like `request.get('/api/users')` and
`http.post('/orders')` are extracted as HTTP **consumer** contracts and can
cross-link to provider endpoints during `group sync`.

## Why

Many front-ends wrap their HTTP client behind a small helper instead of
calling `axios`/`fetch` directly — e.g. uni-app / `luch-request` projects do:

```js
import request from '@/utils/request.js';
export function getUsers() { return request.get('/api/users'); }
```

The Node HTTP plugin hard-coded the consumer client identifier to `axios`
(`(#eq? @obj "axios")`), so these wrapped calls produced **zero** consumer
contracts and therefore **zero** cross-links, even though the URLs are plain
string literals that are trivially extractable. This affects any codebase
that renames or wraps its HTTP client.

## How it works

- The `axios.<verb>(url)` tree-sitter query no longer pins `@obj` to
  `"axios"`; it captures the object identifier and the plugin filters it
  against a configurable client-identifier set in `scanBundle`.
- The set defaults to `{"axios"}` (built-in), and is widened by the aliases
  threaded from `group.yaml` → `HttpRouteExtractor` → each Node plugin's
  `prepareRepo` → `scan`. No tree-sitter query is recompiled per config.
- `framework` on each detection is now the matched identifier (`axios` stays
  `axios`; a wrapped `request` reports `request`).

## Backward compatibility

- Default `http_client_aliases: []` ⇒ only `axios` is recognized — **identical
  behavior to before**. The existing axios/fetch/jQuery consumer tests pass
  unchanged.
- Object-form (`axios({ url })`) and `fetch`/jQuery detection are untouched.
- New `detect` key defaults to `[]`, so existing groups are unaffected on the
  next sync.

## How to verify

```bash
cd gitnexus && npm install && npm run build
npx vitest run test/unit/group/http-route-extractor.test.ts   # incl. 2 new tests
npx vitest run test/unit/group/config-parser.test.ts          # incl. 4 new tests
npx tsc --noEmit
```

New tests:
- `http-route-extractor.test.ts`: a wrapped `request.get()` is **not** detected
  without aliases (no false positives), and **is** detected (GET + DELETE) when
  `new HttpRouteExtractor(['request'])` is configured.
- `config-parser.test.ts`: default `[]`, explicit list parsing, and validation
  errors for non-array / non-string entries.

## Real-world validation

Validated on a real 2-repo group (a uni-app / `luch-request` frontend that
wraps its client as `request` + a Spring backend). With
`detect.http_client_aliases: [request]`, `group sync` cross-links went from
**0 → 135** (exact, confidence 1.0). Spot-checked links are correct round
trips, e.g. `POST /wx/login` matches the frontend `request.post("wx/login")`
to the backend `@PostMapping("/login")` under a `/wx` class mapping. Without
the alias the same group produces 0 cross-links.

## Risk / rollback

- Low. The change is additive and opt-in; the default code path is unchanged.
- Scope limited to member-style `ident.verb(stringLiteral)` consumer calls.
  String-concatenation URLs and `uni.request({ url })` object-form calls are
  still out of scope (documented limitation, not a regression).
- Rollback is a straight revert of this commit — no migration, no stored-data
  format change.

## Out of scope (possible follow-ups)

- Java provider `@RequestMapping(value = "...")` named-argument extraction
  (separate precision improvement, unrelated to this consumer-side change).
- Configurable client aliases for the object-form (`client({ url })`) and for
  non-Node language plugins.
- `api_impact` / `route_map` resolve a single repo's graph `Route` nodes, which
  for Spring/Java back-ends are not always populated from `@RequestMapping` /
  `@GetMapping` handlers — so an exact lookup like `api_impact route="/wx/login"`
  can return "no routes" even though the route exists as a provider contract and
  cross-links correctly in `group sync`. Cross-repo consumers remain reachable
  via `query repo:"@group"` and the group contracts resource; populating graph
  `Route` nodes from Spring handlers would let `api_impact` cover Java back-ends.