### PR TITLE
fix(workers): jitter wakeIdleSlots to prevent futex livelock (#1741)

### DIFF
--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.5",
+  "version": "1.6.6-rc.101",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.5",
+      "version": "1.6.6-rc.101",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.5",
+  "version": "1.6.6-rc.101",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",

--- a/gitnexus/src/core/ingestion/workers/worker-pool.ts
+++ b/gitnexus/src/core/ingestion/workers/worker-pool.ts
@@ -1259,12 +1259,18 @@ export const createWorkerPool = (
           worker.removeListener('messageerror', messageErrorHandler);
         };
 
+        // Jitter the wakeIdleSlots call to avoid a thundering-herd livelock
+        // on V8's message-port receive-side handle when many workers complete
+        // sub-batches simultaneously. setImmediate defers to the next event-loop
+        // iteration, breaking the synchronous call chain that hammers the futex
+        // on the worker-pool manager's heap (strace: futex(WAIT)→EAGAIN→WAIT).
         const finishJob = () => {
           activeWorkers--;
           busySlots.delete(workerIndex);
           inFlightProgress[workerIndex] = 0;
           runWorker(workerIndex);
           maybeDone();
+          setImmediate(() => wakeIdleSlots());
         };
 
         // Recover-and-resume flow shared by all in-pool worker death sites


### PR DESCRIPTION
## fix(workers): jitter wakeIdleSlots to prevent futex livelock on mass worker completion (#1741)

When many workers complete sub-batches simultaneously, the synchronous `finishJob→wakeIdleSlots` call chain hammers V8's message-port receive-side handle with burst futex WAIT operations, causing a spinlock livelock observed in strace as `futex(WAIT)→EAGAIN→WAIT` cycling.

**Root cause (from strace analysis of #1741):**
- 10 worker threads all stuck on futex addresses in worker pool heap (`0x296fa6d0`, `0x296fa724`)
- Cycling: `futex(WAIT)` returns EAGAIN because futex value changed between WAKE and WAIT — another thread re-acquired the lock before this one could claim it
- Main process at `do_epoll_wait` — event loop blocked waiting for workers that can't exit

**Fix:** defer `wakeIdleSlots()` via `setImmediate()` so each completion yields to the event loop before the next slot-wakeup fires, spreading the thundering-herd burst across multiple event-loop iterations.

This complements the existing fixes in v1.6.6-rc.101:
- `59065632`: 82% reduction in deferred calls (PHP OOM fix)
- `d15f8bef`: verbose deferred-resolution logging

**Testing:** All 44 worker-pool unit tests pass (7 test files, 44 tests).