### PR TITLE
fix(typescript): fix HOC pattern false positives and add export default HOC support

### DIFF
--- a/gitnexus/src/core/ingestion/call-processor.ts
+++ b/gitnexus/src/core/ingestion/call-processor.ts
@@ -408,7 +408,7 @@ const findEnclosingFunction = (
 
   while (current) {
     if (FUNCTION_NODE_TYPES.has(current.type)) {
-      const efnResult = provider.methodExtractor?.extractFunctionName?.(current);
+      const efnResult = provider.methodExtractor?.extractFunctionName?.(current, filePath);
       const funcName = efnResult?.funcName ?? genericFuncName(current);
       const label = efnResult?.label ?? inferFunctionLabel(current.type);
 
@@ -923,6 +923,7 @@ export const processCalls = async (
     const importedReturnTypes = importedReturnTypesMap?.get(file.path);
     const importedRawReturnTypes = importedRawReturnTypesMap?.get(file.path);
     const typeEnv = buildTypeEnv(tree, language, {
+      filePath: file.path,
       model: ctx.model,
       parentMap,
       importedBindings,
@@ -1291,7 +1292,8 @@ export const processCalls = async (
         while (p) {
           if (FUNCTION_NODE_TYPES.has(p.type)) {
             const funcName =
-              provider.methodExtractor?.extractFunctionName?.(p)?.funcName ?? genericFuncName(p);
+              provider.methodExtractor?.extractFunctionName?.(p, file.path)?.funcName ??
+              genericFuncName(p);
             if (funcName) {
               scope = `${funcName}@${p.startIndex}`;
               break;

--- a/gitnexus/src/core/ingestion/languages/javascript/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/javascript/captures.ts
@@ -41,6 +41,11 @@ import { synthesizeTsReceiverBinding } from '../typescript/receiver-binding.js';
 import { isArrayMethodCallbackArrow } from '../typescript/array-callback.js';
 import { getTreeSitterBufferSize } from '../../constants.js';
 import { parseSourceSafe } from '../../../tree-sitter/safe-parse.js';
+import {
+  deriveDefaultExportHocName,
+  isBlockedDefaultExportHoc,
+  isDefaultExportHocFunctionNode,
+} from '../../ts-js-hoc-utils.js';
 
 /** JS function-like node types that may carry a synthesized `this` binding.
  *  Kept in sync with the `@scope.function` patterns in `query.ts`. */
@@ -653,6 +658,20 @@ export function emitJsScopeCaptures(
       const arrowNode = findFunctionNode(tree.rootNode, fnDeclAnchor.range);
       if (arrowNode !== null && isArrayMethodCallbackArrow(arrowNode)) {
         continue;
+      }
+      if (arrowNode !== null && isBlockedDefaultExportHoc(arrowNode)) {
+        continue;
+      }
+    }
+
+    if (fnDeclAnchor !== undefined) {
+      const fnNode = findFunctionNode(tree.rootNode, fnDeclAnchor.range);
+      if (fnNode !== null && isDefaultExportHocFunctionNode(fnNode)) {
+        grouped['@declaration.name'] = syntheticCapture(
+          '@declaration.name',
+          fnNode,
+          deriveDefaultExportHocName(filePath),
+        );
       }
     }
 

--- a/gitnexus/src/core/ingestion/languages/javascript/query.ts
+++ b/gitnexus/src/core/ingestion/languages/javascript/query.ts
@@ -48,6 +48,10 @@
 
 import Parser from 'tree-sitter';
 import JS from 'tree-sitter-javascript';
+import {
+  ARRAY_METHOD_NOT_ANY_OF_PREDICATE,
+  DEFAULT_EXPORT_IDENTIFIER_NOT_ANY_OF_PREDICATE,
+} from '../../ts-js-hoc-utils.js';
 
 const JS_GRAMMAR = JS as Parameters<Parser['setLanguage']>[0];
 
@@ -180,7 +184,7 @@ const JAVASCRIPT_SCOPE_QUERY = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (arrow_function) @declaration.function)))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
 (lexical_declaration
   (variable_declarator
@@ -190,7 +194,7 @@ const JAVASCRIPT_SCOPE_QUERY = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (function_expression) @declaration.function)))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
 (export_statement
   declaration: (lexical_declaration
@@ -219,7 +223,7 @@ const JAVASCRIPT_SCOPE_QUERY = `
           property: (property_identifier) @callee)
         arguments: (arguments
           (arrow_function) @declaration.function))))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
 (export_statement
   declaration: (lexical_declaration
@@ -230,7 +234,7 @@ const JAVASCRIPT_SCOPE_QUERY = `
           property: (property_identifier) @callee)
         arguments: (arguments
           (function_expression) @declaration.function))))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
 (variable_declaration
   (variable_declarator
@@ -256,7 +260,7 @@ const JAVASCRIPT_SCOPE_QUERY = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (arrow_function) @declaration.function)))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
 (variable_declaration
   (variable_declarator
@@ -266,36 +270,41 @@ const JAVASCRIPT_SCOPE_QUERY = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (function_expression) @declaration.function)))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
 ;; HOC-wrapped default exports (JS parity with TS patterns in
-;; languages/typescript/query.ts). The callee identifier provides
-;; @declaration.name since there is no variable_declarator.
-(export_statement
-  (call_expression
-    function: (identifier) @declaration.name
+;; languages/typescript/query.ts). The emit phase rewrites
+;; @declaration.name to a file-derived name so wrapper helpers do not
+;; become the graph-visible symbol name.
+((export_statement
+  value: (call_expression
+    function: (identifier) @hoc
     arguments: (arguments
       (arrow_function) @declaration.function)))
+  ${DEFAULT_EXPORT_IDENTIFIER_NOT_ANY_OF_PREDICATE})
 
-(export_statement
-  (call_expression
-    function: (identifier) @declaration.name
+((export_statement
+  value: (call_expression
+    function: (identifier) @hoc
     arguments: (arguments
       (function_expression) @declaration.function)))
+  ${DEFAULT_EXPORT_IDENTIFIER_NOT_ANY_OF_PREDICATE})
 
-(export_statement
-  (call_expression
+((export_statement
+  value: (call_expression
     function: (member_expression
-      property: (property_identifier) @declaration.name)
+      property: (property_identifier) @callee)
     arguments: (arguments
       (arrow_function) @declaration.function)))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
-(export_statement
-  (call_expression
+((export_statement
+  value: (call_expression
     function: (member_expression
-      property: (property_identifier) @declaration.name)
+      property: (property_identifier) @callee)
     arguments: (arguments
       (function_expression) @declaration.function)))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
 ;; Variable / constant declarations (non-function values).
 (lexical_declaration

--- a/gitnexus/src/core/ingestion/languages/javascript/query.ts
+++ b/gitnexus/src/core/ingestion/languages/javascript/query.ts
@@ -154,10 +154,13 @@ const JAVASCRIPT_SCOPE_QUERY = `
 ;; Those are filtered out emit-side in captures.ts via
 ;; isArrayMethodCallbackArrow (member-expression callee whose property
 ;; is a known Array method), so only the @declaration.const survives.
+;; Excludes common array methods (map, filter, reduce, etc.) to avoid
+;; false positives like \`const x = arr.map(a => ...)\`.
 (lexical_declaration
   (variable_declarator
     name: (identifier) @declaration.name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (arrow_function) @declaration.function))))
 
@@ -165,14 +168,36 @@ const JAVASCRIPT_SCOPE_QUERY = `
   (variable_declarator
     name: (identifier) @declaration.name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (function_expression) @declaration.function))))
+
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @declaration.name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (arrow_function) @declaration.function)))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @declaration.name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (function_expression) @declaration.function)))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
 
 (export_statement
   declaration: (lexical_declaration
     (variable_declarator
       name: (identifier) @declaration.name
       value: (call_expression
+        function: (identifier)
         arguments: (arguments
           (arrow_function) @declaration.function)))))
 
@@ -181,13 +206,37 @@ const JAVASCRIPT_SCOPE_QUERY = `
     (variable_declarator
       name: (identifier) @declaration.name
       value: (call_expression
+        function: (identifier)
         arguments: (arguments
           (function_expression) @declaration.function)))))
+
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @declaration.name
+      value: (call_expression
+        function: (member_expression
+          property: (property_identifier) @callee)
+        arguments: (arguments
+          (arrow_function) @declaration.function))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @declaration.name
+      value: (call_expression
+        function: (member_expression
+          property: (property_identifier) @callee)
+        arguments: (arguments
+          (function_expression) @declaration.function))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
 
 (variable_declaration
   (variable_declarator
     name: (identifier) @declaration.name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (arrow_function) @declaration.function))))
 
@@ -195,8 +244,58 @@ const JAVASCRIPT_SCOPE_QUERY = `
   (variable_declarator
     name: (identifier) @declaration.name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (function_expression) @declaration.function))))
+
+(variable_declaration
+  (variable_declarator
+    name: (identifier) @declaration.name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (arrow_function) @declaration.function)))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+
+(variable_declaration
+  (variable_declarator
+    name: (identifier) @declaration.name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (function_expression) @declaration.function)))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+
+;; HOC-wrapped default exports (JS parity with TS patterns in
+;; languages/typescript/query.ts). The callee identifier provides
+;; @declaration.name since there is no variable_declarator.
+(export_statement
+  (call_expression
+    function: (identifier) @declaration.name
+    arguments: (arguments
+      (arrow_function) @declaration.function)))
+
+(export_statement
+  (call_expression
+    function: (identifier) @declaration.name
+    arguments: (arguments
+      (function_expression) @declaration.function)))
+
+(export_statement
+  (call_expression
+    function: (member_expression
+      property: (property_identifier) @declaration.name)
+    arguments: (arguments
+      (arrow_function) @declaration.function)))
+
+(export_statement
+  (call_expression
+    function: (member_expression
+      property: (property_identifier) @declaration.name)
+    arguments: (arguments
+      (function_expression) @declaration.function)))
 
 ;; Variable / constant declarations (non-function values).
 (lexical_declaration

--- a/gitnexus/src/core/ingestion/languages/typescript.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript.ts
@@ -46,6 +46,11 @@ import {
 } from '../call-extractors/configs/typescript-javascript.js';
 import { createHeritageExtractor } from '../heritage-extractors/generic.js';
 import {
+  ARRAY_METHOD_HOC_BLOCKLIST_SET,
+  DEFAULT_EXPORT_IDENTIFIER_BLOCKLIST_SET,
+  deriveDefaultExportHocName,
+} from '../ts-js-hoc-utils.js';
+import {
   emitTsScopeCaptures,
   interpretTsImport,
   interpretTsTypeBinding,
@@ -66,46 +71,6 @@ import {
   jsMergeBindings,
   jsArityCompatibility,
 } from './javascript/index.js';
-
-// Array prototype methods that must never be treated as HOC wrappers.
-// Mirrors the #not-any-of? blocklist in the tree-sitter query files.
-// Defined at module level to avoid re-allocating on every parse node.
-const ARRAY_METHODS: ReadonlySet<string> = new Set([
-  'map',
-  'filter',
-  'reduce',
-  'forEach',
-  'find',
-  'findIndex',
-  'some',
-  'every',
-  'flatMap',
-  'sort',
-  'splice',
-  'slice',
-  'concat',
-  'fill',
-  'copyWithin',
-  'join',
-  'flat',
-  'at',
-  'entries',
-  'keys',
-  'values',
-  'indexOf',
-  'lastIndexOf',
-  'includes',
-  'pop',
-  'push',
-  'shift',
-  'unshift',
-  'reverse',
-  'reduceRight',
-  'toSorted',
-  'toReversed',
-  'toSpliced',
-  'with',
-]);
 
 /**
  * TypeScript/JavaScript: arrow_function and function_expression are
@@ -135,6 +100,7 @@ const ARRAY_METHODS: ReadonlySet<string> = new Set([
  */
 const tsExtractFunctionName = (
   node: SyntaxNode,
+  filePath?: string,
 ): { funcName: string | null; label: NodeLabel } | null => {
   if (node.type !== 'arrow_function' && node.type !== 'function_expression') return null;
 
@@ -196,7 +162,10 @@ const tsExtractFunctionName = (
     const callee = callExpr.childForFieldName?.('function');
     if (callee?.type === 'member_expression') {
       const property = callee.childForFieldName?.('property');
-      if (property?.type === 'property_identifier' && ARRAY_METHODS.has(property.text)) {
+      if (
+        property?.type === 'property_identifier' &&
+        ARRAY_METHOD_HOC_BLOCKLIST_SET.has(property.text)
+      ) {
         return { funcName: null, label: 'Function' };
       }
     }
@@ -212,18 +181,26 @@ const tsExtractFunctionName = (
       return { funcName: null, label: 'Function' };
     }
 
-    // NEW: export default HOC(arrow) — derive name from callee.
-    // Covers Nuxt/h3 defineEventHandler, Next.js API route handlers, etc.
+    // export default HOC(arrow) — name it from the file, not the wrapper.
+    // This keeps route handlers and wrapped defaults navigable without
+    // collapsing every file onto names like `memo` or `defineEventHandler`.
     if (declarator?.type === 'export_statement') {
       if (callee?.type === 'identifier') {
-        return { funcName: callee.text, label: 'Function' };
-      }
-      // Member-expression callees like React.memo: use the property name
-      if (callee?.type === 'member_expression') {
-        const property = callee.childForFieldName?.('property');
-        if (property) {
-          return { funcName: property.text, label: 'Function' };
+        if (DEFAULT_EXPORT_IDENTIFIER_BLOCKLIST_SET.has(callee.text)) {
+          return { funcName: null, label: 'Function' };
         }
+        return {
+          funcName: filePath ? deriveDefaultExportHocName(filePath) : null,
+          label: 'Function',
+        };
+      }
+      // Member-expression callees like React.memo keep the same file-derived
+      // name, with array-like helpers excluded above.
+      if (callee?.type === 'member_expression') {
+        return {
+          funcName: filePath ? deriveDefaultExportHocName(filePath) : null,
+          label: 'Function',
+        };
       }
       return { funcName: null, label: 'Function' };
     }

--- a/gitnexus/src/core/ingestion/languages/typescript.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript.ts
@@ -67,6 +67,46 @@ import {
   jsArityCompatibility,
 } from './javascript/index.js';
 
+// Array prototype methods that must never be treated as HOC wrappers.
+// Mirrors the #not-any-of? blocklist in the tree-sitter query files.
+// Defined at module level to avoid re-allocating on every parse node.
+const ARRAY_METHODS: ReadonlySet<string> = new Set([
+  'map',
+  'filter',
+  'reduce',
+  'forEach',
+  'find',
+  'findIndex',
+  'some',
+  'every',
+  'flatMap',
+  'sort',
+  'splice',
+  'slice',
+  'concat',
+  'fill',
+  'copyWithin',
+  'join',
+  'flat',
+  'at',
+  'entries',
+  'keys',
+  'values',
+  'indexOf',
+  'lastIndexOf',
+  'includes',
+  'pop',
+  'push',
+  'shift',
+  'unshift',
+  'reverse',
+  'reduceRight',
+  'toSorted',
+  'toReversed',
+  'toSpliced',
+  'with',
+]);
+
 /**
  * TypeScript/JavaScript: arrow_function and function_expression are
  * anonymous AST nodes — they take their name from the surrounding
@@ -141,28 +181,53 @@ const tsExtractFunctionName = (
   // `arguments`, grandparent is `call_expression`, great-grandparent is
   // `variable_declarator`. Walk the chain up and take the variable's name
   // — the meaningful identifier the developer wrote on the LHS. Mirrors
-  // the four registry-primary patterns in `typescript/query.ts`. The
-  // wrapping callee (`forwardRef`, `memo`, `React.memo`, `useCallback`,
-  // user-defined HOCs) is intentionally NOT constrained: any function
-  // call whose result is bound to a const and whose first/positional
-  // argument is an arrow takes the const's name. Chained array-method
-  // calls (`const x = arr.find((y) => p(y))`) match too and produce a
-  // mostly-harmless `Function:x` (consumed as a value, never invoked),
-  // accepted as a small false-positive cost vs. the much larger gain of
-  // capturing the React UI-component idiom.
+  // the four registry-primary patterns in `typescript/query.ts`.
+  //
+  // NOTE: Excludes common array methods (map, filter, reduce, etc.) to avoid
+  // false positives like `const x = arr.map(a => ...)` being classified as
+  // Function when it's actually a Const holding an array.
   if (parent.type === 'arguments') {
     const callExpr = parent.parent;
     if (!callExpr || callExpr.type !== 'call_expression') {
       return { funcName: null, label: 'Function' };
     }
+
+    // Check if callee is a member_expression calling an array method
+    const callee = callExpr.childForFieldName?.('function');
+    if (callee?.type === 'member_expression') {
+      const property = callee.childForFieldName?.('property');
+      if (property?.type === 'property_identifier' && ARRAY_METHODS.has(property.text)) {
+        return { funcName: null, label: 'Function' };
+      }
+    }
+
     const declarator = callExpr.parent;
-    if (!declarator || declarator.type !== 'variable_declarator') {
+
+    // Existing path: const X = HOC(arrow)
+    if (declarator?.type === 'variable_declarator') {
+      const nameNode = declarator.childForFieldName?.('name');
+      if (nameNode?.type === 'identifier') {
+        return { funcName: nameNode.text, label: 'Function' };
+      }
       return { funcName: null, label: 'Function' };
     }
-    const nameNode = declarator.childForFieldName?.('name');
-    if (nameNode?.type === 'identifier') {
-      return { funcName: nameNode.text, label: 'Function' };
+
+    // NEW: export default HOC(arrow) — derive name from callee.
+    // Covers Nuxt/h3 defineEventHandler, Next.js API route handlers, etc.
+    if (declarator?.type === 'export_statement') {
+      if (callee?.type === 'identifier') {
+        return { funcName: callee.text, label: 'Function' };
+      }
+      // Member-expression callees like React.memo: use the property name
+      if (callee?.type === 'member_expression') {
+        const property = callee.childForFieldName?.('property');
+        if (property) {
+          return { funcName: property.text, label: 'Function' };
+        }
+      }
+      return { funcName: null, label: 'Function' };
     }
+
     return { funcName: null, label: 'Function' };
   }
 

--- a/gitnexus/src/core/ingestion/languages/typescript/array-callback.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript/array-callback.ts
@@ -24,47 +24,7 @@
  */
 
 import type { SyntaxNode } from '../../utils/ast-helpers.js';
-
-/**
- * Array prototype higher-order methods whose result is a value, not a
- * function. A callback passed to one of these is an anonymous callback,
- * never a top-level function definition. Identifier-callee HOCs
- * (`forwardRef(...)`, `useCallback(...)`, custom factories) are
- * deliberately NOT listed — they keep their `Function` classification.
- *
- * Trade-off (unchanged from before #1876): a custom *fluent-API* member
- * call with a callback whose method name is not in this set
- * (`qb.where(x => …)`) still classifies as `Function`. There is no clean
- * syntactic line beyond the well-known Array surface, so the set is
- * intentionally closed and easy to extend.
- *
- * Receiver-blind, by design: the match keys on the method NAME only, never
- * the receiver type (tree-sitter has no type information here). So an in-set
- * name on a NON-array receiver — `Map`/`Set` `.forEach`, an RxJS
- * `observable.map(…)`, a query builder `.sort(…)`, a lodash chain
- * `.filter(…)` — is ALSO treated as a callback and has its
- * `@declaration.function` dropped. This is an accepted limitation, not a
- * regression: those bindings hold the call's *result value*, not a callable,
- * so a value def is the correct classification anyway. The only genuine loss
- * is a bespoke DSL whose in-set-named method returns something callable —
- * rare enough to accept rather than guard with type inference. Pinned by the
- * "in-set method on a non-array receiver" case in `*-captures.test.ts`.
- */
-export const ARRAY_CALLBACK_METHODS: ReadonlySet<string> = new Set([
-  'map',
-  'filter',
-  'find',
-  'findIndex',
-  'findLast',
-  'findLastIndex',
-  'forEach',
-  'reduce',
-  'reduceRight',
-  'some',
-  'every',
-  'flatMap',
-  'sort',
-]);
+import { ARRAY_CALLBACK_METHODS } from '../../ts-js-hoc-utils.js';
 
 /**
  * True when `node` (an `arrow_function` / `function_expression`) is the
@@ -77,9 +37,9 @@ export const ARRAY_CALLBACK_METHODS: ReadonlySet<string> = new Set([
  * (`forwardRef(() => …)` — callee is an `identifier`, not a
  * `member_expression`), so neither is ever suppressed.
  *
- * Intentional non-suppressing gaps (preserve current behavior, no
- * regression): parenthesized callee `(arr.map)(cb)` (`parenthesized_expression`)
- * and computed callee `arr['map'](cb)` (`subscript_expression`).
+ * The helper itself only handles direct `member_expression` callees. Broader
+ * shapes like `(arr.map)(cb)` and `arr['map'](cb)` are now filtered at the
+ * query layer, so this emit-side check stays focused on the direct fallback.
  */
 export function isArrayMethodCallbackArrow(node: SyntaxNode): boolean {
   const args = node.parent;

--- a/gitnexus/src/core/ingestion/languages/typescript/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript/captures.ts
@@ -40,6 +40,11 @@ import { computeTsArityMetadata } from './arity-metadata.js';
 import { isArrayMethodCallbackArrow } from './array-callback.js';
 import { getTreeSitterBufferSize } from '../../constants.js';
 import { parseSourceSafe } from '../../../tree-sitter/safe-parse.js';
+import {
+  deriveDefaultExportHocName,
+  isBlockedDefaultExportHoc,
+  isDefaultExportHocFunctionNode,
+} from '../../ts-js-hoc-utils.js';
 
 /** tree-sitter-typescript node types for function-like scopes that may
  *  carry a synthesized `this` binding. Kept in sync with the
@@ -269,6 +274,24 @@ export function emitTsScopeCaptures(
       );
       if (arrowNode !== null && isArrayMethodCallbackArrow(arrowNode)) {
         continue;
+      }
+      if (arrowNode !== null && isBlockedDefaultExportHoc(arrowNode)) {
+        continue;
+      }
+    }
+
+    if (fnDeclAnchor !== undefined) {
+      const fnNode = findFunctionNode(
+        tree.rootNode,
+        fnDeclAnchor.range,
+        groupedNodes['@declaration.function'],
+      );
+      if (fnNode !== null && isDefaultExportHocFunctionNode(fnNode)) {
+        grouped['@declaration.name'] = syntheticCapture(
+          '@declaration.name',
+          fnNode,
+          deriveDefaultExportHocName(filePath),
+        );
       }
     }
 

--- a/gitnexus/src/core/ingestion/languages/typescript/query.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript/query.ts
@@ -277,10 +277,16 @@ const TYPESCRIPT_SCOPE_QUERY = `
 ;; via \`(filePath, type, qualifiedName)\` — second wins. Acceptable;
 ;; multi-arrow-callback APIs are rare (\`new Promise(executor)\` is the
 ;; main one and takes a single executor).
+;;
+;; NOTE: Split into identifier vs member_expression patterns. Member
+;; expressions are filtered with a blocklist of common array methods
+;; (map, filter, reduce, etc.) to avoid false positives like
+;; \`const x = arr.map(a => ...)\` being classified as Function.
 (lexical_declaration
   (variable_declarator
     name: (identifier) @declaration.name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (arrow_function) @declaration.function))))
 
@@ -288,13 +294,35 @@ const TYPESCRIPT_SCOPE_QUERY = `
   (variable_declarator
     name: (identifier) @declaration.name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (function_expression) @declaration.function))))
+
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @declaration.name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (arrow_function) @declaration.function)))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @declaration.name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (function_expression) @declaration.function)))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
 
 (variable_declaration
   (variable_declarator
     name: (identifier) @declaration.name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (arrow_function) @declaration.function))))
 
@@ -302,8 +330,60 @@ const TYPESCRIPT_SCOPE_QUERY = `
   (variable_declarator
     name: (identifier) @declaration.name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (function_expression) @declaration.function))))
+
+(variable_declaration
+  (variable_declarator
+    name: (identifier) @declaration.name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (arrow_function) @declaration.function)))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+
+(variable_declaration
+  (variable_declarator
+    name: (identifier) @declaration.name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (function_expression) @declaration.function)))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+
+;; HOC-wrapped default exports: \`export default defineEventHandler(async (e) => { ... })\`.
+;; The callee identifier provides @declaration.name since there is no
+;; variable_declarator. Covers Nuxt/h3 defineEventHandler, Next.js API
+;; route handlers, and any HOC used as a default export. Member-expression
+;; callees (e.g. \`React.memo\`) use the property as the name.
+(export_statement
+  (call_expression
+    function: (identifier) @declaration.name
+    arguments: (arguments
+      (arrow_function) @declaration.function)))
+
+(export_statement
+  (call_expression
+    function: (identifier) @declaration.name
+    arguments: (arguments
+      (function_expression) @declaration.function)))
+
+(export_statement
+  (call_expression
+    function: (member_expression
+      property: (property_identifier) @declaration.name)
+    arguments: (arguments
+      (arrow_function) @declaration.function)))
+
+(export_statement
+  (call_expression
+    function: (member_expression
+      property: (property_identifier) @declaration.name)
+    arguments: (arguments
+      (function_expression) @declaration.function)))
 
 ;; Method definitions — regular + private (#field) methods.
 (method_definition

--- a/gitnexus/src/core/ingestion/languages/typescript/query.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript/query.ts
@@ -53,6 +53,10 @@
 
 import Parser from 'tree-sitter';
 import TS from 'tree-sitter-typescript';
+import {
+  ARRAY_METHOD_NOT_ANY_OF_PREDICATE,
+  DEFAULT_EXPORT_IDENTIFIER_NOT_ANY_OF_PREDICATE,
+} from '../../ts-js-hoc-utils.js';
 
 // tree-sitter-typescript exports both `typescript` and `tsx` grammars on
 // the default export. The package's `.d.ts` types the default export
@@ -306,7 +310,7 @@ const TYPESCRIPT_SCOPE_QUERY = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (arrow_function) @declaration.function)))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
 (lexical_declaration
   (variable_declarator
@@ -316,7 +320,7 @@ const TYPESCRIPT_SCOPE_QUERY = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (function_expression) @declaration.function)))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
 (variable_declaration
   (variable_declarator
@@ -342,7 +346,7 @@ const TYPESCRIPT_SCOPE_QUERY = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (arrow_function) @declaration.function)))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
 (variable_declaration
   (variable_declarator
@@ -352,38 +356,41 @@ const TYPESCRIPT_SCOPE_QUERY = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (function_expression) @declaration.function)))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with"))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
 ;; HOC-wrapped default exports: \`export default defineEventHandler(async (e) => { ... })\`.
-;; The callee identifier provides @declaration.name since there is no
-;; variable_declarator. Covers Nuxt/h3 defineEventHandler, Next.js API
-;; route handlers, and any HOC used as a default export. Member-expression
-;; callees (e.g. \`React.memo\`) use the property as the name.
-(export_statement
-  (call_expression
-    function: (identifier) @declaration.name
+;; The emit phase rewrites @declaration.name to a file-derived name so
+;; wrappers like \`defineEventHandler\` / \`React.memo\` do not collapse
+;; unrelated modules onto the same symbol name.
+((export_statement
+  value: (call_expression
+    function: (identifier) @hoc
     arguments: (arguments
       (arrow_function) @declaration.function)))
+  ${DEFAULT_EXPORT_IDENTIFIER_NOT_ANY_OF_PREDICATE})
 
-(export_statement
-  (call_expression
-    function: (identifier) @declaration.name
+((export_statement
+  value: (call_expression
+    function: (identifier) @hoc
     arguments: (arguments
       (function_expression) @declaration.function)))
+  ${DEFAULT_EXPORT_IDENTIFIER_NOT_ANY_OF_PREDICATE})
 
-(export_statement
-  (call_expression
+((export_statement
+  value: (call_expression
     function: (member_expression
-      property: (property_identifier) @declaration.name)
+      property: (property_identifier) @callee)
     arguments: (arguments
       (arrow_function) @declaration.function)))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
-(export_statement
-  (call_expression
+((export_statement
+  value: (call_expression
     function: (member_expression
-      property: (property_identifier) @declaration.name)
+      property: (property_identifier) @callee)
     arguments: (arguments
       (function_expression) @declaration.function)))
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE})
 
 ;; Method definitions — regular + private (#field) methods.
 (method_definition

--- a/gitnexus/src/core/ingestion/method-types.ts
+++ b/gitnexus/src/core/ingestion/method-types.ts
@@ -61,6 +61,7 @@ export interface MethodExtractor {
    *  Return null to fall through to the generic extractor. */
   extractFunctionName?(
     node: SyntaxNode,
+    filePath?: string,
   ): { funcName: string | null; label: import('gitnexus-shared').NodeLabel } | null;
 }
 
@@ -98,5 +99,6 @@ export interface MethodExtractionConfig {
    *  Passed through to the MethodExtractor by createMethodExtractor. */
   extractFunctionName?: (
     node: SyntaxNode,
+    filePath?: string,
   ) => { funcName: string | null; label: import('gitnexus-shared').NodeLabel } | null;
 }

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -66,6 +66,11 @@ import {
   getTreeSitterContentByteLength,
   TREE_SITTER_MAX_BUFFER,
 } from './constants.js';
+import {
+  ARRAY_METHOD_HOC_BLOCKLIST_SET,
+  DEFAULT_EXPORT_IDENTIFIER_BLOCKLIST_SET,
+  deriveDefaultExportHocName,
+} from './ts-js-hoc-utils.js';
 
 export type FileProgressCallback = (current: number, total: number, filePath: string) => void;
 
@@ -492,6 +497,7 @@ const processParsingSequential = async (
     // lifecycle and flush-site ownership rules.
     const typeEnv = provider.fieldExtractor
       ? buildTypeEnv(tree, language, {
+          filePath: file.path,
           enclosingFunctionFinder: provider.enclosingFunctionFinder,
           extractFunctionName: provider.methodExtractor?.extractFunctionName,
         })
@@ -535,9 +541,49 @@ const processParsingSequential = async (
       ) {
         return;
       }
+      const exportDefaultCall =
+        nodeLabel === 'Function' && definitionNode?.type === 'export_statement'
+          ? definitionNode.namedChildren.find((child) => child.type === 'call_expression')
+          : undefined;
+      const defaultExportHocName = (() => {
+        if (exportDefaultCall === undefined) return null;
+        const argList = exportDefaultCall.childForFieldName?.('arguments');
+        const callback = argList?.namedChildren.find(
+          (child) => child.type === 'arrow_function' || child.type === 'function_expression',
+        );
+        if (callback === undefined) return null;
+
+        const callee = exportDefaultCall.childForFieldName?.('function');
+        if (
+          callee?.type === 'identifier' &&
+          DEFAULT_EXPORT_IDENTIFIER_BLOCKLIST_SET.has(callee.text)
+        ) {
+          return null;
+        }
+        if (callee?.type === 'member_expression') {
+          const property = callee.childForFieldName?.('property');
+          if (
+            property?.type === 'property_identifier' &&
+            ARRAY_METHOD_HOC_BLOCKLIST_SET.has(property.text)
+          ) {
+            return null;
+          }
+        }
+
+        return deriveDefaultExportHocName(file.path);
+      })();
+
       // Synthesize name for constructors without explicit @name capture (e.g. Swift init)
-      if (!nameNode && nodeLabel !== 'Constructor' && !extractedClassSymbol) return;
-      const nodeName = extractedClassSymbol?.name ?? (nameNode ? nameNode.text : 'init');
+      if (
+        !nameNode &&
+        nodeLabel !== 'Constructor' &&
+        !extractedClassSymbol &&
+        !defaultExportHocName
+      ) {
+        return;
+      }
+      const nodeName =
+        extractedClassSymbol?.name ?? defaultExportHocName ?? (nameNode ? nameNode.text : 'init');
 
       const startLine = definitionNodeForRange
         ? definitionNodeForRange.startPosition.row + lineOffset

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -95,10 +95,17 @@ export const TYPESCRIPT_QUERIES = `
 ; \`tsExtractFunctionName\` for the resolution logic and the \`query.ts\`
 ; comment for the full anchor-discipline rationale and the chained-
 ; array-method trade-off.
+;
+; NOTE: Excludes member-expression calls to common array methods (map, filter,
+; reduce, etc.) to avoid false positives like \`const x = arr.map(a => ...)\`
+; being classified as a Function when it's actually a Const holding an array.
+; Direct identifier calls and member expressions on non-array-methods (like
+; React.memo) are still matched.
 (lexical_declaration
   (variable_declarator
     name: (identifier) @name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (arrow_function))))) @definition.function
 
@@ -106,14 +113,36 @@ export const TYPESCRIPT_QUERIES = `
   (variable_declarator
     name: (identifier) @name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (function_expression))))) @definition.function
+
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (arrow_function))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (function_expression))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
 
 (export_statement
   declaration: (lexical_declaration
     (variable_declarator
       name: (identifier) @name
       value: (call_expression
+        function: (identifier)
         arguments: (arguments
           (arrow_function)))))) @definition.function
 
@@ -122,15 +151,40 @@ export const TYPESCRIPT_QUERIES = `
     (variable_declarator
       name: (identifier) @name
       value: (call_expression
+        function: (identifier)
         arguments: (arguments
           (function_expression)))))) @definition.function
 
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: (call_expression
+        function: (member_expression
+          property: (property_identifier) @callee)
+        arguments: (arguments
+          (arrow_function)))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: (call_expression
+        function: (member_expression
+          property: (property_identifier) @callee)
+        arguments: (arguments
+          (function_expression)))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+
 ; \`var X = HOC(...)\` parity with registry-primary. Legacy code (and any
 ; transpiler output that downlevels \`const\` to \`var\`) hits this shape.
+; Same array-method exclusions as const/let patterns above.
 (variable_declaration
   (variable_declarator
     name: (identifier) @name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (arrow_function))))) @definition.function
 
@@ -138,8 +192,62 @@ export const TYPESCRIPT_QUERIES = `
   (variable_declarator
     name: (identifier) @name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (function_expression))))) @definition.function
+
+(variable_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (arrow_function))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+
+(variable_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (function_expression))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+
+; HOC-wrapped default exports: \`export default defineEventHandler(async (e) => { ... })\`.
+; The callee identifier (e.g. \`defineEventHandler\`) provides the @name since
+; there is no variable_declarator. Mirrors the registry-primary patterns in
+; \`languages/typescript/query.ts\`. Covers Nuxt/h3 defineEventHandler,
+; Next.js API route handlers, Express middleware factories, and any
+; user-defined HOC used as a default export. The callee name is taken as
+; the function name — see \`tsExtractFunctionName\` for the matching logic.
+(export_statement
+  (call_expression
+    function: (identifier) @name
+    arguments: (arguments
+      (arrow_function)))) @definition.function
+
+(export_statement
+  (call_expression
+    function: (identifier) @name
+    arguments: (arguments
+      (function_expression)))) @definition.function
+
+(export_statement
+  (call_expression
+    function: (member_expression
+      property: (property_identifier) @name)
+    arguments: (arguments
+      (arrow_function)))) @definition.function
+
+(export_statement
+  (call_expression
+    function: (member_expression
+      property: (property_identifier) @name)
+    arguments: (arguments
+      (function_expression)))) @definition.function
 
 ; Variable/constant declarations (non-function values).
 ; Overlap with @definition.function patterns is handled by parse-worker dedup.
@@ -329,10 +437,12 @@ export const JAVASCRIPT_QUERIES = `
 ; / debounce / user-defined HOC factories). Both \`const\` and \`var\` forms
 ; are mirrored so JS code that uses \`var\` (or transpiler output) gets the
 ; same attribution as the registry-primary path.
+; Excludes common array methods (map, filter, reduce, etc.) to avoid false positives.
 (lexical_declaration
   (variable_declarator
     name: (identifier) @name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (arrow_function))))) @definition.function
 
@@ -340,14 +450,36 @@ export const JAVASCRIPT_QUERIES = `
   (variable_declarator
     name: (identifier) @name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (function_expression))))) @definition.function
+
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (arrow_function))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (function_expression))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
 
 (export_statement
   declaration: (lexical_declaration
     (variable_declarator
       name: (identifier) @name
       value: (call_expression
+        function: (identifier)
         arguments: (arguments
           (arrow_function)))))) @definition.function
 
@@ -356,14 +488,39 @@ export const JAVASCRIPT_QUERIES = `
     (variable_declarator
       name: (identifier) @name
       value: (call_expression
+        function: (identifier)
         arguments: (arguments
           (function_expression)))))) @definition.function
 
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: (call_expression
+        function: (member_expression
+          property: (property_identifier) @callee)
+        arguments: (arguments
+          (arrow_function)))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+
+(export_statement
+  declaration: (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: (call_expression
+        function: (member_expression
+          property: (property_identifier) @callee)
+        arguments: (arguments
+          (function_expression)))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+
 ; \`var X = HOC(...)\` parity with registry-primary.
+; Same array-method exclusions as const/let patterns.
 (variable_declaration
   (variable_declarator
     name: (identifier) @name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (arrow_function))))) @definition.function
 
@@ -371,8 +528,56 @@ export const JAVASCRIPT_QUERIES = `
   (variable_declarator
     name: (identifier) @name
     value: (call_expression
+      function: (identifier)
       arguments: (arguments
         (function_expression))))) @definition.function
+
+(variable_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (arrow_function))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+
+(variable_declaration
+  (variable_declarator
+    name: (identifier) @name
+    value: (call_expression
+      function: (member_expression
+        property: (property_identifier) @callee)
+      arguments: (arguments
+        (function_expression))))
+  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+
+; HOC-wrapped default exports (JS parity with TS patterns above).
+(export_statement
+  (call_expression
+    function: (identifier) @name
+    arguments: (arguments
+      (arrow_function)))) @definition.function
+
+(export_statement
+  (call_expression
+    function: (identifier) @name
+    arguments: (arguments
+      (function_expression)))) @definition.function
+
+(export_statement
+  (call_expression
+    function: (member_expression
+      property: (property_identifier) @name)
+    arguments: (arguments
+      (arrow_function)))) @definition.function
+
+(export_statement
+  (call_expression
+    function: (member_expression
+      property: (property_identifier) @name)
+    arguments: (arguments
+      (function_expression)))) @definition.function
 
 ; Variable/constant declarations (non-function values).
 ; Overlap with @definition.function patterns is handled by parse-worker dedup.

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -6,6 +6,8 @@
  * compatible with the standard tree-sitter grammars.
  */
 
+import { ARRAY_METHOD_NOT_ANY_OF_PREDICATE } from './ts-js-hoc-utils.js';
+
 // TypeScript queries - works with tree-sitter-typescript
 export const TYPESCRIPT_QUERIES = `
 (class_declaration
@@ -125,7 +127,7 @@ export const TYPESCRIPT_QUERIES = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (arrow_function))))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE}) @definition.function
 
 (lexical_declaration
   (variable_declarator
@@ -135,7 +137,7 @@ export const TYPESCRIPT_QUERIES = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (function_expression))))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE}) @definition.function
 
 (export_statement
   declaration: (lexical_declaration
@@ -164,7 +166,7 @@ export const TYPESCRIPT_QUERIES = `
           property: (property_identifier) @callee)
         arguments: (arguments
           (arrow_function)))))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE}) @definition.function
 
 (export_statement
   declaration: (lexical_declaration
@@ -175,7 +177,7 @@ export const TYPESCRIPT_QUERIES = `
           property: (property_identifier) @callee)
         arguments: (arguments
           (function_expression)))))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE}) @definition.function
 
 ; \`var X = HOC(...)\` parity with registry-primary. Legacy code (and any
 ; transpiler output that downlevels \`const\` to \`var\`) hits this shape.
@@ -204,7 +206,7 @@ export const TYPESCRIPT_QUERIES = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (arrow_function))))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE}) @definition.function
 
 (variable_declaration
   (variable_declarator
@@ -214,38 +216,35 @@ export const TYPESCRIPT_QUERIES = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (function_expression))))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE}) @definition.function
 
 ; HOC-wrapped default exports: \`export default defineEventHandler(async (e) => { ... })\`.
-; The callee identifier (e.g. \`defineEventHandler\`) provides the @name since
-; there is no variable_declarator. Mirrors the registry-primary patterns in
-; \`languages/typescript/query.ts\`. Covers Nuxt/h3 defineEventHandler,
-; Next.js API route handlers, Express middleware factories, and any
-; user-defined HOC used as a default export. The callee name is taken as
-; the function name — see \`tsExtractFunctionName\` for the matching logic.
-(export_statement
-  (call_expression
-    function: (identifier) @name
+; The worker rewrites the wrapper-derived @name to a file-derived symbol name
+; so helpers like \`defineEventHandler\` / \`React.memo\` do not collapse
+; unrelated modules onto the same Function name.
+ (export_statement
+  value: (call_expression
+    function: (identifier) @hoc
     arguments: (arguments
       (arrow_function)))) @definition.function
 
-(export_statement
-  (call_expression
-    function: (identifier) @name
+ (export_statement
+  value: (call_expression
+    function: (identifier) @hoc
     arguments: (arguments
       (function_expression)))) @definition.function
 
-(export_statement
-  (call_expression
+ (export_statement
+  value: (call_expression
     function: (member_expression
-      property: (property_identifier) @name)
+      property: (property_identifier) @callee)
     arguments: (arguments
       (arrow_function)))) @definition.function
 
-(export_statement
-  (call_expression
+ (export_statement
+  value: (call_expression
     function: (member_expression
-      property: (property_identifier) @name)
+      property: (property_identifier) @callee)
     arguments: (arguments
       (function_expression)))) @definition.function
 
@@ -462,7 +461,7 @@ export const JAVASCRIPT_QUERIES = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (arrow_function))))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE}) @definition.function
 
 (lexical_declaration
   (variable_declarator
@@ -472,7 +471,7 @@ export const JAVASCRIPT_QUERIES = `
         property: (property_identifier) @callee)
       arguments: (arguments
         (function_expression))))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE}) @definition.function
 
 (export_statement
   declaration: (lexical_declaration
@@ -501,7 +500,7 @@ export const JAVASCRIPT_QUERIES = `
           property: (property_identifier) @callee)
         arguments: (arguments
           (arrow_function)))))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE}) @definition.function
 
 (export_statement
   declaration: (lexical_declaration
@@ -512,7 +511,7 @@ export const JAVASCRIPT_QUERIES = `
           property: (property_identifier) @callee)
         arguments: (arguments
           (function_expression)))))
-  (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
+  ${ARRAY_METHOD_NOT_ANY_OF_PREDICATE}) @definition.function
 
 ; \`var X = HOC(...)\` parity with registry-primary.
 ; Same array-method exclusions as const/let patterns.
@@ -553,29 +552,29 @@ export const JAVASCRIPT_QUERIES = `
   (#not-any-of? @callee "map" "filter" "reduce" "forEach" "find" "findIndex" "some" "every" "flatMap" "sort" "splice" "slice" "concat" "fill" "copyWithin" "join" "flat" "at" "entries" "keys" "values" "indexOf" "lastIndexOf" "includes" "pop" "push" "shift" "unshift" "reverse" "reduceRight" "toSorted" "toReversed" "toSpliced" "with")) @definition.function
 
 ; HOC-wrapped default exports (JS parity with TS patterns above).
-(export_statement
-  (call_expression
-    function: (identifier) @name
+ (export_statement
+  value: (call_expression
+    function: (identifier) @hoc
     arguments: (arguments
       (arrow_function)))) @definition.function
 
-(export_statement
-  (call_expression
-    function: (identifier) @name
+ (export_statement
+  value: (call_expression
+    function: (identifier) @hoc
     arguments: (arguments
       (function_expression)))) @definition.function
 
-(export_statement
-  (call_expression
+ (export_statement
+  value: (call_expression
     function: (member_expression
-      property: (property_identifier) @name)
+      property: (property_identifier) @callee)
     arguments: (arguments
       (arrow_function)))) @definition.function
 
-(export_statement
-  (call_expression
+ (export_statement
+  value: (call_expression
     function: (member_expression
-      property: (property_identifier) @name)
+      property: (property_identifier) @callee)
     arguments: (arguments
       (function_expression)))) @definition.function
 

--- a/gitnexus/src/core/ingestion/ts-js-hoc-utils.ts
+++ b/gitnexus/src/core/ingestion/ts-js-hoc-utils.ts
@@ -1,0 +1,129 @@
+import path from 'node:path';
+
+import type { SyntaxNode } from './utils/ast-helpers.js';
+
+// Member-expression callees that should never classify a callback-wrapped
+// binding as a top-level Function. This covers callback-taking Array methods
+// plus a few value-returning methods that share the same AST shape.
+export const ARRAY_METHOD_HOC_BLOCKLIST = [
+  'map',
+  'filter',
+  'reduce',
+  'forEach',
+  'find',
+  'findIndex',
+  'some',
+  'every',
+  'flatMap',
+  'sort',
+  'splice',
+  'slice',
+  'concat',
+  'fill',
+  'copyWithin',
+  'join',
+  'flat',
+  'at',
+  'entries',
+  'keys',
+  'values',
+  'indexOf',
+  'lastIndexOf',
+  'includes',
+  'pop',
+  'push',
+  'shift',
+  'unshift',
+  'reverse',
+  'reduceRight',
+  'toSorted',
+  'toReversed',
+  'toSpliced',
+  'with',
+] as const;
+
+export const ARRAY_METHOD_HOC_BLOCKLIST_SET: ReadonlySet<string> = new Set(
+  ARRAY_METHOD_HOC_BLOCKLIST,
+);
+
+// Identifier-callee default exports stay intentionally conservative: only a
+// few obvious callback-taking built-ins are suppressed here. Framework HOCs
+// like defineEventHandler still pass through and are named from the module.
+export const DEFAULT_EXPORT_IDENTIFIER_BLOCKLIST = [
+  'setTimeout',
+  'setInterval',
+  'queueMicrotask',
+  'requestAnimationFrame',
+  'requestIdleCallback',
+] as const;
+
+export const DEFAULT_EXPORT_IDENTIFIER_BLOCKLIST_SET: ReadonlySet<string> = new Set(
+  DEFAULT_EXPORT_IDENTIFIER_BLOCKLIST,
+);
+
+export const ARRAY_CALLBACK_METHODS: ReadonlySet<string> = new Set([
+  'map',
+  'filter',
+  'find',
+  'findIndex',
+  'findLast',
+  'findLastIndex',
+  'forEach',
+  'reduce',
+  'reduceRight',
+  'some',
+  'every',
+  'flatMap',
+  'sort',
+]);
+
+export function buildNotAnyOfPredicate(captureName: string, values: readonly string[]): string {
+  return `(#not-any-of? @${captureName} ${values.map((value) => `"${value}"`).join(' ')})`;
+}
+
+export const ARRAY_METHOD_NOT_ANY_OF_PREDICATE = buildNotAnyOfPredicate(
+  'callee',
+  ARRAY_METHOD_HOC_BLOCKLIST,
+);
+
+export const DEFAULT_EXPORT_IDENTIFIER_NOT_ANY_OF_PREDICATE = buildNotAnyOfPredicate(
+  'hoc',
+  DEFAULT_EXPORT_IDENTIFIER_BLOCKLIST,
+);
+
+export function deriveDefaultExportHocName(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, '/');
+  // Use individual path.posix helpers instead of path.posix.parse() to avoid
+  // triggering the require-safe-parse ESLint rule (which treats any .parse()
+  // call in src/core/ as a potential unsafe tree-sitter direct-parse).
+  const ext = path.posix.extname(normalized);
+  const name = path.posix.basename(normalized, ext);
+  const dir = path.posix.dirname(normalized);
+
+  if (name === 'index') {
+    const parent = path.posix.basename(dir);
+    if (parent !== '' && parent !== '.' && parent !== '/') return parent;
+  }
+
+  return name || 'default';
+}
+
+export function isDefaultExportHocFunctionNode(node: SyntaxNode): boolean {
+  const args = node.parent;
+  if (args === null || args.type !== 'arguments') return false;
+
+  const callExpr = args.parent;
+  if (callExpr === null || callExpr.type !== 'call_expression') return false;
+
+  return callExpr.parent?.type === 'export_statement';
+}
+
+export function isBlockedDefaultExportHoc(node: SyntaxNode): boolean {
+  if (!isDefaultExportHocFunctionNode(node)) return false;
+
+  const callExpr = node.parent?.parent;
+  if (callExpr === null || callExpr?.type !== 'call_expression') return false;
+
+  const callee = callExpr.childForFieldName?.('function');
+  return callee?.type === 'identifier' && DEFAULT_EXPORT_IDENTIFIER_BLOCKLIST_SET.has(callee.text);
+}

--- a/gitnexus/src/core/ingestion/type-env.ts
+++ b/gitnexus/src/core/ingestion/type-env.ts
@@ -152,7 +152,11 @@ const lookupInEnv = (
   callNode: SyntaxNode,
   patternOverrides?: PatternOverrides,
   enclosingFunctionFinder?: (n: SyntaxNode) => { funcName: string; label: NodeLabel } | null,
-  extractFunctionNameHook?: (n: SyntaxNode) => { funcName: string | null; label: NodeLabel } | null,
+  extractFunctionNameHook?: (
+    n: SyntaxNode,
+    filePath?: string,
+  ) => { funcName: string | null; label: NodeLabel } | null,
+  filePath?: string,
 ): string | undefined => {
   // Self/this receiver: resolve to enclosing class name via AST walk
   if (varName === 'self' || varName === 'this' || varName === '$this') {
@@ -170,6 +174,7 @@ const lookupInEnv = (
     callNode,
     enclosingFunctionFinder,
     extractFunctionNameHook,
+    filePath,
   );
 
   // Check position-indexed pattern overrides first (e.g., Kotlin when/is smart casts).
@@ -386,12 +391,17 @@ const extractParentClassFromNode = (classNode: SyntaxNode): string | undefined =
 const findEnclosingScopeKey = (
   node: SyntaxNode,
   enclosingFunctionFinder?: (n: SyntaxNode) => { funcName: string; label: NodeLabel } | null,
-  extractFunctionNameHook?: (n: SyntaxNode) => { funcName: string | null; label: NodeLabel } | null,
+  extractFunctionNameHook?: (
+    n: SyntaxNode,
+    filePath?: string,
+  ) => { funcName: string | null; label: NodeLabel } | null,
+  filePath?: string,
 ): string | undefined => {
   let current = node.parent;
   while (current) {
     if (FUNCTION_NODE_TYPES.has(current.type)) {
-      const funcName = extractFunctionNameHook?.(current)?.funcName ?? genericFuncName(current);
+      const funcName =
+        extractFunctionNameHook?.(current, filePath)?.funcName ?? genericFuncName(current);
       if (funcName) return `${funcName}@${current.startIndex}`;
     }
     // Language-specific hook (e.g., Dart function_body → sibling function_signature)
@@ -783,6 +793,7 @@ const resolveFixpointBindings = (
  * Uses an options object to allow future extensions without positional parameter sprawl.
  */
 export interface BuildTypeEnvOptions {
+  filePath?: string;
   model?: SemanticModel;
   parentMap?: ReadonlyMap<string, readonly string[]>;
   /** Pre-resolved bindings from upstream files (Phase 14).
@@ -807,7 +818,10 @@ export interface BuildTypeEnvOptions {
    *  Replaces the generic name-field lookup for languages with non-standard
    *  AST structures (C/C++ declarator unwrapping, Swift init/deinit, etc.).
    *  When null is returned or not provided, falls back to node.childForFieldName('name')?.text. */
-  extractFunctionName?: (node: SyntaxNode) => { funcName: string | null; label: NodeLabel } | null;
+  extractFunctionName?: (
+    node: SyntaxNode,
+    filePath?: string,
+  ) => { funcName: string | null; label: NodeLabel } | null;
 }
 
 /** Seed cross-file type bindings into the file scope.
@@ -1285,6 +1299,7 @@ export const buildTypeEnv = (
         patternOverrides,
         options?.enclosingFunctionFinder,
         extractFuncNameHook,
+        options?.filePath,
       ),
     constructorBindings: bindings,
     fileScope: () => env.get(FILE_SCOPE) ?? emptyFileScope(),

--- a/gitnexus/src/core/ingestion/utils/ast-helpers.ts
+++ b/gitnexus/src/core/ingestion/utils/ast-helpers.ts
@@ -197,7 +197,11 @@ export function getLabelFromCaptures(
   provider: LanguageProvider,
 ): NodeLabel | null {
   if (captureMap['import'] || captureMap['call']) return null;
-  if (!captureMap['name'] && !captureMap['definition.constructor']) return null;
+  const hasDefaultExportHocNameSeed =
+    captureMap['definition.function'] !== undefined &&
+    (captureMap['hoc'] !== undefined || captureMap['callee'] !== undefined);
+  if (!captureMap['name'] && !captureMap['definition.constructor'] && !hasDefaultExportHocNameSeed)
+    return null;
 
   if (captureMap['definition.function']) {
     if (provider.labelOverride) {

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -20,6 +20,11 @@ import {
   getTreeSitterContentByteLength,
   TREE_SITTER_MAX_BUFFER,
 } from '../constants.js';
+import {
+  ARRAY_METHOD_HOC_BLOCKLIST_SET,
+  DEFAULT_EXPORT_IDENTIFIER_BLOCKLIST_SET,
+  deriveDefaultExportHocName,
+} from '../ts-js-hoc-utils.js';
 import { parseSourceSafe } from '../../tree-sitter/safe-parse.js';
 import type { SymbolTableReader } from '../model/symbol-table.js';
 import type { ExtractedHeritage } from '../model/heritage-map.js';
@@ -588,7 +593,7 @@ const findEnclosingFunctionId = (
   let current = node.parent;
   while (current) {
     if (FUNCTION_NODE_TYPES.has(current.type)) {
-      const efnResult = provider.methodExtractor?.extractFunctionName?.(current);
+      const efnResult = provider.methodExtractor?.extractFunctionName?.(current, filePath);
       const funcName = efnResult?.funcName ?? genericFuncName(current);
       const label = efnResult?.label ?? inferFunctionLabel(current.type);
       if (funcName) {
@@ -1174,6 +1179,7 @@ const processFileGroup = (
     // Constructor bindings are verified against the SymbolTable in processCallsFromExtracted.
     const parentMap: ReadonlyMap<string, readonly string[]> = fileParentMap;
     const typeEnv = buildTypeEnv(tree, language, {
+      filePath: file.path,
       parentMap,
       enclosingFunctionFinder: provider?.enclosingFunctionFinder,
       extractFunctionName: provider?.methodExtractor?.extractFunctionName,
@@ -1713,9 +1719,47 @@ const processFileGroup = (
         processedDefinitionNodes.add(definitionNode.startIndex);
       }
 
+      const exportDefaultCall =
+        nodeLabel === 'Function' && definitionNode?.type === 'export_statement'
+          ? definitionNode.namedChildren.find((child) => child.type === 'call_expression')
+          : undefined;
+      const defaultExportHocName = (() => {
+        if (exportDefaultCall === undefined) return null;
+        const argList = exportDefaultCall.childForFieldName?.('arguments');
+        const callback = argList?.namedChildren.find(
+          (child) => child.type === 'arrow_function' || child.type === 'function_expression',
+        );
+        if (callback === undefined) return null;
+
+        const callee = exportDefaultCall.childForFieldName?.('function');
+        if (
+          callee?.type === 'identifier' &&
+          DEFAULT_EXPORT_IDENTIFIER_BLOCKLIST_SET.has(callee.text)
+        )
+          return null;
+        if (callee?.type === 'member_expression') {
+          const property = callee.childForFieldName?.('property');
+          if (
+            property?.type === 'property_identifier' &&
+            ARRAY_METHOD_HOC_BLOCKLIST_SET.has(property.text)
+          )
+            return null;
+        }
+
+        return deriveDefaultExportHocName(file.path);
+      })();
+
       // Synthesize name for constructors without explicit @name capture (e.g. Swift init)
-      if (!nameNode && nodeLabel !== 'Constructor' && !extractedClassSymbol) continue;
-      const nodeName = extractedClassSymbol?.name ?? (nameNode ? nameNode.text : 'init');
+      if (
+        !nameNode &&
+        nodeLabel !== 'Constructor' &&
+        !extractedClassSymbol &&
+        !defaultExportHocName
+      )
+        continue;
+
+      const nodeName =
+        extractedClassSymbol?.name ?? defaultExportHocName ?? (nameNode ? nameNode.text : 'init');
       const startLine = definitionNode
         ? definitionNode.startPosition.row + lineOffset
         : nameNode

--- a/gitnexus/test/fixtures/lang-resolution/typescript-hoc-wrapped/src/array-method-fp.ts
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-hoc-wrapped/src/array-method-fp.ts
@@ -1,0 +1,24 @@
+// Negative fixture: array method calls whose callback is an arrow must NOT
+// be classified as Functions. The variable holds the transformed array, not a
+// reusable function. Pre-fix these were incorrectly tagged as Function nodes.
+//
+// The names `mappedData`, `filtered`, `reduced` must NOT appear as Function
+// nodes in the graph, and calls inside the callbacks (doStuff) must NOT
+// attribute to those names.
+
+import { doStuff } from './helpers';
+
+interface Account { id: number }
+
+declare const accountsList: Account[];
+
+export const mappedData = accountsList.map((account) => ({
+  id: doStuff(account.id),
+}));
+
+export const filtered = accountsList.filter((account) => doStuff(account.id) > 0);
+
+export const reduced = accountsList.reduce((acc, account) => {
+  doStuff(account.id);
+  return acc + account.id;
+}, 0);

--- a/gitnexus/test/fixtures/lang-resolution/typescript-hoc-wrapped/src/export-default-hoc.ts
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-hoc-wrapped/src/export-default-hoc.ts
@@ -1,10 +1,11 @@
 // export default HOC(arrow) — the pattern used by Nuxt/h3 defineEventHandler,
-// Next.js API route handlers, and similar frameworks. There is no const binding;
-// the callee identifier (e.g. `defineEventHandler`) becomes the function name.
+// Next.js API route handlers, and similar frameworks. There is no const binding,
+// so the graph names the wrapped callback from the file/module rather than the
+// wrapper helper.
 //
 // Pre-fix: these were invisible — no variable_declarator ancestor meant no
 //          @declaration.function match, so calls inside attributed to File.
-// Post-fix: matched by the new export_statement patterns; callee name is used.
+// Post-fix: matched by the new export_statement patterns; the file stem is used.
 
 import { doStuff, helper } from './helpers';
 

--- a/gitnexus/test/fixtures/lang-resolution/typescript-hoc-wrapped/src/export-default-hoc.ts
+++ b/gitnexus/test/fixtures/lang-resolution/typescript-hoc-wrapped/src/export-default-hoc.ts
@@ -1,0 +1,17 @@
+// export default HOC(arrow) — the pattern used by Nuxt/h3 defineEventHandler,
+// Next.js API route handlers, and similar frameworks. There is no const binding;
+// the callee identifier (e.g. `defineEventHandler`) becomes the function name.
+//
+// Pre-fix: these were invisible — no variable_declarator ancestor meant no
+//          @declaration.function match, so calls inside attributed to File.
+// Post-fix: matched by the new export_statement patterns; callee name is used.
+
+import { doStuff, helper } from './helpers';
+
+// Stand-in for h3/defineEventHandler — same call shape.
+const defineEventHandler = <T>(fn: (event: T) => unknown) => fn;
+
+export default defineEventHandler(async (_event) => {
+  doStuff(1);
+  helper('route');
+});

--- a/gitnexus/test/integration/resolvers/typescript-hoc-wrapped.test.ts
+++ b/gitnexus/test/integration/resolvers/typescript-hoc-wrapped.test.ts
@@ -303,4 +303,57 @@ describe('TypeScript HOC-wrapped variable declarations', () => {
       'no Function-sourced CALLS from nested.tsx (all anchors should be File)',
     ).toEqual([]);
   });
+
+  // ─────────────────────────────────────────────────────────────────
+  // export default HOC(arrow) — issue #1876
+  //
+  // `export default defineEventHandler(async (e) => { ... })` has no
+  // variable_declarator ancestor, so the old patterns were invisible.
+  // The new export_statement patterns derive the name from the callee
+  // identifier. The function is registered as Function:defineEventHandler
+  // and its inner calls attribute to that name.
+  // ─────────────────────────────────────────────────────────────────
+
+  it('export default HOC: defineEventHandler calls attribute to defineEventHandler', () => {
+    const calls = getRelationships(result, 'CALLS').filter(
+      (c) => c.sourceFilePath === 'src/export-default-hoc.ts' && c.source === 'defineEventHandler',
+    );
+    const targets = new Set(calls.map((c) => c.target));
+    expect(targets, 'defineEventHandler must call doStuff').toContain('doStuff');
+    expect(targets, 'defineEventHandler must call helper').toContain('helper');
+  });
+
+  it('export default HOC: defineEventHandler is registered as a Function node', () => {
+    const functions = new Set(getNodesByLabel(result, 'Function'));
+    expect(functions, 'defineEventHandler (export default HOC) must be a Function node').toContain(
+      'defineEventHandler',
+    );
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Negative: array methods must NOT produce Function nodes (issue #1876)
+  //
+  // `const x = arr.map(a => ...)` was incorrectly classified as a Function.
+  // The fix splits HOC patterns into identifier vs member_expression variants
+  // and applies a blocklist for common array methods.
+  // ─────────────────────────────────────────────────────────────────
+
+  it('array method callbacks are not registered as Function nodes', () => {
+    const functions = new Set(getNodesByLabel(result, 'Function'));
+    expect(functions, 'mappedData must NOT be a Function node').not.toContain('mappedData');
+    expect(functions, 'filtered must NOT be a Function node').not.toContain('filtered');
+    expect(functions, 'reduced must NOT be a Function node').not.toContain('reduced');
+  });
+
+  it('array method callback calls do not attribute to the const name', () => {
+    for (const constName of ['mappedData', 'filtered', 'reduced']) {
+      const calls = getRelationships(result, 'CALLS').filter(
+        (c) => c.sourceFilePath === 'src/array-method-fp.ts' && c.source === constName,
+      );
+      expect(
+        calls,
+        `no CALLS should attribute to ${constName} (it is an array, not a function)`,
+      ).toEqual([]);
+    }
+  });
 });

--- a/gitnexus/test/integration/resolvers/typescript-hoc-wrapped.test.ts
+++ b/gitnexus/test/integration/resolvers/typescript-hoc-wrapped.test.ts
@@ -43,6 +43,7 @@ import {
   getRelationships,
   edgeSet,
   getNodesByLabel,
+  getNodesByLabelFull,
   runPipelineFromRepo,
   type PipelineResult,
 } from './helpers.js';
@@ -309,24 +310,35 @@ describe('TypeScript HOC-wrapped variable declarations', () => {
   //
   // `export default defineEventHandler(async (e) => { ... })` has no
   // variable_declarator ancestor, so the old patterns were invisible.
-  // The new export_statement patterns derive the name from the callee
-  // identifier. The function is registered as Function:defineEventHandler
-  // and its inner calls attribute to that name.
+  // The new export_statement patterns register it as a function named
+  // from the file/module, not from the wrapper helper.
   // ─────────────────────────────────────────────────────────────────
 
-  it('export default HOC: defineEventHandler calls attribute to defineEventHandler', () => {
+  it('export default HOC: calls attribute to the file-derived function name', () => {
+    const calls = getRelationships(result, 'CALLS').filter(
+      (c) => c.sourceFilePath === 'src/export-default-hoc.ts' && c.source === 'export-default-hoc',
+    );
+    const targets = new Set(calls.map((c) => c.target));
+    expect(targets, 'export-default-hoc must call doStuff').toContain('doStuff');
+    expect(targets, 'export-default-hoc must call helper').toContain('helper');
+  });
+
+  it('export default HOC: the file-derived symbol is registered in the source file', () => {
+    const functions = getNodesByLabelFull(result, 'Function').filter(
+      (node) => node.properties.filePath === 'src/export-default-hoc.ts',
+    );
+    expect(
+      functions.map((node) => node.name),
+      'export-default-hoc must be the graph-visible Function name for the wrapped default export',
+    ).toContain('export-default-hoc');
+  });
+
+  it('export default HOC: inner calls do not attribute to the wrapper helper name', () => {
     const calls = getRelationships(result, 'CALLS').filter(
       (c) => c.sourceFilePath === 'src/export-default-hoc.ts' && c.source === 'defineEventHandler',
     );
-    const targets = new Set(calls.map((c) => c.target));
-    expect(targets, 'defineEventHandler must call doStuff').toContain('doStuff');
-    expect(targets, 'defineEventHandler must call helper').toContain('helper');
-  });
-
-  it('export default HOC: defineEventHandler is registered as a Function node', () => {
-    const functions = new Set(getNodesByLabel(result, 'Function'));
-    expect(functions, 'defineEventHandler (export default HOC) must be a Function node').toContain(
-      'defineEventHandler',
+    expect(calls, 'wrapped default-export calls must not collapse onto defineEventHandler').toEqual(
+      [],
     );
   });
 

--- a/gitnexus/test/unit/call-attribution-issue-1166.test.ts
+++ b/gitnexus/test/unit/call-attribution-issue-1166.test.ts
@@ -534,31 +534,16 @@ describe('issue #1166 follow-up — HOC-wrapped variable declarations', () => {
 
   // ─── Documented trade-offs: pin behaviour so future readers aren't surprised ───
 
-  it('accepted false-positive: `const x = arr.find((y) => p(y))` attributes p to "x"', () => {
-    // The HOC-wrapped pattern (arrow's parent is `arguments`, grandparent is
-    // `call_expression`, great-grandparent is `variable_declarator`) is broad
-    // enough to also match chained array-method callbacks like Array#find /
-    // Array#some / Array#every — where `x` is a *value* (the result of the
-    // method), not a function. The arrow inside borrows the const's name and
-    // its inner calls attribute to it.
-    //
-    // This is documented in `languages/typescript/query.ts` as an accepted
-    // trade-off because:
-    //   1. `x` is never invoked as a function, so no incoming CALLS edge is
-    //      ever created — the spurious `Function:x` is graph-isolated on the
-    //      incoming side.
-    //   2. The outgoing edge `Function:x → predicate` is a minor mis-attribution
-    //      (the call IS happening, just not from a "function called x"), and
-    //      the alternative — narrowing the pattern to known HOC names — would
-    //      require maintaining a wrapper allowlist that breaks for every new
-    //      HOC factory.
-    //
-    // We pin this here so a future change that tightens the pattern is forced
-    // to update this test and re-evaluate the trade-off explicitly.
+  it('does not attribute array-method callbacks to the result binding', () => {
+    // Array-method callbacks used to borrow the surrounding const name via the
+    // HOC-wrapped-function path. That produced phantom callers like
+    // `Function:found -> predicate` even though `found` is the Array#find
+    // result value, not a callable. The array-method blocklist now suppresses
+    // that synthetic Function anchor, so inner calls stay anonymous here.
     const sites = collectCallAttributions(`
       const found = items.find((item) => predicate(item));
     `);
-    expect(findCall(sites, 'predicate')?.attributedTo).toBe('found');
+    expect(findCall(sites, 'predicate')?.attributedTo ?? null).toBeNull();
   });
 
   it('multi-arrow argument: both arrows resolve to the same const name (legacy DAG path)', () => {

--- a/gitnexus/test/unit/scope-resolution/javascript/javascript-captures.test.ts
+++ b/gitnexus/test/unit/scope-resolution/javascript/javascript-captures.test.ts
@@ -112,13 +112,37 @@ describe('emitJsScopeCaptures — #1876 array-method-callback narrowing', () => 
     expect(hasDecl(src, '@declaration.function', 'x')).toBe(false);
   });
 
-  it('does NOT suppress a parenthesized callee `(arr.map)(cb)` (intentional gap)', () => {
+  it('suppresses a parenthesized callee `(arr.map)(cb)`', () => {
     const src = 'const x = (arr.map)((a) => a);';
-    expect(hasDecl(src, '@declaration.function', 'x')).toBe(true);
+    expect(hasDecl(src, '@declaration.function', 'x')).toBe(false);
   });
 
-  it('does NOT suppress a computed callee `arr["map"](cb)` (intentional gap)', () => {
+  it('suppresses a computed callee `arr["map"](cb)`', () => {
     const src = 'const x = arr["map"]((a) => a);';
-    expect(hasDecl(src, '@declaration.function', 'x')).toBe(true);
+    expect(hasDecl(src, '@declaration.function', 'x')).toBe(false);
+  });
+
+  it('suppresses export-default array-method wrappers', () => {
+    const src = 'export default arr.map((a) => a);';
+    expect(countTag(src, '@declaration.function')).toBe(0);
+  });
+
+  it('suppresses obvious built-in callback wrappers in export default', () => {
+    const src = 'export default setTimeout(() => work());';
+    expect(countTag(src, '@declaration.function')).toBe(0);
+  });
+
+  it('rewrites export-default HOC names to the file stem', () => {
+    const matches = emitJsScopeCaptures(
+      'export default React.memo((props) => props);',
+      'routes/health-check.jsx',
+    );
+    expect(
+      matches.some(
+        (m) =>
+          m['@declaration.function'] !== undefined &&
+          m['@declaration.name']?.text === 'health-check',
+      ),
+    ).toBe(true);
   });
 });

--- a/gitnexus/test/unit/scope-resolution/typescript/typescript-captures.test.ts
+++ b/gitnexus/test/unit/scope-resolution/typescript/typescript-captures.test.ts
@@ -572,6 +572,8 @@ describe('emitTsScopeCaptures — #1876 array-method-callback narrowing', () => 
     emitTsScopeCaptures(src, 'test.ts').some(
       (m) => m[tag] !== undefined && m['@declaration.name']?.text === name,
     );
+  const countTag = (src: string, tag: string): number =>
+    emitTsScopeCaptures(src, 'test.ts').filter((m) => m[tag] !== undefined).length;
 
   it('does not emit @declaration.function for `const x = arr.map(a => …)`', () => {
     const src = 'const exportData = accountsList.map((account) => ({ id: account.id }));';
@@ -652,13 +654,37 @@ describe('emitTsScopeCaptures — #1876 array-method-callback narrowing', () => 
     expect(declWithName(src, '@declaration.function', 'x')).toBe(false);
   });
 
-  it('does NOT suppress a parenthesized callee `(arr.map)(cb)` (intentional gap)', () => {
+  it('suppresses a parenthesized callee `(arr.map)(cb)`', () => {
     const src = 'const x = (arr.map)((a) => a);';
-    expect(declWithName(src, '@declaration.function', 'x')).toBe(true);
+    expect(declWithName(src, '@declaration.function', 'x')).toBe(false);
   });
 
-  it('does NOT suppress a computed callee `arr["map"](cb)` (intentional gap)', () => {
+  it('suppresses a computed callee `arr["map"](cb)`', () => {
     const src = 'const x = arr["map"]((a) => a);';
-    expect(declWithName(src, '@declaration.function', 'x')).toBe(true);
+    expect(declWithName(src, '@declaration.function', 'x')).toBe(false);
+  });
+
+  it('suppresses export-default array-method wrappers', () => {
+    const src = 'export default arr.map((a) => a);';
+    expect(countTag(src, '@declaration.function')).toBe(0);
+  });
+
+  it('suppresses obvious built-in callback wrappers in export default', () => {
+    const src = 'export default setTimeout(() => work());';
+    expect(countTag(src, '@declaration.function')).toBe(0);
+  });
+
+  it('rewrites export-default HOC names to the file stem', () => {
+    const matches = emitTsScopeCaptures(
+      'export default React.memo((props) => props);',
+      'routes/health-check.tsx',
+    );
+    expect(
+      matches.some(
+        (m) =>
+          m['@declaration.function'] !== undefined &&
+          m['@declaration.name']?.text === 'health-check',
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes two related issues from #1876:

1. False positives: `const x = arr.map(a => ...)` was incorrectly classified as a Function node. Split HOC patterns into identifier vs member_expression variants and apply a #not-any-of? blocklist for 36 array methods (map, filter, reduce, forEach, etc.) across all four query files. Runtime safety-net in tsExtractFunctionName uses a module-level ARRAY_METHODS constant (avoids per-call Set re-allocation).

2. Missing support: `export default defineEventHandler(async (e) => { ... })` and similar HOC-wrapped default exports were invisible. Added 4 export_statement patterns (TS + JS, legacy + registry-primary) and extended tsExtractFunctionName to derive the function name from the callee identifier.

Now correctly distinguishes:
- `const data = arr.map(account => ({...}))` → Const only (was Function+Const)
- `const Button = forwardRef(...)` → Function:Button (unchanged)
- `const Card = React.memo(...)` → Function:memo (unchanged)
- `export default defineEventHandler(...)` → Function:defineEventHandler (new)

Tests: add 2 fixture files and 4 test cases to typescript-hoc-wrapped suite covering the export default HOC positive case and array method exclusion negative case.

Closes #1876

<img width="%70" alt="image" src="https://github.com/user-attachments/assets/4b6a3a55-e214-40b0-8ba3-e538352a7b87" />

## Motivation / context

Make the edges make more sense and clean. 

## Areas touched

<!-- Check all that apply -->

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- <!-- bullets -->

**Explicitly out of scope / not done here**

- <!-- bullets — prevents reviewers assuming missing work is an oversight -->

## Implementation notes

<!-- Optional: design choices, tradeoffs, follow-ups -->

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [x] `cd gitnexus && npm test`
- [x] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [x] `cd gitnexus && npx tsc --noEmit`
- [x] `cd gitnexus-web && npm test` *(if web changed)*
- [x] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [x] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

## Risk & rollout

<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed
