### PR TITLE
ci(devcontainer): harden smoke build against Docker Hub flakes

### DIFF
--- a/.github/workflows/ci-devcontainer.yml
+++ b/.github/workflows/ci-devcontainer.yml
@@ -88,9 +88,12 @@ jobs:
       # @devcontainers/cli wraps the Dockerfile with `# syntax=docker/dockerfile:1`,
       # which BuildKit resolves from Docker Hub. Hub blips surface as
       # `DeadlineExceeded` / `i/o timeout` on the syntax frontend (see run
-      # 26797815133). Pre-pull plus one build retry matches the policy in
+      # 26797815133). Build retry (2 attempts, 45s backoff) matches
       # `.github/actions/docker-build-push-retry` (docker/build-push-action#1422).
+      # Pre-pull of docker/dockerfile:1 is extra hardening; best-effort so the
+      # build retry still runs if Hub is flaky only during pull.
       - name: Pre-pull BuildKit Dockerfile frontend (retry)
+        continue-on-error: true
         run: |
           set -euo pipefail
           img="docker/dockerfile:1"
@@ -103,13 +106,16 @@ jobs:
               sleep $((attempt * 15))
             fi
           done
-          echo "::error::failed to pull ${img} after 3 attempts"
+          echo "::warning::failed to pre-pull ${img} after 3 attempts; continuing — build step may still succeed"
           exit 1
       - name: Build devcontainer via @devcontainers/cli
         run: |
           set -euo pipefail
           for attempt in 1 2; do
             if npx --yes @devcontainers/cli@0.87.0 build --workspace-folder .; then
+              if [ "$attempt" -eq 2 ]; then
+                echo "::notice::devcontainer build retry succeeded (attempt 2); investigate if this recurs across runs."
+              fi
               exit 0
             fi
             if [ "$attempt" -eq 2 ]; then

--- a/.github/workflows/ci-devcontainer.yml
+++ b/.github/workflows/ci-devcontainer.yml
@@ -84,5 +84,38 @@ jobs:
       # breaking or malicious publish could then change CI behavior, or change
       # how devcontainer.json is read, with no diff to show for it. Bump this pin
       # deliberately, alongside the Dockerfile and devcontainer.json pins.
+      #
+      # @devcontainers/cli wraps the Dockerfile with `# syntax=docker/dockerfile:1`,
+      # which BuildKit resolves from Docker Hub. Hub blips surface as
+      # `DeadlineExceeded` / `i/o timeout` on the syntax frontend (see run
+      # 26797815133). Pre-pull plus one build retry matches the policy in
+      # `.github/actions/docker-build-push-retry` (docker/build-push-action#1422).
+      - name: Pre-pull BuildKit Dockerfile frontend (retry)
+        run: |
+          set -euo pipefail
+          img="docker/dockerfile:1"
+          for attempt in 1 2 3; do
+            if docker pull "$img"; then
+              exit 0
+            fi
+            echo "::warning::docker pull ${img} attempt ${attempt} failed"
+            if [ "$attempt" -lt 3 ]; then
+              sleep $((attempt * 15))
+            fi
+          done
+          echo "::error::failed to pull ${img} after 3 attempts"
+          exit 1
       - name: Build devcontainer via @devcontainers/cli
-        run: npx --yes @devcontainers/cli@0.87.0 build --workspace-folder .
+        run: |
+          set -euo pipefail
+          for attempt in 1 2; do
+            if npx --yes @devcontainers/cli@0.87.0 build --workspace-folder .; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 2 ]; then
+              echo "::error::devcontainer build failed after 2 attempts"
+              exit 1
+            fi
+            echo "::warning::devcontainer build attempt ${attempt} failed; retrying in 45s…"
+            sleep 45
+          done


### PR DESCRIPTION
## Summary

- Fixes flaky **Devcontainer Smoke** failures on `main` (e.g. [run 26797815133](https://github.com/abhigyanpatwari/GitNexus/actions/runs/26797815133)) where BuildKit timed out pulling `docker/dockerfile:1` for the syntax frontend injected by `@devcontainers/cli`.
- Pre-pull `docker/dockerfile:1` with up to 3 attempts and 15s/30s backoff before the build.
- Retry the `@devcontainers/cli` build once after 45s on failure, aligned with `.github/actions/docker-build-push-retry`.

## Test plan

- [ ] **Devcontainer Smoke** workflow passes on this PR (build job should complete).
- [ ] Config-transform unit tests job still passes (unchanged).

Made with [Cursor](https://cursor.com)