### PR TITLE
test(cli): make cli-e2e read-only + eval-server tests robust under load

### DIFF
--- a/gitnexus/test/integration/cli-e2e.test.ts
+++ b/gitnexus/test/integration/cli-e2e.test.ts
@@ -70,7 +70,23 @@ beforeAll(() => {
       GIT_COMMITTER_EMAIL: 'test@test',
     },
   });
-});
+
+  // Index MINI_REPO ONCE into the isolated suite registry so the read-only
+  // tests (query/cypher/impact, eval-server) have a registered repo regardless
+  // of execution order. Previously they relied on an earlier analyze test
+  // having run, and that test silently tolerates a subprocess timeout under
+  // load — so on a busy runner the repo went unregistered and every dependent
+  // test failed confusingly with "no indexed repositories" / exit 1.
+  //
+  // Retried a few times because a tiny fixture analyzes in seconds: a failure
+  // here is almost always transient load, not a defect. Re-running analyze on
+  // an already-indexed repo is a cheap no-op (alreadyUpToDate fast path), so
+  // retrying is safe. A genuine analyze/registration regression is still caught
+  // loudly by the dedicated analyze tests below (which use isolated homes).
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (runCli('analyze', MINI_REPO, 90_000).status === 0) break;
+  }
+}, 300_000);
 
 afterAll(() => {
   // Entire tmp copy goes away — no selective cleanup needed. The shared
@@ -1231,7 +1247,9 @@ describe('CLI end-to-end', () => {
 
   // All tool commands pass --repo to disambiguate when the global registry
   // has multiple indexed repos (e.g. the parent project is also indexed).
-  describe('tool output goes to stdout via fd 1 (#324)', () => {
+  // retry: these spawn the CLI against the suite-indexed mini-repo; a retry
+  // absorbs a transient subprocess hiccup under parallel load (#324 hardening).
+  describe('tool output goes to stdout via fd 1 (#324)', { retry: 2 }, () => {
     it('cypher: JSON appears on stdout, not stderr', () => {
       const result = runCliRaw(
         ['cypher', 'MATCH (n) RETURN n.name LIMIT 3', '--repo', 'mini-repo'],
@@ -1290,7 +1308,7 @@ describe('CLI end-to-end', () => {
 
   // ─── EPIPE clean exit test (#324) ───────────────────────────────────
 
-  describe('EPIPE handling (#324)', () => {
+  describe('EPIPE handling (#324)', { retry: 2 }, () => {
     it('cypher: EPIPE exits with code 0, not stderr dump', () => {
       return new Promise<void>((resolve, reject) => {
         const child = spawn(
@@ -1348,7 +1366,7 @@ describe('CLI end-to-end', () => {
 
   // ─── eval-server READY signal test (#324) ───────────────────────────
 
-  describe('eval-server READY signal (#324)', () => {
+  describe('eval-server READY signal (#324)', { retry: 2 }, () => {
     it('READY signal appears on stdout, not stderr', () => {
       return new Promise<void>((resolve, reject) => {
         const child = spawn(
@@ -1410,7 +1428,7 @@ describe('CLI end-to-end', () => {
   // Verifies --host is wired to the actual bind address, not just accepted.
   // Original flag registration test by Val Vladescu (PR #1602).
 
-  describe('eval-server --host flag', () => {
+  describe('eval-server --host flag', { retry: 2 }, () => {
     it('emits READY signal containing the bound host 127.0.0.1', () => {
       return runEvalServerHostFlagTest(
         ['--port', '0', '--host', '127.0.0.1', '--idle-timeout', '3'],


### PR DESCRIPTION
## Problem

The `cli-e2e.test.ts` read-only tests (`query`/`cypher`/`impact` "JSON on stdout", the EPIPE test) and the `eval-server` tests are flaky under parallel CI load — failing with `expected 1 to be 0` (exit 1) or `eval-server exited unexpectedly … No indexed repositories found`.

**Root cause (reproduced):** those tests assume `mini-repo` was already indexed into the suite's isolated registry by an *earlier* test (`analyze command runs pipeline on mini-repo`). That analyze test silently tolerates a subprocess timeout:

```ts
const result = runCli('analyze', MINI_REPO, 30000);
if (result.status === null) return; // CI timeout tolerance
```

`cli-e2e.test.ts` runs in the `default` integration project (in parallel with the rest of the suite), so under load the 30 s analyze times out, the test "passes" via that tolerance **without registering the repo**, and every downstream test that needs an indexed repo then fails confusingly. Confirmed locally: running only the stdout tests (so no prior analyze runs) reproduces `expected 1 to be 0` exactly.

## Fix

- **`beforeAll` indexes `mini-repo` once** into the isolated suite registry (retried a few times with a generous timeout). Re-analyzing an already-indexed repo is a cheap `alreadyUpToDate` no-op, so the retry is safe. This removes the implicit cross-test ordering dependency — the read-only/eval-server tests no longer depend on some other test having analyzed.
- **The four dependent describes get `{ retry: 2 }`** (Vitest-4 second-argument options) so a transient subprocess hiccup self-heals rather than failing the suite.

Genuine `analyze`/registration regressions are still caught loudly by the dedicated analyze tests (`#1169`, `#829`), which use their own isolated `GITNEXUS_HOME`s and hard-assert — so this does not mask real breakage.

## Verification

```bash
cd gitnexus && npx vitest run test/integration/cli-e2e.test.ts
# Test Files 1 passed (1) — Tests 34 passed (34)
```

- Before: running the stdout tests without a prior analyze → 3 fail (`expected 1 to be 0`).
- After: full file 34/34 pass; the previously-flaky stdout/EPIPE/eval-server tests run and assert (no longer order-dependent).

Test-only change; no runtime/`src` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)