### PR TITLE
refactor(ingestion): share a codec for __heritage__/__property__ markers (Ruby + Dart) (#1994)

### DIFF
--- a/gitnexus/src/core/ingestion/languages/dart/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/dart/captures.ts
@@ -42,7 +42,7 @@ import { getDartParser, getDartScopeQuery } from './query.js';
 import { recordCacheHit, recordCacheMiss } from './cache-stats.js';
 import { getTreeSitterBufferSize } from '../../constants.js';
 import { parseSourceSafe } from '../../../tree-sitter/safe-parse.js';
-import { DART_HERITAGE_PREFIX } from './interpret.js';
+import { encodeMarker } from '../../utils/heritage-marker.js';
 import { DART_BUILT_INS } from './built-ins.js';
 
 const FUNCTION_DECL_TAGS = [
@@ -491,7 +491,7 @@ function emitHeritageMarkers(
   for (let i = 0; i < container.namedChildCount; i++) {
     const c = container.namedChild(i);
     if (c === null || c.type !== 'type_identifier') continue;
-    const payload = `${DART_HERITAGE_PREFIX}${kind}:${c.text}:${className}`;
+    const payload = encodeMarker('heritage', [kind, c.text, className]);
     out.push({ '@import.heritage': syntheticCapture('@import.heritage', c, payload) });
   }
 }

--- a/gitnexus/src/core/ingestion/languages/dart/interpret.ts
+++ b/gitnexus/src/core/ingestion/languages/dart/interpret.ts
@@ -15,10 +15,13 @@
  */
 
 import type { CaptureMatch, ParsedImport, ParsedTypeBinding, TypeRef } from 'gitnexus-shared';
+import { HERITAGE_MARKER_PREFIX } from '../../utils/heritage-marker.js';
 
 /** Marker prefix carried on a side-effect `ParsedImport.targetRaw` for
- *  `implements`/`with` heritage, consumed by `emitDartHeritageEdges`. */
-export const DART_HERITAGE_PREFIX = '__heritage__:';
+ *  `implements`/`with` heritage, consumed by `emitDartHeritageEdges`. Aliased to
+ *  the shared codec prefix (#1994) so the Dart wire prefix has a single source of
+ *  truth and cannot desync from `encodeMarker`/`decodeMarker`. */
+export const DART_HERITAGE_PREFIX = HERITAGE_MARKER_PREFIX;
 
 function stripQuotes(s: string): string {
   return s.replace(/^['"]|['"]$/g, '');

--- a/gitnexus/src/core/ingestion/languages/dart/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/languages/dart/scope-resolver.ts
@@ -36,12 +36,8 @@ import type { KnowledgeGraph } from '../../../graph/types.js';
 import type { ScopeResolver } from '../../scope-resolution/contract/scope-resolver.js';
 import { generateId } from '../../../../lib/utils.js';
 import { dartProvider } from '../dart.js';
-import {
-  dartArityCompatibility,
-  dartMergeBindings,
-  resolveDartImportTarget,
-  DART_HERITAGE_PREFIX,
-} from './index.js';
+import { dartArityCompatibility, dartMergeBindings, resolveDartImportTarget } from './index.js';
+import { decodeMarker } from '../../utils/heritage-marker.js';
 import { expandDartWildcardNames } from './expand-wildcards.js';
 
 interface ClassDefRef {
@@ -109,8 +105,10 @@ function emitDartHeritageEdges(
   for (const parsed of parsedFiles) {
     for (const imp of parsed.parsedImports) {
       const raw = imp.targetRaw;
-      if (typeof raw !== 'string' || !raw.startsWith(DART_HERITAGE_PREFIX)) continue;
-      const parts = raw.slice(DART_HERITAGE_PREFIX.length).split(':');
+      if (typeof raw !== 'string') continue;
+      const decoded = decodeMarker(raw);
+      if (decoded?.kind !== 'heritage') continue;
+      const parts = decoded.fields;
       if (parts.length < 3) continue;
       const [kind, baseName, childName] = parts;
       const childId = pickClassByName(childName!, parsed.filePath, defsByName);

--- a/gitnexus/src/core/ingestion/languages/ruby/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/ruby/captures.ts
@@ -13,6 +13,7 @@ import { synthesizeRubyReceiverBinding, findEnclosingClassOrModule } from './rec
 import { getTreeSitterBufferSize } from '../../constants.js';
 import { parseSourceSafe } from '../../../tree-sitter/safe-parse.js';
 import { splitQualifiedName } from '../../utils/qualified-name.js';
+import { encodeMarker } from '../../utils/heritage-marker.js';
 
 const FUNCTION_NODE_TYPES = ['method', 'singleton_method'] as const;
 const HERITAGE_CALL_NAMES: ReadonlySet<string> = new Set(['include', 'extend', 'prepend']);
@@ -193,7 +194,7 @@ export function emitRubyScopeCaptures(
                     '@import.source': syntheticCapture(
                       '@import.source',
                       callNode,
-                      `__heritage__:${callName}:${mixinName}:${ownerName}`,
+                      encodeMarker('heritage', [callName, mixinName, ownerName]),
                     ),
                     '@import.name': syntheticCapture('@import.name', callNode, mixinName),
                   });
@@ -227,7 +228,7 @@ export function emitRubyScopeCaptures(
                     '@import.source': syntheticCapture(
                       '@import.source',
                       callNode,
-                      `__property__:${callName}:${propName}:${ownerName}`,
+                      encodeMarker('property', [callName, propName, ownerName]),
                     ),
                     '@import.name': syntheticCapture('@import.name', callNode, propName),
                   });

--- a/gitnexus/src/core/ingestion/languages/ruby/import-target.ts
+++ b/gitnexus/src/core/ingestion/languages/ruby/import-target.ts
@@ -9,6 +9,7 @@
 
 import { resolveRubyImportInternal } from '../../import-resolvers/ruby.js';
 import { buildSuffixIndex } from '../../import-resolvers/utils.js';
+import { isHeritageMarker } from '../../utils/heritage-marker.js';
 
 export interface RubyResolveContext {
   readonly fromFile: string;
@@ -37,7 +38,7 @@ export function resolveRubyImportTarget(
   _resolutionConfig?: unknown,
 ): string | readonly string[] | null {
   if (!targetRaw) return null;
-  if (targetRaw.startsWith('__heritage__:') || targetRaw.startsWith('__property__:')) return null;
+  if (isHeritageMarker(targetRaw)) return null;
 
   const fromNormalized = fromFile.replace(/\\/g, '/');
   const fromDir = fromNormalized.includes('/')

--- a/gitnexus/src/core/ingestion/languages/ruby/interpret.ts
+++ b/gitnexus/src/core/ingestion/languages/ruby/interpret.ts
@@ -1,4 +1,5 @@
 import type { CaptureMatch, ParsedImport, ParsedTypeBinding, TypeRef } from 'gitnexus-shared';
+import { isHeritageMarker } from '../../utils/heritage-marker.js';
 
 // ─── interpretImport ──────────────────────────────────────────────────────
 
@@ -21,7 +22,7 @@ export function interpretRubyImport(captures: CaptureMatch): ParsedImport | null
 
   // Heritage-encoded imports (__heritage__:include:Serializable:User)
   // are stored as namespace imports so emitHeritageEdges can read them.
-  if (source.startsWith('__heritage__:') || source.startsWith('__property__:')) {
+  if (isHeritageMarker(source)) {
     const name = captures['@import.name']?.text ?? source;
     return { kind: 'namespace', localName: name, importedName: name, targetRaw: source };
   }

--- a/gitnexus/src/core/ingestion/languages/ruby/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/languages/ruby/scope-resolver.ts
@@ -9,9 +9,7 @@ import { resolveDefGraphId } from '../../scope-resolution/graph-bridge/ids.js';
 import type { GraphNodeLookup } from '../../scope-resolution/graph-bridge/node-lookup.js';
 import type { KnowledgeGraph } from '../../../graph/types.js';
 import { generateId } from '../../../../lib/utils.js';
-
-const HERITAGE_PREFIX = '__heritage__:';
-const PROPERTY_PREFIX = '__property__:';
+import { decodeMarker } from '../../utils/heritage-marker.js';
 
 /**
  * #1991: resolve a BARE mixin reference (`include Loggable`) to a nested module by
@@ -85,8 +83,9 @@ function emitRubyMixinEdges(
 
   for (const parsed of parsedFiles) {
     for (const imp of parsed.parsedImports) {
-      if (!imp.targetRaw.startsWith(HERITAGE_PREFIX)) continue;
-      const parts = imp.targetRaw.slice(HERITAGE_PREFIX.length).split(':');
+      const decoded = decodeMarker(imp.targetRaw);
+      if (decoded?.kind !== 'heritage') continue;
+      const parts = decoded.fields;
       if (parts.length < 3) continue;
       const [kind, mixinName, className] = parts;
       const classGraphId = graphIdByName.get(className!);
@@ -127,8 +126,9 @@ function emitRubyMixinEdges(
 
   for (const parsed of parsedFiles) {
     for (const imp of parsed.parsedImports) {
-      if (!imp.targetRaw.startsWith(PROPERTY_PREFIX)) continue;
-      const parts = imp.targetRaw.slice(PROPERTY_PREFIX.length).split(':');
+      const decoded = decodeMarker(imp.targetRaw);
+      if (decoded?.kind !== 'property') continue;
+      const parts = decoded.fields;
       if (parts.length < 3) continue;
       const [_attrKind, propName, className] = parts;
       const classGraphId = graphIdByName.get(className!);

--- a/gitnexus/src/core/ingestion/utils/heritage-marker.ts
+++ b/gitnexus/src/core/ingestion/utils/heritage-marker.ts
@@ -1,0 +1,58 @@
+/**
+ * #1994: shared codec for the synthetic `__heritage__:` / `__property__:` import
+ * markers used by the Ruby and Dart scope resolvers to carry side-effect facts
+ * (mixin includes, attr_accessor properties) through the import channel. Both
+ * languages share the exact `':'`-delimited wire format, so a single encode/decode
+ * pair removes the per-site hand-rolled string handling that produced the #1981
+ * edge-drop. Language-NEUTRAL — keyed only on the literal prefixes; no provider
+ * branching belongs here.
+ */
+export type MarkerKind = 'heritage' | 'property';
+
+const PREFIX_BY_KIND: Record<MarkerKind, string> = {
+  heritage: '__heritage__:',
+  property: '__property__:',
+};
+
+export const HERITAGE_MARKER_PREFIX = PREFIX_BY_KIND.heritage;
+export const PROPERTY_MARKER_PREFIX = PREFIX_BY_KIND.property;
+
+/**
+ * Build a marker string `<prefix><field>:<field>:...`. The `':'` delimiter IS the
+ * wire format, so a field that itself contains `':'` is structurally invalid and
+ * THROWS — callers must pre-normalize colon-bearing values (e.g. a qualified mixin
+ * arg `Outer::Mixin` → `Outer.Mixin`). This makes the #1981 silent edge-drop a
+ * loud failure instead.
+ */
+export function encodeMarker(kind: MarkerKind, fields: readonly string[]): string {
+  for (const field of fields) {
+    if (field.includes(':')) {
+      throw new Error(
+        `encodeMarker: field "${field}" contains the ':' delimiter; normalize it before encoding`,
+      );
+    }
+  }
+  return PREFIX_BY_KIND[kind] + fields.join(':');
+}
+
+/**
+ * Parse a marker string back into its kind + positional fields, or `null` if `raw`
+ * is not a marker. Mirrors the historical `slice(PREFIX.length).split(':')`.
+ */
+export function decodeMarker(raw: string): { kind: MarkerKind; fields: string[] } | null {
+  if (raw.startsWith(PREFIX_BY_KIND.heritage)) {
+    return { kind: 'heritage', fields: raw.slice(PREFIX_BY_KIND.heritage.length).split(':') };
+  }
+  if (raw.startsWith(PREFIX_BY_KIND.property)) {
+    return { kind: 'property', fields: raw.slice(PREFIX_BY_KIND.property.length).split(':') };
+  }
+  return null;
+}
+
+/**
+ * True if `raw` is a synthetic heritage/property marker — exactly the prior
+ * `startsWith('__heritage__:') || startsWith('__property__:')` pair.
+ */
+export function isHeritageMarker(raw: string): boolean {
+  return raw.startsWith(PREFIX_BY_KIND.heritage) || raw.startsWith(PREFIX_BY_KIND.property);
+}

--- a/gitnexus/test/unit/ingestion/heritage-marker.test.ts
+++ b/gitnexus/test/unit/ingestion/heritage-marker.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  encodeMarker,
+  decodeMarker,
+  isHeritageMarker,
+  HERITAGE_MARKER_PREFIX,
+  PROPERTY_MARKER_PREFIX,
+} from '../../../src/core/ingestion/utils/heritage-marker.js';
+
+describe('heritage-marker codec (#1994)', () => {
+  it('encodes the exact Ruby/Dart wire format (byte-identical to the hand-rolled markers)', () => {
+    expect(encodeMarker('heritage', ['include', 'Loggable', 'App.S'])).toBe(
+      '__heritage__:include:Loggable:App.S',
+    );
+    expect(encodeMarker('property', ['attr_accessor', 'radius', 'Shapes.Circle'])).toBe(
+      '__property__:attr_accessor:radius:Shapes.Circle',
+    );
+    expect(HERITAGE_MARKER_PREFIX).toBe('__heritage__:');
+    expect(PROPERTY_MARKER_PREFIX).toBe('__property__:');
+  });
+
+  it('round-trips encode → decode for both kinds', () => {
+    const heritage = encodeMarker('heritage', ['with', 'Logger', 'Service']);
+    expect(decodeMarker(heritage)).toEqual({
+      kind: 'heritage',
+      fields: ['with', 'Logger', 'Service'],
+    });
+    const property = encodeMarker('property', ['attr_reader', 'name', 'User']);
+    expect(decodeMarker(property)).toEqual({
+      kind: 'property',
+      fields: ['attr_reader', 'name', 'User'],
+    });
+  });
+
+  it('throws on a colon-bearing field (the wire format reserves ":" as the delimiter)', () => {
+    expect(() => encodeMarker('heritage', ['include', 'Outer::Mixin', 'User'])).toThrow(/':'/);
+  });
+
+  it('decodeMarker returns null for non-markers', () => {
+    expect(decodeMarker('./relative/path')).toBeNull();
+    expect(decodeMarker('package:foo/bar.dart')).toBeNull();
+    expect(decodeMarker('')).toBeNull();
+  });
+
+  it('isHeritageMarker matches exactly the prior startsWith pair', () => {
+    expect(isHeritageMarker('__heritage__:include:M:C')).toBe(true);
+    expect(isHeritageMarker('__property__:attr:p:C')).toBe(true);
+    expect(isHeritageMarker('Serializable')).toBe(false);
+    expect(isHeritageMarker('dart:core')).toBe(false);
+  });
+});


### PR DESCRIPTION
> **Stacked PR 5/5** — base `fix/1991-ruby-mixin-module-trait` (#2006). Auto-retargets when #2006 merges.

## Summary

Maintainability follow-up to #1978 / #1982. The Ruby (and, independently, Dart) heritage/property pipeline encoded side-effect facts as `':'`-delimited synthetic-import marker strings, constructed and parsed by hand at ~8 sites with the field layout kept in agreement only by a comment — the structural fragility that produced the #1981 edge-drop. This routes every site through a single shared codec with **no behavioral change** (the `':'` wire format is preserved byte-for-byte).

## What changed

New `gitnexus/src/core/ingestion/utils/heritage-marker.ts`:
- `encodeMarker(kind, fields)` — builds `<prefix><field>:<field>:...`; **throws** on a colon-bearing field (the delimiter is reserved), turning the #1981 silent drop into a loud failure.
- `decodeMarker(raw)` — parses back to `{ kind, fields }` or `null`.
- `isHeritageMarker(raw)` — exactly the prior `startsWith('__heritage__:') || startsWith('__property__:')` pair.

Routed through it:
- **Ruby** — construct (`captures.ts`), parse (`scope-resolver.ts`), and the duplicated guard literals in `interpret.ts` + `import-target.ts`.
- **Dart** — construct (`captures.ts`) + parse (`scope-resolver.ts`). Dart already single-sources its prefix and is heritage-only, so its `import-target` guard is left untouched (no invented `__property__` path).

Language-neutral: the codec keys only on the literal shared prefixes — no provider branching.

## Verification

- New codec unit test: round-trip, colon-throw, prefix bytes, `isHeritageMarker` parity (5 cases).
- `ruby` resolver suite + `ruby-captures-golden`: registry-primary **155/155** with the **golden unchanged (zero diff)** — proving the `':'` wire format is byte-identical; legacy green.
- `dart` resolver suite: registry-primary **63/63**; legacy green.
- `tsc --noEmit` clean; prettier clean.

No new graph edges or behavior — pure refactor.

Closes #1994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
