### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -19,7 +19,7 @@ Evaluate whether GitNexus code intelligence improves AI agent performance on rea
 **Models supported:**
 
 - Claude 3.5 Haiku, Claude Sonnet 4, Claude Opus 4
-- MiniMax M1 2.5
+- MiniMax M3, M2.7
 - GLM 4.7, GLM 5
 - Any model supported by litellm (add a YAML config)
 

--- a/eval/configs/models/minimax-2.5.yaml
+++ b/eval/configs/models/minimax-2.5.yaml
@@ -1,7 +1,0 @@
-# MiniMax M1 2.5 — via OpenRouter (set OPENROUTER_API_KEY in .env)
-model:
-  model_name: 'openrouter/minimax/minimax-m1-2.5'
-  cost_tracking: 'ignore_errors'
-  model_kwargs:
-    max_tokens: 8192
-    temperature: 0

--- a/eval/configs/models/minimax-m2.7.yaml
+++ b/eval/configs/models/minimax-m2.7.yaml
@@ -1,9 +1,9 @@
-# MiniMax M2.5 — via OpenRouter (set OPENROUTER_API_KEY in .env)
+# MiniMax M2.7 — via OpenRouter (set OPENROUTER_API_KEY in .env)
 # Uses text-based model class because MiniMax doesn't support tool_calls natively.
 # The action_regex tells mini-swe-agent to parse ```bash blocks from responses.
 model:
   model_class: litellm_textbased
-  model_name: 'openrouter/minimax/minimax-m2.5'
+  model_name: 'openrouter/minimax/minimax-m2.7'
   action_regex: "```(?:bash|mswea_bash_command)\\s*\\n(.*?)\\n```"
   cost_tracking: 'ignore_errors'
   model_kwargs:

--- a/eval/configs/models/minimax-m3.yaml
+++ b/eval/configs/models/minimax-m3.yaml
@@ -1,0 +1,11 @@
+# MiniMax M3 — via OpenRouter (set OPENROUTER_API_KEY in .env)
+# Uses text-based model class because MiniMax doesn't support tool_calls natively.
+# The action_regex tells mini-swe-agent to parse ```bash blocks from responses.
+model:
+  model_class: litellm_textbased
+  model_name: 'openrouter/minimax/minimax-m3'
+  action_regex: "```(?:bash|mswea_bash_command)\\s*\\n(.*?)\\n```"
+  cost_tracking: 'ignore_errors'
+  model_kwargs:
+    max_tokens: 8192
+    temperature: 0

--- a/gitnexus-claude-plugin/skills/gitnexus-cli/SKILL.md
+++ b/gitnexus-claude-plugin/skills/gitnexus-cli/SKILL.md
@@ -59,7 +59,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 | Flag | Effect |
 |------|--------|
 | `--force` | Force full regeneration, also required to re-gerenate an existing wiki in a different language |
-| `--model <model>` | LLM model (default: minimax/minimax-m2.5) |
+| `--model <model>` | LLM model (default: minimax/minimax-m3) |
 | `--base-url <url>` | LLM API base URL |
 | `--api-key <key>` | LLM API key |
 | `--concurrency <n>` | Parallel LLM calls (default: 3) |

--- a/gitnexus-web/src/components/SettingsPanel.tsx
+++ b/gitnexus-web/src/components/SettingsPanel.tsx
@@ -847,7 +847,7 @@ export const SettingsPanel = ({
                 onToggleVisibility: () => toggleApiKeyVisibility('minimax'),
               }}
               model={{
-                value: settings.minimax?.model ?? 'MiniMax-M2.5',
+                value: settings.minimax?.model ?? 'MiniMax-M3',
                 placeholder: t('settings:providers.minimax.modelPlaceholder'),
                 onChange: (value) =>
                   setSettings((prev) => ({

--- a/gitnexus-web/src/core/llm/settings-service.ts
+++ b/gitnexus-web/src/core/llm/settings-service.ts
@@ -437,7 +437,7 @@ export const getAvailableModels = (provider: LLMProvider): string[] => {
     case 'ollama':
       return ['llama3.2', 'llama3.1', 'mistral', 'codellama', 'deepseek-coder'];
     case 'minimax':
-      return ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed'];
+      return ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'];
     case 'glm':
       return ['GLM-5', 'GLM-5-Turbo', 'GLM-4.7', 'GLM-4.5'];
     case 'deepseek':

--- a/gitnexus-web/src/core/llm/types.ts
+++ b/gitnexus-web/src/core/llm/types.ts
@@ -94,7 +94,7 @@ export interface OpenRouterConfig extends BaseProviderConfig {
 export interface MiniMaxConfig extends BaseProviderConfig {
   provider: 'minimax';
   apiKey: string;
-  model: string; // e.g., 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'
+  model: string; // e.g., 'MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'
 }
 
 /**
@@ -200,7 +200,7 @@ export const DEFAULT_LLM_SETTINGS: LLMSettings = {
   },
   minimax: {
     apiKey: '',
-    model: 'MiniMax-M2.5',
+    model: 'MiniMax-M3',
     temperature: 0.1,
   },
   glm: {

--- a/gitnexus-web/src/locales/en/settings.json
+++ b/gitnexus-web/src/locales/en/settings.json
@@ -65,8 +65,8 @@
       "apiKeyPlaceholder": "Enter your MiniMax API key",
       "helperText": "Get your API key from",
       "helperLinkLabel": "MiniMax Platform",
-      "modelPlaceholder": "e.g., MiniMax-M2.5, MiniMax-M2.5-highspeed",
-      "helperModel": "Available: MiniMax-M2.5 (default), MiniMax-M2.5-highspeed (faster)"
+      "modelPlaceholder": "e.g., MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed",
+      "helperModel": "Available: MiniMax-M3 (default), MiniMax-M2.7, MiniMax-M2.7-highspeed (faster)"
     },
     "glm": {
       "apiKeyPlaceholder": "Enter your Z.AI API key"

--- a/gitnexus-web/src/locales/zh-CN/settings.json
+++ b/gitnexus-web/src/locales/zh-CN/settings.json
@@ -65,8 +65,8 @@
       "apiKeyPlaceholder": "输入 MiniMax API Key",
       "helperText": "从这里获取 API Key：",
       "helperLinkLabel": "MiniMax Platform",
-      "modelPlaceholder": "例如：MiniMax-M2.5、MiniMax-M2.5-highspeed",
-      "helperModel": "可用：MiniMax-M2.5（默认）、MiniMax-M2.5-highspeed（更快）"
+      "modelPlaceholder": "例如：MiniMax-M3、MiniMax-M2.7、MiniMax-M2.7-highspeed",
+      "helperModel": "可用：MiniMax-M3（默认）、MiniMax-M2.7、MiniMax-M2.7-highspeed（更快）"
     },
     "glm": {
       "apiKeyPlaceholder": "输入 Z.AI API Key"

--- a/gitnexus/skills/gitnexus-cli.md
+++ b/gitnexus/skills/gitnexus-cli.md
@@ -59,7 +59,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 | Flag                | Effect                                    |
 | ------------------- | ----------------------------------------- |
 | `--force`           | Force full regeneration                   |
-| `--model <model>`   | LLM model (default: minimax/minimax-m2.5) |
+| `--model <model>`   | LLM model (default: minimax/minimax-m3) |
 | `--base-url <url>`  | LLM API base URL                          |
 | `--api-key <key>`   | LLM API key                               |
 | `--concurrency <n>` | Parallel LLM calls (default: 3)           |

--- a/gitnexus/src/cli/i18n/en.ts
+++ b/gitnexus/src/cli/i18n/en.ts
@@ -190,7 +190,7 @@ export const en = {
   'help.option.wiki.force': 'Force full regeneration even if up to date',
   'help.option.wiki.provider':
     'LLM provider: openai, openrouter, azure, custom, cursor, claude, or codex (default: openai)',
-  'help.option.wiki.model': 'LLM model or Azure deployment name (default: minimax/minimax-m2.5)',
+  'help.option.wiki.model': 'LLM model or Azure deployment name (default: minimax/minimax-m3)',
   'help.option.wiki.baseUrl':
     'LLM API base URL. Azure v1: https://{resource}.openai.azure.com/openai/v1',
   'help.option.wiki.apiKey': 'LLM API key or Azure api-key (saved to ~/.gitnexus/config.json)',

--- a/gitnexus/src/cli/i18n/zh-CN.ts
+++ b/gitnexus/src/cli/i18n/zh-CN.ts
@@ -179,7 +179,7 @@ export const zhCN = {
   'help.option.wiki.force': '即使已是最新也强制完整重新生成',
   'help.option.wiki.provider':
     'LLM 提供商：openai、openrouter、azure、custom、cursor、claude 或 codex（默认：openai）',
-  'help.option.wiki.model': 'LLM 模型或 Azure deployment 名称（默认：minimax/minimax-m2.5）',
+  'help.option.wiki.model': 'LLM 模型或 Azure deployment 名称（默认：minimax/minimax-m3）',
   'help.option.wiki.baseUrl':
     'LLM API base URL。Azure v1：https://{resource}.openai.azure.com/openai/v1',
   'help.option.wiki.apiKey': 'LLM API key 或 Azure api-key（保存到 ~/.gitnexus/config.json）',

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -152,7 +152,7 @@ program
     '--provider <provider>',
     'LLM provider: openai, openrouter, azure, custom, cursor, claude, or codex (default: openai)',
   )
-  .option('--model <model>', 'LLM model or Azure deployment name (default: minimax/minimax-m2.5)')
+  .option('--model <model>', 'LLM model or Azure deployment name (default: minimax/minimax-m3)')
   .option(
     '--base-url <url>',
     'LLM API base URL. Azure v1: https://{resource}.openai.azure.com/openai/v1',

--- a/gitnexus/src/cli/wiki.ts
+++ b/gitnexus/src/cli/wiki.ts
@@ -389,7 +389,7 @@ const wikiCommandImpl = async (inputPath?: string, options?: WikiCommandOptions)
         // OpenAI-compatible provider (OpenAI, OpenRouter, Custom)
         if (choice === '2') {
           baseUrl = 'https://openrouter.ai/api/v1';
-          defaultModel = 'minimax/minimax-m2.5';
+          defaultModel = 'minimax/minimax-m3';
           provider = 'openrouter';
         } else if (choice === '4') {
           baseUrl = await prompt('  Base URL (e.g. http://localhost:11434/v1): ');

--- a/gitnexus/src/core/wiki/llm-client.ts
+++ b/gitnexus/src/core/wiki/llm-client.ts
@@ -81,7 +81,7 @@ export async function resolveLLMConfig(overrides?: Partial<LLMConfig>): Promise<
       overrides?.model ||
       (localProvider ? undefined : process.env.GITNEXUS_MODEL) ||
       savedLocalModel ||
-      (localProvider ? '' : savedConfig.model || 'minimax/minimax-m2.5'),
+      (localProvider ? '' : savedConfig.model || 'minimax/minimax-m3'),
     maxTokens: overrides?.maxTokens ?? 16_384,
     temperature: overrides?.temperature ?? 0,
     provider: savedProvider ?? 'openai',

--- a/gitnexus/test/unit/wiki-flags.test.ts
+++ b/gitnexus/test/unit/wiki-flags.test.ts
@@ -196,7 +196,7 @@ describe('resolveLLMConfig', () => {
     vi.doMock('../../src/storage/repo-manager.js', () => ({
       loadCLIConfig: vi.fn().mockResolvedValue({
         provider: 'openai',
-        model: 'minimax/minimax-m2.5',
+        model: 'minimax/minimax-m3',
       }),
     }));
 
@@ -216,7 +216,7 @@ describe('resolveLLMConfig', () => {
     const config = await resolveLLMConfig();
 
     expect(config.provider).toBe('openai');
-    expect(config.model).toBe('minimax/minimax-m2.5');
+    expect(config.model).toBe('minimax/minimax-m3');
     expect(config.baseUrl).toBe('https://openrouter.ai/api/v1');
   });
 

--- a/gitnexus/test/unit/wiki-llm-client.test.ts
+++ b/gitnexus/test/unit/wiki-llm-client.test.ts
@@ -54,7 +54,7 @@ describe('isReasoningModel', () => {
   });
 
   it('returns false for minimax', () => {
-    expect(isReasoningModel('minimax/minimax-m2.5')).toBe(false);
+    expect(isReasoningModel('minimax/minimax-m3')).toBe(false);
   });
 
   it('respects explicit override', () => {


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model.

## Changes
- Add `MiniMax-M3` to the model selection list and set as default
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove older models (M2.5/M2.1/M2/M1)
- Update CLI default for `--model` flag (`minimax/minimax-m3`)
- Update related unit tests (`wiki-llm-client.test.ts`, `wiki-flags.test.ts`)
- Update i18n / locale strings (en + zh-CN, web + CLI)
- Update eval configs: replace `minimax-2.5.yaml` (M1 2.5) with `minimax-m3.yaml`; rename `minimax-m2.1.yaml` to `minimax-m2.7.yaml` (model ID also updated to `m2.7`)

## Why
`MiniMax-M3` is the latest model, with a 512K context window, up to 128K output, and image input support.

## Testing
- Unit tests updated to reference `minimax/minimax-m3`
- Default model resolution path and CLI help text verified by grep — no stale `M2.5` / `m2.5` references remain in code