### PR TITLE
fix(ingestion): skip File->Member DEFINES edges for class members

### DIFF
--- a/gitnexus/src/core/ingestion/call-processor.ts
+++ b/gitnexus/src/core/ingestion/call-processor.ts
@@ -1033,15 +1033,18 @@ export const processCalls = async (
               ? { declaredType: routedFieldInfo.type }
               : {}),
         });
-        const relId = generateId('DEFINES', `${fileId}->${nodeId}`);
-        graph.addRelationship({
-          id: relId,
-          sourceId: fileId,
-          targetId: nodeId,
-          type: 'DEFINES',
-          confidence: 1.0,
-          reason: '',
-        });
+        // Only emit File -> Property DEFINES for top-level properties (issue #1944).
+        if (!propEnclosingClassId) {
+          const relId = generateId('DEFINES', `${fileId}->${nodeId}`);
+          graph.addRelationship({
+            id: relId,
+            sourceId: fileId,
+            targetId: nodeId,
+            type: 'DEFINES',
+            confidence: 1.0,
+            reason: '',
+          });
+        }
         if (propEnclosingClassId) {
           graph.addRelationship({
             id: generateId('HAS_PROPERTY', `${propEnclosingClassId}->${nodeId}`),

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -828,23 +828,28 @@ const processParsingSequential = async (
         qualifiedName: qualifiedTypeName,
       });
 
-      const fileId = generateId('File', file.path);
-
-      const relId = generateId('DEFINES', `${fileId}->${nodeId}`);
-
-      const relationship: GraphRelationship = {
-        id: relId,
-        sourceId: fileId,
-        targetId: nodeId,
-        type: 'DEFINES',
-        confidence: 1.0,
-        reason: '',
-      };
-
-      graph.addRelationship(relationship);
-
       // ── HAS_METHOD / HAS_PROPERTY: link member to enclosing class ──
       const ownerIdForMemberEdge = enclosingClassId ?? objectLiteralOwnerInfo?.ownerId ?? null;
+
+      // Only emit File -> Symbol DEFINES for top-level symbols. Class members
+      // are reachable via Class -> Member (HAS_METHOD / HAS_PROPERTY), so a
+      // direct File -> Member edge would bypass the class in the graph and
+      // produce a flat radial layout instead of the correct File->Class->Member
+      // hierarchy (issue #1944).
+      if (!ownerIdForMemberEdge) {
+        const fileId = generateId('File', file.path);
+        const relId = generateId('DEFINES', `${fileId}->${nodeId}`);
+        const relationship: GraphRelationship = {
+          id: relId,
+          sourceId: fileId,
+          targetId: nodeId,
+          type: 'DEFINES',
+          confidence: 1.0,
+          reason: '',
+        };
+        graph.addRelationship(relationship);
+      }
+
       if (ownerIdForMemberEdge) {
         const memberEdgeType = nodeLabel === 'Property' ? 'HAS_PROPERTY' : 'HAS_METHOD';
         graph.addRelationship({

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -1557,16 +1557,20 @@ const processFileGroup = (
                       ? { isReadonly: routedFieldInfo.isReadonly }
                       : {}),
                   });
-                  const fileId = generateId('File', file.path);
-                  const relId = generateId('DEFINES', `${fileId}->${nodeId}`);
-                  result.relationships.push({
-                    id: relId,
-                    sourceId: fileId,
-                    targetId: nodeId,
-                    type: 'DEFINES',
-                    confidence: 1.0,
-                    reason: '',
-                  });
+                  // Only emit File -> Property DEFINES for top-level properties
+                  // (issue #1944); class members are reached via HAS_PROPERTY.
+                  if (!propEnclosingClassId) {
+                    const fileId = generateId('File', file.path);
+                    const relId = generateId('DEFINES', `${fileId}->${nodeId}`);
+                    result.relationships.push({
+                      id: relId,
+                      sourceId: fileId,
+                      targetId: nodeId,
+                      type: 'DEFINES',
+                      confidence: 1.0,
+                      reason: '',
+                    });
+                  }
                   if (propEnclosingClassId) {
                     result.relationships.push({
                       id: generateId('HAS_PROPERTY', `${propEnclosingClassId}->${nodeId}`),
@@ -2023,16 +2027,19 @@ const processFileGroup = (
           : {}),
       });
 
-      const fileId = generateId('File', file.path);
-      const relId = generateId('DEFINES', `${fileId}->${nodeId}`);
-      result.relationships.push({
-        id: relId,
-        sourceId: fileId,
-        targetId: nodeId,
-        type: 'DEFINES',
-        confidence: 1.0,
-        reason: '',
-      });
+      // Only emit File -> Symbol DEFINES for top-level symbols (issue #1944).
+      if (ownerId === undefined) {
+        const fileId = generateId('File', file.path);
+        const relId = generateId('DEFINES', `${fileId}->${nodeId}`);
+        result.relationships.push({
+          id: relId,
+          sourceId: fileId,
+          targetId: nodeId,
+          type: 'DEFINES',
+          confidence: 1.0,
+          reason: '',
+        });
+      }
 
       // ── HAS_METHOD / HAS_PROPERTY: link member to enclosing class ──
       if (ownerId !== undefined) {

--- a/gitnexus/src/core/wiki/graph-queries.ts
+++ b/gitnexus/src/core/wiki/graph-queries.ts
@@ -57,6 +57,9 @@ export async function closeWikiDb(): Promise<void> {
 
 /**
  * Get all source files with their exported symbol names and types.
+ * Includes top-level exports (File→DEFINES→n) and exported class members
+ * (File→DEFINES→Class→HAS_METHOD/HAS_PROPERTY→n) since class members no
+ * longer have a direct File→DEFINES edge.
  */
 export async function getFilesWithExports(): Promise<FileWithExports[]> {
   const rows = await executeQuery(
@@ -65,7 +68,12 @@ export async function getFilesWithExports(): Promise<FileWithExports[]> {
     MATCH (f:File)-[:CodeRelation {type: 'DEFINES'}]->(n)
     WHERE n.isExported = true
     RETURN f.filePath AS filePath, n.name AS name, labels(n)[0] AS type
-    ORDER BY f.filePath
+    UNION
+    MATCH (f:File)-[:CodeRelation {type: 'DEFINES'}]->(c)
+          -[mr:CodeRelation]->(n)
+    WHERE mr.type IN ['HAS_METHOD', 'HAS_PROPERTY'] AND n.isExported = true
+    RETURN f.filePath AS filePath, n.name AS name, labels(n)[0] AS type
+    ORDER BY filePath
   `,
   );
 

--- a/gitnexus/test/fixtures/pipeline-golden/mini-repo/expected-graph.json
+++ b/gitnexus/test/fixtures/pipeline-golden/mini-repo/expected-graph.json
@@ -3,7 +3,7 @@
   "fixture": "mini-repo",
   "totalFileCount": 7,
   "symbols": 37,
-  "relationships": 74,
+  "relationships": 73,
   "processes": 4,
   "byType": {
     "Class": 1,
@@ -19,11 +19,11 @@
   "byRelType": {
     "CALLS": 9,
     "CONTAINS": 7,
-    "DEFINES": 21,
+    "DEFINES": 20,
     "HAS_METHOD": 1,
     "IMPORTS": 12,
     "MEMBER_OF": 12,
     "STEP_IN_PROCESS": 12
   },
-  "edgeDigest": "6f414427a20c037df3e336f055c83f987e7d381c9bfa73b4d2be690cb8103302"
+  "edgeDigest": "196198eb9a900721aec892400d141189aa1e874722917843c7f1206805d817f1"
 }


### PR DESCRIPTION
## Summary

Previously every symbol — including Methods and Properties that belong to a class — received a direct File->Symbol DEFINES edge. This caused the radial-layout view to show File linking directly to all Properties and Methods, bypassing their enclosing class node and flattening the OOP hierarchy.

Fix: gate the DEFINES emission on the symbol having no owner. Class members are already reachable through the File->Class DEFINES edge and the Class->Member HAS_METHOD / HAS_PROPERTY edges, so the redundant direct edge is unnecessary and misleading in the graph.

After the fix, the radial layout view looks this (Issue #1944 shows original view):

<img width="80%" alt="image" src="https://github.com/user-attachments/assets/3a7bb23e-1ec0-49e5-9930-3f48838a0e8e" />


## Motivation / context

Closes #1944

## Areas touched

<!-- Check all that apply -->

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- How File & Classes are linked 

**Explicitly out of scope / not done here**

- Support new kinds of links or improving visual styles.

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [ ] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [ ] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(if web changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [x] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

## Risk & rollout

<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed
