### PR TITLE
feat(swift): migrate Swift to scope-based registry resolution (#937)

### DIFF
--- a/gitnexus/bench/scope-capture/baselines.json
+++ b/gitnexus/bench/scope-capture/baselines.json
@@ -25,7 +25,7 @@
     "scaling_budget": 1.5
   },
   "swift": {
-    "fingerprint": "dfd9d65af2e03e2b34956ed70151ab723d40976c9d7331ee00e62a4128c745dc",
+    "fingerprint": "e6870c409c1005944c51dffd6e485005bb206f7afcbc2ef078e0c2f781c2b2ad",
     "scaling_budget": 1.5
   }
 }

--- a/gitnexus/bench/scope-capture/baselines.json
+++ b/gitnexus/bench/scope-capture/baselines.json
@@ -23,5 +23,9 @@
   "ruby": {
     "fingerprint": "0f44b0d153b4534866589db93c582928651238b319cb606f2c6396362770cc18",
     "scaling_budget": 1.5
+  },
+  "swift": {
+    "fingerprint": "dfd9d65af2e03e2b34956ed70151ab723d40976c9d7331ee00e62a4128c745dc",
+    "scaling_budget": 1.5
   }
 }

--- a/gitnexus/bench/scope-capture/measure.mjs
+++ b/gitnexus/bench/scope-capture/measure.mjs
@@ -1,7 +1,7 @@
 /**
  * Unified build-free scope-capture measurement harness for every currently
  * benchmarked language (the ones with a `*-pipeline-benchmark.test.ts`):
- * go, csharp, rust, php, ruby, cobol — plus python lives in its own
+ * go, csharp, rust, php, ruby, cobol, swift — plus python lives in its own
  * `bench/python-scope/` harness (richer: it also covers import resolution).
  *
  * For each language it:
@@ -33,6 +33,7 @@ import { emitRustScopeCaptures } from '../../src/core/ingestion/languages/rust/i
 import { emitPhpScopeCaptures } from '../../src/core/ingestion/languages/php/index.ts';
 import { emitRubyScopeCaptures } from '../../src/core/ingestion/languages/ruby/index.ts';
 import { emitCobolScopeCaptures } from '../../src/core/ingestion/languages/cobol/index.ts';
+import { emitSwiftScopeCaptures } from '../../src/core/ingestion/languages/swift/index.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE_ROOT = path.resolve(__dirname, '..', '..', 'test', 'fixtures', 'lang-resolution');
@@ -160,6 +161,19 @@ const LANGS = [
       '       PROGRAM-ID. BENCH.\n' +
       '       PROCEDURE DIVISION.\n',
     unit: (n) => `       PARA-${String(n).padStart(5, '0')}.\n           DISPLAY "P${n}".\n`,
+  },
+  {
+    name: 'swift',
+    emit: emitSwiftScopeCaptures,
+    fixturePrefix: 'swift',
+    exts: ['.swift'],
+    file: 'bench.swift',
+    header: '',
+    unit: (n) =>
+      `class Entity${n} {\n` +
+      `  var id: Int64 = 0\n  var name: String = ""\n` +
+      `  func getId() -> Int64 { return self.id }\n` +
+      `  func setName(_ v: String) { self.name = v }\n}\n\n`,
   },
 ];
 

--- a/gitnexus/src/core/ingestion/import-resolvers/configs/swift.ts
+++ b/gitnexus/src/core/ingestion/import-resolvers/configs/swift.ts
@@ -14,12 +14,14 @@
  * context). Lookup per import is then O(1).
  *
  * Behavior is preserved bit-for-bit: a file is attributed to a target
- * iff its **lowercased** path starts with `<targetDir>/` (original
- * case), matching the old `normalizedFileList[i].startsWith(targetDir + '/')`
- * comparison; the returned paths are the original-case `allFileList`
- * entries; and the per-target file ORDER follows `allFileList`, so the
- * emitted `{ kind: 'files', files }` set and ordering are identical to
- * the old scan.
+ * iff its **forward-slash (backslash-normalized), case-sensitive** path
+ * starts with `<targetDir>/`, matching the old
+ * `normalizedFileList[i].startsWith(targetDir + '/')` comparison
+ * (`normalizedFileList` is only backslash→forward-slash normalized — NOT
+ * lowercased — so the match is case-sensitive); the returned paths are
+ * the original-case `allFileList` entries; and the per-target file ORDER
+ * follows `allFileList`, so the emitted `{ kind: 'files', files }` set and
+ * ordering are identical to the old scan.
  */
 
 import { SupportedLanguages } from 'gitnexus-shared';
@@ -49,8 +51,8 @@ function getSwiftTargetIndex(
   if (cached !== undefined) return cached;
 
   // Pre-compute each target's directory prefix once (original case, to
-  // match the legacy comparison against the lowercased file list — see
-  // module docstring).
+  // match the legacy comparison against the forward-slash-normalized,
+  // case-sensitive file list — see module docstring).
   const targetPrefixes: { name: string; prefix: string }[] = [];
   const byTarget = new Map<string, string[]>();
   for (const [name, dir] of targets) {
@@ -58,11 +60,12 @@ function getSwiftTargetIndex(
     byTarget.set(name, []);
   }
 
-  // Single pass over the file list. `normalizedFileList` is lowercased and
-  // index-aligned with `allFileList`; attribute the original-case path to
-  // every target whose prefix the lowercased path starts with (a file under
-  // a nested target dir can legitimately belong to multiple configured
-  // targets — the legacy per-import scan would have returned it for each).
+  // Single pass over the file list. `normalizedFileList` is forward-slash
+  // (backslash-normalized), case-sensitive, and index-aligned with
+  // `allFileList`; attribute the original-case path to every target whose
+  // prefix the normalized path starts with (a file under a nested target
+  // dir can legitimately belong to multiple configured targets — the
+  // legacy per-import scan would have returned it for each).
   for (let i = 0; i < ctx.allFileList.length; i++) {
     const norm = ctx.normalizedFileList[i];
     if (!norm.endsWith('.swift')) continue;

--- a/gitnexus/src/core/ingestion/import-resolvers/configs/swift.ts
+++ b/gitnexus/src/core/ingestion/import-resolvers/configs/swift.ts
@@ -1,28 +1,96 @@
 /**
  * Swift import resolution config.
  * Package.swift target map strategy — no standard fallback (unresolved = external framework).
+ *
+ * ## Performance (anti-O(imports × files))
+ *
+ * The previous implementation rescanned the whole `normalizedFileList`
+ * on every import to collect the `.swift` files under the requested
+ * target's directory — O(imports × files) per run, the exact hot path
+ * fixed for Python in PR #1918. We now build a `target → files` index
+ * ONCE per run, memoized on the stable `allFileList` array reference
+ * (the same `ResolveCtx` — and therefore the same array — is passed to
+ * every strategy invocation, per `import-processor`'s build-once
+ * context). Lookup per import is then O(1).
+ *
+ * Behavior is preserved bit-for-bit: a file is attributed to a target
+ * iff its **lowercased** path starts with `<targetDir>/` (original
+ * case), matching the old `normalizedFileList[i].startsWith(targetDir + '/')`
+ * comparison; the returned paths are the original-case `allFileList`
+ * entries; and the per-target file ORDER follows `allFileList`, so the
+ * emitted `{ kind: 'files', files }` set and ordering are identical to
+ * the old scan.
  */
 
 import { SupportedLanguages } from 'gitnexus-shared';
-import type { ImportResolutionConfig, ImportResolverStrategy } from '../types.js';
+import type { ImportResolutionConfig, ImportResolverStrategy, ResolveCtx } from '../types.js';
+
+interface SwiftTargetIndex {
+  /** Target name → original-case `.swift` file paths under that target dir. */
+  readonly byTarget: ReadonlyMap<string, string[]>;
+}
+
+/**
+ * Memoized on the `allFileList` array identity. `import-processor` builds
+ * the `ResolveCtx` once per run and threads the same object (and the same
+ * `allFileList`) through every strategy call, so the WeakMap is keyed on a
+ * stable reference and the index is built once — not once per import. A
+ * fresh run produces a fresh array → a fresh index, so cross-run staleness
+ * is impossible.
+ */
+const SWIFT_TARGET_INDEX_CACHE = new WeakMap<object, SwiftTargetIndex>();
+
+function getSwiftTargetIndex(
+  ctx: ResolveCtx,
+  targets: ReadonlyMap<string, string>,
+): SwiftTargetIndex {
+  const key = ctx.allFileList as object;
+  const cached = SWIFT_TARGET_INDEX_CACHE.get(key);
+  if (cached !== undefined) return cached;
+
+  // Pre-compute each target's directory prefix once (original case, to
+  // match the legacy comparison against the lowercased file list — see
+  // module docstring).
+  const targetPrefixes: { name: string; prefix: string }[] = [];
+  const byTarget = new Map<string, string[]>();
+  for (const [name, dir] of targets) {
+    targetPrefixes.push({ name, prefix: dir + '/' });
+    byTarget.set(name, []);
+  }
+
+  // Single pass over the file list. `normalizedFileList` is lowercased and
+  // index-aligned with `allFileList`; attribute the original-case path to
+  // every target whose prefix the lowercased path starts with (a file under
+  // a nested target dir can legitimately belong to multiple configured
+  // targets — the legacy per-import scan would have returned it for each).
+  for (let i = 0; i < ctx.allFileList.length; i++) {
+    const norm = ctx.normalizedFileList[i];
+    if (!norm.endsWith('.swift')) continue;
+    for (const { name, prefix } of targetPrefixes) {
+      if (norm.startsWith(prefix)) {
+        byTarget.get(name)!.push(ctx.allFileList[i]);
+      }
+    }
+  }
+
+  const index: SwiftTargetIndex = { byTarget };
+  SWIFT_TARGET_INDEX_CACHE.set(key, index);
+  return index;
+}
 
 /** Swift Package.swift target map resolution strategy. */
 export const swiftPackageStrategy: ImportResolverStrategy = (rawImportPath, _filePath, ctx) => {
   const swiftPackageConfig = ctx.configs.swiftPackageConfig;
   if (swiftPackageConfig) {
-    const targetDir = swiftPackageConfig.targets.get(rawImportPath);
-    if (targetDir) {
-      const dirPrefix = targetDir + '/';
-      const files: string[] = [];
-      for (let i = 0; i < ctx.normalizedFileList.length; i++) {
-        if (
-          ctx.normalizedFileList[i].startsWith(dirPrefix) &&
-          ctx.normalizedFileList[i].endsWith('.swift')
-        ) {
-          files.push(ctx.allFileList[i]);
-        }
+    // Only the targets map is needed; build the index lazily so repos
+    // without a Package.swift config pay nothing.
+    if (swiftPackageConfig.targets.has(rawImportPath)) {
+      const index = getSwiftTargetIndex(ctx, swiftPackageConfig.targets);
+      const files = index.byTarget.get(rawImportPath);
+      if (files !== undefined && files.length > 0) {
+        // Copy so callers can't mutate the cached index bucket.
+        return { kind: 'files', files: [...files] };
       }
-      if (files.length > 0) return { kind: 'files', files };
     }
   }
   return null; // External framework (Foundation, UIKit, etc.)

--- a/gitnexus/src/core/ingestion/languages/swift.ts
+++ b/gitnexus/src/core/ingestion/languages/swift.ts
@@ -32,6 +32,16 @@ import { swiftVariableConfig } from '../variable-extractors/configs/swift.js';
 import { createCallExtractor } from '../call-extractors/generic.js';
 import { swiftCallConfig } from '../call-extractors/configs/swift.js';
 import { createHeritageExtractor } from '../heritage-extractors/generic.js';
+import {
+  emitSwiftScopeCaptures,
+  interpretSwiftImport,
+  interpretSwiftTypeBinding,
+  swiftBindingScopeFor,
+  swiftImportOwningScope,
+  swiftReceiverBinding,
+  swiftMergeBindings,
+  swiftArityCompatibility,
+} from './swift/index.js';
 
 /**
  * Group Swift files by SPM target for implicit module visibility.
@@ -332,4 +342,14 @@ export const swiftProvider = defineLanguage({
   implicitImportWirer: wireSwiftImplicitImports,
   orderSameNameTypeCandidates: orderSwiftSameNameTypeCandidates,
   builtInNames: BUILT_INS,
+  // ── Scope-based resolution hooks (RFC #909 Ring 3, issue #937). See
+  //    languages/swift/ for the implementations. ──────────────────────
+  emitScopeCaptures: emitSwiftScopeCaptures,
+  interpretImport: interpretSwiftImport,
+  interpretTypeBinding: interpretSwiftTypeBinding,
+  bindingScopeFor: swiftBindingScopeFor,
+  importOwningScope: swiftImportOwningScope,
+  receiverBinding: swiftReceiverBinding,
+  mergeBindings: (_scope, bindings) => swiftMergeBindings(bindings),
+  arityCompatibility: swiftArityCompatibility,
 });

--- a/gitnexus/src/core/ingestion/languages/swift/arity-metadata.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/arity-metadata.ts
@@ -1,0 +1,49 @@
+/**
+ * Extract Swift arity metadata from a function-like tree-sitter node —
+ * `function_declaration`, `protocol_function_declaration`, or
+ * `init_declaration`.
+ *
+ * Reuses `swiftMethodConfig.extractParameters` so scope-extracted defs
+ * carry the same arity semantics as the legacy parse-worker path:
+ *   - Variadic params (`xs: Int...`) collapse `parameterCount` to
+ *     `undefined`, which `swiftArityCompatibility` treats as "max
+ *     unknown" — the candidate stays eligible at `argCount >= required`.
+ *   - Defaulted params (`= expr`) contribute to `optionalCount`;
+ *     `requiredParameterCount = total − optionalCount`.
+ *   - `parameterTypes` collects declared type names for narrowing; a
+ *     literal `'variadic'` marker is appended for variadic methods so
+ *     `swiftArityCompatibility` can detect them without re-reading AST.
+ */
+
+import type { SyntaxNode } from '../../utils/ast-helpers.js';
+import { swiftMethodConfig } from '../../method-extractors/configs/swift.js';
+
+interface SwiftArityMetadata {
+  readonly parameterCount: number | undefined;
+  readonly requiredParameterCount: number | undefined;
+  readonly parameterTypes: readonly string[] | undefined;
+}
+
+export function computeSwiftArityMetadata(fnNode: SyntaxNode): SwiftArityMetadata {
+  const params = swiftMethodConfig.extractParameters?.(fnNode) ?? [];
+
+  let hasVariadic = false;
+  let optionalCount = 0;
+  const types: string[] = [];
+  for (const p of params) {
+    if (p.isVariadic) hasVariadic = true;
+    else if (p.isOptional) optionalCount++;
+    if (p.type !== null) types.push(p.type);
+  }
+  if (hasVariadic) types.push('variadic');
+
+  const total = params.length;
+  const parameterCount = hasVariadic ? undefined : total;
+  const requiredParameterCount = hasVariadic ? undefined : total - optionalCount;
+
+  return {
+    parameterCount,
+    requiredParameterCount,
+    parameterTypes: types.length > 0 ? types : undefined,
+  };
+}

--- a/gitnexus/src/core/ingestion/languages/swift/arity.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/arity.ts
@@ -1,0 +1,49 @@
+/**
+ * Swift arity check, accommodating variadic and default parameters.
+ *
+ * Per the migration decision (count-primary, labels soft): we narrow on
+ * arity only. Swift's argument labels are a soft signal — a label
+ * mismatch is NOT treated as incompatible here, mirroring how the other
+ * migrated languages narrow and aligning with RFC §4 soft-penalty
+ * semantics. Label-precise dispatch is left to the registry's
+ * type-binding layer.
+ *
+ * The `def` metadata we care about (synthesized by `arity-metadata.ts`):
+ *   - `parameterCount`         — total formal parameters; `undefined`
+ *                                when the method has a variadic param.
+ *   - `requiredParameterCount` — min required (excludes defaulted params
+ *                                and the variadic).
+ *   - `parameterTypes`         — declared type strings; contains the
+ *                                literal `'variadic'` when variadic.
+ *
+ * Verdicts:
+ *   - `'compatible'`   — `requiredParameterCount <= argCount <= parameterCount`,
+ *                        OR the def is variadic (then any `argCount >= required`).
+ *   - `'incompatible'` — argCount below required, OR above max with no variadic.
+ *   - `'unknown'`      — metadata absent / incomplete.
+ *
+ * `'incompatible'` is a soft signal in `Registry.lookup` (penalized but
+ * still considered when no compatible candidate exists), per RFC §4.
+ */
+
+import type { Callsite, SymbolDefinition } from 'gitnexus-shared';
+
+export function swiftArityCompatibility(
+  def: SymbolDefinition,
+  callsite: Callsite,
+): 'compatible' | 'unknown' | 'incompatible' {
+  const max = def.parameterCount;
+  const min = def.requiredParameterCount;
+  if (max === undefined && min === undefined) return 'unknown';
+
+  const argCount = callsite.arity;
+  if (!Number.isFinite(argCount) || argCount < 0) return 'unknown';
+
+  const hasVarArgs =
+    def.parameterTypes !== undefined && def.parameterTypes.some((t) => t === 'variadic');
+
+  if (min !== undefined && argCount < min) return 'incompatible';
+  if (max !== undefined && argCount > max && !hasVarArgs) return 'incompatible';
+
+  return 'compatible';
+}

--- a/gitnexus/src/core/ingestion/languages/swift/cache-stats.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/cache-stats.ts
@@ -1,0 +1,30 @@
+/**
+ * Dev-mode counters for the cross-phase scope-captures parse cache
+ * (Swift mirror of `languages/csharp/cache-stats.ts`).
+ *
+ * Gated by `PROF_SCOPE_RESOLUTION=1`. Production builds fold every
+ * increment into dead code via the module-level `PROF` constant, so
+ * the hot path in `captures.ts` stays branch-free.
+ */
+
+const PROF = process.env.PROF_SCOPE_RESOLUTION === '1';
+
+let CACHE_HITS = 0;
+let CACHE_MISSES = 0;
+
+export function recordCacheHit(): void {
+  if (PROF) CACHE_HITS++;
+}
+
+export function recordCacheMiss(): void {
+  if (PROF) CACHE_MISSES++;
+}
+
+export function getSwiftCaptureCacheStats(): { hits: number; misses: number } {
+  return { hits: CACHE_HITS, misses: CACHE_MISSES };
+}
+
+export function resetSwiftCaptureCacheStats(): void {
+  CACHE_HITS = 0;
+  CACHE_MISSES = 0;
+}

--- a/gitnexus/src/core/ingestion/languages/swift/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/captures.ts
@@ -120,11 +120,7 @@ export function emitSwiftScopeCaptures(
     // @type-binding.constructor (name → callee); chain-follow resolves
     // the callee to its return type. ─────────────────────────────────
     if (grouped['@optional.binding'] !== undefined) {
-      const stmtNode = nodeIfType(
-        nodeMap['@optional.binding'],
-        'if_statement',
-        'guard_statement',
-      );
+      const stmtNode = nodeIfType(nodeMap['@optional.binding'], 'if_statement', 'guard_statement');
       const synth = stmtNode === null ? null : synthesizeOptionalBinding(stmtNode);
       if (synth !== null) out.push(synth);
       continue;

--- a/gitnexus/src/core/ingestion/languages/swift/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/captures.ts
@@ -121,17 +121,39 @@ export function emitSwiftScopeCaptures(
     // the callee to its return type. ─────────────────────────────────
     if (grouped['@optional.binding'] !== undefined) {
       const stmtNode = nodeIfType(nodeMap['@optional.binding'], 'if_statement', 'guard_statement');
-      const synth = stmtNode === null ? null : synthesizeOptionalBinding(stmtNode);
-      if (synth !== null) out.push(synth);
+      if (stmtNode !== null) {
+        for (const synth of synthesizeOptionalBindings(stmtNode)) out.push(synth);
+      }
       continue;
     }
 
-    // ── Field reads: keep only genuine reads (`u.address`); drop the
-    // navigation that is a call's callee (`u.save` in `u.save()`) or an
-    // assignment LHS (a write). Dedup identical spans. ───────────────
+    // ── Field accesses: a `navigation_expression` (`obj.field`) is one of
+    // three things. Drop it when it's a call's callee (`u.save` in
+    // `u.save()` — the @reference.call.member query already covers that).
+    // Re-tag it as a write when it's the LHS of an assignment
+    // (`obj.field = x`) so a `write` ACCESSES edge emits (mirrors
+    // Kotlin/PHP `@reference.write.member`); otherwise keep it as a
+    // genuine read (`u.address`) and dedup identical spans. ───────────
     if (grouped['@reference.read.member'] !== undefined) {
       const navNode = nodeIfType(nodeMap['@reference.read.member'], 'navigation_expression');
-      if (navNode === null || !shouldEmitSwiftReadMember(navNode)) continue;
+      if (navNode === null) continue;
+      if (isSwiftMemberCallCallee(navNode)) continue;
+      if (isSwiftMemberWriteLhs(navNode)) {
+        // Re-tag the read anchor as a write. The extractor's anchor
+        // classifier reads the capture's `.name` (not the map key —
+        // `referenceKindFromAnchor` derives the site kind from
+        // `@reference.<kind>`), so we build a FRESH capture whose `.name`
+        // is the write tag rather than aliasing the read capture object
+        // (which would still classify as a read — a silent no-op). The
+        // sibling `@reference.name` / `@reference.receiver` captures carry
+        // over unchanged so the field + receiver still resolve. (Mirrors
+        // the constructor re-tag below and PHP's write re-tag.)
+        const reKeyed: Record<string, Capture> = { ...grouped };
+        delete reKeyed['@reference.read.member'];
+        reKeyed['@reference.write.member'] = nodeToCapture('@reference.write.member', navNode);
+        out.push(reKeyed);
+        continue;
+      }
       const span = `${navNode.startIndex}-${navNode.endIndex}`;
       if (seenReadSpans.has(span)) continue;
       seenReadSpans.add(span);
@@ -148,9 +170,14 @@ export function emitSwiftScopeCaptures(
       reKeyed['@declaration.class'] = grouped['@declaration.extension'];
       if (extNode !== null) {
         const nameNode = extNode.childForFieldName('name');
+        // For a nested type `extension Foo.Bar`, the name is
+        // `(user_type (type_identifier Foo) (type_identifier Bar))`; the
+        // EXTENDED type is the trailing identifier `Bar` (lastNamedChild),
+        // not `Foo`. For a single `extension Foo`, first === last, so this
+        // is unchanged. Members must hoist onto `Bar`, not `Foo`.
         const bare =
           nameNode?.type === 'user_type'
-            ? (nameNode.firstNamedChild?.text ?? nameNode.text)
+            ? (nameNode.lastNamedChild?.text ?? nameNode.text)
             : (nameNode?.text ?? grouped['@declaration.name']?.text ?? '');
         if (bare !== '') {
           reKeyed['@declaration.name'] = syntheticCapture('@declaration.name', extNode, bare);
@@ -258,43 +285,96 @@ export function emitSwiftScopeCaptures(
   return out;
 }
 
-/** Synthesize a `@type-binding.constructor` for an if-let / guard-let
- *  optional binding: `if let u = getUser()` → `u: getUser` (chain-follow
- *  resolves getUser → its return type). The statement has a flat shape —
- *  a `bound_identifier:` field for the name and separate `condition:`
- *  children, one of which is the bound value (a call_expression, possibly
- *  wrapped in await/try). Returns null when the value isn't a call. */
-function synthesizeOptionalBinding(stmtNode: SyntaxNode): CaptureMatch | null {
-  const nameNode = stmtNode.childForFieldName('bound_identifier');
-  if (nameNode === null) return null;
+/** Synthesize a `@type-binding.constructor` for EACH clause of an
+ *  if-let / guard-let optional binding:
+ *    `if let u = getUser()` → one binding `u: getUser`
+ *    `if let a = makeA(), let b = makeB()` → two bindings `a: makeA`, `b: makeB`
+ *  (chain-follow resolves each callee → its return type).
+ *
+ *  The statement has a FLAT child list (verified, tree-sitter-swift 0.7.1):
+ *  each clause is `value_binding_pattern` · `simple_identifier` (the bound
+ *  name) · `=` · value, where value is a `call_expression` directly, or an
+ *  `await_expression` / `try_expression` wrapping one. NOTE: every bound
+ *  name carries the `bound_identifier` field, but `childForFieldName`
+ *  returns only the FIRST — so we walk the children in order instead.
+ *
+ *  Clauses whose value isn't a call (`if let a = optionalVar`) are skipped
+ *  WITHOUT consuming the following clause's call. Single-clause output is
+ *  byte-identical to the prior single-binding implementation. `if_statement`
+ *  and `guard_statement` share this shape and are handled identically. */
+function synthesizeOptionalBindings(stmtNode: SyntaxNode): CaptureMatch[] {
+  const out: CaptureMatch[] = [];
 
-  let callee: SyntaxNode | null = null;
+  // State machine over the flat clause list. `pendingName` is the bound
+  // name of the clause currently awaiting its value; `awaitingName` is set
+  // right after a `value_binding_pattern` so the next `simple_identifier`
+  // is taken as the name (not as a value).
+  let pendingName: SyntaxNode | null = null;
+  let awaitingName = false;
+
   for (let i = 0; i < stmtNode.childCount; i++) {
     const child = stmtNode.child(i);
     if (child === null) continue;
-    if (child.type === 'call_expression') {
-      callee = child.namedChild(0);
-      break;
+
+    // The clause list ends at the body / else / statements.
+    if (child.type === 'statements' || child.type === '{' || child.text === 'else') break;
+
+    if (child.type === 'value_binding_pattern') {
+      // A new clause begins; any prior clause whose value never arrived was
+      // a non-call clause — drop it without consuming this one.
+      pendingName = null;
+      awaitingName = true;
+      continue;
     }
-    if (child.type === 'await_expression' || child.type === 'try_expression') {
-      for (let j = 0; j < child.namedChildCount; j++) {
-        const inner = child.namedChild(j);
-        if (inner !== null && inner.type === 'call_expression') {
-          callee = inner.namedChild(0);
-          break;
-        }
+
+    if (awaitingName) {
+      if (child.type === 'simple_identifier') {
+        pendingName = child;
+        awaitingName = false;
       }
-      if (callee !== null) break;
+      continue;
+    }
+
+    if (pendingName === null) continue;
+    if (child.text === '=' || child.text === ',') continue;
+
+    // First non-`=` node after the name is the clause value. Take a binding
+    // only when it's a call; clear pendingName either way so a non-call
+    // clause doesn't steal the next clause's call.
+    const callee = optionalBindingCallee(child);
+    if (callee !== null) {
+      out.push({
+        '@type-binding.constructor': nodeToCapture('@type-binding.constructor', stmtNode),
+        '@type-binding.name': syntheticCapture('@type-binding.name', pendingName, pendingName.text),
+        '@type-binding.type': syntheticCapture('@type-binding.type', callee, callee.text),
+      });
+    }
+    pendingName = null;
+  }
+
+  return out;
+}
+
+/** Resolve an optional-binding clause VALUE node to its call callee
+ *  (`simple_identifier`), unwrapping a single `await`/`try` layer. Returns
+ *  null when the value isn't a bare-identifier call (e.g. `optionalVar`,
+ *  or `obj.method()` — which must NOT bind to `obj`). */
+function optionalBindingCallee(value: SyntaxNode): SyntaxNode | null {
+  let call: SyntaxNode | null = null;
+  if (value.type === 'call_expression') {
+    call = value;
+  } else if (value.type === 'await_expression' || value.type === 'try_expression') {
+    for (let j = 0; j < value.namedChildCount; j++) {
+      const inner = value.namedChild(j);
+      if (inner !== null && inner.type === 'call_expression') {
+        call = inner;
+        break;
+      }
     }
   }
-  if (callee === null || callee.type !== 'simple_identifier') return null;
-
-  const m: Record<string, Capture> = {
-    '@type-binding.constructor': nodeToCapture('@type-binding.constructor', stmtNode),
-    '@type-binding.name': syntheticCapture('@type-binding.name', nameNode, nameNode.text),
-    '@type-binding.type': syntheticCapture('@type-binding.type', callee, callee.text),
-  };
-  return m;
+  if (call === null) return null;
+  const callee = call.namedChild(0);
+  return callee !== null && callee.type === 'simple_identifier' ? callee : null;
 }
 
 /** Synthesize a `@type-binding.constructor` for `let x = Type.init(...)`.
@@ -334,20 +414,26 @@ function synthesizeInitCtorBinding(propNode: SyntaxNode): CaptureMatch | null {
   return m;
 }
 
-/** A navigation_expression (`a.b`) is a genuine field read unless it is
- *  the callee of a call (`a.b()` — a member call) or the LHS of an
- *  assignment (`a.b = …` — a write). The receiver chain of a deeper
- *  access (`user.address` in `user.address.save()`) has parent
- *  navigation_expression (not call_expression), so it is correctly kept. */
-function shouldEmitSwiftReadMember(navNode: SyntaxNode): boolean {
+/** Is this navigation_expression the callee of a call (`a.b` in `a.b()`)?
+ *  That is a member call, already captured by @reference.call.member, so
+ *  the read.member emission must be dropped. */
+function isSwiftMemberCallCallee(navNode: SyntaxNode): boolean {
+  return navNode.parent?.type === 'call_expression';
+}
+
+/** Is this navigation_expression the LHS of an assignment (`a.b = …` — a
+ *  field write)? tree-sitter-swift wraps the assignment target in a
+ *  `directly_assignable_expression`, so the write discriminator is the
+ *  GRANDPARENT `assignment` reached via that wrapper — NOT a direct
+ *  `parent.type === 'assignment'` (which never matches; the old guard was
+ *  dead). The inner `obj.a` of `obj.a.b = x` has parent
+ *  `navigation_expression` (the outer access), so it is correctly NOT a
+ *  write — only the outermost nav under `directly_assignable_expression`
+ *  is the write target. */
+function isSwiftMemberWriteLhs(navNode: SyntaxNode): boolean {
   const parent = navNode.parent;
-  if (parent === null) return true;
-  if (parent.type === 'call_expression') return false;
-  if (parent.type === 'assignment') {
-    const lhs = parent.childForFieldName('target') ?? parent.firstNamedChild;
-    if (lhs !== null && lhs.id === navNode.id) return false;
-  }
-  return true;
+  if (parent === null || parent.type !== 'directly_assignable_expression') return false;
+  return parent.parent?.type === 'assignment';
 }
 
 /** Attach @declaration.parameter-count / required-parameter-count /

--- a/gitnexus/src/core/ingestion/languages/swift/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/captures.ts
@@ -1,0 +1,402 @@
+/**
+ * `emitScopeCaptures` for Swift.
+ *
+ * Drives the Swift scope query against tree-sitter-swift and groups raw
+ * matches into `CaptureMatch[]` for the central extractor. Synthesizes
+ * several streams on top of the raw query captures:
+ *
+ *   1. **Decomposed imports** — each `import_declaration` is re-emitted
+ *      with `@import.kind/source/name` markers (and `@import.testable`
+ *      when present) so `interpretSwiftImport` recovers the ParsedImport
+ *      shape without re-parsing raw text (`import-decomposer.ts`).
+ *   2. **Optional bindings** — `if let u = getUser()` / `guard let …`
+ *      synthesize a `@type-binding.constructor` (name → callee) by
+ *      walking the anchored statement (`@optional.binding`).
+ *   3. **Receiver bindings** — `self` (+ `super`) `@type-binding.self`
+ *      anchors on every instance method/init (`receiver-binding.ts`).
+ *   4. **Signature bindings** — parameter-type and return-type
+ *      `@type-binding.*` synthesized from the function node, because
+ *      Swift's grammar reuses the `name:` field for func-name / param /
+ *      return so a query can't disambiguate (`signature-bindings.ts`).
+ *   5. **Arity metadata** — `@declaration.parameter-count` etc. on
+ *      function-like declarations and `@reference.arity` on call sites,
+ *      so the registry can narrow by arity (`arity-metadata.ts`).
+ *
+ * Extension handling: a `class_declaration` whose `name:` is a
+ * `(user_type …)` is an `extension Foo { … }`. The query tags it
+ * `@declaration.extension`; we re-key it to `@declaration.class` with a
+ * synthesized `@declaration.name` of the extended type so its members
+ * hoist onto `Foo`'s scope (`populateClassOwnedMembers` completes the
+ * ownership stamp) — the same mechanism C# uses for `partial class`.
+ *
+ * Pure given the input source text. No I/O, no globals consulted.
+ */
+
+import type { Capture, CaptureMatch } from 'gitnexus-shared';
+import {
+  nodeIfType,
+  nodeToCapture,
+  syntheticCapture,
+  type SyntaxNode,
+} from '../../utils/ast-helpers.js';
+import { splitSwiftImport } from './import-decomposer.js';
+import { computeSwiftArityMetadata } from './arity-metadata.js';
+import { synthesizeSwiftReceiverBinding } from './receiver-binding.js';
+import { synthesizeSwiftSignatureBindings } from './signature-bindings.js';
+import { getSwiftParser, getSwiftScopeQuery } from './query.js';
+import { recordCacheHit, recordCacheMiss } from './cache-stats.js';
+import { getTreeSitterBufferSize } from '../../constants.js';
+import { parseSourceSafe } from '../../../tree-sitter/safe-parse.js';
+
+/** Declaration anchors that carry function-like arity metadata. */
+const FUNCTION_DECL_TAGS = ['@declaration.method', '@declaration.constructor'] as const;
+
+/** tree-sitter-swift node types that carry arity. */
+const FUNCTION_NODE_TYPES = [
+  'function_declaration',
+  'protocol_function_declaration',
+  'init_declaration',
+] as const;
+
+/** Function-like nodes eligible for receiver-binding synthesis. */
+const RECEIVER_NODE_TYPES = [
+  'function_declaration',
+  'init_declaration',
+  'deinit_declaration',
+] as const;
+
+export function emitSwiftScopeCaptures(
+  sourceText: string,
+  _filePath: string,
+  cachedTree?: unknown,
+): readonly CaptureMatch[] {
+  // Reuse the parse phase's cached Tree when available; otherwise parse.
+  let tree = cachedTree as ReturnType<ReturnType<typeof getSwiftParser>['parse']> | undefined;
+  if (tree === undefined) {
+    tree = parseSourceSafe(getSwiftParser(), sourceText, undefined, {
+      bufferSize: getTreeSitterBufferSize(sourceText),
+    });
+    recordCacheMiss();
+  } else {
+    recordCacheHit();
+  }
+
+  const rawMatches = getSwiftScopeQuery().matches(tree.rootNode);
+  const out: CaptureMatch[] = [];
+  // Dedup genuine field reads by span — tree-sitter-swift can match the
+  // same navigation_expression twice (stacked nodes with identical spans).
+  const seenReadSpans = new Set<string>();
+
+  for (const m of rawMatches) {
+    // Group captures by tag. Tree-sitter strips the leading `@`; put it
+    // back so the central extractor's prefix lookups work. Keep a
+    // parallel tag → node map so anchors resolve via nodeIfType (the
+    // captured node IS the node at that range — no findNodeAtRange
+    // root-walk, the O(matches × rootChildren) hot path fixed in #1918).
+    const grouped: Record<string, Capture> = {};
+    const nodeMap: Record<string, SyntaxNode> = {};
+    for (const c of m.captures) {
+      const tag = '@' + c.name;
+      grouped[tag] = nodeToCapture(tag, c.node);
+      nodeMap[tag] = c.node;
+    }
+    if (Object.keys(grouped).length === 0) continue;
+
+    // ── Imports ──────────────────────────────────────────────────────
+    if (grouped['@import.statement'] !== undefined) {
+      const stmtNode = nodeIfType(nodeMap['@import.statement'], 'import_declaration');
+      if (stmtNode !== null) {
+        const decomposed = splitSwiftImport(stmtNode);
+        if (decomposed !== null) {
+          out.push(decomposed);
+          continue;
+        }
+      }
+      out.push(grouped); // defensive fallback
+      continue;
+    }
+
+    // ── Optional bindings: if-let / guard-let. Synthesize a
+    // @type-binding.constructor (name → callee); chain-follow resolves
+    // the callee to its return type. ─────────────────────────────────
+    if (grouped['@optional.binding'] !== undefined) {
+      const stmtNode = nodeIfType(
+        nodeMap['@optional.binding'],
+        'if_statement',
+        'guard_statement',
+      );
+      const synth = stmtNode === null ? null : synthesizeOptionalBinding(stmtNode);
+      if (synth !== null) out.push(synth);
+      continue;
+    }
+
+    // ── Field reads: keep only genuine reads (`u.address`); drop the
+    // navigation that is a call's callee (`u.save` in `u.save()`) or an
+    // assignment LHS (a write). Dedup identical spans. ───────────────
+    if (grouped['@reference.read.member'] !== undefined) {
+      const navNode = nodeIfType(nodeMap['@reference.read.member'], 'navigation_expression');
+      if (navNode === null || !shouldEmitSwiftReadMember(navNode)) continue;
+      const span = `${navNode.startIndex}-${navNode.endIndex}`;
+      if (seenReadSpans.has(span)) continue;
+      seenReadSpans.add(span);
+      out.push(grouped);
+      continue;
+    }
+
+    // ── Extensions: re-key @declaration.extension → @declaration.class
+    // with the extended type's bare name so members hoist onto it. ────
+    if (grouped['@declaration.extension'] !== undefined) {
+      const extNode = nodeIfType(nodeMap['@declaration.extension'], 'class_declaration');
+      const reKeyed: Record<string, Capture> = { ...grouped };
+      delete reKeyed['@declaration.extension'];
+      reKeyed['@declaration.class'] = grouped['@declaration.extension'];
+      if (extNode !== null) {
+        const nameNode = extNode.childForFieldName('name');
+        const bare =
+          nameNode?.type === 'user_type'
+            ? (nameNode.firstNamedChild?.text ?? nameNode.text)
+            : (nameNode?.text ?? grouped['@declaration.name']?.text ?? '');
+        if (bare !== '') {
+          reKeyed['@declaration.name'] = syntheticCapture('@declaration.name', extNode, bare);
+        }
+      }
+      out.push(reKeyed);
+      continue;
+    }
+
+    // ── `let x = Type.init(...)` — explicit-initializer call. The
+    // constructor type-binding query only matches a bare `Type(...)`
+    // (simple_identifier callee); the `Type.init(...)` navigation form
+    // needs a synthesized `x: Type` binding so a later `x.method()`
+    // resolves. Emitted in ADDITION to the normal @declaration.property
+    // match, which still flows through to the final push below. ───────
+    if (grouped['@declaration.property'] !== undefined) {
+      const propNode = nodeIfType(nodeMap['@declaration.property'], 'property_declaration');
+      const synth = propNode === null ? null : synthesizeInitCtorBinding(propNode);
+      if (synth !== null) out.push(synth);
+    }
+
+    // ── init: synthesize @declaration.name = "init" (no name field). ──
+    if (
+      grouped['@declaration.constructor'] !== undefined &&
+      grouped['@declaration.name'] === undefined
+    ) {
+      const initNode = nodeIfType(nodeMap['@declaration.constructor'], 'init_declaration');
+      if (initNode !== null) {
+        grouped['@declaration.name'] = syntheticCapture('@declaration.name', initNode, 'init');
+      }
+    }
+
+    // ── @scope.function: arity + receiver + signature bindings. ──────
+    if (grouped['@scope.function'] !== undefined) {
+      const fnNodeForArity = nodeIfType(
+        nodeMap['@scope.function'] ??
+          nodeMap['@declaration.method'] ??
+          nodeMap['@declaration.constructor'],
+        ...FUNCTION_NODE_TYPES,
+      );
+      if (fnNodeForArity !== null) attachArityMetadata(grouped, fnNodeForArity);
+      out.push(grouped);
+
+      const recvNode = nodeIfType(nodeMap['@scope.function'], ...RECEIVER_NODE_TYPES);
+      if (recvNode !== null) {
+        for (const synth of synthesizeSwiftReceiverBinding(recvNode)) out.push(synth);
+      }
+      const sigNode = nodeIfType(nodeMap['@scope.function'], ...FUNCTION_NODE_TYPES);
+      if (sigNode !== null) {
+        for (const synth of synthesizeSwiftSignatureBindings(sigNode)) out.push(synth);
+      }
+      continue;
+    }
+
+    // ── Arity metadata on function-like declarations (non-scope). ────
+    const declTag = FUNCTION_DECL_TAGS.find((t) => grouped[t] !== undefined);
+    if (declTag !== undefined) {
+      const fnNode = nodeIfType(nodeMap[declTag], ...FUNCTION_NODE_TYPES);
+      if (fnNode !== null) attachArityMetadata(grouped, fnNode);
+    }
+
+    // ── Constructor calls: Swift has no `new`, so `Foo()` is a free call
+    // whose callee is a type. Re-tag an UpperCamelCase free-call callee as
+    // a constructor reference so the resolver's constructor branch targets
+    // the type's Constructor/Class (mirrors how other no-`new` languages
+    // classify `Type(...)`). Types are UpperCamelCase by Swift convention;
+    // functions are lowerCamelCase — so the first-letter test is a reliable
+    // syntactic discriminator with no scope lookup. ──────────────────────
+    if (grouped['@reference.call.free'] !== undefined) {
+      const calleeName = grouped['@reference.name']?.text ?? '';
+      const first = calleeName.charAt(0);
+      if (first !== '' && first === first.toUpperCase() && first !== first.toLowerCase()) {
+        // Build a fresh capture whose `.name` is the constructor tag — the
+        // extractor's anchor classifier reads the capture's `.name`, not the
+        // map key, so reusing the free-call capture object would keep
+        // classifying it as a free call (silent no-op).
+        const callNode = nodeMap['@reference.call.free'];
+        grouped['@reference.call.constructor'] = nodeToCapture(
+          '@reference.call.constructor',
+          callNode,
+        );
+        nodeMap['@reference.call.constructor'] = callNode;
+        delete grouped['@reference.call.free'];
+      }
+    }
+
+    // ── @reference.arity on call sites. ──────────────────────────────
+    const callTag = (
+      ['@reference.call.free', '@reference.call.member', '@reference.call.constructor'] as const
+    ).find((t) => grouped[t] !== undefined);
+    if (callTag !== undefined && grouped['@reference.arity'] === undefined) {
+      const callNode = nodeIfType(nodeMap[callTag], 'call_expression');
+      if (callNode !== null) {
+        grouped['@reference.arity'] = syntheticCapture(
+          '@reference.arity',
+          callNode,
+          String(countCallArguments(callNode)),
+        );
+      }
+    }
+
+    out.push(grouped);
+  }
+
+  return out;
+}
+
+/** Synthesize a `@type-binding.constructor` for an if-let / guard-let
+ *  optional binding: `if let u = getUser()` → `u: getUser` (chain-follow
+ *  resolves getUser → its return type). The statement has a flat shape —
+ *  a `bound_identifier:` field for the name and separate `condition:`
+ *  children, one of which is the bound value (a call_expression, possibly
+ *  wrapped in await/try). Returns null when the value isn't a call. */
+function synthesizeOptionalBinding(stmtNode: SyntaxNode): CaptureMatch | null {
+  const nameNode = stmtNode.childForFieldName('bound_identifier');
+  if (nameNode === null) return null;
+
+  let callee: SyntaxNode | null = null;
+  for (let i = 0; i < stmtNode.childCount; i++) {
+    const child = stmtNode.child(i);
+    if (child === null) continue;
+    if (child.type === 'call_expression') {
+      callee = child.namedChild(0);
+      break;
+    }
+    if (child.type === 'await_expression' || child.type === 'try_expression') {
+      for (let j = 0; j < child.namedChildCount; j++) {
+        const inner = child.namedChild(j);
+        if (inner !== null && inner.type === 'call_expression') {
+          callee = inner.namedChild(0);
+          break;
+        }
+      }
+      if (callee !== null) break;
+    }
+  }
+  if (callee === null || callee.type !== 'simple_identifier') return null;
+
+  const m: Record<string, Capture> = {
+    '@type-binding.constructor': nodeToCapture('@type-binding.constructor', stmtNode),
+    '@type-binding.name': syntheticCapture('@type-binding.name', nameNode, nameNode.text),
+    '@type-binding.type': syntheticCapture('@type-binding.type', callee, callee.text),
+  };
+  return m;
+}
+
+/** Synthesize a `@type-binding.constructor` for `let x = Type.init(...)`.
+ *  The property's `value:` is a call_expression whose callee is a
+ *  navigation_expression `Type.init`; bind `x` to the navigation target
+ *  `Type` (the explicit-initializer form of `let x = Type(...)`). Returns
+ *  null for any other value shape (e.g. `let x = obj.method()`, which must
+ *  NOT bind x to `obj`). */
+function synthesizeInitCtorBinding(propNode: SyntaxNode): CaptureMatch | null {
+  const namePattern = propNode.childForFieldName('name');
+  const nameNode = namePattern?.childForFieldName('bound_identifier') ?? null;
+  if (nameNode === null) return null;
+
+  const value = propNode.childForFieldName('value');
+  if (value === null || value.type !== 'call_expression') return null;
+
+  const callee = value.namedChild(0);
+  if (callee === null || callee.type !== 'navigation_expression') return null;
+
+  const target = callee.childForFieldName('target');
+  const suffix = callee.childForFieldName('suffix');
+  const member = suffix?.childForFieldName('suffix') ?? null;
+  if (
+    target === null ||
+    target.type !== 'simple_identifier' ||
+    member === null ||
+    member.text !== 'init'
+  ) {
+    return null;
+  }
+
+  const m: Record<string, Capture> = {
+    '@type-binding.constructor': nodeToCapture('@type-binding.constructor', propNode),
+    '@type-binding.name': syntheticCapture('@type-binding.name', nameNode, nameNode.text),
+    '@type-binding.type': syntheticCapture('@type-binding.type', target, target.text),
+  };
+  return m;
+}
+
+/** A navigation_expression (`a.b`) is a genuine field read unless it is
+ *  the callee of a call (`a.b()` — a member call) or the LHS of an
+ *  assignment (`a.b = …` — a write). The receiver chain of a deeper
+ *  access (`user.address` in `user.address.save()`) has parent
+ *  navigation_expression (not call_expression), so it is correctly kept. */
+function shouldEmitSwiftReadMember(navNode: SyntaxNode): boolean {
+  const parent = navNode.parent;
+  if (parent === null) return true;
+  if (parent.type === 'call_expression') return false;
+  if (parent.type === 'assignment') {
+    const lhs = parent.childForFieldName('target') ?? parent.firstNamedChild;
+    if (lhs !== null && lhs.id === navNode.id) return false;
+  }
+  return true;
+}
+
+/** Attach @declaration.parameter-count / required-parameter-count /
+ *  parameter-types synthesized from a function-like node. */
+function attachArityMetadata(grouped: Record<string, Capture>, fnNode: SyntaxNode): void {
+  const arity = computeSwiftArityMetadata(fnNode);
+  if (arity.parameterCount !== undefined) {
+    grouped['@declaration.parameter-count'] = syntheticCapture(
+      '@declaration.parameter-count',
+      fnNode,
+      String(arity.parameterCount),
+    );
+  }
+  if (arity.requiredParameterCount !== undefined) {
+    grouped['@declaration.required-parameter-count'] = syntheticCapture(
+      '@declaration.required-parameter-count',
+      fnNode,
+      String(arity.requiredParameterCount),
+    );
+  }
+  if (arity.parameterTypes !== undefined) {
+    grouped['@declaration.parameter-types'] = syntheticCapture(
+      '@declaration.parameter-types',
+      fnNode,
+      JSON.stringify(arity.parameterTypes),
+    );
+  }
+}
+
+/** Count call arguments: the `value_argument` named children of the
+ *  call's `call_suffix > value_arguments`. */
+function countCallArguments(callNode: SyntaxNode): number {
+  for (let i = 0; i < callNode.namedChildCount; i++) {
+    const child = callNode.namedChild(i);
+    if (child === null || child.type !== 'call_suffix') continue;
+    for (let j = 0; j < child.namedChildCount; j++) {
+      const va = child.namedChild(j);
+      if (va === null || va.type !== 'value_arguments') continue;
+      let n = 0;
+      for (let k = 0; k < va.namedChildCount; k++) {
+        const arg = va.namedChild(k);
+        if (arg !== null && arg.type === 'value_argument') n++;
+      }
+      return n;
+    }
+  }
+  return 0;
+}

--- a/gitnexus/src/core/ingestion/languages/swift/implicit-imports.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/implicit-imports.ts
@@ -11,55 +11,56 @@
  * finalized `ImportEdge`s — of which there are none here, because there
  * is no syntactic `import`. This hook emits the missing edges directly.
  *
- * Module identity: Swift has no in-source `package X` marker. We
- * approximate module membership by the file's immediate containing
- * directory — the same directory-grouping proxy `populateSwiftTargetSiblings`
- * (`target-siblings.ts`) uses for sibling binding visibility. Every pair
- * of distinct `.swift` files in the same directory gets a directed
- * IMPORTS edge in both directions (whole-module visibility is symmetric).
+ * Module identity: Swift has no in-source `package X` marker. Module
+ * membership is the SPM target *subtree* (`Sources/<Target>/…`), threaded
+ * in via the SPM target map (`resolutionConfig` → `coerceSwiftTargets`)
+ * and grouped by `groupSwiftFilesBySpmTarget` — replicating legacy
+ * `groupSwiftFilesByTarget`. With no scanned source dir the map is null
+ * and all files form one `__default__` module (single-Xcode-project
+ * assumption). Every pair of distinct `.swift` files in the same module
+ * gets a directed IMPORTS edge in both directions (whole-module
+ * visibility is symmetric).
  *
  * Node identity + edge construction mirror the generic `emitImportEdges`
  * convention (`graph-bridge/imports-to-edges.ts`): `generateId('File', path)`
  * for endpoints and `generateId('IMPORTS', key)` for the relationship id,
- * deduped by `(sourceFile -> targetFile)`.
+ * deduped by `(sourceFile -> targetFile)`. Re-invocation idempotency comes
+ * from `graph.addRelationship` id-dedup (the same `IMPORTS` id is produced
+ * for a given ordered pair), so no local `seen` set is needed.
  */
 
 import type { ParsedFile } from 'gitnexus-shared';
 import type { KnowledgeGraph } from '../../../graph/types.js';
 import type { GraphNodeLookup } from '../../scope-resolution/graph-bridge/node-lookup.js';
 import { generateId } from '../../../../lib/utils.js';
+import { coerceSwiftTargets, groupSwiftFilesBySpmTarget } from './target-grouping.js';
 
 export function emitSwiftImplicitImportEdges(
   graph: KnowledgeGraph,
   parsedFiles: readonly ParsedFile[],
   _nodeLookup: GraphNodeLookup,
+  resolutionConfig?: unknown,
 ): void {
-  // Group files by immediate containing directory (the module proxy).
-  const filesByDir = new Map<string, string[]>();
-  for (const parsed of parsedFiles) {
-    const dir = containingDir(parsed.filePath);
-    const list = filesByDir.get(dir) ?? [];
-    list.push(parsed.filePath);
-    filesByDir.set(dir, list);
-  }
+  // Group files by SPM target subtree (the module). No-source-dir → all
+  // files in one `__default__` bucket.
+  const targets = coerceSwiftTargets(resolutionConfig);
+  const filesByTarget = groupSwiftFilesBySpmTarget(
+    parsedFiles,
+    (parsed) => parsed.filePath,
+    targets,
+  );
 
-  // Dedup so each ordered (source -> target) pair emits at most once even
-  // if the hook is invoked more than once during re-resolution.
-  const seen = new Set<string>();
-
-  for (const [, files] of filesByDir) {
-    if (files.length < 2) continue; // no siblings to import
-    for (const source of files) {
-      for (const target of files) {
-        if (source === target) continue; // no self-import
-        const dedupKey = `${source}->${target}`;
-        if (seen.has(dedupKey)) continue;
-        seen.add(dedupKey);
+  for (const [, group] of filesByTarget) {
+    if (group.length < 2) continue; // no siblings to import
+    for (const source of group) {
+      for (const target of group) {
+        if (source.filePath === target.filePath) continue; // no self-import
+        const dedupKey = `${source.filePath}->${target.filePath}`;
 
         graph.addRelationship({
           id: generateId('IMPORTS', dedupKey),
-          sourceId: generateId('File', source),
-          targetId: generateId('File', target),
+          sourceId: generateId('File', source.filePath),
+          targetId: generateId('File', target.filePath),
           type: 'IMPORTS',
           confidence: 1.0,
           reason: 'swift-scope: implicit module visibility',
@@ -67,10 +68,4 @@ export function emitSwiftImplicitImportEdges(
       }
     }
   }
-}
-
-function containingDir(filePath: string): string {
-  const normalized = filePath.replace(/\\/g, '/');
-  const idx = normalized.lastIndexOf('/');
-  return idx === -1 ? '' : normalized.slice(0, idx);
 }

--- a/gitnexus/src/core/ingestion/languages/swift/implicit-imports.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/implicit-imports.ts
@@ -1,0 +1,76 @@
+/**
+ * Swift same-module implicit IMPORTS-edge emission for the
+ * `emitImplicitImportEdges` hook.
+ *
+ * Swift gives every file in a module (an SPM target) visibility of every
+ * other file's top-level declarations WITHOUT any `import` statement
+ * (whole-module visibility). The legacy DAG models this with File→File
+ * IMPORTS edges via `wireSwiftImplicitImports`; under registry-primary
+ * that wirer's `addImportEdge` is gated off, and the scope-resolution
+ * import pipeline (`emitImportEdges`) only materializes edges from
+ * finalized `ImportEdge`s — of which there are none here, because there
+ * is no syntactic `import`. This hook emits the missing edges directly.
+ *
+ * Module identity: Swift has no in-source `package X` marker. We
+ * approximate module membership by the file's immediate containing
+ * directory — the same directory-grouping proxy `populateSwiftTargetSiblings`
+ * (`target-siblings.ts`) uses for sibling binding visibility. Every pair
+ * of distinct `.swift` files in the same directory gets a directed
+ * IMPORTS edge in both directions (whole-module visibility is symmetric).
+ *
+ * Node identity + edge construction mirror the generic `emitImportEdges`
+ * convention (`graph-bridge/imports-to-edges.ts`): `generateId('File', path)`
+ * for endpoints and `generateId('IMPORTS', key)` for the relationship id,
+ * deduped by `(sourceFile -> targetFile)`.
+ */
+
+import type { ParsedFile } from 'gitnexus-shared';
+import type { KnowledgeGraph } from '../../../graph/types.js';
+import type { GraphNodeLookup } from '../../scope-resolution/graph-bridge/node-lookup.js';
+import { generateId } from '../../../../lib/utils.js';
+
+export function emitSwiftImplicitImportEdges(
+  graph: KnowledgeGraph,
+  parsedFiles: readonly ParsedFile[],
+  _nodeLookup: GraphNodeLookup,
+): void {
+  // Group files by immediate containing directory (the module proxy).
+  const filesByDir = new Map<string, string[]>();
+  for (const parsed of parsedFiles) {
+    const dir = containingDir(parsed.filePath);
+    const list = filesByDir.get(dir) ?? [];
+    list.push(parsed.filePath);
+    filesByDir.set(dir, list);
+  }
+
+  // Dedup so each ordered (source -> target) pair emits at most once even
+  // if the hook is invoked more than once during re-resolution.
+  const seen = new Set<string>();
+
+  for (const [, files] of filesByDir) {
+    if (files.length < 2) continue; // no siblings to import
+    for (const source of files) {
+      for (const target of files) {
+        if (source === target) continue; // no self-import
+        const dedupKey = `${source}->${target}`;
+        if (seen.has(dedupKey)) continue;
+        seen.add(dedupKey);
+
+        graph.addRelationship({
+          id: generateId('IMPORTS', dedupKey),
+          sourceId: generateId('File', source),
+          targetId: generateId('File', target),
+          type: 'IMPORTS',
+          confidence: 1.0,
+          reason: 'swift-scope: implicit module visibility',
+        });
+      }
+    }
+  }
+}
+
+function containingDir(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, '/');
+  const idx = normalized.lastIndexOf('/');
+  return idx === -1 ? '' : normalized.slice(0, idx);
+}

--- a/gitnexus/src/core/ingestion/languages/swift/import-decomposer.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/import-decomposer.ts
@@ -1,0 +1,95 @@
+/**
+ * Decompose a Swift `import_declaration` into a `CaptureMatch` carrying
+ * the synthesized markers `@import.kind` / `@import.source` /
+ * `@import.name` / `@import.testable` that `interpretSwiftImport`
+ * consumes.
+ *
+ * Swift imports are whole-module (no named members), so this is 1:1 —
+ * one `import` produces exactly one import. The split layer exposes the
+ * module name and the `@testable` flag without pushing raw-text parsing
+ * into `interpret.ts`.
+ *
+ *   import Foundation        → kind=namespace, source=Foundation
+ *   import Foo.Bar           → kind=namespace, source=Foo (SPM target),
+ *                              name=Foo.Bar (full path, for reference)
+ *   @testable import MyApp   → kind=namespace, source=MyApp, testable=1
+ *
+ * Verified against tree-sitter-swift 0.7.1:
+ *   (import_declaration
+ *     (modifiers (attribute (user_type (type_identifier))))?   ; @testable / @_exported
+ *     (identifier (simple_identifier)+))                        ; one per dotted segment
+ */
+
+import type { Capture, CaptureMatch } from 'gitnexus-shared';
+import { nodeToCapture, syntheticCapture, type SyntaxNode } from '../../utils/ast-helpers.js';
+
+interface SwiftImportSpec {
+  /** SPM target name — the first dotted segment (`Foo` in `import Foo.Bar`). */
+  readonly source: string;
+  /** Full dotted module path (`Foo.Bar`). */
+  readonly fullPath: string;
+  /** True for `@testable import` (test-scope visibility; resolves identically). */
+  readonly testable: boolean;
+  readonly atNode: SyntaxNode;
+}
+
+export function splitSwiftImport(stmtNode: SyntaxNode): CaptureMatch | null {
+  if (stmtNode.type !== 'import_declaration') return null;
+  const spec = parseSwiftImport(stmtNode);
+  if (spec === null) return null;
+  return buildImportMatch(stmtNode, spec);
+}
+
+function parseSwiftImport(node: SyntaxNode): SwiftImportSpec | null {
+  let testable = false;
+  let identifierNode: SyntaxNode | null = null;
+
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
+    if (child === null) continue;
+    if (child.type === 'modifiers') {
+      // Any attribute whose text mentions `testable` flips the flag.
+      if (/\btestable\b/.test(child.text)) testable = true;
+    } else if (child.type === 'identifier') {
+      identifierNode = child;
+    }
+  }
+
+  if (identifierNode === null) return null;
+
+  // The module path is one or more simple_identifier children, one per
+  // dotted segment. The SPM target is the FIRST segment.
+  const segments: string[] = [];
+  for (let i = 0; i < identifierNode.namedChildCount; i++) {
+    const seg = identifierNode.namedChild(i);
+    if (seg !== null && seg.type === 'simple_identifier') segments.push(seg.text);
+  }
+  if (segments.length === 0) {
+    // Fall back to the raw identifier text (e.g. a grammar shape we didn't
+    // anticipate). Split on `.` to recover the target segment.
+    const raw = identifierNode.text.trim();
+    if (raw === '') return null;
+    const parts = raw.split('.');
+    return { source: parts[0], fullPath: raw, testable, atNode: node };
+  }
+
+  return {
+    source: segments[0],
+    fullPath: segments.join('.'),
+    testable,
+    atNode: node,
+  };
+}
+
+function buildImportMatch(stmtNode: SyntaxNode, spec: SwiftImportSpec): CaptureMatch {
+  const m: Record<string, Capture> = {
+    '@import.statement': nodeToCapture('@import.statement', stmtNode),
+    '@import.kind': syntheticCapture('@import.kind', spec.atNode, 'namespace'),
+    '@import.source': syntheticCapture('@import.source', spec.atNode, spec.source),
+    '@import.name': syntheticCapture('@import.name', spec.atNode, spec.fullPath),
+  };
+  if (spec.testable) {
+    m['@import.testable'] = syntheticCapture('@import.testable', spec.atNode, '1');
+  }
+  return m;
+}

--- a/gitnexus/src/core/ingestion/languages/swift/import-target.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/import-target.ts
@@ -1,0 +1,103 @@
+/**
+ * `resolveImportTarget` adapter for the Swift `ScopeResolver`.
+ *
+ * Swift's `import ModuleName` brings in a whole SPM target / framework
+ * module. The scope-resolution contract passes only `allFilePaths` (no
+ * `SwiftPackageConfig`), so we resolve a module name to the `.swift`
+ * files under a directory segment named after the module — the SPM
+ * convention `Sources/<Module>/*.swift` (and the common
+ * `<Module>/*.swift` layout). This needs no manifest parsing.
+ *
+ * Same-module (intra-target) visibility — the bulk of Swift cross-file
+ * resolution, which needs NO `import` statement — is handled separately
+ * by `populateSwiftTargetSiblings` (see `target-siblings.ts`). This
+ * adapter only resolves EXPLICIT `import` statements (cross-module).
+ *
+ * Returns all matching files (one ImportEdge per file, like Go's
+ * package resolver) so every exported symbol in the module materializes
+ * a binding. Returns `null` for external frameworks (Foundation, UIKit,
+ * …) that have no in-repo directory.
+ *
+ * Performance: the directory→files grouping is memoized on the stable
+ * `allFilePaths` Set identity (the same Set is threaded to every import
+ * in a run), so it is built once per run — NOT once per import. Mirrors
+ * Python's `getPythonFileIndex` WeakMap pattern (PR #1918).
+ */
+
+import type { ParsedImport, WorkspaceIndex } from 'gitnexus-shared';
+
+export interface SwiftResolveContext {
+  readonly fromFile: string;
+  /** `ReadonlySet` so the orchestrator's stable run-level set flows
+   *  straight through to the memoized index key. */
+  readonly allFilePaths: ReadonlySet<string>;
+}
+
+interface SwiftModuleIndex {
+  /** Module (directory-segment) name → original-case `.swift` files
+   *  whose path contains a `/<module>/` directory segment. */
+  readonly byModule: Map<string, string[]>;
+}
+
+const SWIFT_MODULE_INDEX_CACHE = new WeakMap<ReadonlySet<string>, SwiftModuleIndex>();
+
+function getSwiftModuleIndex(allFilePaths: ReadonlySet<string>): SwiftModuleIndex {
+  const cached = SWIFT_MODULE_INDEX_CACHE.get(allFilePaths);
+  if (cached !== undefined) return cached;
+
+  const byModule = new Map<string, string[]>();
+  for (const raw of allFilePaths) {
+    const norm = raw.replace(/\\/g, '/');
+    if (!norm.endsWith('.swift')) continue;
+    // Each interior directory segment is a candidate module name. A file
+    // `Sources/Models/User.swift` is attributed to module `Sources` and
+    // module `Models`; an `import Models` then resolves to it.
+    const segments = norm.split('/');
+    // Drop the filename (last segment); the rest are directory segments.
+    for (let i = 0; i < segments.length - 1; i++) {
+      const seg = segments[i];
+      if (seg === '') continue;
+      let bucket = byModule.get(seg);
+      if (bucket === undefined) {
+        bucket = [];
+        byModule.set(seg, bucket);
+      }
+      bucket.push(raw);
+    }
+  }
+
+  const index: SwiftModuleIndex = { byModule };
+  SWIFT_MODULE_INDEX_CACHE.set(allFilePaths, index);
+  return index;
+}
+
+export function resolveSwiftImportTarget(
+  parsedImport: ParsedImport,
+  workspaceIndex: WorkspaceIndex,
+): string | readonly string[] | null {
+  const ctx = workspaceIndex as SwiftResolveContext | undefined;
+  // Duck-type the set (PR #1918 P2: don't `instanceof Set`).
+  const allFilePaths = (ctx as { allFilePaths?: unknown } | undefined)?.allFilePaths;
+  if (
+    ctx === undefined ||
+    typeof (ctx as { fromFile?: unknown }).fromFile !== 'string' ||
+    typeof (allFilePaths as { has?: unknown } | undefined)?.has !== 'function' ||
+    typeof (allFilePaths as Iterable<string> | undefined)?.[Symbol.iterator] !== 'function'
+  ) {
+    return null;
+  }
+
+  // Swift import target is the SPM module name (first dotted segment).
+  const targetRaw = parsedImport.targetRaw;
+  if (targetRaw === null || targetRaw === '') return null;
+  const moduleName = targetRaw.split('.')[0];
+  if (moduleName === '') return null;
+
+  const index = getSwiftModuleIndex(ctx.allFilePaths);
+  const files = index.byModule.get(moduleName);
+  if (files === undefined || files.length === 0) return null; // external framework
+
+  // Exclude the importer itself (a file under `Foo/` importing `Foo`).
+  const out = files.filter((f) => f !== ctx.fromFile);
+  return out.length > 0 ? out : null;
+}

--- a/gitnexus/src/core/ingestion/languages/swift/index.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/index.ts
@@ -17,6 +17,7 @@
  *   - `arity.ts`             — Swift arity compatibility (count-primary)
  *   - `arity-metadata.ts`    — synthesize arity metadata from declarations
  *   - `import-target.ts`     — `(ParsedImport, WorkspaceIndex) → file path` adapter
+ *   - `target-grouping.ts`   — group same-module files by SPM target subtree
  *   - `target-siblings.ts`   — same-SPM-target implicit cross-file visibility
  *   - `implicit-imports.ts`  — same-SPM-target File→File IMPORTS edges
  *   - `sibling-type-bindings.ts` — mirror sibling return-type typeBindings
@@ -30,6 +31,7 @@ export { interpretSwiftImport, interpretSwiftTypeBinding } from './interpret.js'
 export { swiftMergeBindings } from './merge-bindings.js';
 export { swiftArityCompatibility } from './arity.js';
 export { resolveSwiftImportTarget, type SwiftResolveContext } from './import-target.js';
+export { groupSwiftFilesBySpmTarget, coerceSwiftTargets } from './target-grouping.js';
 export { populateSwiftTargetSiblings } from './target-siblings.js';
 export { emitSwiftImplicitImportEdges } from './implicit-imports.js';
 export { mirrorSwiftSiblingTypeBindings } from './sibling-type-bindings.js';

--- a/gitnexus/src/core/ingestion/languages/swift/index.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Swift scope-resolution hooks (RFC #909 Ring 3, issue #937 — the final
+ * per-language migration).
+ *
+ * Public API barrel. Consumers import from this file rather than the
+ * individual modules.
+ *
+ * Module layout (each file is a single concern):
+ *
+ *   - `query.ts`             — tree-sitter query + lazy parser/query singletons
+ *   - `captures.ts`          — `emitSwiftScopeCaptures` orchestrator
+ *   - `import-decomposer.ts` — each `import` → ParsedImport-shaped captures
+ *   - `interpret.ts`         — capture-match → `ParsedImport` / `ParsedTypeBinding`
+ *   - `simple-hooks.ts`      — small/no-op hooks made explicit
+ *   - `receiver-binding.ts`  — synthesize `self` / `super` type-bindings
+ *   - `merge-bindings.ts`    — Swift import-vs-local precedence
+ *   - `arity.ts`             — Swift arity compatibility (count-primary)
+ *   - `arity-metadata.ts`    — synthesize arity metadata from declarations
+ *   - `import-target.ts`     — `(ParsedImport, WorkspaceIndex) → file path` adapter
+ *   - `target-siblings.ts`   — same-SPM-target implicit cross-file visibility
+ *   - `implicit-imports.ts`  — same-SPM-target File→File IMPORTS edges
+ *   - `sibling-type-bindings.ts` — mirror sibling return-type typeBindings
+ *   - `scope-resolver.ts`    — `ScopeResolver` registered in `SCOPE_RESOLVERS`
+ *   - `cache-stats.ts`       — PROF_SCOPE_RESOLUTION cache hit/miss counters
+ */
+
+export { emitSwiftScopeCaptures } from './captures.js';
+export { getSwiftCaptureCacheStats, resetSwiftCaptureCacheStats } from './cache-stats.js';
+export { interpretSwiftImport, interpretSwiftTypeBinding } from './interpret.js';
+export { swiftMergeBindings } from './merge-bindings.js';
+export { swiftArityCompatibility } from './arity.js';
+export { resolveSwiftImportTarget, type SwiftResolveContext } from './import-target.js';
+export { populateSwiftTargetSiblings } from './target-siblings.js';
+export { emitSwiftImplicitImportEdges } from './implicit-imports.js';
+export { mirrorSwiftSiblingTypeBindings } from './sibling-type-bindings.js';
+export {
+  swiftBindingScopeFor,
+  swiftImportOwningScope,
+  swiftReceiverBinding,
+} from './simple-hooks.js';

--- a/gitnexus/src/core/ingestion/languages/swift/interpret.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/interpret.ts
@@ -1,0 +1,95 @@
+/**
+ * Capture-match → semantic-shape interpreters for Swift.
+ *
+ *   - `interpretSwiftImport`      → `ParsedImport`
+ *   - `interpretSwiftTypeBinding`  → `ParsedTypeBinding`
+ *
+ * Import matches arrive pre-decomposed by `emitSwiftScopeCaptures` (one
+ * import per match, with synthesized `@import.kind/source/name` markers
+ * and an optional `@import.testable` flag). Type-binding matches arrive
+ * from the raw query captures — each `@type-binding.*` anchor carries
+ * `@type-binding.name` + `@type-binding.type`.
+ */
+
+import type { CaptureMatch, ParsedImport, ParsedTypeBinding, TypeRef } from 'gitnexus-shared';
+
+// ─── interpretImport ──────────────────────────────────────────────────────
+
+export function interpretSwiftImport(captures: CaptureMatch): ParsedImport | null {
+  const sourceCap = captures['@import.source'];
+  if (sourceCap === undefined) return null;
+
+  // Swift imports are whole-module (wildcard semantics): `import Foundation`
+  // brings the entire module into scope, no named members. The SPM target
+  // (first dotted segment) is the resolution target; the full path is kept
+  // as importedName for reference. `@testable` resolves identically to a
+  // plain import (same module is visible in test scope).
+  const source = sourceCap.text;
+  const fullPath = captures['@import.name']?.text ?? source;
+  return {
+    kind: 'namespace',
+    localName: source,
+    importedName: fullPath,
+    targetRaw: source,
+  };
+}
+
+// ─── interpretTypeBinding ─────────────────────────────────────────────────
+
+export function interpretSwiftTypeBinding(captures: CaptureMatch): ParsedTypeBinding | null {
+  const nameCap = captures['@type-binding.name'];
+  const typeCap = captures['@type-binding.type'];
+  if (nameCap === undefined || typeCap === undefined) return null;
+
+  // Normalize so receiver-typed resolution treats these identically:
+  //   `User?` / `User!`           → User   (optional / IUO)
+  //   `[User]`                    → User   (array sugar)
+  //   `Array<User>` / `Optional<User>` → User (single-arg generic)
+  //   `Foundation.URL`            → URL    (qualifier)
+  const rawType = stripQualifier(stripGeneric(stripArraySugar(stripOptional(typeCap.text.trim()))));
+
+  let source: TypeRef['source'] = 'parameter-annotation';
+  if (captures['@type-binding.self'] !== undefined) source = 'self';
+  else if (captures['@type-binding.constructor'] !== undefined) source = 'constructor-inferred';
+  else if (captures['@type-binding.annotation'] !== undefined) source = 'annotation';
+  else if (captures['@type-binding.alias'] !== undefined) source = 'assignment-inferred';
+  else if (captures['@type-binding.return'] !== undefined) source = 'return-annotation';
+
+  return { boundName: nameCap.text, rawTypeName: rawType, source };
+}
+
+/** `User?` / `User!` → `User`. */
+function stripOptional(text: string): string {
+  if (text.endsWith('?') || text.endsWith('!')) return text.slice(0, -1).trim();
+  return text;
+}
+
+/** `[User]` → `User` (array sugar). `[K: V]` (dictionary) is left alone —
+ *  element semantics aren't unambiguous. */
+function stripArraySugar(text: string): string {
+  if (text.startsWith('[') && text.endsWith(']') && !text.includes(':')) {
+    return text.slice(1, -1).trim();
+  }
+  return text;
+}
+
+/**
+ * Unwrap a single-arg generic collection wrapper — `Array<User>`,
+ * `Optional<User>`, `Set<User>` — to its element type. Mirrors C#'s
+ * `stripGeneric`. Multi-arg generics (`Dictionary<K, V>`,
+ * `Result<T, E>`) are left alone.
+ */
+function stripGeneric(text: string): string {
+  const single = text.match(
+    /^(?:[A-Za-z_][A-Za-z0-9_.]*\.)?(?:Array|Optional|Set|ContiguousArray|ArraySlice)<([^,<>]+)>$/,
+  );
+  if (single !== null) return single[1].trim();
+  return text;
+}
+
+/** `Foundation.URL` → `URL`. */
+function stripQualifier(text: string): string {
+  const lastDot = text.lastIndexOf('.');
+  if (lastDot === -1) return text;
+  return text.slice(lastDot + 1);
+}

--- a/gitnexus/src/core/ingestion/languages/swift/merge-bindings.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/merge-bindings.ts
@@ -1,0 +1,52 @@
+/**
+ * Swift shadowing precedence for the `mergeBindings` hook.
+ *
+ * Tier ranking (lower wins in shadowing):
+ *
+ *   - 0: `local` — a type member, method, local var, or parameter
+ *        declared in this scope.
+ *   - 1: `import` / `namespace` / `reexport` — names brought in by an
+ *        `import ModuleName` (whole-module, including `@testable`).
+ *   - 2: `wildcard` — reserved; Swift's whole-module import already
+ *        behaves like a namespace tier, so this is rarely populated.
+ *
+ * Swift resolves an ambiguity between two imported modules by requiring
+ * an explicit `Module.Symbol` qualifier; for receiver-typed dispatch we
+ * treat all imports as one tier. Locals always shadow imports.
+ *
+ * Within a surviving tier we de-dup by `DefId`, last-write-wins.
+ */
+
+import type { BindingRef } from 'gitnexus-shared';
+
+const TIER_LOCAL = 0;
+const TIER_IMPORT = 1;
+const TIER_WILDCARD = 2;
+const TIER_UNKNOWN = 3;
+
+function tierOf(b: BindingRef): number {
+  switch (b.origin) {
+    case 'local':
+      return TIER_LOCAL;
+    case 'reexport':
+    case 'import':
+    case 'namespace':
+      return TIER_IMPORT;
+    case 'wildcard':
+      return TIER_WILDCARD;
+    default:
+      return TIER_UNKNOWN;
+  }
+}
+
+export function swiftMergeBindings(bindings: readonly BindingRef[]): readonly BindingRef[] {
+  if (bindings.length === 0) return bindings;
+
+  let bestTier = Number.POSITIVE_INFINITY;
+  for (const b of bindings) bestTier = Math.min(bestTier, tierOf(b));
+  const survivors = bindings.filter((b) => tierOf(b) === bestTier);
+
+  const seen = new Map<string, BindingRef>();
+  for (const b of survivors) seen.set(b.def.nodeId, b);
+  return [...seen.values()];
+}

--- a/gitnexus/src/core/ingestion/languages/swift/query.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/query.ts
@@ -1,0 +1,199 @@
+/**
+ * Tree-sitter query for Swift scope captures (RFC §5.1).
+ *
+ * Captures the structural skeleton the generic scope-resolution
+ * pipeline consumes: scopes (module/class/function), declarations
+ * (class-likes, methods, init, properties), imports, type bindings
+ * (parameter annotations, property/field annotations, constructor
+ * inference, receiver self), and references (call sites, member calls).
+ *
+ * Swift specifics that shape this query (all verified against
+ * tree-sitter-swift 0.7.1 live s-expressions):
+ *
+ *   - `class`, `struct`, AND `extension` all parse to a single node
+ *     type `class_declaration`. They are distinguished by the `name:`
+ *     field node type: class/struct name is a bare `(type_identifier)`,
+ *     while an extension's name field wraps the extended type in a
+ *     `(user_type (type_identifier))`. The capture below grabs all
+ *     three under `@scope.class` + `@declaration.class`; the captures
+ *     orchestrator (`captures.ts`) re-tags extensions via the
+ *     user_type discriminator so extension members hoist onto the
+ *     extended type.
+ *   - `protocol_declaration` is its own node; its bodyless method
+ *     requirements are `protocol_function_declaration` (NOT
+ *     `function_declaration`).
+ *   - `init_declaration` has no `name:` field — identity is the `init`
+ *     keyword. The captures layer synthesizes its `@declaration.name`.
+ *   - Inside a `parameter`, BOTH the label and the type use the field
+ *     name `name:` — disambiguate by child node type (simple_identifier
+ *     = label, user_type = type). Parameter type bindings are therefore
+ *     synthesized in `captures.ts`, not matched here.
+ *   - A labeled call argument wraps its label in a dedicated
+ *     `value_argument_label` node.
+ *   - `self` is its own node `self_expression`; a `self.member()` call
+ *     is `call_expression > navigation_expression(target: self_expression,
+ *     suffix: navigation_suffix > simple_identifier)`.
+ *   - `import_declaration` carries the module path as an `(identifier
+ *     (simple_identifier)+)` — one `simple_identifier` per dotted
+ *     segment. `@testable` and other attributes surface as a leading
+ *     `(modifiers (attribute (user_type (type_identifier))))`.
+ *
+ * Exposes lazy `Parser` and `Query` singletons so callers don't pay
+ * tree-sitter init cost per file.
+ */
+
+import Parser from 'tree-sitter';
+import Swift from 'tree-sitter-swift';
+
+const SWIFT_SCOPE_QUERY = `
+;; ── Scopes ──────────────────────────────────────────────────────────
+(source_file) @scope.module
+
+;; class / struct / extension all parse to class_declaration; the
+;; captures orchestrator splits extensions out via the user_type
+;; name discriminator.
+(class_declaration) @scope.class
+(protocol_declaration) @scope.class
+
+(function_declaration) @scope.function
+(protocol_function_declaration) @scope.function
+(init_declaration) @scope.function
+(deinit_declaration) @scope.function
+
+;; ── Declarations — types ────────────────────────────────────────────
+;; class / struct: name is a bare type_identifier.
+(class_declaration
+  name: (type_identifier) @declaration.name) @declaration.class
+
+;; extension: name is (user_type (type_identifier)). Captured separately
+;; so captures.ts can re-tag it as an extension of the wrapped type.
+(class_declaration
+  name: (user_type) @declaration.name) @declaration.extension
+
+(protocol_declaration
+  name: (type_identifier) @declaration.name) @declaration.interface
+
+;; ── Declarations — methods / init / properties ──────────────────────
+(function_declaration
+  name: (simple_identifier) @declaration.name) @declaration.method
+
+(protocol_function_declaration
+  name: (simple_identifier) @declaration.name) @declaration.method
+
+;; init has no name field — captures.ts synthesizes @declaration.name = "init".
+(init_declaration) @declaration.constructor
+
+(property_declaration
+  name: (pattern
+    bound_identifier: (simple_identifier) @declaration.name)) @declaration.property
+
+;; ── Imports ─────────────────────────────────────────────────────────
+;; Single anchor per import; the captures layer decomposes the module
+;; path (and detects @testable) into @import.kind/source/name markers.
+(import_declaration) @import.statement
+
+;; ── Type bindings — property annotations: \`var owner: Owner\` ─────────
+(property_declaration
+  name: (pattern
+    bound_identifier: (simple_identifier) @type-binding.name)
+  (type_annotation
+    (user_type (type_identifier) @type-binding.type))) @type-binding.annotation
+
+;; ── Type bindings — stored / local-var constructor inference:
+;; \`let p = Product(...)\` (constructor) and \`let u = getUser()\`
+;; (free-call result; chain-follow resolves getUser → its return type).
+;; property_declaration is the node for both class-level stored
+;; properties AND let/var inside a function body. ───────────────────
+(property_declaration
+  name: (pattern
+    bound_identifier: (simple_identifier) @type-binding.name)
+  value: (call_expression
+    (simple_identifier) @type-binding.type)) @type-binding.constructor
+
+;; \`let u = await fetchUser()\` — unwrap the await wrapper to the call.
+(property_declaration
+  name: (pattern
+    bound_identifier: (simple_identifier) @type-binding.name)
+  value: (await_expression
+    (call_expression
+      (simple_identifier) @type-binding.type))) @type-binding.constructor
+
+;; \`let r = try parseRepo()\` — unwrap the try wrapper to the call.
+(property_declaration
+  name: (pattern
+    bound_identifier: (simple_identifier) @type-binding.name)
+  value: (try_expression
+    (call_expression
+      (simple_identifier) @type-binding.type))) @type-binding.constructor
+
+;; ── Optional binding anchors: if-let / guard-let. In tree-sitter-swift
+;; 0.7.1 these are if_statement / guard_statement with a flat shape — a
+;; \`bound_identifier:\` field for the name plus separate \`condition:\`
+;; children (one of which is the bound value expression). A static .scm
+;; pattern can't pair the name with the value across those sibling
+;; condition fields, so we only ANCHOR the statement here and synthesize
+;; the @type-binding.constructor in captures.ts (synthesizeOptionalBinding)
+;; by walking the node. (A nonexistent if_let_binding node type would throw
+;; TSQueryErrorNodeType and break the WHOLE query — do not reintroduce it.)
+(if_statement
+  bound_identifier: (simple_identifier)) @optional.binding
+(guard_statement
+  bound_identifier: (simple_identifier)) @optional.binding
+
+;; NOTE: parameter-type bindings (\`func f(u: User)\`) and function
+;; return-type bindings (\`func getUser() -> User\`) are NOT matched by
+;; tree-sitter patterns here. Swift's grammar reuses the SAME \`name:\`
+;; field for the function name, each parameter's label, AND the return
+;; type, so a two-\`name:\`-field query cross-assigns and produces garbage
+;; bindings (\`save: save\`). They are synthesized in code instead —
+;; \`captures.ts\` reads the function node via
+;; \`swiftMethodConfig.extractParameters\` / \`extractReturnType\`, which
+;; handle the grammar correctly. (Mirrors how receiver + arity are
+;; synthesized rather than queried.)
+
+;; ── References — field reads: \`u.address\` (member access that is NOT a
+;; call callee or assignment LHS). Emit-side filtering in captures.ts
+;; drops call targets and write LHS so only genuine reads emit ACCESSES.
+(navigation_expression
+  target: (_) @reference.receiver
+  suffix: (navigation_suffix
+    suffix: (simple_identifier) @reference.name)) @reference.read.member
+
+;; ── References — free calls: \`foo(...)\` ─────────────────────────────
+(call_expression
+  (simple_identifier) @reference.name) @reference.call.free
+
+;; ── References — member / method calls: \`obj.method(...)\` ───────────
+;; navigation_expression carries the receiver (target:) and the member
+;; (suffix > navigation_suffix > simple_identifier). \`self\` is a
+;; self_expression; other receivers are simple_identifier / nested
+;; navigation_expression — capture the whole target as @reference.receiver.
+(call_expression
+  (navigation_expression
+    target: (_) @reference.receiver
+    suffix: (navigation_suffix
+      suffix: (simple_identifier) @reference.name))) @reference.call.member
+
+;; ── References — constructor calls handled via @reference.call.free
+;; (a Swift \`Foo(...)\` is a call_expression with a simple_identifier
+;; callee; pickConstructorOrClass in free-call fallback targets the
+;; type's Constructor). No separate object_creation node in Swift.
+`;
+
+let _parser: Parser | null = null;
+let _query: Parser.Query | null = null;
+
+export function getSwiftParser(): Parser {
+  if (_parser === null) {
+    _parser = new Parser();
+    _parser.setLanguage(Swift as Parameters<Parser['setLanguage']>[0]);
+  }
+  return _parser;
+}
+
+export function getSwiftScopeQuery(): Parser.Query {
+  if (_query === null) {
+    _query = new Parser.Query(Swift as Parameters<Parser['setLanguage']>[0], SWIFT_SCOPE_QUERY);
+  }
+  return _query;
+}

--- a/gitnexus/src/core/ingestion/languages/swift/receiver-binding.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/receiver-binding.ts
@@ -26,6 +26,7 @@
 
 import type { Capture, CaptureMatch } from 'gitnexus-shared';
 import { nodeToCapture, syntheticCapture, type SyntaxNode } from '../../utils/ast-helpers.js';
+import { swiftMethodConfig } from '../../method-extractors/configs/swift.js';
 
 const TYPE_DECL_NODE_TYPES = new Set(['class_declaration', 'protocol_declaration']);
 
@@ -55,7 +56,11 @@ function enclosingTypeName(typeNode: SyntaxNode): string | null {
   if (nameNode === null) return null;
   if (nameNode.type === 'user_type') {
     // extension Foo { } → name is (user_type (type_identifier)).
-    const inner = nameNode.firstNamedChild;
+    // extension Foo.Bar { } → (user_type (type_identifier Foo)
+    // (type_identifier Bar)); the extended type — and therefore `self` —
+    // is the TRAILING identifier `Bar` (lastNamedChild), not `Foo`. For a
+    // single identifier first === last, so this is unchanged.
+    const inner = nameNode.lastNamedChild;
     return inner?.text ?? nameNode.text;
   }
   return nameNode.text;
@@ -93,16 +98,17 @@ function firstInheritedType(typeNode: SyntaxNode): string | null {
   return null;
 }
 
+/** A Swift type method (`static func` OR `class func`) has no `self`
+ *  instance receiver. Delegate to `swiftMethodConfig.isStatic`, which is
+ *  the single source of truth: `static func` emits the modifier under a
+ *  `modifiers > property_modifier` wrapper, but `class func` emits a BARE
+ *  anonymous `class` token directly under `function_declaration` (verified,
+ *  tree-sitter-swift 0.7.1). `swiftMethodConfig.isStatic` covers both via
+ *  `hasKeyword(node, 'static'|'class')` (scans direct children) and
+ *  `hasModifier(...)` — so reusing it avoids re-deriving the same scan and
+ *  fixes the prior `modifiers`-only check that missed `class func`. */
 function isStaticMethod(fnNode: SyntaxNode): boolean {
-  // `static` / `class` (type-method) modifier appears under a `modifiers`
-  // child or as a leading keyword token.
-  for (let i = 0; i < fnNode.namedChildCount; i++) {
-    const child = fnNode.namedChild(i);
-    if (child !== null && child.type === 'modifiers' && /\b(static|class)\b/.test(child.text)) {
-      return true;
-    }
-  }
-  return false;
+  return swiftMethodConfig.isStatic(fnNode);
 }
 
 /**

--- a/gitnexus/src/core/ingestion/languages/swift/receiver-binding.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/receiver-binding.ts
@@ -1,0 +1,157 @@
+/**
+ * Synthesize `@type-binding.self` captures for Swift instance methods —
+ * one for `self` (always on non-static methods inside a type body) and
+ * optionally one for `super` (only on class methods when the enclosing
+ * class declares a superclass).
+ *
+ * Mirrors `languages/csharp/receiver-binding.ts`. tree-sitter can't
+ * express "the implicit receiver of a non-static member of a
+ * class/struct/extension/protocol" via a static `.scm` pattern because
+ * the receiver isn't a parameter — it's implicit. Synthesis in code is
+ * the same approach C#/Python use for `this`/`self`.
+ *
+ * Swift AST facts (tree-sitter-swift 0.7.1, verified):
+ *   - class / struct / extension all parse to `class_declaration`. For
+ *     class/struct the `name:` field is `(type_identifier)`; for an
+ *     extension it is `(user_type (type_identifier))` wrapping the
+ *     EXTENDED type — so `self` in an extension binds to the extended
+ *     type, which is exactly what we want for method dispatch.
+ *   - `protocol_declaration` has a `(type_identifier)` name.
+ *   - the method body is the `body:` field (`function_body`); a bodyless
+ *     `protocol_function_declaration` has no function scope to anchor to.
+ *   - a superclass / conformance is an `(inheritance_specifier
+ *     inherits_from: (user_type (type_identifier)))` child of the
+ *     class_declaration.
+ */
+
+import type { Capture, CaptureMatch } from 'gitnexus-shared';
+import { nodeToCapture, syntheticCapture, type SyntaxNode } from '../../utils/ast-helpers.js';
+
+const TYPE_DECL_NODE_TYPES = new Set(['class_declaration', 'protocol_declaration']);
+
+const FUNCTION_NODE_TYPES = new Set([
+  'function_declaration',
+  'init_declaration',
+  'deinit_declaration',
+]);
+
+/** Walk up to the enclosing type declaration (class/struct/extension/
+ *  protocol). Nested local functions still see `self` from the enclosing
+ *  type, so don't stop at function-like nodes. */
+function findEnclosingTypeDeclaration(node: SyntaxNode): SyntaxNode | null {
+  let cur: SyntaxNode | null = node.parent;
+  while (cur !== null) {
+    if (TYPE_DECL_NODE_TYPES.has(cur.type)) return cur;
+    cur = cur.parent;
+  }
+  return null;
+}
+
+/** Bare type name of the enclosing type. class/struct → type_identifier
+ *  text; extension → the wrapped user_type's identifier text; protocol →
+ *  type_identifier text. */
+function enclosingTypeName(typeNode: SyntaxNode): string | null {
+  const nameNode = typeNode.childForFieldName('name');
+  if (nameNode === null) return null;
+  if (nameNode.type === 'user_type') {
+    // extension Foo { } → name is (user_type (type_identifier)).
+    const inner = nameNode.firstNamedChild;
+    return inner?.text ?? nameNode.text;
+  }
+  return nameNode.text;
+}
+
+/** Is this declaration a `class` (vs `struct`/`extension`)? Only classes
+ *  have a meaningful `super`. Detected by the leading keyword token —
+ *  class/struct/extension share the `class_declaration` node type. */
+function isClassKeyword(typeNode: SyntaxNode): boolean {
+  for (let i = 0; i < typeNode.childCount; i++) {
+    const child = typeNode.child(i);
+    if (child !== null && !child.isNamed) {
+      const t = child.text.trim();
+      if (t === 'class') return true;
+      if (t === 'struct' || t === 'extension' || t === 'enum' || t === 'actor') return false;
+    }
+  }
+  return false;
+}
+
+/** First inherited type (superclass or first protocol) as raw text, or
+ *  null. For a class the first `inheritance_specifier` is conventionally
+ *  the superclass — `super.x()` only compiles when that is true. */
+function firstInheritedType(typeNode: SyntaxNode): string | null {
+  for (let i = 0; i < typeNode.namedChildCount; i++) {
+    const child = typeNode.namedChild(i);
+    if (child === null || child.type !== 'inheritance_specifier') continue;
+    const inheritsFrom = child.childForFieldName('inherits_from') ?? child.firstNamedChild;
+    if (inheritsFrom === null) return null;
+    if (inheritsFrom.type === 'user_type') {
+      return inheritsFrom.firstNamedChild?.text ?? inheritsFrom.text;
+    }
+    return inheritsFrom.text;
+  }
+  return null;
+}
+
+function isStaticMethod(fnNode: SyntaxNode): boolean {
+  // `static` / `class` (type-method) modifier appears under a `modifiers`
+  // child or as a leading keyword token.
+  for (let i = 0; i < fnNode.namedChildCount; i++) {
+    const child = fnNode.namedChild(i);
+    if (child !== null && child.type === 'modifiers' && /\b(static|class)\b/.test(child.text)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Build zero, one, or two `@type-binding.self` matches for `fnNode`:
+ *  - `null`/`[]` if the function is free (no enclosing type), static, or
+ *    the enclosing type has no resolvable name, or the function is
+ *    bodyless (no scope to anchor to).
+ *  - one match (`self`) for instance methods of a class/struct/extension/
+ *    protocol.
+ *  - two matches (`self` + `super`) only when the function lives in a
+ *    `class` (keyword) declaration with a declared superclass.
+ *
+ * Caller must guarantee `FUNCTION_NODE_TYPES.has(fnNode.type)`.
+ */
+export function synthesizeSwiftReceiverBinding(fnNode: SyntaxNode): CaptureMatch[] {
+  if (!FUNCTION_NODE_TYPES.has(fnNode.type)) return [];
+  if (isStaticMethod(fnNode)) return [];
+
+  const enclosingType = findEnclosingTypeDeclaration(fnNode);
+  if (enclosingType === null) return [];
+
+  const enclosingName = enclosingTypeName(enclosingType);
+  if (enclosingName === null) return [];
+
+  // Anchor inside the function scope. `body:` is the function_body; its
+  // range is guaranteed inside the function scope (unlike the method's
+  // start position, which maps to the enclosing type scope via
+  // positionIndex). Bodyless declarations have no function scope.
+  const anchorNode = fnNode.childForFieldName('body');
+  if (anchorNode === null) return [];
+
+  const out: CaptureMatch[] = [buildReceiverMatch(anchorNode, 'self', enclosingName)];
+
+  // `super` only for class methods with a declared superclass.
+  if (isClassKeyword(enclosingType)) {
+    const superType = firstInheritedType(enclosingType);
+    if (superType !== null) {
+      out.push(buildReceiverMatch(anchorNode, 'super', superType));
+    }
+  }
+
+  return out;
+}
+
+function buildReceiverMatch(anchorNode: SyntaxNode, name: string, typeText: string): CaptureMatch {
+  const m: Record<string, Capture> = {
+    '@type-binding.self': nodeToCapture('@type-binding.self', anchorNode),
+    '@type-binding.name': syntheticCapture('@type-binding.name', anchorNode, name),
+    '@type-binding.type': syntheticCapture('@type-binding.type', anchorNode, typeText),
+  };
+  return m;
+}

--- a/gitnexus/src/core/ingestion/languages/swift/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/scope-resolver.ts
@@ -20,8 +20,11 @@
  *     type-binding layer.
  *   - **Same-module visibility**: every file in an SPM target sees its
  *     siblings' top-level defs without an `import`. Modeled via
- *     `populateSwiftTargetSiblings` (directory-grouped), mirroring Go's
- *     package siblings.
+ *     `populateSwiftTargetSiblings`, grouped by the SPM target *subtree*
+ *     (`Sources/<Target>/…`) via `groupSwiftFilesBySpmTarget` fed from the
+ *     `loadResolutionConfig` SPM map, mirroring Go's package siblings. With
+ *     no scanned source dir (no `Sources/`/`Package/Sources/`/`src/`) the
+ *     map is null and all files form one `__default__` module.
  *   - **`super`** is the superclass receiver (`super.method()`); plain
  *     `self` is the instance receiver. Both synthesized in
  *     `receiver-binding.ts`.
@@ -33,16 +36,19 @@
  *      Array where Element: Equatable`) are not narrowed — the `Self`
  *      type of a protocol method resolves to the protocol, not the
  *      conforming type.
- *   2. **Cross-module `import` resolution** is directory-segment based
- *      (`import Foo` → files under a `Foo/` dir); no `Package.swift`
- *      manifest parsing. Same-target visibility (the common case) is
- *      handled by sibling augmentation, not imports.
+ *   2. **Cross-module `import` resolution** is still directory-segment
+ *      based (`import Foo` → files under a `Foo/` dir); explicit imports do
+ *      not yet consult the SPM target map (follow-up, tracked under #1935).
+ *      Same-target visibility (the common case) IS SPM-target-subtree
+ *      accurate — handled by sibling augmentation grouped via
+ *      `groupSwiftFilesBySpmTarget`, not by explicit imports.
  *   3. **Operator / subscript overloads** dispatch by name only.
  *   4. **`@_exported import` re-exports** are treated as plain imports.
  */
 
 import type { ParsedFile } from 'gitnexus-shared';
 import { SupportedLanguages } from 'gitnexus-shared';
+import { loadSwiftPackageConfig } from '../../language-config.js';
 import { buildMro, defaultLinearize } from '../../scope-resolution/passes/mro.js';
 import { populateClassOwnedMembers, isClassLike } from '../../scope-resolution/scope/walkers.js';
 import { resolveDefGraphId } from '../../scope-resolution/graph-bridge/ids.js';
@@ -67,6 +73,15 @@ const swiftScopeResolver: ScopeResolver = {
   language: SupportedLanguages.Swift,
   languageProvider: swiftProvider,
   importEdgeReason: 'swift-scope: import',
+
+  // Load the SPM target map (Sources/<Target>/ subtree mapping) once per
+  // workspace pass. Threaded through the orchestrator as `resolutionConfig`
+  // and consumed by the three same-module grouping hooks
+  // (`emitImplicitImportEdges`, `populateNamespaceSiblings`,
+  // `mirrorNamespaceTypeBindings`) via `coerceSwiftTargets` so they group by
+  // the SPM target subtree, not the immediate directory. Mirrors
+  // `goScopeResolver`'s `loadGoModulePath`.
+  loadResolutionConfig: (repoPath: string) => loadSwiftPackageConfig(repoPath),
 
   resolveImportTarget: (targetRaw, fromFile, allFilePaths) => {
     const ws: SwiftResolveContext = { fromFile, allFilePaths };

--- a/gitnexus/src/core/ingestion/languages/swift/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/scope-resolver.ts
@@ -1,0 +1,212 @@
+/**
+ * Swift `ScopeResolver` registered in `SCOPE_RESOLVERS` and consumed by
+ * the generic `runScopeResolution` orchestrator (RFC #909 Ring 3,
+ * issue #937 — the final per-language migration).
+ *
+ * Closest reference: C# (`csharpScopeResolver`) — both are OOP with
+ * classes, structs, interfaces/protocols, and explicit instance
+ * receivers. MRO follows Kotlin's shape (single superclass + multiple
+ * protocol conformance).
+ *
+ * ## Swift specifics
+ *
+ *   - **Extensions** add members to an existing type. `emitSwiftScopeCaptures`
+ *     re-keys an `extension Foo { … }` to a `class_declaration`-style def
+ *     named `Foo`, so its members land on `Foo`'s scope and the shared
+ *     `populateClassOwnedMembers` stamps them with `Foo`'s ownerId — the
+ *     same mechanism C# uses for `partial class`. No separate hoist pass.
+ *   - **Labeled arguments** narrow by ARITY only (count-primary, labels
+ *     soft) — see `arity.ts`. Label-precise dispatch is deferred to the
+ *     type-binding layer.
+ *   - **Same-module visibility**: every file in an SPM target sees its
+ *     siblings' top-level defs without an `import`. Modeled via
+ *     `populateSwiftTargetSiblings` (directory-grouped), mirroring Go's
+ *     package siblings.
+ *   - **`super`** is the superclass receiver (`super.method()`); plain
+ *     `self` is the instance receiver. Both synthesized in
+ *     `receiver-binding.ts`.
+ *
+ * ## Known limitations (conscious migration trade-offs; parity gate flags
+ * anything that matters in the corpus)
+ *
+ *   1. **Protocol associated types / generic constraints** (`extension
+ *      Array where Element: Equatable`) are not narrowed — the `Self`
+ *      type of a protocol method resolves to the protocol, not the
+ *      conforming type.
+ *   2. **Cross-module `import` resolution** is directory-segment based
+ *      (`import Foo` → files under a `Foo/` dir); no `Package.swift`
+ *      manifest parsing. Same-target visibility (the common case) is
+ *      handled by sibling augmentation, not imports.
+ *   3. **Operator / subscript overloads** dispatch by name only.
+ *   4. **`@_exported import` re-exports** are treated as plain imports.
+ */
+
+import type { ParsedFile } from 'gitnexus-shared';
+import { SupportedLanguages } from 'gitnexus-shared';
+import { buildMro, defaultLinearize } from '../../scope-resolution/passes/mro.js';
+import { populateClassOwnedMembers, isClassLike } from '../../scope-resolution/scope/walkers.js';
+import { resolveDefGraphId } from '../../scope-resolution/graph-bridge/ids.js';
+import type { GraphNodeLookup } from '../../scope-resolution/graph-bridge/node-lookup.js';
+import type { KnowledgeGraph } from '../../../graph/types.js';
+import type { ScopeResolver } from '../../scope-resolution/contract/scope-resolver.js';
+import { swiftProvider } from '../swift.js';
+import {
+  swiftArityCompatibility,
+  swiftMergeBindings,
+  interpretSwiftImport,
+  resolveSwiftImportTarget,
+  populateSwiftTargetSiblings,
+  emitSwiftImplicitImportEdges,
+  mirrorSwiftSiblingTypeBindings,
+  type SwiftResolveContext,
+} from './index.js';
+
+const swiftScopeResolver: ScopeResolver = {
+  language: SupportedLanguages.Swift,
+  languageProvider: swiftProvider,
+  importEdgeReason: 'swift-scope: import',
+
+  resolveImportTarget: (targetRaw, fromFile, allFilePaths) => {
+    const ws: SwiftResolveContext = { fromFile, allFilePaths };
+    return resolveSwiftImportTarget(
+      interpretSwiftImport({
+        '@import.source': { name: '@import.source', text: targetRaw, range: ZERO_RANGE },
+      }) ?? { kind: 'namespace', localName: targetRaw, importedName: targetRaw, targetRaw },
+      ws,
+    );
+  },
+
+  // Swift shadowing: local declarations hide imports.
+  mergeBindings: (existing, incoming) => [...swiftMergeBindings([...existing, ...incoming])],
+
+  // Adapter: swiftArityCompatibility uses (def, callsite); contract is (callsite, def).
+  arityCompatibility: (callsite, def) => swiftArityCompatibility(def, callsite),
+
+  buildMro: (graph, parsedFiles, nodeLookup) => buildSwiftMro(graph, parsedFiles, nodeLookup),
+
+  // Methods/properties/init are owned by their enclosing class/struct/
+  // extension(→extended type)/protocol. Extension members hoist for free
+  // because captures.ts re-keys the extension to a Class def named after
+  // the extended type.
+  populateOwners: (parsed: ParsedFile) => populateClassOwnedMembers(parsed),
+
+  // `super.method()` dispatches through the superclass chain.
+  isSuperReceiver: (text) => text.trim() === 'super',
+
+  // Whole-module same-target visibility without `import`.
+  populateNamespaceSiblings: populateSwiftTargetSiblings,
+
+  // Same-target File→File IMPORTS edges (no syntactic `import`). The
+  // generic finalized-ImportEdge pipeline has nothing to emit here, so
+  // these whole-module-visibility edges are emitted directly.
+  emitImplicitImportEdges: emitSwiftImplicitImportEdges,
+
+  // Mirror sibling files' return-type typeBindings into each file's
+  // module scope so cross-file chains (`let u = siblingFn(); u.m()`)
+  // resolve. Whole-module visibility has no import edge for
+  // `propagateImportedReturnTypes` to follow, so this directory-sibling
+  // mirror feeds it (mirrors Go's namespace-typeBinding mirror).
+  mirrorNamespaceTypeBindings: mirrorSwiftSiblingTypeBindings,
+
+  // Swift is statically typed — type info is reliable; the field-fallback
+  // heuristic over-connects, so keep it off. Return-type propagation on.
+  fieldFallbackOnMethodLookup: false,
+  propagatesReturnTypesAcrossImports: true,
+
+  // Swift has no `new` keyword: `UserService()` is a bare call that
+  // resolves to the type's Constructor/Class. With whole-module sibling
+  // visibility, the callee is reachable workspace-wide, so allow the
+  // global free-call fallback (as Python/Go/Ruby/COBOL do for the same
+  // no-`new` constructor + cross-file free-call shape).
+  allowGlobalFreeCallFallback: true,
+
+  // Swift's call graph models `Type(...)` as a reference to the type
+  // itself, not its `init` — both the legacy DAG and this test suite link
+  // `Foo()` to the Class node even when an explicit `init` exists.
+  constructorCallTargetsClass: true,
+};
+
+export { swiftScopeResolver };
+
+const ZERO_RANGE = { startLine: 0, startCol: 0, endLine: 0, endCol: 0 } as const;
+
+/**
+ * Swift MRO — `defaultLinearize` (EXTENDS-only superclass chain) extended
+ * with protocol ancestors discovered via `IMPLEMENTS` edges. Protocols
+ * with default method implementations (via protocol extensions) are
+ * inherited by conforming types without an explicit `override`; the
+ * generic EXTENDS-only MRO would miss them because the conformer has no
+ * EXTENDS link to the protocol.
+ *
+ * Mirrors `buildKotlinMro`: append protocols after the superclass chain
+ * (Swift requires an explicit implementation on ambiguity, so first-seen
+ * ordering approximates method lookup). Transitive protocol inheritance
+ * (`protocol A: B`) is closed via BFS.
+ */
+function buildSwiftMro(
+  graph: KnowledgeGraph,
+  parsedFiles: readonly ParsedFile[],
+  nodeLookup: GraphNodeLookup,
+): Map<string, string[]> {
+  const mro = buildMro(graph, parsedFiles, nodeLookup, defaultLinearize);
+
+  const defIdByGraphId = new Map<string, string>();
+  for (const parsed of parsedFiles) {
+    for (const def of parsed.localDefs) {
+      if (!isClassLike(def.type)) continue;
+      const graphId = resolveDefGraphId(parsed.filePath, def, nodeLookup);
+      if (graphId !== undefined) defIdByGraphId.set(graphId, def.nodeId);
+    }
+  }
+
+  const directImpls = new Map<string, string[]>();
+  for (const rel of graph.iterRelationshipsByType('IMPLEMENTS')) {
+    const source = defIdByGraphId.get(rel.sourceId);
+    const target = defIdByGraphId.get(rel.targetId);
+    if (source === undefined || target === undefined) continue;
+    let list = directImpls.get(source);
+    if (list === undefined) {
+      list = [];
+      directImpls.set(source, list);
+    }
+    if (!list.includes(target)) list.push(target);
+  }
+
+  for (const [classDefId, extendsMro] of mro) {
+    const ancestorChain = [classDefId, ...extendsMro];
+    const seeds: string[] = [];
+    for (const ancestorId of ancestorChain) {
+      for (const ifaceId of directImpls.get(ancestorId) ?? []) seeds.push(ifaceId);
+    }
+    if (seeds.length === 0) continue;
+    const protocols = closeProtocols(seeds, directImpls);
+    mro.set(classDefId, [...extendsMro, ...protocols.filter((i) => !extendsMro.includes(i))]);
+  }
+
+  // Types that only conform to protocols (no superclass) still need an MRO.
+  for (const [classDefId, ifaces] of directImpls) {
+    if (mro.has(classDefId)) continue;
+    mro.set(classDefId, closeProtocols([...ifaces], directImpls));
+  }
+
+  return mro;
+}
+
+function closeProtocols(
+  seeds: readonly string[],
+  directImpls: ReadonlyMap<string, readonly string[]>,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const queue: string[] = [...seeds];
+  while (queue.length > 0) {
+    const cur = queue.shift()!;
+    if (seen.has(cur)) continue;
+    seen.add(cur);
+    out.push(cur);
+    for (const next of directImpls.get(cur) ?? []) {
+      if (!seen.has(next)) queue.push(next);
+    }
+  }
+  return out;
+}

--- a/gitnexus/src/core/ingestion/languages/swift/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/scope-resolver.ts
@@ -61,6 +61,8 @@ import {
   type SwiftResolveContext,
 } from './index.js';
 
+const ZERO_RANGE = { startLine: 0, startCol: 0, endLine: 0, endCol: 0 } as const;
+
 const swiftScopeResolver: ScopeResolver = {
   language: SupportedLanguages.Swift,
   languageProvider: swiftProvider,
@@ -127,8 +129,6 @@ const swiftScopeResolver: ScopeResolver = {
 };
 
 export { swiftScopeResolver };
-
-const ZERO_RANGE = { startLine: 0, startCol: 0, endLine: 0, endCol: 0 } as const;
 
 /**
  * Swift MRO — `defaultLinearize` (EXTENDS-only superclass chain) extended

--- a/gitnexus/src/core/ingestion/languages/swift/sibling-type-bindings.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/sibling-type-bindings.ts
@@ -1,0 +1,79 @@
+/**
+ * Swift same-module return-type typeBinding mirroring for the
+ * `mirrorNamespaceTypeBindings` hook.
+ *
+ * Swift gives every file in a module (an SPM target) visibility of every
+ * sibling's top-level declarations without a syntactic `import`. For a
+ * chained call like
+ *
+ *   App.swift:    let user = getUser(); user.save()   // user → getUser → ?
+ *   Models.swift: func getUser() -> User { … }        // getUser → User
+ *
+ * to resolve `user.save()` cross-file, App.swift's scope chain must be
+ * able to follow `getUser → User`. The function return-type binding
+ * (`getUser → User`) lives on Models.swift's module scope, so we mirror
+ * sibling module-scope typeBindings into the importer's module scope —
+ * the same trick Go uses (`mirrorGoNamespaceTypeBindings`), but Swift has
+ * no namespace-import edges, so module membership is approximated by the
+ * file's immediate containing directory (the SPM-target proxy used by
+ * `populateSwiftTargetSiblings`).
+ *
+ * Runs after `populateNamespaceSiblings` and before
+ * `propagateImportedReturnTypes`, so the SCC-ordered propagation pass
+ * sees the mirrored bindings and chains `user → getUser → User` to the
+ * terminal class. Each mirrored binding is chain-followed inside its
+ * source module first so we mirror the terminal type, not an intermediate
+ * intra-module reference. `Scope.typeBindings` is mutated via the
+ * sanctioned non-frozen Map cast (Contract Invariant I6).
+ */
+
+import type { ParsedFile, TypeRef } from 'gitnexus-shared';
+import type { ScopeResolutionIndexes } from '../../model/scope-resolution-indexes.js';
+import type { WorkspaceResolutionIndex } from '../../scope-resolution/workspace-index.js';
+import { followChainPostFinalize } from '../../scope-resolution/passes/imported-return-types.js';
+
+export function mirrorSwiftSiblingTypeBindings(
+  parsedFiles: readonly ParsedFile[],
+  indexes: ScopeResolutionIndexes,
+  workspaceIndex: WorkspaceResolutionIndex,
+): void {
+  const moduleScopeByFile = workspaceIndex.moduleScopeByFile;
+
+  // Group files by immediate containing directory (the module proxy).
+  const filesByDir = new Map<string, string[]>();
+  for (const parsed of parsedFiles) {
+    const dir = containingDir(parsed.filePath);
+    const list = filesByDir.get(dir) ?? [];
+    list.push(parsed.filePath);
+    filesByDir.set(dir, list);
+  }
+
+  for (const [, files] of filesByDir) {
+    if (files.length < 2) continue; // no siblings to mirror from
+    for (const importerFile of files) {
+      const importerModule = moduleScopeByFile.get(importerFile);
+      if (importerModule === undefined) continue;
+
+      for (const sourceFile of files) {
+        if (sourceFile === importerFile) continue;
+        const sourceModule = moduleScopeByFile.get(sourceFile);
+        if (sourceModule === undefined) continue;
+
+        for (const [name, ref] of sourceModule.typeBindings) {
+          if (name.length === 0) continue;
+          // A local annotation on the importer must win over a sibling's.
+          if (importerModule.typeBindings.has(name)) continue;
+
+          const terminal = followChainPostFinalize(ref, sourceModule.id, indexes);
+          (importerModule.typeBindings as Map<string, TypeRef>).set(name, terminal);
+        }
+      }
+    }
+  }
+}
+
+function containingDir(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, '/');
+  const idx = normalized.lastIndexOf('/');
+  return idx === -1 ? '' : normalized.slice(0, idx);
+}

--- a/gitnexus/src/core/ingestion/languages/swift/sibling-type-bindings.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/sibling-type-bindings.ts
@@ -14,9 +14,11 @@
  * (`getUser → User`) lives on Models.swift's module scope, so we mirror
  * sibling module-scope typeBindings into the importer's module scope —
  * the same trick Go uses (`mirrorGoNamespaceTypeBindings`), but Swift has
- * no namespace-import edges, so module membership is approximated by the
- * file's immediate containing directory (the SPM-target proxy used by
- * `populateSwiftTargetSiblings`).
+ * no namespace-import edges, so module membership is the SPM target
+ * subtree (`Sources/<Target>/…`): threaded in via the SPM target map
+ * (`resolutionConfig` → `coerceSwiftTargets`) and grouped by
+ * `groupSwiftFilesBySpmTarget` (replicating legacy `groupSwiftFilesByTarget`;
+ * no-source-dir → all files form one `__default__` module).
  *
  * Runs after `populateNamespaceSiblings` and before
  * `propagateImportedReturnTypes`, so the SCC-ordered propagation pass
@@ -31,25 +33,28 @@ import type { ParsedFile, TypeRef } from 'gitnexus-shared';
 import type { ScopeResolutionIndexes } from '../../model/scope-resolution-indexes.js';
 import type { WorkspaceResolutionIndex } from '../../scope-resolution/workspace-index.js';
 import { followChainPostFinalize } from '../../scope-resolution/passes/imported-return-types.js';
+import { coerceSwiftTargets, groupSwiftFilesBySpmTarget } from './target-grouping.js';
 
 export function mirrorSwiftSiblingTypeBindings(
   parsedFiles: readonly ParsedFile[],
   indexes: ScopeResolutionIndexes,
   workspaceIndex: WorkspaceResolutionIndex,
+  resolutionConfig?: unknown,
 ): void {
   const moduleScopeByFile = workspaceIndex.moduleScopeByFile;
 
-  // Group files by immediate containing directory (the module proxy).
-  const filesByDir = new Map<string, string[]>();
-  for (const parsed of parsedFiles) {
-    const dir = containingDir(parsed.filePath);
-    const list = filesByDir.get(dir) ?? [];
-    list.push(parsed.filePath);
-    filesByDir.set(dir, list);
-  }
+  // Group files by SPM target subtree (the module). No-source-dir → all
+  // files in one `__default__` bucket.
+  const targets = coerceSwiftTargets(resolutionConfig);
+  const filesByTarget = groupSwiftFilesBySpmTarget(
+    parsedFiles,
+    (parsed) => parsed.filePath,
+    targets,
+  );
 
-  for (const [, files] of filesByDir) {
-    if (files.length < 2) continue; // no siblings to mirror from
+  for (const [, group] of filesByTarget) {
+    if (group.length < 2) continue; // no siblings to mirror from
+    const files = group.map((parsed) => parsed.filePath);
     for (const importerFile of files) {
       const importerModule = moduleScopeByFile.get(importerFile);
       if (importerModule === undefined) continue;
@@ -70,10 +75,4 @@ export function mirrorSwiftSiblingTypeBindings(
       }
     }
   }
-}
-
-function containingDir(filePath: string): string {
-  const normalized = filePath.replace(/\\/g, '/');
-  const idx = normalized.lastIndexOf('/');
-  return idx === -1 ? '' : normalized.slice(0, idx);
 }

--- a/gitnexus/src/core/ingestion/languages/swift/signature-bindings.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/signature-bindings.ts
@@ -52,7 +52,12 @@ export function synthesizeSwiftSignatureBindings(fnNode: SyntaxNode): CaptureMat
   if (NAMED_FUNCTION_NODE_TYPES.has(fnNode.type)) {
     const funcName = swiftMethodConfig.extractName?.(fnNode);
     const returnType = swiftMethodConfig.extractReturnType?.(fnNode);
-    if (funcName !== undefined && funcName !== '' && returnType !== undefined && returnType !== '') {
+    if (
+      funcName !== undefined &&
+      funcName !== '' &&
+      returnType !== undefined &&
+      returnType !== ''
+    ) {
       out.push(buildBindingMatch(fnNode, '@type-binding.return', funcName, returnType));
     }
   }

--- a/gitnexus/src/core/ingestion/languages/swift/signature-bindings.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/signature-bindings.ts
@@ -1,0 +1,75 @@
+/**
+ * Synthesize parameter-type and function return-type `@type-binding.*`
+ * captures for a Swift function-like node.
+ *
+ * Why synthesized rather than queried: Swift's tree-sitter grammar reuses
+ * the field name `name:` for the function name, each parameter's label,
+ * each parameter's type, AND the function's return type. A tree-sitter
+ * query with two `name:` fields cross-assigns those captures and produces
+ * garbage bindings (e.g. `save: save`). Reading the node via the existing
+ * `swiftMethodConfig.extractParameters` / `extractReturnType` extractors
+ * — which already handle the grammar correctly for the legacy parse path
+ * — yields the right name→type pairs. This mirrors how receiver and arity
+ * metadata are synthesized in `captures.ts` instead of queried.
+ *
+ *   - **Parameter bindings** anchor inside the function body so the
+ *     binding lands in the Function scope: `func f(u: User) { u.save() }`
+ *     → `u: User` visible in f's body.
+ *   - **Return-type binding** anchors at the function node and carries
+ *     `@type-binding.return`, which `swiftBindingScopeFor` hoists to the
+ *     Module scope so `propagateImportedReturnTypes` mirrors it across
+ *     files and callers see `let u = getUser(); u.save()`.
+ */
+
+import type { Capture, CaptureMatch } from 'gitnexus-shared';
+import { nodeToCapture, syntheticCapture, type SyntaxNode } from '../../utils/ast-helpers.js';
+import { swiftMethodConfig } from '../../method-extractors/configs/swift.js';
+
+const NAMED_FUNCTION_NODE_TYPES = new Set([
+  'function_declaration',
+  'protocol_function_declaration',
+]);
+
+export function synthesizeSwiftSignatureBindings(fnNode: SyntaxNode): CaptureMatch[] {
+  const out: CaptureMatch[] = [];
+
+  // ── Parameter bindings (anchor in the body for Function-scope landing) ──
+  const params = swiftMethodConfig.extractParameters?.(fnNode) ?? [];
+  if (params.length > 0) {
+    const bodyNode = fnNode.childForFieldName('body');
+    // Anchor params inside the body when present; for bodyless protocol
+    // requirements there is no Function scope to bind locals into, so skip.
+    if (bodyNode !== null) {
+      for (const p of params) {
+        if (p.type === null || p.name === '') continue;
+        out.push(buildBindingMatch(bodyNode, '@type-binding.parameter', p.name, p.type));
+      }
+    }
+  }
+
+  // ── Return-type binding (function name → return type, hoisted to Module) ──
+  // Only named functions have a name to bind; init/deinit have no return.
+  if (NAMED_FUNCTION_NODE_TYPES.has(fnNode.type)) {
+    const funcName = swiftMethodConfig.extractName?.(fnNode);
+    const returnType = swiftMethodConfig.extractReturnType?.(fnNode);
+    if (funcName !== undefined && funcName !== '' && returnType !== undefined && returnType !== '') {
+      out.push(buildBindingMatch(fnNode, '@type-binding.return', funcName, returnType));
+    }
+  }
+
+  return out;
+}
+
+function buildBindingMatch(
+  anchorNode: SyntaxNode,
+  sourceTag: '@type-binding.parameter' | '@type-binding.return',
+  name: string,
+  typeText: string,
+): CaptureMatch {
+  const m: Record<string, Capture> = {
+    [sourceTag]: nodeToCapture(sourceTag, anchorNode),
+    '@type-binding.name': syntheticCapture('@type-binding.name', anchorNode, name),
+    '@type-binding.type': syntheticCapture('@type-binding.type', anchorNode, typeText),
+  };
+  return m;
+}

--- a/gitnexus/src/core/ingestion/languages/swift/simple-hooks.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/simple-hooks.ts
@@ -1,0 +1,82 @@
+/**
+ * Trivial / no-op-ish hooks for the Swift provider. Kept together
+ * because each is a few lines and they share a theme: they make the
+ * provider's choice explicit rather than relying on "absence == default"
+ * so reviewers don't have to re-derive the analysis.
+ */
+
+import type {
+  CaptureMatch,
+  ParsedImport,
+  Scope,
+  ScopeId,
+  ScopeTree,
+  TypeRef,
+} from 'gitnexus-shared';
+
+// ─── bindingScopeFor ──────────────────────────────────────────────────────
+
+/** Swift uses the central extractor's "innermost enclosing scope" default
+ *  for most declarations: class-body declarations attach to the Class
+ *  scope, function-body locals to the Function scope.
+ *
+ *  Exception: **function return-type bindings** (`@type-binding.return`)
+ *  must hoist to the Module scope. The default auto-hoist promotes only
+ *  one level (Function → its parent). For top-level functions the parent
+ *  is already the Module so the default works, but for methods declared
+ *  inside a class/struct/extension the parent is the Class — the return
+ *  binding would get stuck there, invisible to:
+ *    - chain-follow's parent-chain walk (`let u = getUser(); u.save()`);
+ *    - cross-file `propagateImportedReturnTypes`, which reads only
+ *      `sourceModule.typeBindings`.
+ *  Walking to Module restores both. Mirrors `csharpBindingScopeFor`. */
+export function swiftBindingScopeFor(
+  decl: CaptureMatch,
+  innermost: Scope,
+  tree: ScopeTree,
+): ScopeId | null {
+  if (decl['@type-binding.return'] !== undefined) {
+    let cur: Scope | undefined = innermost;
+    while (cur !== undefined && cur.kind !== 'Module') {
+      const parentId: ScopeId | null = cur.parent ?? null;
+      if (parentId === null) break;
+      cur = tree.getScope(parentId);
+    }
+    if (cur !== undefined && cur.kind === 'Module') return cur.id;
+  }
+  return null;
+}
+
+// ─── importOwningScope ────────────────────────────────────────────────────
+
+/** Swift imports only appear at file (module) scope and bring a whole
+ *  module into view there. Attach the import to the Module scope; for any
+ *  other innermost scope delegate to the default (returns null). */
+export function swiftImportOwningScope(
+  _imp: ParsedImport,
+  innermost: Scope,
+  _tree: ScopeTree,
+): ScopeId | null {
+  if (innermost.kind === 'Module') return innermost.id;
+  return null;
+}
+
+// ─── receiverBinding ──────────────────────────────────────────────────────
+
+/** Look up `self` (or `super`) in the function scope's type bindings.
+ *
+ *  `self` / `super` are synthesized as type bindings on instance methods
+ *  during capture emission (`receiver-binding.ts`) — `self` for every
+ *  method inside a class/struct/extension/protocol body, and `super`
+ *  additionally for methods of a class with a declared superclass. This
+ *  hook returns a non-null `TypeRef` for instance-method bodies.
+ *
+ *  Returns `null` for static methods (no `self` synthesized), free
+ *  functions (no enclosing type), and non-Function scopes. */
+export function swiftReceiverBinding(functionScope: Scope): TypeRef | null {
+  if (functionScope.kind !== 'Function') return null;
+  return (
+    functionScope.typeBindings.get('self') ?? functionScope.typeBindings.get('super') ?? null
+  );
+}
+

--- a/gitnexus/src/core/ingestion/languages/swift/simple-hooks.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/simple-hooks.ts
@@ -75,8 +75,5 @@ export function swiftImportOwningScope(
  *  functions (no enclosing type), and non-Function scopes. */
 export function swiftReceiverBinding(functionScope: Scope): TypeRef | null {
   if (functionScope.kind !== 'Function') return null;
-  return (
-    functionScope.typeBindings.get('self') ?? functionScope.typeBindings.get('super') ?? null
-  );
+  return functionScope.typeBindings.get('self') ?? functionScope.typeBindings.get('super') ?? null;
 }
-

--- a/gitnexus/src/core/ingestion/languages/swift/target-grouping.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/target-grouping.ts
@@ -1,0 +1,104 @@
+/**
+ * Swift SPM-target file grouping for the registry-primary same-module
+ * hooks (`implicit-imports.ts`, `target-siblings.ts`,
+ * `sibling-type-bindings.ts`).
+ *
+ * A Swift module is an SPM *target* — a directory *subtree*
+ * (`Sources/<Target>/…`), not a single immediate directory. Grouping by
+ * the immediate containing directory (the prior `containingDir` proxy)
+ * drops cross-directory same-module edges and can mis-resolve a
+ * constructor call to a wrong same-simple-named type in another target.
+ *
+ * This module duplicates the legacy `groupSwiftFilesByTarget`
+ * (`languages/swift.ts`) semantics **verbatim** so the registry-primary
+ * path matches legacy SPM-subtree grouping without touching the legacy
+ * pipeline (hard constraint: legacy stays byte-identical). The SPM target
+ * map is threaded in via the `resolutionConfig` channel
+ * (`loadSwiftPackageConfig` → `resolutionConfig` → these hooks); see
+ * `scope-resolver.ts` and `scope-resolution/pipeline/run.ts`.
+ *
+ * NOTE: This intentionally differs from the import-config module's
+ * leading-`startsWith` (`import-resolvers/configs/swift.ts`): that module
+ * fans a file out to EVERY matching target (a nested file can belong to
+ * multiple configured target dirs there), whereas legacy module grouping
+ * assigns each file to the FIRST matching target only (legacy `break`s) —
+ * one bucket per file. Do not copy the import-config behavior here.
+ */
+
+import type { SwiftPackageConfig } from '../../language-config.js';
+
+const DEFAULT_TARGET = '__default__';
+
+/**
+ * Group `items` by SPM target subtree, replicating legacy
+ * `groupSwiftFilesByTarget` semantics exactly:
+ *
+ *   - `targets` null/empty (no scanned source dir found) → ALL items go to
+ *     a single `__default__` bucket (single-Xcode-project assumption).
+ *   - Otherwise: a file matches a target when its normalized path either
+ *     starts with `<targetDir>/` (`indexOf === 0`) OR contains it at a `/`
+ *     boundary (`norm[idx - 1] === '/'`). Each file is assigned to the
+ *     FIRST matching target only (one bucket per file, no fan-out).
+ *   - Files matching no target fall into the `__default__` bucket.
+ *
+ * `targets` is `name → directory` (the `SwiftPackageConfig.targets` map).
+ */
+export function groupSwiftFilesBySpmTarget<T>(
+  items: readonly T[],
+  getPath: (item: T) => string,
+  targets: ReadonlyMap<string, string> | null,
+): Map<string, T[]> {
+  // No SPM config -> single target (common for Xcode projects).
+  if (targets === null || targets.size === 0) {
+    return new Map([[DEFAULT_TARGET, [...items]]]);
+  }
+
+  // Pre-convert target dirs to normalized prefix format once.
+  const targetPrefixes = [...targets.entries()].map(([name, dir]) => ({
+    name,
+    prefix: dir.replace(/\\/g, '/') + '/',
+  }));
+
+  const groups = new Map<string, T[]>();
+  const defaultGroup: T[] = [];
+
+  for (const item of items) {
+    const rawPath = getPath(item);
+    const normalized = rawPath.includes('\\') ? rawPath.replace(/\\/g, '/') : rawPath;
+    let assigned = false;
+    for (const { name, prefix } of targetPrefixes) {
+      const idx = normalized.indexOf(prefix);
+      if (idx === 0 || (idx > 0 && normalized[idx - 1] === '/')) {
+        let group = groups.get(name);
+        if (group === undefined) {
+          group = [];
+          groups.set(name, group);
+        }
+        group.push(item);
+        assigned = true;
+        break; // FIRST match only — one bucket per file, no fan-out.
+      }
+    }
+    if (!assigned) defaultGroup.push(item);
+  }
+
+  if (defaultGroup.length > 0) groups.set(DEFAULT_TARGET, defaultGroup);
+  return groups;
+}
+
+/**
+ * Duck-type the opaque `resolutionConfig` (loaded by
+ * `loadSwiftPackageConfig` and threaded through the orchestrator) into the
+ * SPM `targets` map, or `null` when no Swift package config is present.
+ *
+ * Uses structural duck-typing (no `instanceof`) because the value crosses
+ * the `unknown`-typed `resolutionConfig` channel and may be `null`,
+ * `undefined`, or a config object whose `targets` is a `Map<string,string>`.
+ */
+export function coerceSwiftTargets(resolutionConfig: unknown): ReadonlyMap<string, string> | null {
+  const config = resolutionConfig as Partial<SwiftPackageConfig> | null | undefined;
+  if (config != null && config.targets instanceof Map) {
+    return config.targets;
+  }
+  return null;
+}

--- a/gitnexus/src/core/ingestion/languages/swift/target-siblings.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/target-siblings.ts
@@ -8,16 +8,14 @@
  * visibility — `populateGoPackageSiblings` is the template.
  *
  * Module identity: Swift has no in-source `package X` marker. The SPM
- * target is a directory subtree (`Sources/<Target>/…`). The legacy
- * `wireSwiftImplicitImports` (in `languages/swift.ts`) groups files by
- * SPM target when a `Package.swift` config is present, else treats ALL
- * Swift files as one module (`__default__`, single-Xcode-project
- * assumption). The scope-resolution contract does not thread the SPM
- * config here, so we approximate module membership by the file's
- * immediate containing directory — every `.swift` file in the same
- * directory sees its siblings' top-level defs. This matches the common
- * fixture / single-target layout and avoids over-connecting unrelated
- * directories.
+ * target is a directory subtree (`Sources/<Target>/…`). Module membership
+ * is threaded in via the SPM target map (`ctx.resolutionConfig` →
+ * `coerceSwiftTargets`) and grouped by `groupSwiftFilesBySpmTarget`,
+ * replicating legacy `wireSwiftImplicitImports`'s `groupSwiftFilesByTarget`:
+ * files are grouped by SPM target subtree when a package config is present,
+ * else ALL Swift files form one module (`__default__`,
+ * single-Xcode-project assumption). Every `.swift` file in the same target
+ * sees its siblings' top-level defs.
  *
  * Bindings are added through the append-only `bindingAugmentations`
  * channel (Contract Invariant I8) with `origin: 'namespace'`, exactly
@@ -27,25 +25,33 @@
 
 import type { BindingRef, ParsedFile, ScopeId, SymbolDefinition } from 'gitnexus-shared';
 import type { ScopeResolutionIndexes } from '../../model/scope-resolution-indexes.js';
+import { coerceSwiftTargets, groupSwiftFilesBySpmTarget } from './target-grouping.js';
 
 export function populateSwiftTargetSiblings(
   parsedFiles: readonly ParsedFile[],
   indexes: ScopeResolutionIndexes,
-  _ctx: { readonly fileContents: ReadonlyMap<string, string> },
+  ctx: {
+    readonly fileContents: ReadonlyMap<string, string>;
+    readonly resolutionConfig?: unknown;
+  },
 ): void {
-  // Group files by immediate containing directory (the module proxy).
-  const filesByDir = new Map<string, { filePath: string; defs: SymbolDefinition[] }[]>();
-  for (const parsed of parsedFiles) {
-    const dir = containingDir(parsed.filePath);
-    const list = filesByDir.get(dir) ?? [];
-    list.push({ filePath: parsed.filePath, defs: [...parsed.localDefs] });
-    filesByDir.set(dir, list);
-  }
+  // Group files by SPM target subtree (the module). No-source-dir → all
+  // files in one `__default__` bucket.
+  const targets = coerceSwiftTargets(ctx.resolutionConfig);
+  const filesByTarget = groupSwiftFilesBySpmTarget(
+    parsedFiles,
+    (parsed) => parsed.filePath,
+    targets,
+  );
 
   const augmentations = indexes.bindingAugmentations as Map<ScopeId, Map<string, BindingRef[]>>;
 
-  for (const [, siblings] of filesByDir) {
-    if (siblings.length < 2) continue; // no siblings to share
+  for (const [, group] of filesByTarget) {
+    if (group.length < 2) continue; // no siblings to share
+    const siblings = group.map((parsed) => ({
+      filePath: parsed.filePath,
+      defs: [...parsed.localDefs] as SymbolDefinition[],
+    }));
     for (const target of siblings) {
       for (const receiver of siblings) {
         if (receiver.filePath === target.filePath) continue; // no self-reference
@@ -62,12 +68,6 @@ export function populateSwiftTargetSiblings(
       }
     }
   }
-}
-
-function containingDir(filePath: string): string {
-  const normalized = filePath.replace(/\\/g, '/');
-  const idx = normalized.lastIndexOf('/');
-  return idx === -1 ? '' : normalized.slice(0, idx);
 }
 
 function getAugmentationBucket(

--- a/gitnexus/src/core/ingestion/languages/swift/target-siblings.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/target-siblings.ts
@@ -1,0 +1,89 @@
+/**
+ * Swift same-module (SPM target) implicit visibility for the
+ * `populateNamespaceSiblings` hook.
+ *
+ * Swift gives every file in a module access to every other file's
+ * top-level declarations WITHOUT any `import` statement (whole-module
+ * visibility). This is the Swift analogue of Go's same-package sibling
+ * visibility — `populateGoPackageSiblings` is the template.
+ *
+ * Module identity: Swift has no in-source `package X` marker. The SPM
+ * target is a directory subtree (`Sources/<Target>/…`). The legacy
+ * `wireSwiftImplicitImports` (in `languages/swift.ts`) groups files by
+ * SPM target when a `Package.swift` config is present, else treats ALL
+ * Swift files as one module (`__default__`, single-Xcode-project
+ * assumption). The scope-resolution contract does not thread the SPM
+ * config here, so we approximate module membership by the file's
+ * immediate containing directory — every `.swift` file in the same
+ * directory sees its siblings' top-level defs. This matches the common
+ * fixture / single-target layout and avoids over-connecting unrelated
+ * directories.
+ *
+ * Bindings are added through the append-only `bindingAugmentations`
+ * channel (Contract Invariant I8) with `origin: 'namespace'`, exactly
+ * like the Go implementation — `indexes.bindings` is frozen post-
+ * finalize and must not be mutated.
+ */
+
+import type { BindingRef, ParsedFile, ScopeId, SymbolDefinition } from 'gitnexus-shared';
+import type { ScopeResolutionIndexes } from '../../model/scope-resolution-indexes.js';
+
+export function populateSwiftTargetSiblings(
+  parsedFiles: readonly ParsedFile[],
+  indexes: ScopeResolutionIndexes,
+  _ctx: { readonly fileContents: ReadonlyMap<string, string> },
+): void {
+  // Group files by immediate containing directory (the module proxy).
+  const filesByDir = new Map<string, { filePath: string; defs: SymbolDefinition[] }[]>();
+  for (const parsed of parsedFiles) {
+    const dir = containingDir(parsed.filePath);
+    const list = filesByDir.get(dir) ?? [];
+    list.push({ filePath: parsed.filePath, defs: [...parsed.localDefs] });
+    filesByDir.set(dir, list);
+  }
+
+  const augmentations = indexes.bindingAugmentations as Map<ScopeId, Map<string, BindingRef[]>>;
+
+  for (const [, siblings] of filesByDir) {
+    if (siblings.length < 2) continue; // no siblings to share
+    for (const target of siblings) {
+      for (const receiver of siblings) {
+        if (receiver.filePath === target.filePath) continue; // no self-reference
+        const receiverModule = indexes.moduleScopes.byFilePath.get(receiver.filePath);
+        if (receiverModule === undefined) continue;
+
+        for (const def of target.defs) {
+          const name = def.qualifiedName?.split('.').pop() ?? def.qualifiedName ?? '';
+          if (name === '') continue;
+          const bucket = getAugmentationBucket(augmentations, receiverModule, name);
+          if (bucket.some((b) => b.def.nodeId === def.nodeId)) continue;
+          bucket.push({ def, origin: 'namespace' });
+        }
+      }
+    }
+  }
+}
+
+function containingDir(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, '/');
+  const idx = normalized.lastIndexOf('/');
+  return idx === -1 ? '' : normalized.slice(0, idx);
+}
+
+function getAugmentationBucket(
+  augmentations: Map<ScopeId, Map<string, BindingRef[]>>,
+  scopeId: ScopeId,
+  name: string,
+): BindingRef[] {
+  let scopeBindings = augmentations.get(scopeId);
+  if (scopeBindings === undefined) {
+    scopeBindings = new Map<string, BindingRef[]>();
+    augmentations.set(scopeId, scopeBindings);
+  }
+  let bucketArr = scopeBindings.get(name);
+  if (bucketArr === undefined) {
+    bucketArr = [];
+    scopeBindings.set(name, bucketArr);
+  }
+  return bucketArr;
+}

--- a/gitnexus/src/core/ingestion/registry-primary-flag.ts
+++ b/gitnexus/src/core/ingestion/registry-primary-flag.ts
@@ -82,6 +82,7 @@ export const MIGRATED_LANGUAGES: ReadonlySet<SupportedLanguages> = new Set<Suppo
   SupportedLanguages.Rust,
   SupportedLanguages.Ruby,
   SupportedLanguages.Cobol,
+  SupportedLanguages.Swift,
 ]);
 
 /**

--- a/gitnexus/src/core/ingestion/scope-resolution/contract/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/contract/scope-resolver.ts
@@ -460,6 +460,29 @@ export interface ScopeResolver {
   ) => void;
 
   /**
+   * Optional hook to emit IMPORTS edges that no syntactic import
+   * statement produces. Some languages grant files implicit visibility
+   * of one another within a compilation unit (e.g. every file in a
+   * build target sees its siblings' top-level declarations without an
+   * explicit import). The generic import pipeline only emits File→File
+   * IMPORTS edges from finalized `ImportEdge`s, so a language with this
+   * implicit-visibility rule has no edge to emit through that path.
+   *
+   * Runs immediately after `emitHeritageEdges` (so it shares the same
+   * pre-MRO surface: writable graph, parsedFiles, nodeLookup). Must be
+   * idempotent — the orchestrator may invoke it more than once during
+   * re-resolution. Implementations dedup their own emissions.
+   *
+   * Default: undefined (cross-file visibility requires an explicit
+   * import; the finalized-ImportEdge pipeline covers it).
+   */
+  readonly emitImplicitImportEdges?: (
+    graph: KnowledgeGraph,
+    parsedFiles: readonly ParsedFile[],
+    nodeLookup: GraphNodeLookup,
+  ) => void;
+
+  /**
    * Mutate `parsed.localDefs[i].ownerId` to point at the structural
    * owner. Python's rule: methods (Function defs whose parent scope
    * is Class) AND class-body fields (defs in Class scopes) are owned
@@ -582,6 +605,16 @@ export interface ScopeResolver {
    * but is too loose as a default for strict module systems.
    */
   readonly allowGlobalFreeCallFallback?: boolean;
+
+  /**
+   * When true, a constructor-form call `Type(...)` links to the Class def
+   * itself rather than its explicit Constructor def. Default
+   * (undefined/false) targets the explicit Constructor when one exists,
+   * else falls back to the Class. Languages whose call graph models
+   * `Type(...)` as a reference to the type (not its initializer) — e.g.
+   * Swift — opt in.
+   */
+  readonly constructorCallTargetsClass?: boolean;
 
   /**
    * Optional per-slot conversion-rank function for overload resolution.

--- a/gitnexus/src/core/ingestion/scope-resolution/contract/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/contract/scope-resolver.ts
@@ -473,6 +473,12 @@ export interface ScopeResolver {
    * idempotent — the orchestrator may invoke it more than once during
    * re-resolution. Implementations dedup their own emissions.
    *
+   * `resolutionConfig` is the opaque per-workspace value returned by
+   * `loadResolutionConfig` (same channel threaded into `resolveImportTarget`).
+   * Swift uses it to group same-module files by the SPM target subtree;
+   * languages that don't need per-workspace config ignore the trailing
+   * parameter (it is optional so existing impls keep compiling).
+   *
    * Default: undefined (cross-file visibility requires an explicit
    * import; the finalized-ImportEdge pipeline covers it).
    */
@@ -480,6 +486,7 @@ export interface ScopeResolver {
     graph: KnowledgeGraph,
     parsedFiles: readonly ParsedFile[],
     nodeLookup: GraphNodeLookup,
+    resolutionConfig?: unknown,
   ) => void;
 
   /**
@@ -800,6 +807,12 @@ export interface ScopeResolver {
        *  itself; the cache is opt-in for hooks that need AST-level
        *  facts beyond what `ParsedFile` exposes. */
       readonly treeCache?: { get(filePath: string): unknown };
+      /** Opaque per-workspace value from `loadResolutionConfig` (same
+       *  channel threaded into `resolveImportTarget`). Swift uses it to
+       *  group same-module siblings by the SPM target subtree; languages
+       *  that don't need per-workspace config ignore it. Optional so
+       *  existing impls keep compiling. */
+      readonly resolutionConfig?: unknown;
     },
   ) => void;
 
@@ -843,12 +856,20 @@ export interface ScopeResolver {
    * `NewUser → User` mirrored from the target package). Runs after
    * `populateNamespaceSiblings` and before `propagateImportedReturnTypes`
    * so the SCC-ordered pass sees the mirrored bindings.
+   *
+   * `resolutionConfig` is the opaque per-workspace value returned by
+   * `loadResolutionConfig` (same channel threaded into `resolveImportTarget`).
+   * Swift uses it to group same-module sibling files by the SPM target
+   * subtree; languages that don't need per-workspace config ignore the
+   * trailing parameter (it is optional so existing impls keep compiling).
+   *
    * Default: undefined (no namespace typeBinding mirroring).
    */
   readonly mirrorNamespaceTypeBindings?: (
     parsedFiles: readonly ParsedFile[],
     indexes: ScopeResolutionIndexes,
     workspaceIndex: import('../../scope-resolution/workspace-index.js').WorkspaceResolutionIndex,
+    resolutionConfig?: unknown,
   ) => void;
 
   /**

--- a/gitnexus/src/core/ingestion/scope-resolution/passes/free-call-fallback.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/passes/free-call-fallback.ts
@@ -97,6 +97,11 @@ export function emitFreeCallFallback(
   // per call site. Same name + callable-kind filter that the previous scan
   // applied (see pickUniqueGlobalCallable JSDoc). Cost: O(|defs|) once.
   const globalCallablesBySimpleName = buildGlobalCallableIndex(scopes);
+  // Sibling index for constructor-form class fallback. Built once here so
+  // pickUniqueGlobalClass is O(1)-per-site rather than re-scanning
+  // defs.byId.values() at every constructor call. Same simple-name keying
+  // and class-like kind filter the previous per-site scan applied.
+  const globalClassesBySimpleName = buildGlobalClassIndex(scopes);
 
   for (const parsed of parsedFiles) {
     for (const site of parsed.referenceSites) {
@@ -125,7 +130,7 @@ export function emitFreeCallFallback(
           // a unique workspace-wide Class def by simple name (gated on the
           // same global-fallback opt-in as free calls). Then target the
           // Class or its Constructor per the language's preference.
-          const globalClass = pickUniqueGlobalClass(site.name, scopes);
+          const globalClass = pickUniqueGlobalClass(site.name, globalClassesBySimpleName);
           if (globalClass !== undefined) {
             fnDef =
               options.constructorCallTargetsClass === true
@@ -481,6 +486,46 @@ function buildGlobalCallableIndex(
   return out;
 }
 
+/**
+ * Build a `simpleName -> class-like defs` index from `scopes.defs` once per
+ * pass — the structural sibling of `buildGlobalCallableIndex`, consumed by
+ * `pickUniqueGlobalClass` so constructor-form fallback is O(1)-per-site
+ * instead of O(|defs|).
+ *
+ * **Kind filter (KTD5 — KEEP `'Interface'`):** the set is
+ * `Class | Struct | Interface`, matching the idiomatic class-like set used
+ * elsewhere in the scope-resolution bridge (`graph-bridge/ids.ts`,
+ * `node-lookup.ts`). This is a behavior-PRESERVING perf refactor for all 8
+ * `allowGlobalFreeCallFallback` languages — the previous per-site scan used
+ * exactly this filter. Excluding Swift `protocol` (`Interface`) defs because
+ * protocols aren't instantiable is a *separate* Swift-semantics question with
+ * its own test; dropping `Interface` here would be a deliberate
+ * behavior-changing edit, not part of U5.
+ *
+ * Bucket insertion order follows `defs.byId.values()` iteration order, so the
+ * downstream "keep first" / ambiguity ordering in `pickUniqueGlobalClass` is
+ * byte-identical to the old linear scan (equivalence verified).
+ *
+ * Exported for unit testing — language-agnostic logic, exercised via synthetic
+ * stubs in `pick-unique-global-class.test.ts`.
+ */
+export function buildGlobalClassIndex(
+  scopes: ScopeResolutionIndexes,
+): ReadonlyMap<string, readonly SymbolDefinition[]> {
+  const out = new Map<string, SymbolDefinition[]>();
+  for (const def of scopes.defs.byId.values()) {
+    if (def.type !== 'Class' && def.type !== 'Struct' && def.type !== 'Interface') continue;
+    const qualified = def.qualifiedName;
+    if (qualified === undefined || qualified.length === 0) continue;
+    const dot = qualified.lastIndexOf('.');
+    const simple = dot === -1 ? qualified : qualified.slice(dot + 1);
+    const bucket = out.get(simple);
+    if (bucket) bucket.push(def);
+    else out.set(simple, [def]);
+  }
+  return out;
+}
+
 function pickUniqueGlobalCallable(
   name: string,
   model: SemanticModel,
@@ -644,19 +689,23 @@ function pickConstructorOrClass(
  *  node. Genuinely distinct types with the same simple name are
  *  ambiguous and leave the call unresolved rather than guessing. Gated
  *  by the caller on `allowGlobalFallback`, mirroring
- *  `pickUniqueGlobalCallable`. */
-function pickUniqueGlobalClass(
+ *  `pickUniqueGlobalCallable`.
+ *
+ *  Consumes the once-built `buildGlobalClassIndex` (`simpleName ->
+ *  class-like defs`) so each call site is O(1) rather than O(|defs|).
+ *  The index's `Class | Struct | Interface` kind filter is intentionally
+ *  KEPT (KTD5) — see `buildGlobalClassIndex` for why dropping `Interface`
+ *  would be a separate, behavior-changing Swift-semantics edit.
+ *
+ *  Exported for unit testing — language-agnostic logic, exercised via
+ *  synthetic stubs in `pick-unique-global-class.test.ts`. The production
+ *  call site is the constructor-form fallback in `emitFreeCallFallback`. */
+export function pickUniqueGlobalClass(
   name: string,
-  scopes: ScopeResolutionIndexes,
+  index: ReadonlyMap<string, readonly SymbolDefinition[]>,
 ): SymbolDefinition | undefined {
   let found: SymbolDefinition | undefined;
-  for (const def of scopes.defs.byId.values()) {
-    if (def.type !== 'Class' && def.type !== 'Struct' && def.type !== 'Interface') continue;
-    const qualified = def.qualifiedName;
-    if (qualified === undefined || qualified.length === 0) continue;
-    const dot = qualified.lastIndexOf('.');
-    const simple = dot === -1 ? qualified : qualified.slice(dot + 1);
-    if (simple !== name) continue;
+  for (const def of index.get(name) ?? []) {
     // Same qualified name = same logical type (extension / partial-class
     // fragment); keep the first and don't treat it as ambiguous.
     if (found !== undefined && found.qualifiedName !== def.qualifiedName) return undefined;

--- a/gitnexus/src/core/ingestion/scope-resolution/passes/free-call-fallback.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/passes/free-call-fallback.ts
@@ -58,6 +58,9 @@ export function emitFreeCallFallback(
   workspaceIndex: WorkspaceResolutionIndex,
   options: {
     readonly allowGlobalFallback?: boolean;
+    /** When true, `Type(...)` constructor calls link to the Class def
+     *  itself rather than its explicit Constructor. Swift opts in. */
+    readonly constructorCallTargetsClass?: boolean;
     readonly isFileLocalDef?: (def: SymbolDefinition) => boolean;
     readonly isCallableVisibleFromCaller?: (ctx: {
       readonly callerParsed: ParsedFile;
@@ -108,7 +111,27 @@ export function emitFreeCallFallback(
       if (site.callForm === 'constructor') {
         const classDef = findClassBindingInScope(site.inScope, site.name, scopes);
         if (classDef !== undefined) {
-          fnDef = pickConstructorOrClass(classDef, workspaceIndex, scopes);
+          // Most languages link `Type(...)` to the explicit Constructor def
+          // when one exists (else the Class). Languages that model the call
+          // as a reference to the type itself opt into
+          // `constructorCallTargetsClass` and always link to the Class.
+          fnDef =
+            options.constructorCallTargetsClass === true
+              ? classDef
+              : pickConstructorOrClass(classDef, workspaceIndex, scopes);
+        } else if (options.allowGlobalFallback === true) {
+          // The constructed type may live in a sibling/imported file that is
+          // not in the call-site's lexical scope-chain bindings. Fall back to
+          // a unique workspace-wide Class def by simple name (gated on the
+          // same global-fallback opt-in as free calls). Then target the
+          // Class or its Constructor per the language's preference.
+          const globalClass = pickUniqueGlobalClass(site.name, scopes);
+          if (globalClass !== undefined) {
+            fnDef =
+              options.constructorCallTargetsClass === true
+                ? globalClass
+                : pickConstructorOrClass(globalClass, workspaceIndex, scopes);
+          }
         }
       }
       // Implicit-this overload narrowing: an unqualified call inside
@@ -610,6 +633,36 @@ function pickConstructorOrClass(
     }
   }
   return classDef;
+}
+
+/** Find a unique workspace-wide class-like def by simple name, for a
+ *  constructor-form call `Type(...)` whose type lives outside the call
+ *  site's lexical bindings (a sibling/imported file). Returns the def
+ *  only when all matches share ONE qualified name — i.e. they are
+ *  fragments of a single logical type (partial classes / extensions
+ *  that re-key onto the same type), which resolve to the same graph
+ *  node. Genuinely distinct types with the same simple name are
+ *  ambiguous and leave the call unresolved rather than guessing. Gated
+ *  by the caller on `allowGlobalFallback`, mirroring
+ *  `pickUniqueGlobalCallable`. */
+function pickUniqueGlobalClass(
+  name: string,
+  scopes: ScopeResolutionIndexes,
+): SymbolDefinition | undefined {
+  let found: SymbolDefinition | undefined;
+  for (const def of scopes.defs.byId.values()) {
+    if (def.type !== 'Class' && def.type !== 'Struct' && def.type !== 'Interface') continue;
+    const qualified = def.qualifiedName;
+    if (qualified === undefined || qualified.length === 0) continue;
+    const dot = qualified.lastIndexOf('.');
+    const simple = dot === -1 ? qualified : qualified.slice(dot + 1);
+    if (simple !== name) continue;
+    // Same qualified name = same logical type (extension / partial-class
+    // fragment); keep the first and don't treat it as ambiguous.
+    if (found !== undefined && found.qualifiedName !== def.qualifiedName) return undefined;
+    if (found === undefined) found = def;
+  }
+  return found;
 }
 
 /** Walk up from the call-site scope to the enclosing class scope,

--- a/gitnexus/src/core/ingestion/scope-resolution/pipeline/registry.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/pipeline/registry.ts
@@ -24,6 +24,7 @@ import { javascriptScopeResolver } from '../../languages/javascript/scope-resolv
 import { kotlinScopeResolver } from '../../languages/kotlin/scope-resolver.js';
 import { rubyScopeResolver } from '../../languages/ruby/scope-resolver.js';
 import { cobolScopeResolver } from '../../languages/cobol/scope-resolver.js';
+import { swiftScopeResolver } from '../../languages/swift/scope-resolver.js';
 
 /** Map of `SupportedLanguages` → `ScopeResolver`. The phase iterates
  *  this map intersected with `MIGRATED_LANGUAGES` (the per-language
@@ -46,4 +47,5 @@ export const SCOPE_RESOLVERS: ReadonlyMap<SupportedLanguages, ScopeResolver> = n
   [SupportedLanguages.Kotlin, kotlinScopeResolver],
   [SupportedLanguages.Ruby, rubyScopeResolver],
   [SupportedLanguages.Cobol, cobolScopeResolver],
+  [SupportedLanguages.Swift, swiftScopeResolver],
 ]);

--- a/gitnexus/src/core/ingestion/scope-resolution/pipeline/run.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/pipeline/run.ts
@@ -318,7 +318,7 @@ export function runScopeResolution(
   // implicit cross-file visibility (no syntactic import statement). The
   // finalized-ImportEdge pipeline (`emitImportEdges`) cannot produce these
   // because there is no `ImportEdge` to materialize. Idempotent.
-  provider.emitImplicitImportEdges?.(graph, parsedFiles, nodeLookup);
+  provider.emitImplicitImportEdges?.(graph, parsedFiles, nodeLookup, resolutionConfig);
   // Rebuild the node lookup after heritage-edge emission. Languages like
   // Ruby create Property graph nodes inside `emitHeritageEdges`; those
   // nodes must be visible to downstream passes (`emitReceiverBoundCalls`
@@ -361,6 +361,7 @@ export function runScopeResolution(
     provider.populateNamespaceSiblings(parsedFiles, indexes, {
       fileContents: getFileContents(),
       treeCache,
+      resolutionConfig,
     });
   }
 
@@ -370,7 +371,7 @@ export function runScopeResolution(
   // propagateImportedReturnTypes so the SCC-ordered pass sees the
   // mirrored bindings.
   if (provider.mirrorNamespaceTypeBindings !== undefined) {
-    provider.mirrorNamespaceTypeBindings(parsedFiles, indexes, workspaceIndex);
+    provider.mirrorNamespaceTypeBindings(parsedFiles, indexes, workspaceIndex, resolutionConfig);
   }
 
   // Cross-file return-type propagation (Contract Invariant I3 timing:

--- a/gitnexus/src/core/ingestion/scope-resolution/pipeline/run.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/pipeline/run.ts
@@ -314,6 +314,11 @@ export function runScopeResolution(
   // heritage clauses. Must run BEFORE `buildMro` so MRO construction sees
   // the freshly-emitted IMPLEMENTS edges.
   provider.emitHeritageEdges?.(graph, parsedFiles, nodeLookup);
+  // Implicit IMPORTS-edge hook — for languages whose files have compiler-
+  // implicit cross-file visibility (no syntactic import statement). The
+  // finalized-ImportEdge pipeline (`emitImportEdges`) cannot produce these
+  // because there is no `ImportEdge` to materialize. Idempotent.
+  provider.emitImplicitImportEdges?.(graph, parsedFiles, nodeLookup);
   // Rebuild the node lookup after heritage-edge emission. Languages like
   // Ruby create Property graph nodes inside `emitHeritageEdges`; those
   // nodes must be visible to downstream passes (`emitReceiverBoundCalls`
@@ -444,6 +449,7 @@ export function runScopeResolution(
     workspaceIndex,
     {
       allowGlobalFallback: provider.allowGlobalFreeCallFallback === true,
+      constructorCallTargetsClass: provider.constructorCallTargetsClass === true,
       isFileLocalDef: provider.isFileLocalDef,
       isCallableVisibleFromCaller: provider.isCallableVisibleFromCaller,
       resolveAdlCandidates: provider.resolveAdlCandidates,

--- a/gitnexus/test/fixtures/lang-resolution/swift-class-func-receiver/Service.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-class-func-receiver/Service.swift
@@ -1,0 +1,35 @@
+class Service {
+    var label: String = ""
+
+    func handle() {
+        // Service's instance method.
+    }
+
+    func instanceCaller() {
+        // control: an instance method HAS a `self` receiver, so the
+        // instance-property read `self.label` resolves with full
+        // self-binding provenance.
+        self.handle()
+        let l = self.label
+        _ = l
+    }
+
+    class func classCaller() {
+        // `class func` is a TYPE method — it has NO `self` instance
+        // receiver. Pre-fix, `class func` wrongly got a `self: Service`
+        // instance binding, so `self.label` resolved with the SAME
+        // high-confidence provenance as an instance method. Post-fix it
+        // behaves exactly like `static func` (no instance self-binding).
+        self.handle()
+        let l = self.label
+        _ = l
+    }
+
+    static func staticCaller() {
+        // parity control: `static func` is a type method too (same rule);
+        // its `self.label` provenance is the baseline `class func` must match.
+        self.handle()
+        let l = self.label
+        _ = l
+    }
+}

--- a/gitnexus/test/fixtures/lang-resolution/swift-member-write-access/App.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-member-write-access/App.swift
@@ -1,0 +1,8 @@
+func transfer(acct: Account) {
+    acct.owner = "alice"
+}
+
+func inspect(acct: Account) -> String {
+    let who = acct.owner
+    return who
+}

--- a/gitnexus/test/fixtures/lang-resolution/swift-member-write-access/Models.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-member-write-access/Models.swift
@@ -1,0 +1,17 @@
+class Account {
+    var balance: Int = 0
+    var owner: String = ""
+
+    init(start: Int) {
+        self.balance = start
+    }
+
+    func deposit(amount: Int) {
+        self.balance = amount
+    }
+
+    func readBalance() -> Int {
+        let current = self.balance
+        return current
+    }
+}

--- a/gitnexus/test/fixtures/lang-resolution/swift-multi-if-let/App.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-multi-if-let/App.swift
@@ -1,0 +1,12 @@
+func processIfLet() {
+    if let a = makeA(), let b = makeB() {
+        a.m()
+        b.shared()
+    }
+}
+
+func processGuardLet() {
+    guard let a = makeA(), let b = makeB() else { return }
+    a.m()
+    b.shared()
+}

--- a/gitnexus/test/fixtures/lang-resolution/swift-multi-if-let/Models.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-multi-if-let/Models.swift
@@ -1,0 +1,30 @@
+class A {
+    func m() {
+        // A's distinctly-named method (resolves via the FIRST if-let
+        // clause binding `a: makeA() -> A`).
+    }
+}
+
+class B {
+    func shared() {
+        // B.shared — SAME method name as Decoy.shared below, so a bare
+        // `b.shared()` is ambiguous for a unique-name global fallback and
+        // can ONLY resolve to B.shared via the SECOND if-let clause binding
+        // `b: makeB() -> B`. A first-clause-only reader misses that binding,
+        // so `b.shared()` stays unresolved.
+    }
+}
+
+class Decoy {
+    func shared() {
+        // collides with B.shared to defeat the name-only fallback.
+    }
+}
+
+func makeA() -> A {
+    return A()
+}
+
+func makeB() -> B {
+    return B()
+}

--- a/gitnexus/test/fixtures/lang-resolution/swift-multidir-target/Package.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-multidir-target/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "MultiDirTarget",
+    targets: [
+        .target(name: "Alpha"),
+        .target(name: "Beta"),
+    ]
+)

--- a/gitnexus/test/fixtures/lang-resolution/swift-multidir-target/Sources/Alpha/Core/User.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-multidir-target/Sources/Alpha/Core/User.swift
@@ -1,0 +1,5 @@
+class User {
+    func alphaSave() {
+        print("alpha save")
+    }
+}

--- a/gitnexus/test/fixtures/lang-resolution/swift-multidir-target/Sources/Alpha/Entry/App.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-multidir-target/Sources/Alpha/Entry/App.swift
@@ -1,0 +1,4 @@
+func processEntities() {
+    let user = User()
+    user.alphaSave()
+}

--- a/gitnexus/test/fixtures/lang-resolution/swift-multidir-target/Sources/Beta/Core/User.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-multidir-target/Sources/Beta/Core/User.swift
@@ -1,0 +1,5 @@
+class User {
+    func betaSave() {
+        print("beta save")
+    }
+}

--- a/gitnexus/test/fixtures/lang-resolution/swift-multifolder-nopackage/Models/User.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-multifolder-nopackage/Models/User.swift
@@ -1,0 +1,5 @@
+class User {
+    func save() {
+        print("save")
+    }
+}

--- a/gitnexus/test/fixtures/lang-resolution/swift-multifolder-nopackage/Services/App.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-multifolder-nopackage/Services/App.swift
@@ -1,0 +1,4 @@
+func processEntities() {
+    let user = User()
+    user.save()
+}

--- a/gitnexus/test/fixtures/lang-resolution/swift-nested-extension/Extension.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-nested-extension/Extension.swift
@@ -1,0 +1,10 @@
+extension Foo.Bar {
+    func added() {
+        // `self.base()` must resolve to Bar.base because `self == Bar` (the
+        // TRAILING identifier of `Foo.Bar`). `added` must also hoist onto
+        // Bar. Pre-fix, `extension Foo.Bar` re-keyed the extended type and
+        // bound `self` to `Foo` (the LEADING identifier), so `self.base()`
+        // resolved against `Foo` — which has no `base` — instead of Bar.
+        self.base()
+    }
+}

--- a/gitnexus/test/fixtures/lang-resolution/swift-nested-extension/Types.swift
+++ b/gitnexus/test/fixtures/lang-resolution/swift-nested-extension/Types.swift
@@ -1,0 +1,16 @@
+enum Foo {
+    struct Bar {
+        func base() {
+            // Bar's own method. A same-named `base` lives on Decoy below,
+            // so a bare `base()` call is ambiguous for a unique-name global
+            // fallback — it resolves to Bar.base only when the extension's
+            // `self` is the trailing type `Bar`.
+        }
+    }
+}
+
+class Decoy {
+    func base() {
+        // collides with Bar.base to defeat the name-only fallback.
+    }
+}

--- a/gitnexus/test/fixtures/swift-captures-golden/expected-captures.json
+++ b/gitnexus/test/fixtures/swift-captures-golden/expected-captures.json
@@ -1,0 +1,178 @@
+{
+  "swift-abstract-dispatch/Sources/App.swift": {
+    "captureGroups": 9,
+    "digest": "56b82214cca3ed89312d84d6b04a48ee13cbe748ea6978e9bffa20ce46ac0930"
+  },
+  "swift-abstract-dispatch/Sources/Repository.swift": {
+    "captureGroups": 23,
+    "digest": "c97501a445d79f137705c040e57437f6488d4c87ee80f003ec547eb45e8fc35b"
+  },
+  "swift-await-try/App.swift": {
+    "captureGroups": 13,
+    "digest": "7ba2042b0cb0a6e5c5d459dc460c509ace477b0ce97bec0cc8aaf981f320e69a"
+  },
+  "swift-await-try/Models.swift": {
+    "captureGroups": 20,
+    "digest": "59f0a1aaa2884d12ff60c615cf73b3385894afba7b2d3d0cda74ff8648802d0b"
+  },
+  "swift-call-result-binding/App.swift": {
+    "captureGroups": 7,
+    "digest": "979534a46ee420a7a5dfd6b029c9fe5d67ca1b00f3bdc5e8977d72a1c316b75d"
+  },
+  "swift-call-result-binding/Models.swift": {
+    "captureGroups": 14,
+    "digest": "177c25e87bb0507385cb1da50ebb08305c83c62af637311fad53928ba1d491bc"
+  },
+  "swift-child-extends-parent/Sources/App.swift": {
+    "captureGroups": 10,
+    "digest": "19b16f002f2e10b661ada767769723ed92c6101fbf8dd895a9077c563c06946d"
+  },
+  "swift-child-extends-parent/Sources/Child.swift": {
+    "captureGroups": 3,
+    "digest": "4af236b587337ef59887abed10892d2f179b1ad502664086d85139ee840b51fd"
+  },
+  "swift-child-extends-parent/Sources/Parent.swift": {
+    "captureGroups": 7,
+    "digest": "ee1086e1a0cbfc57f381401b81b2e150f422a64cd3b937f083a1fbbd85e5a27e"
+  },
+  "swift-constructor-fallback/App.swift": {
+    "captureGroups": 7,
+    "digest": "782cf85fcfe24b2baea6226f09226d23adc2bab591380bd33600cfe8509dbb83"
+  },
+  "swift-constructor-fallback/Service.swift": {
+    "captureGroups": 7,
+    "digest": "685538adb8aede40f7969572a4c8ba3d491413de22798e109800a121d8d88223"
+  },
+  "swift-constructor-type-inference/Models/Repo.swift": {
+    "captureGroups": 14,
+    "digest": "d67814c2f6c6a5c0e98aea4328351ae06faefcbb3daf6ed8f5c115f347a33e4d"
+  },
+  "swift-constructor-type-inference/Models/User.swift": {
+    "captureGroups": 14,
+    "digest": "cf523c394b9a30aa3b59d1f47a0afa5ad9dfd37fbddb9b799f355027e55ed16f"
+  },
+  "swift-constructor-type-inference/Services/App.swift": {
+    "captureGroups": 12,
+    "digest": "a9c40a2dcb51c6e6a9adbaa869183eed90a81302729d4d7a0c300084ea2978e1"
+  },
+  "swift-export-visibility/App.swift": {
+    "captureGroups": 10,
+    "digest": "6be49190e8a120ed1c3c3812afaa717f60fc12dae82d4b1b7158a358c53ea75a"
+  },
+  "swift-export-visibility/Visible.swift": {
+    "captureGroups": 15,
+    "digest": "9531822091fc521783d6815f03ed503f8d1010289b401f6f2b2057b422de3e76"
+  },
+  "swift-extension-dedup/App.swift": {
+    "captureGroups": 7,
+    "digest": "f7062b53f33ec548a2ba5836ef5507b4c662d74ac4935dc654e6f95081f6fcbd"
+  },
+  "swift-extension-dedup/Product.swift": {
+    "captureGroups": 14,
+    "digest": "68417cd9791edae71b515540d229caad1b3d5b2485ec475c6226f283fa301be8"
+  },
+  "swift-extension-dedup/ProductExtensions.swift": {
+    "captureGroups": 8,
+    "digest": "1e072eb427bb17ea1a225bcc85e0defe74297e3e0ae05c7dc9c04a7e870b0508"
+  },
+  "swift-field-types/App.swift": {
+    "captureGroups": 6,
+    "digest": "2cb023f94129e0bd07e1116892bad2597eb0f3aa02079deb029d5e3604311999"
+  },
+  "swift-field-types/Models.swift": {
+    "captureGroups": 20,
+    "digest": "e55d0207f950d63ace5efb93551971b10e1fc6cc264e17098f006aa606d1e19c"
+  },
+  "swift-for-loop-inference/App.swift": {
+    "captureGroups": 5,
+    "digest": "3b2bb68ff42fb763aaff8228fe37217ac2e49d7d318a1442e547ae5b44d98fd1"
+  },
+  "swift-for-loop-inference/Models.swift": {
+    "captureGroups": 11,
+    "digest": "5423257303f45305269592ec1d4e64e1fcdc0aa1387f5adab5fa53a9906fc8e2"
+  },
+  "swift-if-let-guard-let/App.swift": {
+    "captureGroups": 11,
+    "digest": "813609b316982a0d58c99590468d80e6159317187d55cef0f5b1e85ccc442c64"
+  },
+  "swift-if-let-guard-let/Models.swift": {
+    "captureGroups": 19,
+    "digest": "a21d2c56f0d5665da624993acbf14b2ede5aa4e2b9f161b8f9b21fc261707609"
+  },
+  "swift-implicit-imports/App.swift": {
+    "captureGroups": 7,
+    "digest": "5a423f851ee81956f48209e618c71668394e2a7312d812656a7f326233bc1387"
+  },
+  "swift-implicit-imports/Models.swift": {
+    "captureGroups": 7,
+    "digest": "9d0a738f1fdd31c1e204b20f1ccc76428f9f300eed82191da63f70799ff18f09"
+  },
+  "swift-init-cross-file/User.swift": {
+    "captureGroups": 17,
+    "digest": "da1d228a64d3bb0a4c9f6f1be9f13382ecd5c729faa76ceb0da3f27fafe19cfb"
+  },
+  "swift-init-cross-file/main.swift": {
+    "captureGroups": 8,
+    "digest": "3007e4849cf77cc6cb360a1dbf70abec414a408076020f4730d01b8a80c1ddd3"
+  },
+  "swift-method-enrichment/Sources/Animal.swift": {
+    "captureGroups": 22,
+    "digest": "4b7aa00484047437a9e6af3faf12cd6a4e9575bf4dd7d6454e29f05459cf8795"
+  },
+  "swift-method-enrichment/Sources/App.swift": {
+    "captureGroups": 10,
+    "digest": "906c1f026eb183306a19eff5fafd888fc8982434e2ab07bc886100b99653359b"
+  },
+  "swift-overload-dispatch/App.swift": {
+    "captureGroups": 7,
+    "digest": "db8515d0d61419e827767ced61b6bb1949e672b8df11c35cc96882d60f007e07"
+  },
+  "swift-overload-dispatch/Repository.swift": {
+    "captureGroups": 11,
+    "digest": "b5ed80965325806c715d1c3a65163b014e0bbba5ca7e2df9d7c81b084fada15e"
+  },
+  "swift-overload-dispatch/SqlRepository.swift": {
+    "captureGroups": 22,
+    "digest": "0f90013bd74e3c8ee8d040f433144c2e470bd7af391cda22171b36df90d8db86"
+  },
+  "swift-parent-resolution/Sources/Models/BaseModel.swift": {
+    "captureGroups": 7,
+    "digest": "f8a7f98e0df2132df1bd48efef94135214a4072cf47ac5e42e64c99da50bcaa6"
+  },
+  "swift-parent-resolution/Sources/Models/Serializable.swift": {
+    "captureGroups": 6,
+    "digest": "684be5a2e9d7c03c4a9ce209fe5719a776ad4fe0ed12a7a79ba64eed6f34a40e"
+  },
+  "swift-parent-resolution/Sources/Models/User.swift": {
+    "captureGroups": 8,
+    "digest": "035816ff924424620539717e70c5a9c3f771ed4b5e7e167d94ccda9bd8abad7b"
+  },
+  "swift-return-type-inference/App.swift": {
+    "captureGroups": 21,
+    "digest": "ec0a14090e0240bdd52a955cf7c95c2bc994085ca1482911dd882c5cdaa17c81"
+  },
+  "swift-return-type-inference/Models.swift": {
+    "captureGroups": 27,
+    "digest": "c5bedb2b8fa8715cac1450026beb8144a908b1d3a3cbbab2da344095f9577e08"
+  },
+  "swift-return-type/App.swift": {
+    "captureGroups": 7,
+    "digest": "979534a46ee420a7a5dfd6b029c9fe5d67ca1b00f3bdc5e8977d72a1c316b75d"
+  },
+  "swift-return-type/Models.swift": {
+    "captureGroups": 18,
+    "digest": "075863d32f5b64de86300be3c05fc186222a594471cd4159bf63943dc12ab733"
+  },
+  "swift-self-this-resolution/Sources/Models/Repo.swift": {
+    "captureGroups": 7,
+    "digest": "2f104d81deb40413f23cec9ed5e1e11585cd7075c101158fc95ed3c44cb7e778"
+  },
+  "swift-self-this-resolution/Sources/Models/User.swift": {
+    "captureGroups": 11,
+    "digest": "c0c8e583896b1d9c889b43682d53b0d6b8194f54a27ae16a4d89a5ad79354fdc"
+  },
+  "synthetic:dao-20": {
+    "captureGroups": 321,
+    "digest": "4db4e22f456ed3dfe5742bad18a387892d6b3c2740aa10ab01c73e312b68066c"
+  }
+}

--- a/gitnexus/test/fixtures/swift-captures-golden/expected-captures.json
+++ b/gitnexus/test/fixtures/swift-captures-golden/expected-captures.json
@@ -35,6 +35,10 @@
     "captureGroups": 7,
     "digest": "ee1086e1a0cbfc57f381401b81b2e150f422a64cd3b937f083a1fbbd85e5a27e"
   },
+  "swift-class-func-receiver/Service.swift": {
+    "captureGroups": 24,
+    "digest": "04431e0287afed4c37779fb8fbf1d8cbe00ff917d6512fefcec5d7da1db69de8"
+  },
   "swift-constructor-fallback/App.swift": {
     "captureGroups": 7,
     "digest": "782cf85fcfe24b2baea6226f09226d23adc2bab591380bd33600cfe8509dbb83"
@@ -45,11 +49,11 @@
   },
   "swift-constructor-type-inference/Models/Repo.swift": {
     "captureGroups": 14,
-    "digest": "d67814c2f6c6a5c0e98aea4328351ae06faefcbb3daf6ed8f5c115f347a33e4d"
+    "digest": "a1e1b75aa5a637bdf1e47ffd5cea61b2f6b139078db766d4926d0d99086abe34"
   },
   "swift-constructor-type-inference/Models/User.swift": {
     "captureGroups": 14,
-    "digest": "cf523c394b9a30aa3b59d1f47a0afa5ad9dfd37fbddb9b799f355027e55ed16f"
+    "digest": "107563b39540473845aeafc30aae96191eae60ba56bed8d8b13dd98aaef72f0a"
   },
   "swift-constructor-type-inference/Services/App.swift": {
     "captureGroups": 12,
@@ -69,7 +73,7 @@
   },
   "swift-extension-dedup/Product.swift": {
     "captureGroups": 14,
-    "digest": "68417cd9791edae71b515540d229caad1b3d5b2485ec475c6226f283fa301be8"
+    "digest": "86c0c65ace3809f2f13cca1dabe54328c354923cde0e29e526542a9291a66522"
   },
   "swift-extension-dedup/ProductExtensions.swift": {
     "captureGroups": 8,
@@ -109,11 +113,19 @@
   },
   "swift-init-cross-file/User.swift": {
     "captureGroups": 17,
-    "digest": "da1d228a64d3bb0a4c9f6f1be9f13382ecd5c729faa76ceb0da3f27fafe19cfb"
+    "digest": "238af425526a62a088a1c4b3ba75c9249e375ffbeedb991c1b7481fa20e11543"
   },
   "swift-init-cross-file/main.swift": {
     "captureGroups": 8,
     "digest": "3007e4849cf77cc6cb360a1dbf70abec414a408076020f4730d01b8a80c1ddd3"
+  },
+  "swift-member-write-access/App.swift": {
+    "captureGroups": 11,
+    "digest": "43c147d979761375f88bccd980f9db2274a937a3157ecaf93ca337fa54d0ae39"
+  },
+  "swift-member-write-access/Models.swift": {
+    "captureGroups": 23,
+    "digest": "e830e3dca7d6c6260181b78d4af5bc61e031bdce3a451588989f17223a5eac1c"
   },
   "swift-method-enrichment/Sources/Animal.swift": {
     "captureGroups": 22,
@@ -122,6 +134,14 @@
   "swift-method-enrichment/Sources/App.swift": {
     "captureGroups": 10,
     "digest": "906c1f026eb183306a19eff5fafd888fc8982434e2ab07bc886100b99653359b"
+  },
+  "swift-multi-if-let/App.swift": {
+    "captureGroups": 17,
+    "digest": "30faed5011af965b20a9e7e3698a3cdbabbdaf148f4818f031891ec7130b3f7f"
+  },
+  "swift-multi-if-let/Models.swift": {
+    "captureGroups": 24,
+    "digest": "0c072ac3f476a9e563190de555eeaff09a62128d9e7760912655cea9bdefbe6e"
   },
   "swift-multidir-target/Package.swift": {
     "captureGroups": 5,
@@ -146,6 +166,14 @@
   "swift-multifolder-nopackage/Services/App.swift": {
     "captureGroups": 7,
     "digest": "7ed3ccfa724fd58d3c9e10a176101364f2a01f20a7a87f9e3d76b715e4a307d8"
+  },
+  "swift-nested-extension/Extension.swift": {
+    "captureGroups": 7,
+    "digest": "3e6dfc7895f9c257be1524e43f004497faca6f765311474fc4bcc85f1d222940"
+  },
+  "swift-nested-extension/Types.swift": {
+    "captureGroups": 13,
+    "digest": "16d599d9805cba59b1bb22598b09e1d25e3dd80da52a4a2c04c23581a8b65d6e"
   },
   "swift-overload-dispatch/App.swift": {
     "captureGroups": 7,
@@ -177,7 +205,7 @@
   },
   "swift-return-type-inference/Models.swift": {
     "captureGroups": 27,
-    "digest": "c5bedb2b8fa8715cac1450026beb8144a908b1d3a3cbbab2da344095f9577e08"
+    "digest": "3d1a5a4fe1deb91dc2ba74f71e7bc0b42dbe1dde3b374891fbb3fcf8d265f3a8"
   },
   "swift-return-type/App.swift": {
     "captureGroups": 7,
@@ -185,7 +213,7 @@
   },
   "swift-return-type/Models.swift": {
     "captureGroups": 18,
-    "digest": "075863d32f5b64de86300be3c05fc186222a594471cd4159bf63943dc12ab733"
+    "digest": "dcb5562e378f8672c85ade10d2dc38b499af2cc02efeb4c0f80ac8ce83ce7d02"
   },
   "swift-self-this-resolution/Sources/Models/Repo.swift": {
     "captureGroups": 7,
@@ -197,6 +225,6 @@
   },
   "synthetic:dao-20": {
     "captureGroups": 321,
-    "digest": "4db4e22f456ed3dfe5742bad18a387892d6b3c2740aa10ab01c73e312b68066c"
+    "digest": "abd793dd5a0196a9795ff62cee1b1b0905e69ea45092b6efd0decdc9bc84270c"
   }
 }

--- a/gitnexus/test/fixtures/swift-captures-golden/expected-captures.json
+++ b/gitnexus/test/fixtures/swift-captures-golden/expected-captures.json
@@ -123,6 +123,30 @@
     "captureGroups": 10,
     "digest": "906c1f026eb183306a19eff5fafd888fc8982434e2ab07bc886100b99653359b"
   },
+  "swift-multidir-target/Package.swift": {
+    "captureGroups": 5,
+    "digest": "7c27b1db8b34bf3e81963c29f9f51f1226c1012b7a028c6207209914412b9d5f"
+  },
+  "swift-multidir-target/Sources/Alpha/Core/User.swift": {
+    "captureGroups": 7,
+    "digest": "b5fa3ef978d5bb5322a433761891ffaa86988f805bc9d419cfa1f24e9fcffa39"
+  },
+  "swift-multidir-target/Sources/Alpha/Entry/App.swift": {
+    "captureGroups": 7,
+    "digest": "3f5df4e88a54d05032cb00c999551cb4f41e0782616ec0cdbf353f3b80a4404d"
+  },
+  "swift-multidir-target/Sources/Beta/Core/User.swift": {
+    "captureGroups": 7,
+    "digest": "10c5e3b4724499ce2e43f1838a516e0387f74045450560aec033e3357d99fd62"
+  },
+  "swift-multifolder-nopackage/Models/User.swift": {
+    "captureGroups": 7,
+    "digest": "4a05d8ee43df38acb8c91ee66bd0b9c5f4ede20f1330a2977981cf431c16fb1e"
+  },
+  "swift-multifolder-nopackage/Services/App.swift": {
+    "captureGroups": 7,
+    "digest": "7ed3ccfa724fd58d3c9e10a176101364f2a01f20a7a87f9e3d76b715e4a307d8"
+  },
   "swift-overload-dispatch/App.swift": {
     "captureGroups": 7,
     "digest": "db8515d0d61419e827767ced61b6bb1949e672b8df11c35cc96882d60f007e07"

--- a/gitnexus/test/integration/resolvers/helpers.ts
+++ b/gitnexus/test/integration/resolvers/helpers.ts
@@ -206,6 +206,15 @@ const LEGACY_RESOLVER_PARITY_EXPECTED_FAILURES: Readonly<Record<string, Readonly
     // (pass under registry-primary, fail under legacy). Currently
     // empty — all 127 tests pass under legacy mode.
   ]),
+  swift: new Set<string>([
+    // Swift scope-resolution currently achieves 77/77 parity.
+    // Tests listed here are scope-resolver-only correctness wins
+    // (pass under registry-primary, fail under legacy). Currently
+    // empty — all 77 tests pass under legacy mode. Later remediation
+    // units (registry-primary-only correctness fixes) register their
+    // test names here; backporting to legacy is out of scope per the
+    // migration policy.
+  ]),
   cpp: new Set<string>([
     // The legacy DAG path has no scope-aware filtering on the global
     // free-call fallback, so `#include`d headers still leak class

--- a/gitnexus/test/integration/resolvers/helpers.ts
+++ b/gitnexus/test/integration/resolvers/helpers.ts
@@ -207,13 +207,40 @@ const LEGACY_RESOLVER_PARITY_EXPECTED_FAILURES: Readonly<Record<string, Readonly
     // empty — all 127 tests pass under legacy mode.
   ]),
   swift: new Set<string>([
-    // Swift scope-resolution currently achieves 77/77 parity.
-    // Tests listed here are scope-resolver-only correctness wins
-    // (pass under registry-primary, fail under legacy). Currently
-    // empty — all 77 tests pass under legacy mode. Later remediation
-    // units (registry-primary-only correctness fixes) register their
-    // test names here; backporting to legacy is out of scope per the
-    // migration policy.
+    // Swift scope-resolution achieves 77/77 baseline parity. The tests
+    // listed here are scope-resolver-only correctness wins from the U4
+    // remediation (PR #1948): they PASS under registry-primary but FAIL
+    // under the legacy DAG, which has no equivalent mechanism. Backporting
+    // to legacy is out of scope per the migration policy. Each entry below
+    // states the registry-primary mechanism and why legacy can't match.
+    //
+    // BUG1 read-edge: the legacy DAG emits a `read` ACCESSES edge only for
+    // a field-access CHAIN that feeds a call (e.g. `user.address.save()`);
+    // a STANDALONE field read (`let current = self.balance`) produces no
+    // read ACCESSES under legacy. The scope-resolver emits it from the
+    // reference-site `read` kind. (The write-edge and no-spurious-read
+    // assertions DO pass both legs and are not skipped.)
+    'still emits a read ACCESSES for a genuine standalone field read (not the write LHS)',
+    // BUG2 class-func: the observable signal is the RESOLUTION PROVENANCE of
+    // a `self.<property>` read inside a `class func` vs `static func` vs an
+    // instance method. The legacy DAG cannot resolve these self-property
+    // reads at all (it emits no ACCESSES for this fixture), so the
+    // provenance-parity check is a scope-resolver-only correctness check.
+    'a class func gets no instance self-binding (parity with static func; instance method differs)',
+    // BUG3 second-binding: the second `if let` / `guard let` clause binding
+    // (`b: makeB() -> B`) is inferred only by the scope-resolver's
+    // per-clause `@type-binding.constructor` synthesis. The colliding
+    // `B.shared` / `Decoy.shared` defeats a unique-name global fallback, so
+    // legacy leaves `b.shared()` unresolved.
+    'resolves b.shared() to B.shared via the SECOND if-let clause binding',
+    'resolves b.shared() to B.shared via the SECOND guard-let clause binding',
+    // BUG4 nested-extension self-call: `added` hoists onto Bar in both legs
+    // (the HAS_METHOD assertion is NOT skipped), but resolving the
+    // `self.base()` call to `Bar.base` (self == Bar, the trailing identifier
+    // of `Foo.Bar`) depends on the scope-resolver's extension `self`
+    // type-binding plus its cross-file self-dispatch; the legacy DAG leaves
+    // the `self.base()` call unresolved for this fixture.
+    'resolves self.base() inside added() to Bar.base (self == Bar), not Foo',
   ]),
   cpp: new Set<string>([
     // The legacy DAG path has no scope-aware filtering on the global

--- a/gitnexus/test/integration/resolvers/swift.test.ts
+++ b/gitnexus/test/integration/resolvers/swift.test.ts
@@ -1022,3 +1022,247 @@ describe.skipIf(!swiftAvailable)(
     });
   },
 );
+
+// ---------------------------------------------------------------------------
+// U4 — BUG1: member-write read/write classification (issue #1948). A Swift
+// assignment LHS `obj.field = x` is wrapped in `directly_assignable_expression`
+// (verified, tree-sitter-swift 0.7.1), so the old `parent.type === 'assignment'`
+// write guard was dead — member writes leaked as spurious READ ACCESSES and no
+// WRITE edge emitted. The fix re-tags the write-LHS navigation to
+// `@reference.write.member`, so a `write` ACCESSES edge emits (for BOTH a
+// `self.field = x` receiver-bound write AND a non-self `obj.field = x`) and no
+// spurious read appears at the LHS. The genuine standalone field READs
+// (`let y = obj.field`) are a registry-primary-only correctness win — the
+// legacy DAG emits read ACCESSES only for field-access CHAINS feeding a call,
+// not standalone reads — so the read-control assertion is skip-gated.
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!swiftAvailable)('Swift member-write ACCESSES (read/write classification)', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'swift-member-write-access'), () => {});
+  }, 60000);
+
+  it('emits write ACCESSES for self.field = x (self-receiver) with no spurious read at the LHS', () => {
+    const accesses = getRelationships(result, 'ACCESSES');
+    // init: `self.balance = start`; deposit: `self.balance = amount`.
+    const balanceWrites = accesses.filter(
+      (e) => e.target === 'balance' && e.targetLabel === 'Property' && e.rel.reason === 'write',
+    );
+    const writeSources = balanceWrites.map((e) => e.source).sort();
+    expect(writeSources).toContain('init');
+    expect(writeSources).toContain('deposit');
+    // No spurious READ at the write LHS (init/deposit only WRITE balance).
+    const balanceReadsFromWriters = accesses.filter(
+      (e) =>
+        e.target === 'balance' &&
+        e.rel.reason === 'read' &&
+        (e.source === 'init' || e.source === 'deposit'),
+    );
+    expect(balanceReadsFromWriters).toHaveLength(0);
+  });
+
+  it('emits write ACCESSES for obj.field = y (non-self receiver) with no spurious read at the LHS', () => {
+    const accesses = getRelationships(result, 'ACCESSES');
+    // App.swift `transfer`: `acct.owner = "alice"` — non-self receiver,
+    // `acct`'s type (Account) must resolve first, then `owner` resolves.
+    const ownerWrite = accesses.find(
+      (e) =>
+        e.target === 'owner' &&
+        e.targetLabel === 'Property' &&
+        e.source === 'transfer' &&
+        e.rel.reason === 'write',
+    );
+    expect(ownerWrite).toBeDefined();
+    expect(ownerWrite!.targetFilePath).toBe('Models.swift');
+    // No spurious READ at the LHS of the non-self write.
+    const spuriousRead = accesses.find(
+      (e) => e.target === 'owner' && e.source === 'transfer' && e.rel.reason === 'read',
+    );
+    expect(spuriousRead).toBeUndefined();
+  });
+
+  // legacy_skip: registry-primary-only. The legacy DAG emits a read ACCESSES
+  // only for a field-access CHAIN feeding a call (e.g. `user.address.save()`);
+  // a STANDALONE field read (`let current = self.balance`, `let who = acct.owner`)
+  // produces no read ACCESSES under legacy. The scope-resolver emits it via the
+  // reference-site `read` kind. Registered in helpers.ts; backporting the read
+  // edge to legacy is out of scope per the migration policy.
+  it('still emits a read ACCESSES for a genuine standalone field read (not the write LHS)', () => {
+    const accesses = getRelationships(result, 'ACCESSES');
+    // readBalance: `let current = self.balance` (self read).
+    const balanceRead = accesses.find(
+      (e) => e.target === 'balance' && e.source === 'readBalance' && e.rel.reason === 'read',
+    );
+    expect(balanceRead).toBeDefined();
+    expect(balanceRead!.targetLabel).toBe('Property');
+    // inspect: `let who = acct.owner` (non-self read).
+    const ownerRead = accesses.find(
+      (e) => e.target === 'owner' && e.source === 'inspect' && e.rel.reason === 'read',
+    );
+    expect(ownerRead).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U4 — BUG2: `class func` self-binding (issue #1948). A Swift `class func`
+// (type method) emits a BARE anonymous `class` token directly under
+// `function_declaration` (verified, tree-sitter-swift 0.7.1), whereas
+// `static func` emits it under a `modifiers > property_modifier` wrapper. The
+// old `isStaticMethod` scanned only the `modifiers` wrapper, so a `class func`
+// wrongly received a `self: <Type>` INSTANCE binding (it should have none — a
+// type method has no instance receiver). The fix delegates to
+// `swiftMethodConfig.isStatic`, which detects both via `hasKeyword('class')`.
+//
+// Observable signal: an instance `self.label` property read resolves with full
+// self-binding provenance (`reason === 'read'`), but inside a `class func` /
+// `static func` `self.label` has no instance binding, so it resolves only via
+// the weaker lexical name fallback (`reason === 'scope-resolution: read'`).
+// Pre-fix, the `class func` read carried the instance-binding provenance like
+// `instanceCaller`; post-fix it matches `staticCaller`.
+//
+// legacy_skip: registry-primary-only — the legacy DAG cannot resolve these
+// self-property reads at all (it emits no ACCESSES for this fixture), so the
+// provenance-parity assertion is a scope-resolver-only correctness check.
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!swiftAvailable)('Swift class func receiver (no instance self-binding)', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'swift-class-func-receiver'), () => {});
+  }, 60000);
+
+  it('a class func gets no instance self-binding (parity with static func; instance method differs)', () => {
+    const accesses = getRelationships(result, 'ACCESSES');
+    const reasonFor = (src: string): string | undefined =>
+      accesses.find((e) => e.target === 'label' && e.source === src && e.targetLabel === 'Property')
+        ?.rel.reason;
+
+    const instanceReason = reasonFor('instanceCaller');
+    const classFuncReason = reasonFor('classCaller');
+    const staticFuncReason = reasonFor('staticCaller');
+
+    // Instance method has a real `self` receiver: full self-binding provenance.
+    expect(instanceReason).toBe('read');
+    // `class func` must behave EXACTLY like `static func`: no instance
+    // self-binding, so the read resolves only via the lexical name fallback.
+    expect(classFuncReason).toBe('scope-resolution: read');
+    expect(staticFuncReason).toBe('scope-resolution: read');
+    expect(classFuncReason).toBe(staticFuncReason);
+    // And it must NOT carry the instance method's self-binding provenance.
+    expect(classFuncReason).not.toBe(instanceReason);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U4 — BUG3: multi-clause `if let` / `guard let` (issue #1948).
+// `if let a = makeA(), let b = makeB()` has a FLAT child list where each clause
+// is `value_binding_pattern · simple_identifier · = · call_expression`
+// (verified, tree-sitter-swift 0.7.1). The old code read only the FIRST clause
+// (`childForFieldName('bound_identifier')` returns just `a`), so the second
+// binding `b: makeB() -> B` was never inferred. The fix walks all clauses and
+// emits one `@type-binding.constructor` per clause.
+//
+// Observable signal: `b.shared()` where B.shared collides with Decoy.shared, so
+// it resolves to B.shared ONLY via the second clause binding — a unique-name
+// global fallback is ambiguous. The first clause `a.m()` (unique name) resolves
+// in both legs; the second clause `b.shared()` is registry-primary-only.
+//
+// legacy_skip: registry-primary-only — legacy cannot infer the second clause's
+// type binding and the ambiguous `shared` defeats its name fallback, so
+// `b.shared()` stays unresolved under legacy.
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!swiftAvailable)('Swift multi-clause if-let / guard-let binding', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'swift-multi-if-let'), () => {});
+  }, 60000);
+
+  it('detects A, B and Decoy classes', () => {
+    const classes = getNodesByLabel(result, 'Class');
+    expect(classes).toContain('A');
+    expect(classes).toContain('B');
+    expect(classes).toContain('Decoy');
+  });
+
+  it('resolves b.shared() to B.shared via the SECOND if-let clause binding', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const sharedCall = calls.find(
+      (c) =>
+        c.target === 'shared' &&
+        c.source === 'processIfLet' &&
+        c.rel.targetId === 'Function:Models.swift:B.shared#0',
+    );
+    expect(sharedCall).toBeDefined();
+    // It must NOT resolve to the colliding Decoy.shared.
+    const decoyCall = calls.find(
+      (c) =>
+        c.target === 'shared' &&
+        c.source === 'processIfLet' &&
+        c.rel.targetId === 'Function:Models.swift:Decoy.shared#0',
+    );
+    expect(decoyCall).toBeUndefined();
+  });
+
+  it('resolves b.shared() to B.shared via the SECOND guard-let clause binding', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const sharedCall = calls.find(
+      (c) =>
+        c.target === 'shared' &&
+        c.source === 'processGuardLet' &&
+        c.rel.targetId === 'Function:Models.swift:B.shared#0',
+    );
+    expect(sharedCall).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U4 — BUG4: nested-type extension re-keying (issue #1948).
+// `extension Foo.Bar` parses to a `(user_type (type_identifier Foo)
+// (type_identifier Bar))` name. The old code took `firstNamedChild` (`Foo`) as
+// the extended type, re-keying the extension's members onto `Foo` and binding
+// `self` to `Foo`. The fix uses `lastNamedChild` (`Bar`, the trailing
+// identifier) in BOTH the captures re-key and `enclosingTypeName`, so members
+// hoist onto Bar and `self == Bar`. Single-identifier `extension Foo` is
+// unchanged (first === last). `base()` is split across files (Types.swift /
+// Extension.swift) with a colliding Decoy.base so resolution depends purely on
+// `self == Bar`.
+//
+// The HAS_METHOD hoisting assertion passes BOTH legs (not skipped). The
+// `self.base() -> Bar.base` resolution is registry-primary-only (the legacy
+// DAG leaves the cross-file extension self-call unresolved), so that exact
+// test is registered in the `swift` skip-set in helpers.ts (verified
+// empirically under REGISTRY_PRIMARY_SWIFT=0).
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!swiftAvailable)('Swift nested-type extension (extension Foo.Bar)', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'swift-nested-extension'), () => {});
+  }, 60000);
+
+  it('hoists added onto Bar (HAS_METHOD Foo.Bar -> added), not Foo', () => {
+    const hasMethod = getRelationships(result, 'HAS_METHOD');
+    const addedEdge = hasMethod.find(
+      (e) => e.target === 'added' && e.rel.sourceId === 'Class:Extension.swift:Foo.Bar',
+    );
+    expect(addedEdge).toBeDefined();
+    // Must NOT hoist onto a bare `Foo` owner.
+    const onFoo = hasMethod.find(
+      (e) => e.target === 'added' && e.rel.sourceId === 'Class:Types.swift:Foo',
+    );
+    expect(onFoo).toBeUndefined();
+  });
+
+  it('resolves self.base() inside added() to Bar.base (self == Bar), not Foo', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const baseCall = calls.find((c) => c.target === 'base' && c.source === 'added');
+    expect(baseCall).toBeDefined();
+    expect(baseCall!.rel.targetId).toBe('Function:Types.swift:Bar.base#0');
+  });
+});

--- a/gitnexus/test/integration/resolvers/swift.test.ts
+++ b/gitnexus/test/integration/resolvers/swift.test.ts
@@ -6,10 +6,11 @@
  * NOTE: Swift is installed as an optional dependency. These tests skip gracefully
  * if a consumer installs without optional dependencies.
  */
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, expect, beforeAll } from 'vitest';
 import path from 'path';
 import {
   FIXTURES,
+  createResolverParityIt,
   getRelationships,
   getNodesByLabel,
   getNodesByLabelFull,
@@ -19,6 +20,8 @@ import {
 } from './helpers.js';
 import { isLanguageAvailable } from '../../../src/core/tree-sitter/parser-loader.js';
 import { SupportedLanguages } from '../../../src/config/supported-languages.js';
+
+const it = createResolverParityIt('swift');
 
 const swiftAvailable = isLanguageAvailable(SupportedLanguages.Swift);
 

--- a/gitnexus/test/integration/resolvers/swift.test.ts
+++ b/gitnexus/test/integration/resolvers/swift.test.ts
@@ -901,3 +901,124 @@ describe.skipIf(!swiftAvailable)(
     });
   },
 );
+
+// ---------------------------------------------------------------------------
+// U3 — SPM-target subtree grouping (issue #1948). A Swift module is an SPM
+// TARGET (a directory SUBTREE `Sources/<Target>/…`), not the immediate
+// containing directory. `swift-multidir-target` has target `Alpha` spread
+// across `Sources/Alpha/Core` + `Sources/Alpha/Entry` plus a colliding
+// same-simple-named `User` in target `Beta` (`Sources/Beta/Core`). Grouping
+// by SPM target (not by immediate dir) keeps Alpha's two subdirs in one
+// module, so `User()` in Alpha/Entry resolves to Alpha/Core/User (NOT
+// Beta/Core/User) and cross-dir IMPORTS within Alpha emit — while Alpha and
+// Beta stay distinct modules with NO IMPORTS between them.
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!swiftAvailable)('Swift SPM multi-directory target grouping', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'swift-multidir-target'), () => {});
+  }, 60000);
+
+  it('resolves User() in Alpha/Entry to Alpha/Core/User, not Beta/Core/User', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const ctorCall = calls.find(
+      (c) =>
+        c.target === 'User' &&
+        c.targetLabel === 'Class' &&
+        c.sourceFilePath === 'Sources/Alpha/Entry/App.swift',
+    );
+    expect(ctorCall).toBeDefined();
+    expect(ctorCall!.targetFilePath).toBe('Sources/Alpha/Core/User.swift');
+  });
+
+  it('resolves user.alphaSave() across directories within the Alpha target', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const memberCall = calls.find(
+      (c) => c.target === 'alphaSave' && c.source === 'processEntities',
+    );
+    expect(memberCall).toBeDefined();
+    expect(memberCall!.targetFilePath).toBe('Sources/Alpha/Core/User.swift');
+  });
+
+  it('emits cross-directory IMPORTS edges within the Alpha target (Entry <-> Core)', () => {
+    const imports = getRelationships(result, 'IMPORTS');
+    const entryToCore = imports.find(
+      (c) =>
+        c.sourceFilePath === 'Sources/Alpha/Entry/App.swift' &&
+        c.targetFilePath === 'Sources/Alpha/Core/User.swift',
+    );
+    const coreToEntry = imports.find(
+      (c) =>
+        c.sourceFilePath === 'Sources/Alpha/Core/User.swift' &&
+        c.targetFilePath === 'Sources/Alpha/Entry/App.swift',
+    );
+    expect(entryToCore).toBeDefined();
+    expect(coreToEntry).toBeDefined();
+  });
+
+  it('does NOT emit IMPORTS across distinct targets (no Alpha <-> Beta)', () => {
+    const imports = getRelationships(result, 'IMPORTS');
+    const crossTarget = imports.find(
+      (c) =>
+        (c.sourceFilePath.startsWith('Sources/Alpha/') &&
+          c.targetFilePath.startsWith('Sources/Beta/')) ||
+        (c.sourceFilePath.startsWith('Sources/Beta/') &&
+          c.targetFilePath.startsWith('Sources/Alpha/')),
+    );
+    expect(crossTarget).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U3 — No-package multi-folder fallback (issue #1948). With NO scanned
+// source dir (`Sources/`/`Package/Sources/`/`src/`) `loadSwiftPackageConfig`
+// returns null, so ALL files form one `__default__` module (single-Xcode-
+// project assumption). `swift-multifolder-nopackage` spreads files across
+// `Models/` + `Services/` with no manifest; cross-folder visibility must
+// still resolve and emit IMPORTS because the whole repo is one module.
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!swiftAvailable)(
+  'Swift no-package multi-folder fallback (__default__ module)',
+  () => {
+    let result: PipelineResult;
+
+    beforeAll(async () => {
+      result = await runPipelineFromRepo(
+        path.join(FIXTURES, 'swift-multifolder-nopackage'),
+        () => {},
+      );
+    }, 60000);
+
+    it('resolves User() in Services to Models/User.swift across folders', () => {
+      const calls = getRelationships(result, 'CALLS');
+      const ctorCall = calls.find(
+        (c) =>
+          c.target === 'User' &&
+          c.targetLabel === 'Class' &&
+          c.sourceFilePath === 'Services/App.swift',
+      );
+      expect(ctorCall).toBeDefined();
+      expect(ctorCall!.targetFilePath).toBe('Models/User.swift');
+    });
+
+    it('resolves user.save() across folders to Models/User.swift', () => {
+      const calls = getRelationships(result, 'CALLS');
+      const memberCall = calls.find((c) => c.target === 'save' && c.source === 'processEntities');
+      expect(memberCall).toBeDefined();
+      expect(memberCall!.targetFilePath).toBe('Models/User.swift');
+    });
+
+    it('emits cross-folder IMPORTS edges between Models and Services', () => {
+      const imports = getRelationships(result, 'IMPORTS');
+      const crossFolder = imports.find(
+        (c) =>
+          (c.sourceFilePath === 'Services/App.swift' && c.targetFilePath === 'Models/User.swift') ||
+          (c.sourceFilePath === 'Models/User.swift' && c.targetFilePath === 'Services/App.swift'),
+      );
+      expect(crossFolder).toBeDefined();
+    });
+  },
+);

--- a/gitnexus/test/integration/swift-scope-capture-tripwire.test.ts
+++ b/gitnexus/test/integration/swift-scope-capture-tripwire.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tripwire: emitSwiftScopeCaptures must stay O(n) in entity count.
+ *
+ * #1848 (Go) was an O(n²) scope-capture regression: each capture re-derived
+ * its node via findNodeAtRange(tree.rootNode, …), so capture extraction went
+ * quadratic on big files. Swift threads the captured node through directly
+ * (issue #937, RFC #909 Ring 3). This guards against a re-introduction by
+ * asserting the per-entity cost stays roughly flat across a 4× size increase.
+ *
+ * Complements bench/scope-capture/measure.mjs (which pins a fingerprint + a
+ * 1.5× scaling budget for the `--check` CI job): this always-on test fails the
+ * normal suite — no GITNEXUS_BENCH gate, no committed baseline — if the path
+ * regresses to quadratic.
+ *
+ * Swift is an optional dependency; skips gracefully if the grammar isn't built.
+ *
+ * Kept out of the unit suite's tight timeout: lives in integration where a few
+ * hundred ms of generated-source parsing is acceptable. Pattern mirrors
+ * test/integration/csharp-scope-capture-tripwire.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { emitSwiftScopeCaptures } from '../../src/core/ingestion/languages/swift/index.js';
+import { isLanguageAvailable } from '../../src/core/tree-sitter/parser-loader.js';
+import { SupportedLanguages } from '../../src/config/supported-languages.js';
+
+const swiftAvailable = isLanguageAvailable(SupportedLanguages.Swift);
+
+/** Generate a Swift source file with `n` DAO-style classes. */
+function generateSource(n: number): string {
+  const classes: string[] = [];
+  for (let i = 0; i < n; i++) {
+    classes.push(
+      `class Entity${i} {\n` +
+        `  var id: Int64 = 0\n` +
+        `  var name: String = ""\n` +
+        `  func getId() -> Int64 { return self.id }\n` +
+        `  func setName(_ v: String) { self.name = v }\n` +
+        `}`,
+    );
+  }
+  return classes.join('\n\n');
+}
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m]! : (s[m - 1]! + s[m]!) / 2;
+}
+
+/** Median elapsed ms to run `emitSwiftScopeCaptures` over `reps` runs. */
+function timeEmit(n: number, reps: number): number {
+  const src = generateSource(n);
+  // Warm up parser/query compilation so the first run's JIT cost is excluded.
+  emitSwiftScopeCaptures(src, 'warmup.swift');
+  const samples: number[] = [];
+  for (let i = 0; i < reps; i++) {
+    const start = process.hrtime.bigint();
+    emitSwiftScopeCaptures(src, `bench-${n}.swift`);
+    samples.push(Number(process.hrtime.bigint() - start) / 1e6);
+  }
+  return median(samples);
+}
+
+describe.skipIf(!swiftAvailable)('swift scope-capture scaling (O(n) tripwire)', () => {
+  it('emits at least one capture per entity', () => {
+    const matches = emitSwiftScopeCaptures(generateSource(250), 'count.swift');
+    expect(matches.length).toBeGreaterThan(250);
+  });
+
+  it('per-entity cost stays roughly flat from 250 to 1000 entities', () => {
+    const reps = 5;
+    const tSmall = timeEmit(250, reps);
+    const tLarge = timeEmit(1000, reps);
+
+    // Linear would be ~4× (4× the entities). Allow generous headroom for noise
+    // and parser variance; quadratic would be ~16×, so 8× cleanly separates them.
+    const ratio = tLarge / Math.max(tSmall, 0.001);
+    expect(ratio).toBeLessThan(8);
+  });
+});

--- a/gitnexus/test/unit/registry-primary-flag.test.ts
+++ b/gitnexus/test/unit/registry-primary-flag.test.ts
@@ -108,20 +108,20 @@ describe('isRegistryPrimary', () => {
   it('isolates flags per-language (one on does not affect others)', () => {
     process.env['REGISTRY_PRIMARY_PYTHON'] = 'true';
     expect(isRegistryPrimary(SupportedLanguages.Python)).toBe(true);
-    // Swift is not in MIGRATED_LANGUAGES — default false stays
+    // Dart is not in MIGRATED_LANGUAGES — default false stays
     // false regardless of Python's flag.
-    expect(isRegistryPrimary(SupportedLanguages.Swift)).toBe(false);
+    expect(isRegistryPrimary(SupportedLanguages.Dart)).toBe(false);
   });
 
   it('respects a mid-process env-var mutation (no stale cache)', () => {
-    // Use Swift — not in MIGRATED_LANGUAGES — so the unset default is
+    // Use Dart — not in MIGRATED_LANGUAGES — so the unset default is
     // deterministically `false`, independent of which languages have
     // been flipped to registry-primary.
-    expect(isRegistryPrimary(SupportedLanguages.Swift)).toBe(false);
-    process.env['REGISTRY_PRIMARY_SWIFT'] = 'true';
-    expect(isRegistryPrimary(SupportedLanguages.Swift)).toBe(true);
-    delete process.env['REGISTRY_PRIMARY_SWIFT'];
-    expect(isRegistryPrimary(SupportedLanguages.Swift)).toBe(false);
+    expect(isRegistryPrimary(SupportedLanguages.Dart)).toBe(false);
+    process.env['REGISTRY_PRIMARY_DART'] = 'true';
+    expect(isRegistryPrimary(SupportedLanguages.Dart)).toBe(true);
+    delete process.env['REGISTRY_PRIMARY_DART'];
+    expect(isRegistryPrimary(SupportedLanguages.Dart)).toBe(false);
   });
 
   it('handles the CPlusPlus → REGISTRY_PRIMARY_CPP mapping correctly', () => {

--- a/gitnexus/test/unit/scope-resolution/pick-unique-global-class.test.ts
+++ b/gitnexus/test/unit/scope-resolution/pick-unique-global-class.test.ts
@@ -117,7 +117,11 @@ describe('pickUniqueGlobalClass — once-built global class index (U5)', () => {
     // KTD5: Interface stays in the filter for the behavior-preserving 8-lang
     // refactor. A future protocol-exclusion change must break THIS test
     // deliberately rather than silently.
-    const proto = mkDef({ nodeId: 'def:Drawable', type: 'Interface', qualifiedName: 'ui.Drawable' });
+    const proto = mkDef({
+      nodeId: 'def:Drawable',
+      type: 'Interface',
+      qualifiedName: 'ui.Drawable',
+    });
     expect(resolve('Drawable', [proto])?.nodeId).toBe('def:Drawable');
   });
 

--- a/gitnexus/test/unit/scope-resolution/pick-unique-global-class.test.ts
+++ b/gitnexus/test/unit/scope-resolution/pick-unique-global-class.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for `pickUniqueGlobalClass` + `buildGlobalClassIndex` — the
+ * constructor-form global class fallback in `free-call-fallback.ts`.
+ *
+ * U5 (Swift remediation, 2026-05-31) replaced a per-call-site
+ * `scopes.defs.byId.values()` rescan with a once-built `simpleName ->
+ * class-like defs` index, making each constructor-form fallback site O(1)
+ * instead of O(|defs|). The refactor is behavior-PRESERVING for all 8
+ * `allowGlobalFreeCallFallback` languages (c, cpp, go, javascript, php, ruby,
+ * rust, swift) — the only observable change is performance.
+ *
+ * These tests exercise the helpers via synthetic `SymbolDefinition` stubs — no
+ * fixtures, no pipeline — mirroring the `pick-implicit-this-overload.test.ts`
+ * precedent. They assert:
+ *   - the resolution contract (unique / same-qualifiedName-keep-first /
+ *     distinct-qualifiedName-ambiguous);
+ *   - the `Class | Struct | Interface` kind filter, including KEEP-`Interface`
+ *     (KTD5 — a future drop of `Interface` is a deliberate test-breaking
+ *     change, not an accident);
+ *   - equivalence with a reference linear scan, which guards the O(n)->O(1)
+ *     ordering invariant the refactor relies on.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { SymbolDefinition } from 'gitnexus-shared';
+import {
+  buildGlobalClassIndex,
+  pickUniqueGlobalClass,
+} from '../../../src/core/ingestion/scope-resolution/passes/free-call-fallback.js';
+import type { ScopeResolutionIndexes } from '../../../src/core/ingestion/model/scope-resolution-indexes.js';
+
+const mkDef = (overrides: Partial<SymbolDefinition> & { nodeId: string }): SymbolDefinition => ({
+  filePath: 'x.swift',
+  type: 'Class',
+  qualifiedName: overrides.nodeId,
+  ...overrides,
+});
+
+/** Wrap a flat def list as the `scopes.defs.byId` map `buildGlobalClassIndex`
+ *  iterates. Insertion order is preserved by `Map`, so this reproduces the
+ *  `defs.byId.values()` iteration order the old per-site scan walked. */
+const mkScopes = (defs: readonly SymbolDefinition[]): ScopeResolutionIndexes =>
+  ({
+    defs: {
+      byId: new Map(defs.map((d) => [d.nodeId, d])),
+    },
+  }) as unknown as ScopeResolutionIndexes;
+
+/** Reference O(|defs|) linear scan — the pre-U5 `pickUniqueGlobalClass` body,
+ *  kept verbatim so the equivalence test can prove the index path matches it
+ *  for every scenario. */
+const referenceLinearScan = (
+  name: string,
+  scopes: ScopeResolutionIndexes,
+): SymbolDefinition | undefined => {
+  let found: SymbolDefinition | undefined;
+  for (const def of scopes.defs.byId.values()) {
+    if (def.type !== 'Class' && def.type !== 'Struct' && def.type !== 'Interface') continue;
+    const qualified = def.qualifiedName;
+    if (qualified === undefined || qualified.length === 0) continue;
+    const dot = qualified.lastIndexOf('.');
+    const simple = dot === -1 ? qualified : qualified.slice(dot + 1);
+    if (simple !== name) continue;
+    if (found !== undefined && found.qualifiedName !== def.qualifiedName) return undefined;
+    if (found === undefined) found = def;
+  }
+  return found;
+};
+
+const resolve = (name: string, defs: readonly SymbolDefinition[]): SymbolDefinition | undefined =>
+  pickUniqueGlobalClass(name, buildGlobalClassIndex(mkScopes(defs)));
+
+describe('pickUniqueGlobalClass — once-built global class index (U5)', () => {
+  it('returns the def for a unique simple-name match', () => {
+    const user = mkDef({ nodeId: 'def:User', qualifiedName: 'app.User' });
+    const result = resolve('User', [user]);
+    expect(result?.nodeId).toBe('def:User');
+  });
+
+  it('keeps the first fragment when matches share one qualifiedName (extension / partial)', () => {
+    // Same logical type re-keyed across extension / partial-class fragments —
+    // they resolve to the same graph node, so this is NOT ambiguous.
+    const main = mkDef({ nodeId: 'def:User#1', qualifiedName: 'app.User' });
+    const ext = mkDef({ nodeId: 'def:User#2', qualifiedName: 'app.User' });
+    const result = resolve('User', [main, ext]);
+    expect(result?.nodeId).toBe('def:User#1');
+  });
+
+  it('returns undefined for a distinct-qualifiedName collision (ambiguous)', () => {
+    // Two genuinely distinct types sharing a simple name → unresolved rather
+    // than guessing.
+    const a = mkDef({ nodeId: 'def:a.User', qualifiedName: 'a.User' });
+    const b = mkDef({ nodeId: 'def:b.User', qualifiedName: 'b.User' });
+    const result = resolve('User', [a, b]);
+    expect(result).toBeUndefined();
+  });
+
+  it('does not index non-class-like kinds (Function/Method/Constructor/Enum/Record)', () => {
+    const defs: SymbolDefinition[] = [
+      mkDef({ nodeId: 'def:fn', type: 'Function', qualifiedName: 'app.Foo' }),
+      mkDef({ nodeId: 'def:m', type: 'Method', qualifiedName: 'app.Foo' }),
+      mkDef({ nodeId: 'def:ctor', type: 'Constructor', qualifiedName: 'app.Foo' }),
+      mkDef({ nodeId: 'def:enum', type: 'Enum', qualifiedName: 'app.Foo' }),
+      mkDef({ nodeId: 'def:rec', type: 'Record', qualifiedName: 'app.Foo' }),
+    ];
+    const index = buildGlobalClassIndex(mkScopes(defs));
+    expect(index.has('Foo')).toBe(false);
+    expect(pickUniqueGlobalClass('Foo', index)).toBeUndefined();
+  });
+
+  it('resolves a Struct match', () => {
+    const point = mkDef({ nodeId: 'def:Point', type: 'Struct', qualifiedName: 'geo.Point' });
+    expect(resolve('Point', [point])?.nodeId).toBe('def:Point');
+  });
+
+  it('resolves an Interface match (locks in KEEP-Interface — KTD5)', () => {
+    // KTD5: Interface stays in the filter for the behavior-preserving 8-lang
+    // refactor. A future protocol-exclusion change must break THIS test
+    // deliberately rather than silently.
+    const proto = mkDef({ nodeId: 'def:Drawable', type: 'Interface', qualifiedName: 'ui.Drawable' });
+    expect(resolve('Drawable', [proto])?.nodeId).toBe('def:Drawable');
+  });
+
+  it('skips defs with empty or undefined qualifiedName', () => {
+    const defs: SymbolDefinition[] = [
+      mkDef({ nodeId: 'def:empty', qualifiedName: '' }),
+      mkDef({ nodeId: 'def:undef', qualifiedName: undefined }),
+    ];
+    const index = buildGlobalClassIndex(mkScopes(defs));
+    expect(index.size).toBe(0);
+    expect(pickUniqueGlobalClass('', index)).toBeUndefined();
+  });
+
+  it('returns undefined for a missing-name lookup', () => {
+    const user = mkDef({ nodeId: 'def:User', qualifiedName: 'app.User' });
+    expect(resolve('Nonexistent', [user])).toBeUndefined();
+  });
+
+  it('keys by the last dotted segment, not the full qualifiedName', () => {
+    // Deeply-qualified name — lookup is by simple name only.
+    const deep = mkDef({ nodeId: 'def:deep', qualifiedName: 'a.b.c.Widget' });
+    expect(resolve('Widget', [deep])?.nodeId).toBe('def:deep');
+    expect(resolve('a.b.c.Widget', [deep])).toBeUndefined();
+  });
+
+  it('matches an undotted qualifiedName by its whole value', () => {
+    const bare = mkDef({ nodeId: 'def:Bare', qualifiedName: 'Bare' });
+    expect(resolve('Bare', [bare])?.nodeId).toBe('def:Bare');
+  });
+
+  it('equivalence: index result == reference linear scan for every scenario', () => {
+    // One combined corpus mixing class-like kinds, excluded kinds, same- and
+    // distinct-qualifiedName collisions, and skipped defs — exercised across a
+    // battery of names. The index path must agree with the linear scan on
+    // BOTH the resolved nodeId and the ambiguous/miss (undefined) outcome,
+    // which is what guards the O(n)->O(1) ordering invariant.
+    const corpus: SymbolDefinition[] = [
+      mkDef({ nodeId: 'def:User#1', qualifiedName: 'app.User' }),
+      mkDef({ nodeId: 'def:fn', type: 'Function', qualifiedName: 'app.User' }),
+      mkDef({ nodeId: 'def:User#2', qualifiedName: 'app.User' }), // same-qn fragment
+      mkDef({ nodeId: 'def:a.Item', qualifiedName: 'a.Item' }),
+      mkDef({ nodeId: 'def:b.Item', qualifiedName: 'b.Item' }), // distinct-qn collision
+      mkDef({ nodeId: 'def:Point', type: 'Struct', qualifiedName: 'geo.Point' }),
+      mkDef({ nodeId: 'def:Drawable', type: 'Interface', qualifiedName: 'ui.Drawable' }),
+      mkDef({ nodeId: 'def:Enumish', type: 'Enum', qualifiedName: 'app.Enumish' }),
+      mkDef({ nodeId: 'def:empty', qualifiedName: '' }),
+      mkDef({ nodeId: 'def:undef', qualifiedName: undefined }),
+    ];
+    const scopes = mkScopes(corpus);
+    const index = buildGlobalClassIndex(scopes);
+    const names = [
+      'User', // same-qn keep-first
+      'Item', // distinct-qn ambiguous
+      'Point', // struct
+      'Drawable', // interface
+      'Enumish', // excluded kind → miss
+      'Missing', // miss
+      '', // skipped-qn → miss
+    ];
+    for (const name of names) {
+      const fromIndex = pickUniqueGlobalClass(name, index);
+      const fromScan = referenceLinearScan(name, scopes);
+      expect(fromIndex?.nodeId).toBe(fromScan?.nodeId);
+    }
+  });
+});

--- a/gitnexus/test/unit/scope-resolution/swift/swift-captures-golden.test.ts
+++ b/gitnexus/test/unit/scope-resolution/swift/swift-captures-golden.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Golden capture-parity test for `emitSwiftScopeCaptures` (issue #937, RFC #909
+ * Ring 3 — the final per-language migration to scope-based resolution).
+ *
+ * Pins the exact capture output of `emitSwiftScopeCaptures` across the whole
+ * `test/fixtures/lang-resolution/swift-*` corpus plus a synthetic generated-DAO
+ * source, so any future drift in the Swift scope-capture path fails CI rather
+ * than only being caught by the coarse `bench/scope-capture` fingerprint job or
+ * the pipeline-level resolver tests.
+ *
+ * This is a FORWARD-DRIFT guard: it locks in the current (verified-at-parity)
+ * capture output as the baseline. It does not independently re-prove the
+ * original legacy↔registry parity — that is established by
+ * `test/integration/resolvers/swift.test.ts` (77/77 in both modes).
+ *
+ * Regenerate the golden intentionally with `UPDATE_GOLDEN=1` in the environment.
+ *
+ * Per fixture the snapshot stores `{ captureGroups, digest }`:
+ *   - captureGroups: number of capture matches (makes a count change legible)
+ *   - digest: sha256 of a match-grouped, order-sensitive (emission-order)
+ *     canonicalization (see canonicalize* below). Order-sensitivity is safe
+ *     because emitSwiftScopeCaptures output is deterministic, and it makes the
+ *     digest a true byte-identical guard (a reordering refactor is real drift).
+ *     Nothing path/time/id-dependent leaks in.
+ *
+ * Pattern: mirrors test/unit/scope-resolution/csharp/csharp-captures-golden.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import fs from 'fs';
+import crypto from 'crypto';
+import { emitSwiftScopeCaptures } from '../../../../src/core/ingestion/languages/swift/index.js';
+import { isLanguageAvailable } from '../../../../src/core/tree-sitter/parser-loader.js';
+import { SupportedLanguages } from '../../../../src/config/supported-languages.js';
+import type { CaptureMatch } from 'gitnexus-shared';
+
+// Swift is an optional dependency; skip gracefully if the grammar isn't installed.
+const swiftAvailable = isLanguageAvailable(SupportedLanguages.Swift);
+
+// This test lives at test/unit/scope-resolution/swift/, so fixtures are THREE
+// levels up (mirrors the csharp/go golden tests).
+const FIXTURE_ROOT = path.resolve(__dirname, '..', '..', '..', 'fixtures', 'lang-resolution');
+const GOLDEN_DIR = path.resolve(__dirname, '..', '..', '..', 'fixtures', 'swift-captures-golden');
+const GOLDEN_FILE = path.join(GOLDEN_DIR, 'expected-captures.json');
+
+const UPDATE = process.env.UPDATE_GOLDEN === '1';
+
+interface FixtureSnapshot {
+  captureGroups: number;
+  digest: string;
+}
+type Snapshot = Record<string, FixtureSnapshot>;
+
+/**
+ * Canonicalize ONE match. A CaptureMatch is a Record<tag, Capture> (multiple
+ * captures per match), so we group by match to preserve match identity:
+ * build one `tag|text|startLine:startCol-endLine:endCol` string per capture,
+ * sort them within the match, and join. We deliberately do NOT flatten every
+ * capture into one global list — that would lose match boundaries.
+ */
+function canonicalizeMatch(match: CaptureMatch): string {
+  const parts: string[] = [];
+  for (const tag of Object.keys(match)) {
+    const cap = match[tag]!;
+    const r = cap.range;
+    parts.push(`${tag}|${cap.text}|${r.startLine}:${r.startCol}-${r.endLine}:${r.endCol}`);
+  }
+  parts.sort();
+  return parts.join(';');
+}
+
+/** Order-sensitive (emission-order) digest of a full capture result (match-grouped). */
+function digestCaptures(matches: readonly CaptureMatch[]): string {
+  // No cross-match sort: the digest reflects emission order so a reordering
+  // refactor surfaces as drift. Within-match key order IS normalized
+  // (canonicalizeMatch sorts), since a CaptureMatch is an unordered Record.
+  const matchStrings = matches.map(canonicalizeMatch);
+  return crypto.createHash('sha256').update(matchStrings.join('\n')).digest('hex');
+}
+
+function snapshotOf(src: string, filePath: string): FixtureSnapshot {
+  const matches = emitSwiftScopeCaptures(src, filePath);
+  return { captureGroups: matches.length, digest: digestCaptures(matches) };
+}
+
+/** All `.swift` files under `lang-resolution/swift-*`, as sorted repo-relative-ish keys. */
+function collectSwiftFixtures(): { key: string; absPath: string }[] {
+  const out: { key: string; absPath: string }[] = [];
+  for (const entry of fs.readdirSync(FIXTURE_ROOT, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith('swift-')) continue;
+    const stack = [path.join(FIXTURE_ROOT, entry.name)];
+    while (stack.length) {
+      const dir = stack.pop()!;
+      for (const c of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, c.name);
+        if (c.isDirectory()) stack.push(p);
+        else if (c.name.endsWith('.swift')) {
+          out.push({ key: path.relative(FIXTURE_ROOT, p).split(path.sep).join('/'), absPath: p });
+        }
+      }
+    }
+  }
+  out.sort((a, b) => a.key.localeCompare(b.key));
+  return out;
+}
+
+/**
+ * Small deterministic generated-DAO source — a correctness-scale shape mirroring
+ * the synthetic DAO unit from bench/scope-capture/measure.mjs: N classes, each
+ * carrying stored properties plus getter/setter methods.
+ */
+function generateDao(entityCount: number): string {
+  let src = '';
+  for (let i = 0; i < entityCount; i++) {
+    src +=
+      `class Entity${i} {\n` +
+      `  var id: Int64 = 0\n  var name: String = ""\n` +
+      `  func getId() -> Int64 { return self.id }\n` +
+      `  func setName(_ v: String) { self.name = v }\n}\n\n`;
+  }
+  return src;
+}
+
+function buildSnapshot(): Snapshot {
+  const snap: Snapshot = {};
+  for (const { key, absPath } of collectSwiftFixtures()) {
+    snap[key] = snapshotOf(fs.readFileSync(absPath, 'utf8'), absPath);
+  }
+  snap['synthetic:dao-20'] = snapshotOf(generateDao(20), 'zz_generated_dao.swift');
+  // Stable key order for deterministic JSON serialization.
+  return Object.fromEntries(
+    Object.keys(snap)
+      .sort()
+      .map((k) => [k, snap[k]!]),
+  );
+}
+
+function formatGolden(snap: Snapshot): string {
+  return JSON.stringify(snap, null, 2) + '\n';
+}
+
+/**
+ * Pure decision for what the golden test should do — extracted so the
+ * fail-on-missing-in-CI rule is unit-testable without touching the filesystem
+ * (and can never corrupt the committed golden). A missing golden must NOT
+ * self-heal in CI; locally it regenerates as a first-run convenience.
+ */
+type GoldenAction = 'regenerate' | 'compare' | 'fail';
+function resolveGoldenAction(opts: {
+  update: boolean;
+  exists: boolean;
+  isCI: boolean;
+}): GoldenAction {
+  if (opts.update) return 'regenerate';
+  if (!opts.exists) return opts.isCI ? 'fail' : 'regenerate';
+  return 'compare';
+}
+
+describe.skipIf(!swiftAvailable)('Swift scope captures — golden parity', () => {
+  it('matches the committed golden snapshot across all swift-* fixtures + DAO shape', () => {
+    const snapshot = buildSnapshot();
+
+    // Read the golden once (no existsSync-then-use, which is a TOCTOU race):
+    // ENOENT means the golden is missing; reuse `existing` for the compare path.
+    let existing: string | undefined;
+    try {
+      existing = fs.readFileSync(GOLDEN_FILE, 'utf8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+
+    const action = resolveGoldenAction({
+      update: UPDATE,
+      exists: existing !== undefined,
+      isCI: !!process.env.CI, // truthy check: fires on any CI runner, not just CI==='true'
+    });
+
+    if (action === 'fail') {
+      throw new Error(
+        `[swift-captures-golden] golden file missing at ${GOLDEN_FILE} in CI. A missing golden must ` +
+          `not self-heal in CI — regenerate it locally with UPDATE_GOLDEN=1 and commit it.`,
+      );
+    }
+
+    if (action === 'regenerate') {
+      fs.mkdirSync(GOLDEN_DIR, { recursive: true });
+      fs.writeFileSync(GOLDEN_FILE, formatGolden(snapshot), 'utf8');
+      console.log(
+        `[swift-captures-golden] ${UPDATE ? 'Regenerated' : 'Created'} golden at ${GOLDEN_FILE}`,
+      );
+      return;
+    }
+
+    const expected: Snapshot = JSON.parse(existing!);
+    expect(
+      snapshot,
+      'emitSwiftScopeCaptures output drifted from the committed golden. If this drift is intentional ' +
+        '(or the digest scheme changed), regenerate with ' +
+        'UPDATE_GOLDEN=1 npx vitest run test/unit/scope-resolution/swift/swift-captures-golden.test.ts',
+    ).toEqual(expected);
+  });
+
+  // The fail-on-missing-in-CI rule, asserted purely (no filesystem mutation).
+  it.each([
+    { update: true, exists: false, isCI: true, expected: 'regenerate' },
+    { update: false, exists: false, isCI: true, expected: 'fail' },
+    { update: false, exists: false, isCI: false, expected: 'regenerate' },
+    { update: false, exists: true, isCI: true, expected: 'compare' },
+    { update: false, exists: true, isCI: false, expected: 'compare' },
+  ])(
+    'resolveGoldenAction($update,$exists,$isCI) -> $expected',
+    ({ update, exists, isCI, expected }) => {
+      expect(resolveGoldenAction({ update, exists, isCI })).toBe(expected);
+    },
+  );
+
+  it('produces a deterministic digest across repeated runs', () => {
+    const src = generateDao(8);
+    expect(digestCaptures(emitSwiftScopeCaptures(src, 'a.swift'))).toBe(
+      digestCaptures(emitSwiftScopeCaptures(src, 'a.swift')),
+    );
+  });
+
+  it('digest is sensitive to capture-match emission order', () => {
+    const matches = emitSwiftScopeCaptures(generateDao(6), 'a.swift');
+    expect(matches.length).toBeGreaterThan(1);
+    const reversed = [...matches].reverse();
+    // Reordering the emission changes the digest — the true byte-identical guard.
+    expect(digestCaptures(reversed)).not.toBe(digestCaptures(matches));
+  });
+
+  it('records a capture-group count for every fixture and the DAO shape', () => {
+    const snapshot = buildSnapshot();
+    const fixtureKeys = collectSwiftFixtures().map((f) => f.key);
+    // Every collected fixture is present in the snapshot.
+    for (const k of fixtureKeys) expect(snapshot[k]).toBeDefined();
+    // The DAO shape (which has symbols) yields a non-empty capture set.
+    expect(snapshot['synthetic:dao-20']!.captureGroups).toBeGreaterThan(0);
+  });
+});

--- a/gitnexus/test/unit/scope-resolution/swift/target-grouping.test.ts
+++ b/gitnexus/test/unit/scope-resolution/swift/target-grouping.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Drift-guard unit test for `groupSwiftFilesBySpmTarget` (issue #1948 U3,
+ * KTD2).
+ *
+ * `groupSwiftFilesBySpmTarget` (`languages/swift/target-grouping.ts`)
+ * DUPLICATES the legacy `groupSwiftFilesByTarget` (`languages/swift.ts`)
+ * SPM-subtree semantics so the registry-primary same-module hooks group by
+ * the SPM target subtree without touching the legacy pipeline (hard
+ * constraint: legacy stays byte-identical). Because the duplication can
+ * silently drift if legacy is later changed, this test pins the exact
+ * bucketing for representative inputs so a future divergence surfaces
+ * loudly:
+ *
+ *   1. A multi-subdir single target buckets into ONE group.
+ *   2. A file matching two overlapping same-named target prefixes is
+ *      assigned to the FIRST target only (legacy `break`s — no fan-out).
+ *   3. Unmatched files AND the no-targets case route to `__default__` = all.
+ *
+ * `coerceSwiftTargets` is also covered: it duck-types `{ targets: Map }`
+ * (no `instanceof` on the config object) and returns `null` otherwise.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  groupSwiftFilesBySpmTarget,
+  coerceSwiftTargets,
+} from '../../../../src/core/ingestion/languages/swift/target-grouping.js';
+
+const id = (s: string) => s;
+
+describe('groupSwiftFilesBySpmTarget — legacy SPM-subtree parity (drift guard)', () => {
+  it('buckets a multi-subdir single target into ONE group', () => {
+    const files = [
+      'Sources/Alpha/Core/User.swift',
+      'Sources/Alpha/Entry/App.swift',
+      'Sources/Alpha/Util/Helpers.swift',
+    ];
+    const targets = new Map([['Alpha', 'Sources/Alpha']]);
+
+    const groups = groupSwiftFilesBySpmTarget(files, id, targets);
+
+    expect([...groups.keys()]).toEqual(['Alpha']);
+    expect(groups.get('Alpha')).toEqual(files);
+    expect(groups.has('__default__')).toBe(false);
+  });
+
+  it('assigns a file matching two overlapping same-named prefixes to the FIRST target only', () => {
+    // Both targets are prefixes of the file's path (Beta dir nested under
+    // Alpha). Legacy `break`s on the first match → one bucket per file.
+    const files = ['Sources/Alpha/Beta/User.swift'];
+    const targets = new Map([
+      ['Alpha', 'Sources/Alpha'],
+      ['Beta', 'Sources/Alpha/Beta'],
+    ]);
+
+    const groups = groupSwiftFilesBySpmTarget(files, id, targets);
+
+    expect(groups.get('Alpha')).toEqual(files);
+    expect(groups.has('Beta')).toBe(false);
+  });
+
+  it('matches a target dir only at a `/` boundary, not a substring', () => {
+    // "Sources/Alpha" must NOT match "Sources/AlphaBeta/..." — the legacy
+    // predicate requires idx===0 or a preceding `/`.
+    const files = ['Sources/AlphaBeta/User.swift'];
+    const targets = new Map([['Alpha', 'Sources/Alpha']]);
+
+    const groups = groupSwiftFilesBySpmTarget(files, id, targets);
+
+    expect(groups.has('Alpha')).toBe(false);
+    expect(groups.get('__default__')).toEqual(files);
+  });
+
+  it('routes unmatched files (with targets present) to __default__', () => {
+    const files = ['Sources/Alpha/User.swift', 'Loose/Orphan.swift'];
+    const targets = new Map([['Alpha', 'Sources/Alpha']]);
+
+    const groups = groupSwiftFilesBySpmTarget(files, id, targets);
+
+    expect(groups.get('Alpha')).toEqual(['Sources/Alpha/User.swift']);
+    expect(groups.get('__default__')).toEqual(['Loose/Orphan.swift']);
+  });
+
+  it('routes ALL files to __default__ when targets is null (no source dir found)', () => {
+    const files = ['Models/User.swift', 'Services/App.swift'];
+
+    const groups = groupSwiftFilesBySpmTarget(files, id, null);
+
+    expect([...groups.keys()]).toEqual(['__default__']);
+    expect(groups.get('__default__')).toEqual(files);
+  });
+
+  it('routes ALL files to __default__ when targets is empty', () => {
+    const files = ['Models/User.swift', 'Services/App.swift'];
+
+    const groups = groupSwiftFilesBySpmTarget(files, id, new Map());
+
+    expect([...groups.keys()]).toEqual(['__default__']);
+    expect(groups.get('__default__')).toEqual(files);
+  });
+
+  it('groups generic items via getPath (not just strings)', () => {
+    const items = [
+      { filePath: 'Sources/Alpha/Core/User.swift', tag: 1 },
+      { filePath: 'Sources/Beta/Core/User.swift', tag: 2 },
+    ];
+    const targets = new Map([
+      ['Alpha', 'Sources/Alpha'],
+      ['Beta', 'Sources/Beta'],
+    ]);
+
+    const groups = groupSwiftFilesBySpmTarget(items, (i) => i.filePath, targets);
+
+    expect(groups.get('Alpha')).toEqual([items[0]]);
+    expect(groups.get('Beta')).toEqual([items[1]]);
+  });
+
+  it('normalizes backslash paths to forward-slash before matching', () => {
+    const files = ['Sources\\Alpha\\Core\\User.swift'];
+    const targets = new Map([['Alpha', 'Sources/Alpha']]);
+
+    const groups = groupSwiftFilesBySpmTarget(files, id, targets);
+
+    expect(groups.get('Alpha')).toEqual(files);
+  });
+});
+
+describe('coerceSwiftTargets — duck-type the opaque resolutionConfig', () => {
+  it('returns the targets map from a SwiftPackageConfig-shaped object', () => {
+    const targets = new Map([['Alpha', 'Sources/Alpha']]);
+    expect(coerceSwiftTargets({ targets })).toBe(targets);
+  });
+
+  it('returns null for null / undefined / non-config values', () => {
+    expect(coerceSwiftTargets(null)).toBeNull();
+    expect(coerceSwiftTargets(undefined)).toBeNull();
+    expect(coerceSwiftTargets({})).toBeNull();
+    expect(coerceSwiftTargets({ targets: 'not-a-map' })).toBeNull();
+    expect(coerceSwiftTargets({ goModule: { modulePath: 'x' } })).toBeNull();
+  });
+});

--- a/gitnexus/test/unit/sequential-language-availability.test.ts
+++ b/gitnexus/test/unit/sequential-language-availability.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../src/core/tree-sitter/parser-loader.js', () => ({
   loadParser: vi.fn(async () => ({
@@ -20,9 +20,20 @@ import { createResolutionContext } from '../../src/core/ingestion/model/resoluti
 import * as parserLoader from '../../src/core/tree-sitter/parser-loader.js';
 
 import { _captureLogger } from '../../src/core/logger.js';
+import type { LoggerCapture } from '../../src/core/logger.js';
 describe('sequential native parser availability', () => {
+  // Hoisted so a stray live capture from a failed warn test can always be
+  // torn down in afterEach — otherwise a single assertion failure cascades
+  // into `_captureLogger: a previous capture is still active` (logger.ts).
+  let cap: LoggerCapture | undefined;
+
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cap?.restore();
+    cap = undefined;
   });
 
   it('skips Swift files in processImports when the native parser is unavailable', async () => {
@@ -44,36 +55,37 @@ describe('sequential native parser availability', () => {
   });
 
   it('warns when processImports skips files in verbose mode', async () => {
-    const cap = _captureLogger();
+    cap = _captureLogger();
     const previous = process.env.GITNEXUS_VERBOSE;
     process.env.GITNEXUS_VERBOSE = '1';
-    vi.mocked(parserLoader.isLanguageAvailable).mockReturnValue(false);
+    try {
+      vi.mocked(parserLoader.isLanguageAvailable).mockReturnValue(false);
 
-    await processImports(
-      createKnowledgeGraph(),
-      [{ path: 'App.swift', content: 'import Foundation' }],
-      createASTCache(),
-      createResolutionContext(),
-      undefined,
-      '/tmp/repo',
-      ['App.swift'],
-    );
+      await processImports(
+        createKnowledgeGraph(),
+        [{ path: 'App.swift', content: 'import Foundation' }],
+        createASTCache(),
+        createResolutionContext(),
+        undefined,
+        '/tmp/repo',
+        ['App.swift'],
+      );
 
-    expect(
-      cap
-        .records()
-        .some(
-          (r) =>
-            r.msg ===
-            '[ingestion] Skipped 1 swift file(s) in import processing — swift parser not available.',
-        ),
-    ).toBe(true);
-
-    cap.restore();
-    if (previous === undefined) {
-      delete process.env.GITNEXUS_VERBOSE;
-    } else {
-      process.env.GITNEXUS_VERBOSE = previous;
+      expect(
+        cap
+          .records()
+          .some(
+            (r) =>
+              r.msg ===
+              '[ingestion] Skipped 1 swift file(s) in import processing — swift parser not available.',
+          ),
+      ).toBe(true);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.GITNEXUS_VERBOSE;
+      } else {
+        process.env.GITNEXUS_VERBOSE = previous;
+      }
     }
   });
 
@@ -93,33 +105,45 @@ describe('sequential native parser availability', () => {
   });
 
   it('warns when processCalls skips files in verbose mode', async () => {
-    const cap = _captureLogger();
+    cap = _captureLogger();
     const previous = process.env.GITNEXUS_VERBOSE;
+    // Swift is now registry-primary (MIGRATED_LANGUAGES), and
+    // call-processor gates registry-primary languages before the skip
+    // counter — so force the legacy path off here to exercise the
+    // skip/warn branch. (We do NOT edit the processor.)
+    const previousFlag = process.env.REGISTRY_PRIMARY_SWIFT;
     process.env.GITNEXUS_VERBOSE = '1';
-    vi.mocked(parserLoader.isLanguageAvailable).mockReturnValue(false);
+    process.env.REGISTRY_PRIMARY_SWIFT = '0';
+    try {
+      vi.mocked(parserLoader.isLanguageAvailable).mockReturnValue(false);
 
-    await processCalls(
-      createKnowledgeGraph(),
-      [{ path: 'App.swift', content: 'func demo() {}' }],
-      createASTCache(),
-      createResolutionContext(),
-    );
+      await processCalls(
+        createKnowledgeGraph(),
+        [{ path: 'App.swift', content: 'func demo() {}' }],
+        createASTCache(),
+        createResolutionContext(),
+      );
 
-    expect(
-      cap
-        .records()
-        .some(
-          (r) =>
-            r.msg ===
-            '[ingestion] Skipped 1 swift file(s) in call processing — swift parser not available.',
-        ),
-    ).toBe(true);
-
-    cap.restore();
-    if (previous === undefined) {
-      delete process.env.GITNEXUS_VERBOSE;
-    } else {
-      process.env.GITNEXUS_VERBOSE = previous;
+      expect(
+        cap
+          .records()
+          .some(
+            (r) =>
+              r.msg ===
+              '[ingestion] Skipped 1 swift file(s) in call processing — swift parser not available.',
+          ),
+      ).toBe(true);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.GITNEXUS_VERBOSE;
+      } else {
+        process.env.GITNEXUS_VERBOSE = previous;
+      }
+      if (previousFlag === undefined) {
+        delete process.env.REGISTRY_PRIMARY_SWIFT;
+      } else {
+        process.env.REGISTRY_PRIMARY_SWIFT = previousFlag;
+      }
     }
   });
 
@@ -139,33 +163,34 @@ describe('sequential native parser availability', () => {
   });
 
   it('warns when processHeritage skips files in verbose mode', async () => {
-    const cap = _captureLogger();
+    cap = _captureLogger();
     const previous = process.env.GITNEXUS_VERBOSE;
     process.env.GITNEXUS_VERBOSE = '1';
-    vi.mocked(parserLoader.isLanguageAvailable).mockReturnValue(false);
+    try {
+      vi.mocked(parserLoader.isLanguageAvailable).mockReturnValue(false);
 
-    await processHeritage(
-      createKnowledgeGraph(),
-      [{ path: 'App.swift', content: 'class AppViewController: UIViewController {}' }],
-      createASTCache(),
-      createResolutionContext(),
-    );
+      await processHeritage(
+        createKnowledgeGraph(),
+        [{ path: 'App.swift', content: 'class AppViewController: UIViewController {}' }],
+        createASTCache(),
+        createResolutionContext(),
+      );
 
-    expect(
-      cap
-        .records()
-        .some(
-          (r) =>
-            r.msg ===
-            '[ingestion] Skipped 1 swift file(s) in heritage processing — swift parser not available.',
-        ),
-    ).toBe(true);
-
-    cap.restore();
-    if (previous === undefined) {
-      delete process.env.GITNEXUS_VERBOSE;
-    } else {
-      process.env.GITNEXUS_VERBOSE = previous;
+      expect(
+        cap
+          .records()
+          .some(
+            (r) =>
+              r.msg ===
+              '[ingestion] Skipped 1 swift file(s) in heritage processing — swift parser not available.',
+          ),
+      ).toBe(true);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.GITNEXUS_VERBOSE;
+      } else {
+        process.env.GITNEXUS_VERBOSE = previous;
+      }
     }
   });
 
@@ -185,33 +210,34 @@ describe('sequential native parser availability', () => {
   });
 
   it('warns when processParsing skips files in verbose mode', async () => {
-    const cap = _captureLogger();
+    cap = _captureLogger();
     const previous = process.env.GITNEXUS_VERBOSE;
     process.env.GITNEXUS_VERBOSE = '1';
-    vi.mocked(parserLoader.isLanguageAvailable).mockReturnValue(false);
+    try {
+      vi.mocked(parserLoader.isLanguageAvailable).mockReturnValue(false);
 
-    await processParsing(
-      createKnowledgeGraph(),
-      [{ path: 'App.swift', content: 'class AppViewController: UIViewController {}' }],
-      createSymbolTable(),
-      createASTCache(),
-    );
+      await processParsing(
+        createKnowledgeGraph(),
+        [{ path: 'App.swift', content: 'class AppViewController: UIViewController {}' }],
+        createSymbolTable(),
+        createASTCache(),
+      );
 
-    expect(
-      cap
-        .records()
-        .some(
-          (r) =>
-            r.msg ===
-            '[ingestion] Skipped 1 swift file(s) in parsing processing — swift parser not available.',
-        ),
-    ).toBe(true);
-
-    cap.restore();
-    if (previous === undefined) {
-      delete process.env.GITNEXUS_VERBOSE;
-    } else {
-      process.env.GITNEXUS_VERBOSE = previous;
+      expect(
+        cap
+          .records()
+          .some(
+            (r) =>
+              r.msg ===
+              '[ingestion] Skipped 1 swift file(s) in parsing processing — swift parser not available.',
+          ),
+      ).toBe(true);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.GITNEXUS_VERBOSE;
+      } else {
+        process.env.GITNEXUS_VERBOSE = previous;
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

Ring 3 of RFC #909 — **Swift is the final language migrated** to the scope-based registry resolution pipeline. This flips Swift into `MIGRATED_LANGUAGES`, making registry-primary call resolution the production default.

Closes #937.

## Parity (Definition of Done)

Dual-mode resolver parity proven — `test/integration/resolvers/swift.test.ts` passes **77/77 in both modes**:

| Mode | Result |
|------|--------|
| Legacy DAG (`REGISTRY_PRIMARY_SWIFT=0`) | ✅ 77/77 |
| Registry-primary (`REGISTRY_PRIMARY_SWIFT=1`) | ✅ 77/77 |

Full Swift test glob: **3 files / 88 tests pass** (77 resolver + 9 golden + 2 tripwire). `tsc --noEmit` clean. No cross-language resolver regressions. Benchmark `--check` passes for all 7 languages (Swift scaling 0.98 = linear).

## What changed

**New language module** `src/core/ingestion/languages/swift/` (mirrors `csharp/`): query, captures, interpret, import-decomposer, receiver-binding, signature-bindings, arity (+metadata), merge-bindings, simple-hooks, import-target, target-siblings, implicit-imports, sibling-type-bindings, scope-resolver, cache-stats, index. Parse-time hooks wired into the existing flat `languages/swift.ts` (coexists with the `swift/` dir, like kotlin); resolver registered in the scope-resolution registry.

**tree-sitter-swift 0.7.1 specifics** (handled in the Swift module, not shared code):
- `class` / `struct` / `extension` all parse to `class_declaration`; extensions are re-keyed onto the extended type so members hoist (like C# partial classes).
- if-let / guard-let have no `if_let_binding` node — the optional binding is synthesized from `if_statement` / `guard_statement`.
- the `name:` field is reused for func name, param labels, param types and return type, so param/return type-bindings are synthesized in code (`signature-bindings.ts`) rather than via a multi-name query.
- no `new` keyword: `Type(...)` and `Type.init(...)` are synthesized into constructor type-bindings.

**Shared-pipeline additions** (language-agnostic per AGENTS.md — no language names in shared ingestion code):
- `constructorCallTargetsClass` on the `ScopeResolver` contract + free-call-fallback option + `run.ts` wiring: when true, `Type(...)` links to the Class def rather than its explicit `init` Constructor.
- `pickUniqueGlobalClass`: constructor-branch global fallback for cross-file types absent from the call site's lexical bindings, deduped by `qualifiedName` so extension/partial fragments aren't treated as ambiguous.
- `emitImplicitImportEdges`: same-module File→File `IMPORTS` edges (Swift whole-module visibility has no syntactic import to drive the generic ImportEdge pipeline).

**Import resolution**: rewrote the O(n²) module scan in `import-resolvers/configs/swift.ts` with a WeakMap-memoized index.

**Benchmarks & guards**:
- Swift added to `bench/scope-capture/measure.mjs` + `baselines.json` (fingerprint + 1.5× scaling budget).
- golden capture-parity test `test/unit/scope-resolution/swift/swift-captures-golden.test.ts` (+ `fixtures/swift-captures-golden/`), mirrors the csharp golden.
- O(n) scope-capture tripwire `test/integration/swift-scope-capture-tripwire.test.ts`.

## Test plan

- [x] `REGISTRY_PRIMARY_SWIFT=0 npx vitest run test/integration/resolvers/swift.test.ts` → 77/77
- [x] `REGISTRY_PRIMARY_SWIFT=1 npx vitest run test/integration/resolvers/swift.test.ts` → 77/77
- [x] `npx vitest run swift` → 88/88
- [x] `node --import tsx bench/scope-capture/measure.mjs --check` → PASS (7 languages)
- [x] `npx tsc --noEmit` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #1935