### PR TITLE
fix(csharp): capture record and struct heritage

### DIFF
--- a/gitnexus/src/core/ingestion/languages/csharp/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/csharp/captures.ts
@@ -257,7 +257,29 @@ export function emitCsharpScopeCaptures(
   }
 
   out.push(...synthesizeGenericTypeArgumentReferences(tree.rootNode));
+  out.push(...synthesizeBaseClassInheritanceReferences(tree.rootNode));
 
+  return out;
+}
+
+function synthesizeBaseClassInheritanceReferences(root: SyntaxNode): CaptureMatch[] {
+  const out: CaptureMatch[] = [];
+  visit(root, (node) => {
+    if (node.type !== 'class_declaration' && node.type !== 'record_declaration') return;
+
+    const baseList = findNamedChild(node, 'base_list');
+    if (baseList === null) return;
+    const base = baseList.namedChild(0);
+    if (base === null) return;
+    if (base.type !== 'primary_constructor_base_type') return;
+
+    const name = baseLookupName(base);
+    if (name === null) return;
+    out.push({
+      '@reference.inherits': nodeToCapture('@reference.inherits', base),
+      '@reference.name': syntheticCapture('@reference.name', base, name),
+    });
+  });
   return out;
 }
 
@@ -299,6 +321,14 @@ function terminalTypeNameNode(node: SyntaxNode): SyntaxNode | null {
     default:
       return null;
   }
+}
+
+function baseLookupName(node: SyntaxNode): string | null {
+  const typeNode =
+    node.type === 'primary_constructor_base_type' ? node.childForFieldName('type') : node;
+  if (typeNode === null) return null;
+  const nameNode = terminalTypeNameNode(typeNode);
+  return nameNode?.text ?? null;
 }
 
 function findNamedChild(node: SyntaxNode, type: string): SyntaxNode | null {

--- a/gitnexus/src/core/ingestion/languages/csharp/receiver-binding.ts
+++ b/gitnexus/src/core/ingestion/languages/csharp/receiver-binding.ts
@@ -54,13 +54,22 @@ function typeName(typeNode: SyntaxNode): string | null {
  *  form so downstream interpret layer can strip generics/qualifiers
  *  the same way as other type-binding captures. Returns null when the
  *  type has no base (or an empty base_list). */
+function baseTypeText(baseNode: SyntaxNode): string | null {
+  const typeNode =
+    baseNode.type === 'primary_constructor_base_type'
+      ? baseNode.childForFieldName('type')
+      : baseNode;
+  if (typeNode === null) return null;
+  return typeNode.text;
+}
+
 function firstBaseText(typeNode: SyntaxNode): string | null {
   for (let i = 0; i < typeNode.namedChildCount; i++) {
     const child = typeNode.namedChild(i);
     if (child === null || child.type !== 'base_list') continue;
     const firstBase = child.namedChild(0);
     if (firstBase === null) return null;
-    return firstBase.text;
+    return baseTypeText(firstBase);
   }
   return null;
 }

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -1109,6 +1109,39 @@ export const CSHARP_QUERIES = `
   (base_list (identifier) @heritage.extends)) @heritage
 (class_declaration name: (identifier) @heritage.class
   (base_list (generic_name (identifier) @heritage.extends))) @heritage
+(class_declaration name: (identifier) @heritage.class
+  (base_list (qualified_name name: (identifier) @heritage.extends))) @heritage
+(class_declaration name: (identifier) @heritage.class
+  (base_list (qualified_name name: (generic_name (identifier) @heritage.extends)))) @heritage
+
+; Records and structs can also carry base_list entries. Records may inherit a
+; class; structs and records can implement interfaces. Primary-constructor base
+; entries wrap the actual base type under primary_constructor_base_type.type.
+(record_declaration name: (identifier) @heritage.class
+  (base_list (identifier) @heritage.extends)) @heritage
+(record_declaration name: (identifier) @heritage.class
+  (base_list (generic_name (identifier) @heritage.extends))) @heritage
+(record_declaration name: (identifier) @heritage.class
+  (base_list (qualified_name name: (identifier) @heritage.extends))) @heritage
+(record_declaration name: (identifier) @heritage.class
+  (base_list (qualified_name name: (generic_name (identifier) @heritage.extends)))) @heritage
+(record_declaration name: (identifier) @heritage.class
+  (base_list (primary_constructor_base_type type: (identifier) @heritage.extends))) @heritage
+(record_declaration name: (identifier) @heritage.class
+  (base_list (primary_constructor_base_type type: (generic_name (identifier) @heritage.extends)))) @heritage
+(record_declaration name: (identifier) @heritage.class
+  (base_list (primary_constructor_base_type type: (qualified_name name: (identifier) @heritage.extends)))) @heritage
+(record_declaration name: (identifier) @heritage.class
+  (base_list (primary_constructor_base_type type: (qualified_name name: (generic_name (identifier) @heritage.extends))))) @heritage
+
+(struct_declaration name: (identifier) @heritage.class
+  (base_list (identifier) @heritage.extends)) @heritage
+(struct_declaration name: (identifier) @heritage.class
+  (base_list (generic_name (identifier) @heritage.extends))) @heritage
+(struct_declaration name: (identifier) @heritage.class
+  (base_list (qualified_name name: (identifier) @heritage.extends))) @heritage
+(struct_declaration name: (identifier) @heritage.class
+  (base_list (qualified_name name: (generic_name (identifier) @heritage.extends)))) @heritage
 
 ; Interface inheritance: interface IFoo : IBar / interface IFoo : IBar, IBaz
 ; Without these patterns, interface-to-interface relationships are never
@@ -1117,6 +1150,10 @@ export const CSHARP_QUERIES = `
   (base_list (identifier) @heritage.extends)) @heritage
 (interface_declaration name: (identifier) @heritage.class
   (base_list (generic_name (identifier) @heritage.extends))) @heritage
+(interface_declaration name: (identifier) @heritage.class
+  (base_list (qualified_name name: (identifier) @heritage.extends))) @heritage
+(interface_declaration name: (identifier) @heritage.class
+  (base_list (qualified_name name: (generic_name (identifier) @heritage.extends)))) @heritage
 
 ; Write access: obj.field = value
 (assignment_expression

--- a/gitnexus/test/fixtures/lang-resolution/issue-1924-csharp-heritage/src/Contracts/Detail/IQualified.cs
+++ b/gitnexus/test/fixtures/lang-resolution/issue-1924-csharp-heritage/src/Contracts/Detail/IQualified.cs
@@ -1,0 +1,5 @@
+namespace Contracts.Detail;
+
+public interface IQualified
+{
+}

--- a/gitnexus/test/fixtures/lang-resolution/issue-1924-csharp-heritage/src/Contracts/IAuditable.cs
+++ b/gitnexus/test/fixtures/lang-resolution/issue-1924-csharp-heritage/src/Contracts/IAuditable.cs
@@ -1,0 +1,6 @@
+namespace Contracts;
+
+public interface IAuditable
+{
+    bool Save();
+}

--- a/gitnexus/test/fixtures/lang-resolution/issue-1924-csharp-heritage/src/Models/AuditStamp.cs
+++ b/gitnexus/test/fixtures/lang-resolution/issue-1924-csharp-heritage/src/Models/AuditStamp.cs
@@ -1,0 +1,9 @@
+namespace Models;
+
+public struct AuditStamp : Contracts.IAuditable, Contracts.Detail.IQualified
+{
+    public bool Save()
+    {
+        return true;
+    }
+}

--- a/gitnexus/test/fixtures/lang-resolution/issue-1924-csharp-heritage/src/Models/BaseEntity.cs
+++ b/gitnexus/test/fixtures/lang-resolution/issue-1924-csharp-heritage/src/Models/BaseEntity.cs
@@ -1,0 +1,9 @@
+namespace Models;
+
+public record BaseEntity(string Name)
+{
+    public virtual bool Save()
+    {
+        return true;
+    }
+}

--- a/gitnexus/test/fixtures/lang-resolution/issue-1924-csharp-heritage/src/Models/UserRecord.cs
+++ b/gitnexus/test/fixtures/lang-resolution/issue-1924-csharp-heritage/src/Models/UserRecord.cs
@@ -1,0 +1,10 @@
+namespace Models;
+
+public record UserRecord(string Name) : Models.BaseEntity(Name), Contracts.IAuditable
+{
+    public override bool Save()
+    {
+        base.Save();
+        return true;
+    }
+}

--- a/gitnexus/test/integration/resolvers/csharp.test.ts
+++ b/gitnexus/test/integration/resolvers/csharp.test.ts
@@ -2267,14 +2267,9 @@ describe('C# record base resolution (record inheritance + base.Save)', () => {
     expect(all).toContain('UserRecord');
   });
 
-  it('does not emit a spurious self-EXTENDS (record heritage not emitted by C# heritage queries)', () => {
-    // NOTE: C# tree-sitter heritage queries cover class/interface
-    // declarations but not `record_declaration`, so records don't
-    // emit an EXTENDS edge today. The record-base linkage is still
-    // visible via `base.Save()` resolution (next test). This
-    // assertion pins the negative invariant so a future heritage
-    // extension for records can flip both tests at once.
+  it('emits EXTENDS for record inheritance without a self-edge', () => {
     const extends_ = getRelationships(result, 'EXTENDS');
+    expect(edgeSet(extends_)).toContain('UserRecord → BaseEntity');
     const selfExtend = extends_.find((e) => e.source === 'UserRecord' && e.target === 'UserRecord');
     expect(selfExtend).toBeUndefined();
   });
@@ -2288,13 +2283,6 @@ describe('C# record base resolution (record inheritance + base.Save)', () => {
         c.targetFilePath === 'src/Models/BaseEntity.cs',
     );
     expect(baseSave).toBeDefined();
-    // NOTE: no `rel.reason` assertion here. Records don't emit EXTENDS
-    // edges today (see the negative-invariant test above), so the
-    // super-branch MRO lookup returns no ancestor and the edge is
-    // produced by the downstream reference-index fallback instead of
-    // the canonical super path. The `csharp-super-resolution` and
-    // `csharp-generic-parent` suites pin the super-branch reason on
-    // paths that do go through MRO.
     const selfSave = calls.find(
       (c) =>
         c.source === 'Save' &&
@@ -2302,6 +2290,44 @@ describe('C# record base resolution (record inheritance + base.Save)', () => {
         c.targetFilePath === 'src/Models/UserRecord.cs',
     );
     expect(selfSave).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #1924 F10/F11: record/struct heritage plus qualified and
+// primary-constructor base types.
+// ---------------------------------------------------------------------------
+
+describe('C# record/struct heritage capture gaps (#1924 F10/F11)', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(path.join(FIXTURES, 'issue-1924-csharp-heritage'), () => {});
+  }, 60000);
+
+  it('emits EXTENDS for qualified primary-constructor record bases', () => {
+    const extends_ = getRelationships(result, 'EXTENDS');
+    expect(edgeSet(extends_)).toContain('UserRecord → BaseEntity');
+  });
+
+  it('emits IMPLEMENTS for record and struct qualified interface bases', () => {
+    const implements_ = getRelationships(result, 'IMPLEMENTS');
+    const edges = edgeSet(implements_);
+    expect(edges).toContain('UserRecord → IAuditable');
+    expect(edges).toContain('AuditStamp → IAuditable');
+    expect(edges).toContain('AuditStamp → IQualified');
+  });
+
+  it('keeps base.Save() on the record bound to BaseEntity.Save', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const baseSave = calls.find(
+      (c) =>
+        c.source === 'Save' &&
+        c.target === 'Save' &&
+        c.sourceFilePath === 'src/Models/UserRecord.cs' &&
+        c.targetFilePath === 'src/Models/BaseEntity.cs',
+    );
+    expect(baseSave).toBeDefined();
   });
 });
 

--- a/gitnexus/test/unit/scope-resolution/csharp/csharp-captures.test.ts
+++ b/gitnexus/test/unit/scope-resolution/csharp/csharp-captures.test.ts
@@ -308,6 +308,18 @@ describe('emitCsharpScopeCaptures — receiver-binding synthesis (`this` / `base
     expect(baseMatch!['@type-binding.type'].text).toBe('BaseModel');
   });
 
+  it('emits primary-constructor base binding without constructor arguments', () => {
+    const matches = emitCsharpScopeCaptures(
+      'record User(string Name) : Models.BaseEntity(Name) { public bool M() { base.Save(); return true; } }',
+      'test.cs',
+    );
+    const baseMatch = matches.find(
+      (m) => '@type-binding.self' in m && m['@type-binding.name'].text === 'base',
+    );
+    expect(baseMatch).toBeDefined();
+    expect(baseMatch!['@type-binding.type'].text).toBe('Models.BaseEntity');
+  });
+
   it('does not emit `this` or `base` for static methods', () => {
     const matches = emitCsharpScopeCaptures('class User { public static void M() { } }', 'test.cs');
     const receiverMatches = matches.filter((m) => '@type-binding.self' in m);
@@ -464,5 +476,20 @@ describe('emitCsharpScopeCaptures — references', () => {
       .map((m) => m['@reference.name'].text);
 
     expect(names).toContain('USER_INFO');
+  });
+
+  it('synthesizes inheritance reference for primary-constructor record base types', () => {
+    const matches = emitCsharpScopeCaptures(
+      'record User(string Name) : Models.BaseEntity(Name) { }',
+      'test.cs',
+    );
+    const inherits = matches.find((m) => '@reference.inherits' in m);
+    expect(inherits).toBeDefined();
+    expect(inherits!['@reference.name'].text).toBe('BaseEntity');
+  });
+
+  it('does not synthesize scope inheritance for interface-only class bases', () => {
+    const matches = emitCsharpScopeCaptures('class Worker : IJob { }', 'test.cs');
+    expect(matches.some((m) => '@reference.inherits' in m)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- capture C# record and struct base_list heritage, including qualified and generic base names
- strip primary-constructor base arguments for base receiver binding and scope inheritance references
- add issue #1924 F10/F11 fixture coverage for record EXTENDS, record/struct IMPLEMENTS, and base.Save resolution

## Tests
- npx vitest run test/unit/scope-resolution/csharp/csharp-captures.test.ts --maxWorkers=1
- npx vitest run test/integration/query-compilation.test.ts --maxWorkers=1
- npx vitest run test/integration/resolvers/csharp.test.ts --maxWorkers=1
- npx tsc --noEmit
- npm test (local Windows full-suite run: 10182 passed; 4 failed. Reruns passed for phase-timer and parse-impl-large-fixture. The remaining isolated failures are existing local Windows/upstream-main issues: literal-collectors POSIX path suffix expectation and worker/sequential parity on the latest File->Member DEFINES change. Upstream main CI is green at 070c3d51.)
- node .\\gitnexus\\dist\\cli\\index.js detect-changes

Refs #1924 (F10/F11 scoped slice).