### PR TITLE
fix(go): capture multi-name declarations

### DIFF
--- a/gitnexus/src/core/ingestion/field-extractors/configs/go.ts
+++ b/gitnexus/src/core/ingestion/field-extractors/configs/go.ts
@@ -3,6 +3,8 @@
 import { SupportedLanguages } from 'gitnexus-shared';
 import type { FieldExtractionConfig } from '../generic.js';
 import { extractSimpleTypeName } from '../../type-extractors/shared.js';
+import type { FieldVisibility } from '../../field-types.js';
+import type { SyntaxNode } from '../../utils/ast-helpers.js';
 
 /**
  * Go field extraction config.
@@ -13,14 +15,52 @@ import { extractSimpleTypeName } from '../../type-extractors/shared.js';
  * Visibility in Go is based on the first character: uppercase = exported (public),
  * lowercase = unexported (package).
  */
+function goVisibilityForName(name: string): FieldVisibility {
+  const first = name.charAt(0);
+  return first === first.toUpperCase() && first !== first.toLowerCase() ? 'public' : 'package';
+}
+
+function extractGoFieldNames(node: SyntaxNode): string[] {
+  const names: string[] = [];
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
+    if (child?.type === 'field_identifier') names.push(child.text);
+  }
+  return names;
+}
+
 export const goConfig: FieldExtractionConfig = {
   language: SupportedLanguages.Go,
-  typeDeclarationNodes: ['type_declaration'],
+  typeDeclarationNodes: ['type_declaration', 'struct_type'],
   fieldNodeTypes: ['field_declaration'],
   bodyNodeTypes: ['field_declaration_list'],
   defaultVisibility: 'package',
 
+  extractOwnerName(node) {
+    if (node.type === 'struct_type') {
+      return node.parent?.type === 'type_spec'
+        ? node.parent.childForFieldName('name')?.text
+        : undefined;
+    }
+    const typeSpec = node.namedChildren.find((child) => child.type === 'type_spec');
+    return typeSpec?.childForFieldName('name')?.text;
+  },
+
+  findBodyNodes(node) {
+    if (node.type === 'struct_type') {
+      const body = node.namedChildren.find((child) => child.type === 'field_declaration_list');
+      return body ? [body] : [];
+    }
+    const typeSpec = node.namedChildren.find((child) => child.type === 'type_spec');
+    const typeNode = typeSpec?.childForFieldName('type');
+    const body = typeNode?.namedChildren.find((child) => child.type === 'field_declaration_list');
+    return body ? [body] : [];
+  },
+
   extractName(node) {
+    const firstName = extractGoFieldNames(node)[0];
+    if (firstName) return firstName;
+
     // field_declaration > name:(field_identifier)
     const name = node.childForFieldName('name');
     if (name) return name.text;
@@ -31,6 +71,8 @@ export const goConfig: FieldExtractionConfig = {
     }
     return undefined;
   },
+
+  extractNames: extractGoFieldNames,
 
   extractType(node) {
     // field_declaration > type:(type_identifier | pointer_type | ...)
@@ -52,6 +94,10 @@ export const goConfig: FieldExtractionConfig = {
       return first === first.toUpperCase() && first !== first.toLowerCase() ? 'public' : 'package';
     }
     return 'package';
+  },
+
+  extractVisibilityForName(_node, name) {
+    return goVisibilityForName(name);
   },
 
   isStatic(_node) {

--- a/gitnexus/src/core/ingestion/field-extractors/generic.ts
+++ b/gitnexus/src/core/ingestion/field-extractors/generic.ts
@@ -33,6 +33,10 @@ export interface FieldExtractionConfig {
   bodyNodeTypes: string[];
   /** Default visibility when no modifier is present */
   defaultVisibility: FieldVisibility;
+  /** Extract owner type name from a type declaration node. */
+  extractOwnerName?: (node: SyntaxNode) => string | undefined;
+  /** Find body nodes inside a type declaration node. */
+  findBodyNodes?: (node: SyntaxNode) => SyntaxNode[];
   /**
    * Extract field name from a field declaration node.
    * Use this for nodes that declare exactly one field.
@@ -49,6 +53,8 @@ export interface FieldExtractionConfig {
   extractType: (node: SyntaxNode) => string | undefined;
   /** Extract visibility from a field declaration node */
   extractVisibility: (node: SyntaxNode) => FieldVisibility;
+  /** Extract visibility for one field name from a multi-name declaration. */
+  extractVisibilityForName?: (node: SyntaxNode, name: string) => FieldVisibility;
   /** Check if a field is static */
   isStatic: (node: SyntaxNode) => boolean;
   /** Check if a field is readonly/final/const */
@@ -84,10 +90,9 @@ export function createFieldExtractor(config: FieldExtractionConfig): FieldExtrac
     extract(node: SyntaxNode, context: FieldExtractorContext): ExtractedFields | null {
       if (!this.isTypeDeclaration(node)) return null;
 
-      const nameNode = node.childForFieldName('name');
-      if (!nameNode) return null;
+      const ownerFqn = config.extractOwnerName?.(node) ?? node.childForFieldName('name')?.text;
+      if (!ownerFqn) return null;
 
-      const ownerFqn = nameNode.text;
       const fields: FieldInfo[] = [];
 
       // Find body container(s)
@@ -110,6 +115,8 @@ export function createFieldExtractor(config: FieldExtractionConfig): FieldExtrac
     // ------------------------------------------------------------------
 
     private findBodies(node: SyntaxNode): SyntaxNode[] {
+      if (config.findBodyNodes) return config.findBodyNodes(node);
+
       const result: SyntaxNode[] = [];
       // Try named 'body' field first
       const bodyField = node.childForFieldName('body');
@@ -179,7 +186,7 @@ export function createFieldExtractor(config: FieldExtractionConfig): FieldExtrac
       return {
         name,
         type,
-        visibility: config.extractVisibility(node),
+        visibility: config.extractVisibilityForName?.(node, name) ?? config.extractVisibility(node),
         isStatic: config.isStatic(node),
         isReadonly: config.isReadonly(node),
         sourceFile: context.filePath,

--- a/gitnexus/src/core/ingestion/languages/go/query.ts
+++ b/gitnexus/src/core/ingestion/languages/go/query.ts
@@ -53,11 +53,15 @@ const GO_SCOPE_QUERY = `
 ;; Declarations — variables
 (var_declaration
   (var_spec
-    name: (identifier) @declaration.name)) @declaration.variable
+    (identifier) @declaration.name)) @declaration.variable
+(var_declaration
+  (var_spec_list
+    (var_spec
+      (identifier) @declaration.name))) @declaration.variable
 
 (const_declaration
   (const_spec
-    name: (identifier) @declaration.name)) @declaration.const
+    (identifier) @declaration.name)) @declaration.const
 
 (short_var_declaration
   left: (expression_list (identifier) @declaration.name)) @declaration.variable

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -27,6 +27,7 @@ import {
 import { detectFrameworkFromAST } from './framework-detection.js';
 import { buildTypeEnv } from './type-env.js';
 import type { FieldInfo, FieldExtractorContext } from './field-types.js';
+import type { VariableExtractorContext } from './variable-types.js';
 import type { MethodInfo } from './method-types.js';
 import {
   buildMethodProps,
@@ -387,7 +388,7 @@ function seqGetFieldInfo(
   return cached;
 }
 
-const processParsingSequential = async (
+export const processParsingSequential = async (
   graph: KnowledgeGraph,
   files: { path: string; content: string }[],
   symbolTable: SymbolTableWriter,
@@ -915,6 +916,28 @@ const processParsingSequential = async (
           }
         }
         // All 15 tree-sitter languages register a FieldExtractor — no fallback needed.
+      }
+
+      if (
+        (nodeLabel === 'Const' || nodeLabel === 'Static' || nodeLabel === 'Variable') &&
+        definitionNode &&
+        provider.variableExtractor
+      ) {
+        const varCtx: VariableExtractorContext = {
+          filePath: file.path,
+          language,
+        };
+        const varInfo = provider.variableExtractor
+          .extractAll(definitionNode, varCtx)
+          .find((info) => info.name === nodeName);
+        if (varInfo) {
+          if (varInfo.type) declaredType = varInfo.type;
+          seqVisibility = varInfo.visibility;
+          seqIsStatic = varInfo.isStatic;
+          methodProps.isConst = varInfo.isConst;
+          methodProps.isMutable = varInfo.isMutable;
+          methodProps.scope = varInfo.scope;
+        }
       }
 
       // Apply field metadata to the graph node retroactively

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -27,7 +27,7 @@ import {
 import { detectFrameworkFromAST } from './framework-detection.js';
 import { buildTypeEnv } from './type-env.js';
 import type { FieldInfo, FieldExtractorContext } from './field-types.js';
-import type { VariableExtractorContext } from './variable-types.js';
+import type { VariableExtractorContext, VariableInfo } from './variable-types.js';
 import type { MethodInfo } from './method-types.js';
 import {
   buildMethodProps,
@@ -410,6 +410,7 @@ export const processParsingSequential = async (
     seqFieldInfoCache.clear();
     seqMethodExtractCache.clear();
     seqMethodMapCache.clear();
+    const seqVariableInfoCache = new Map<number, Map<string, VariableInfo>>();
 
     onFileProgress?.(i + 1, total, file.path);
 
@@ -923,13 +924,20 @@ export const processParsingSequential = async (
         definitionNode &&
         provider.variableExtractor
       ) {
-        const varCtx: VariableExtractorContext = {
-          filePath: file.path,
-          language,
-        };
-        const varInfo = provider.variableExtractor
-          .extractAll(definitionNode, varCtx)
-          .find((info) => info.name === nodeName);
+        let variableInfoByName = seqVariableInfoCache.get(definitionNode.startIndex);
+        if (!variableInfoByName) {
+          const varCtx: VariableExtractorContext = {
+            filePath: file.path,
+            language,
+          };
+          variableInfoByName = new Map(
+            provider.variableExtractor
+              .extractAll(definitionNode, varCtx)
+              .map((info) => [info.name, info]),
+          );
+          seqVariableInfoCache.set(definitionNode.startIndex, variableInfoByName);
+        }
+        const varInfo = variableInfoByName.get(nodeName);
         if (varInfo) {
           if (varInfo.type) declaredType = varInfo.type;
           seqVisibility = varInfo.visibility;
@@ -945,6 +953,9 @@ export const processParsingSequential = async (
       if (seqIsStatic !== undefined) node.properties.isStatic = seqIsStatic;
       if (seqIsReadonly !== undefined) node.properties.isReadonly = seqIsReadonly;
       if (declaredType !== undefined) node.properties.declaredType = declaredType;
+      if (methodProps.isConst !== undefined) node.properties.isConst = methodProps.isConst;
+      if (methodProps.isMutable !== undefined) node.properties.isMutable = methodProps.isMutable;
+      if (methodProps.scope !== undefined) node.properties.scope = methodProps.scope;
 
       symbolTable.add(file.path, nodeName, nodeId, nodeLabel, {
         parameterCount: methodProps.parameterCount as number | undefined,

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -835,8 +835,9 @@ export const GO_QUERIES = `
 (call_expression function: (selector_expression field: (field_identifier) @call.name)) @call
 
 ; Const/var declarations
-(const_declaration (const_spec name: (identifier) @name)) @definition.const
-(var_declaration (var_spec name: (identifier) @name)) @definition.variable
+(const_declaration (const_spec (identifier) @name)) @definition.const
+(var_declaration (var_spec (identifier) @name)) @definition.variable
+(var_declaration (var_spec_list (var_spec (identifier) @name))) @definition.variable
 
 ; Short variable declaration: x := 5
 (short_var_declaration left: (expression_list (identifier) @name)) @definition.variable

--- a/gitnexus/src/core/ingestion/variable-extractors/configs/go.ts
+++ b/gitnexus/src/core/ingestion/variable-extractors/configs/go.ts
@@ -21,7 +21,72 @@ import type { SyntaxNode } from '../../utils/ast-helpers.js';
  * Visibility: uppercase first letter = exported (public), lowercase = unexported (package).
  */
 
+function goVisibilityForName(name: string): VariableVisibility {
+  const firstChar = name.charAt(0);
+  return firstChar === firstChar.toUpperCase() && firstChar !== firstChar.toLowerCase()
+    ? 'public'
+    : 'package';
+}
+
+function collectGoSpecNames(spec: SyntaxNode): string[] {
+  const names: string[] = [];
+  for (let i = 0; i < spec.namedChildCount; i++) {
+    const child = spec.namedChild(i);
+    if (!child) continue;
+    if (child.type === 'identifier') {
+      names.push(child.text);
+      continue;
+    }
+    break;
+  }
+  return names;
+}
+
+function collectGoSpecs(node: SyntaxNode): SyntaxNode[] {
+  const specs: SyntaxNode[] = [];
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
+    if (child?.type === 'var_spec' || child?.type === 'const_spec') {
+      specs.push(child);
+      continue;
+    }
+    if (child?.type === 'var_spec_list') {
+      specs.push(...collectGoSpecs(child));
+    }
+  }
+  return specs;
+}
+
+function collectGoDeclarationNames(node: SyntaxNode): string[] {
+  if (node.type === 'short_var_declaration') {
+    const left = node.childForFieldName('left');
+    if (left?.type !== 'expression_list') return [];
+    return left.namedChildren
+      .filter((child: SyntaxNode) => child.type === 'identifier')
+      .map((child: SyntaxNode) => child.text);
+  }
+
+  const names: string[] = [];
+  for (const spec of collectGoSpecs(node)) names.push(...collectGoSpecNames(spec));
+  return names;
+}
+
+function findGoSpecForName(node: SyntaxNode, name: string): SyntaxNode | undefined {
+  for (const spec of collectGoSpecs(node)) {
+    if (collectGoSpecNames(spec).includes(name)) return spec;
+  }
+  return undefined;
+}
+
+function extractGoSpecType(spec: SyntaxNode): string | undefined {
+  const typeNode = spec.childForFieldName('type');
+  return typeNode ? (extractSimpleTypeName(typeNode) ?? typeNode.text?.trim()) : undefined;
+}
+
 function extractGoVarName(node: SyntaxNode): string | undefined {
+  const firstName = collectGoDeclarationNames(node)[0];
+  if (firstName) return firstName;
+
   // var_declaration/const_declaration → var_spec/const_spec → identifier
   for (let i = 0; i < node.namedChildCount; i++) {
     const child = node.namedChild(i);
@@ -47,12 +112,9 @@ function extractGoVarName(node: SyntaxNode): string | undefined {
 }
 
 function extractGoVarType(node: SyntaxNode): string | undefined {
-  for (let i = 0; i < node.namedChildCount; i++) {
-    const child = node.namedChild(i);
-    if (child?.type === 'var_spec' || child?.type === 'const_spec') {
-      const typeNode = child.childForFieldName('type');
-      if (typeNode) return extractSimpleTypeName(typeNode) ?? typeNode.text?.trim();
-    }
+  for (const spec of collectGoSpecs(node)) {
+    const typeName = extractGoSpecType(spec);
+    if (typeName) return typeName;
   }
   return undefined;
 }
@@ -66,6 +128,11 @@ export const goVariableConfig: VariableExtractionConfig = {
   extractName: extractGoVarName,
   extractType: extractGoVarType,
 
+  extractTypeForName(node, name) {
+    const spec = findGoSpecForName(node, name);
+    return spec ? extractGoSpecType(spec) : undefined;
+  },
+
   extractVisibility(node): VariableVisibility {
     const name = extractGoVarName(node);
     if (!name) return 'package';
@@ -74,6 +141,12 @@ export const goVariableConfig: VariableExtractionConfig = {
     return firstChar === firstChar.toUpperCase() && firstChar !== firstChar.toLowerCase()
       ? 'public'
       : 'package';
+  },
+
+  extractNames: collectGoDeclarationNames,
+
+  extractVisibilityForName(_node, name): VariableVisibility {
+    return goVisibilityForName(name);
   },
 
   isConst(node) {

--- a/gitnexus/src/core/ingestion/variable-extractors/generic.ts
+++ b/gitnexus/src/core/ingestion/variable-extractors/generic.ts
@@ -77,13 +77,17 @@ export function createVariableExtractor(config: VariableExtractionConfig): Varia
     },
 
     extract(node: SyntaxNode, context: VariableExtractorContext): VariableInfo | null {
-      if (!allNodeTypes.has(node.type)) return null;
+      return this.extractAll(node, context)[0] ?? null;
+    },
 
-      const name = config.extractName(node);
-      if (!name) return null;
+    extractAll(node: SyntaxNode, context: VariableExtractorContext): VariableInfo[] {
+      if (!allNodeTypes.has(node.type)) return [];
 
-      const type = config.extractType(node) ?? null;
-      const visibility = config.extractVisibility(node);
+      const names = config.extractNames
+        ? config.extractNames(node)
+        : [config.extractName(node)].filter((name): name is string => Boolean(name));
+      if (names.length === 0) return [];
+
       // isConst/isStatic: node type membership is a hint, but config.isConst/isStatic
       // has final say. For languages where const and non-const share a node type
       // (e.g., TS lexical_declaration for both const and let), config.isConst disambiguates.
@@ -92,17 +96,17 @@ export function createVariableExtractor(config: VariableExtractionConfig): Varia
       const isMutable = config.isMutable(node);
       const scope = determineScope(node);
 
-      return {
+      return names.map((name) => ({
         name,
-        type,
-        visibility,
+        type: config.extractTypeForName?.(node, name) ?? config.extractType(node) ?? null,
+        visibility: config.extractVisibilityForName?.(node, name) ?? config.extractVisibility(node),
         isConst,
         isStatic,
         isMutable,
         scope,
         sourceFile: context.filePath,
         line: node.startPosition.row + 1,
-      };
+      }));
     },
   };
 }

--- a/gitnexus/src/core/ingestion/variable-types.ts
+++ b/gitnexus/src/core/ingestion/variable-types.ts
@@ -59,6 +59,9 @@ export interface VariableExtractor {
   /** Extract variable metadata from a declaration node.
    *  Returns null if the node is not a recognized variable declaration. */
   extract(node: SyntaxNode, context: VariableExtractorContext): VariableInfo | null;
+  /** Extract every variable metadata entry from a declaration node.
+   *  Returns [] if the node is not a recognized variable declaration. */
+  extractAll(node: SyntaxNode, context: VariableExtractorContext): VariableInfo[];
   /** Check if a node is a recognized variable declaration type. */
   isVariableDeclaration(node: SyntaxNode): boolean;
 }
@@ -78,10 +81,16 @@ export interface VariableExtractionConfig {
   variableNodeTypes: string[];
   /** Extract the variable name from a declaration node */
   extractName: (node: SyntaxNode) => string | undefined;
+  /** Extract multiple variable names from a declaration node. */
+  extractNames?: (node: SyntaxNode) => string[];
   /** Extract type annotation from a declaration node */
   extractType: (node: SyntaxNode) => string | undefined;
+  /** Extract type annotation for one variable name from a multi-name declaration. */
+  extractTypeForName?: (node: SyntaxNode, name: string) => string | undefined;
   /** Extract visibility from a declaration node */
   extractVisibility: (node: SyntaxNode) => VariableVisibility;
+  /** Extract visibility for one variable name from a multi-name declaration. */
+  extractVisibilityForName?: (node: SyntaxNode, name: string) => VariableVisibility;
   /** Check if a declaration is const/immutable */
   isConst: (node: SyntaxNode) => boolean;
   /** Check if a declaration is static */

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -1984,7 +1984,9 @@ const processFileGroup = (
           filePath: file.path,
           language,
         };
-        const varInfo = provider.variableExtractor.extract(definitionNode, varCtx);
+        const varInfo = provider.variableExtractor
+          .extractAll(definitionNode, varCtx)
+          .find((info) => info.name === nodeName);
         if (varInfo) {
           if (varInfo.type) declaredType = varInfo.type;
           methodProps.visibility = varInfo.visibility;

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -84,7 +84,7 @@ import {
 import type { NodeLabel, ParameterTypeClass } from 'gitnexus-shared';
 import type { FieldInfo, FieldExtractorContext } from '../field-types.js';
 import type { MethodInfo, MethodExtractorContext } from '../method-types.js';
-import type { VariableExtractorContext } from '../variable-types.js';
+import type { VariableExtractorContext, VariableInfo } from '../variable-types.js';
 import {
   buildMethodProps,
   arityForIdFromInfo,
@@ -1210,7 +1210,8 @@ const processFileGroup = (
     // Track start indices of definition nodes already processed by higher-priority captures
     // (e.g. @definition.function) to avoid duplicate nodes when @definition.const/@definition.variable
     // patterns overlap with the same source range.
-    const processedDefinitionNodes = new Set<number>();
+    const processedDefinitionNodes = new Set<string>();
+    const variableInfoCache = new Map<number, Map<string, VariableInfo>>();
 
     for (const match of matches) {
       const captureMap: Record<string, SyntaxNode> = {};
@@ -1651,20 +1652,6 @@ const processFileGroup = (
         continue;
       }
 
-      // Dedup: variable captures (Const/Static/Variable) may overlap with higher-priority
-      // captures (e.g. `const fn = () => {}` matches both @definition.function and @definition.const).
-      // Skip variable captures whose definition node was already processed.
-      if (
-        (nodeLabel === 'Const' || nodeLabel === 'Static' || nodeLabel === 'Variable') &&
-        definitionNode &&
-        processedDefinitionNodes.has(definitionNode.startIndex)
-      ) {
-        continue;
-      }
-      if (definitionNode) {
-        processedDefinitionNodes.add(definitionNode.startIndex);
-      }
-
       const exportDefaultCall =
         nodeLabel === 'Function' && definitionNode?.type === 'export_statement'
           ? definitionNode.namedChildren.find((child) => child.type === 'call_expression')
@@ -1706,6 +1693,25 @@ const processFileGroup = (
 
       const nodeName =
         extractedClassSymbol?.name ?? defaultExportHocName ?? (nameNode ? nameNode.text : 'init');
+      // Dedup: variable captures (Const/Static/Variable) may overlap with higher-priority
+      // captures (e.g. `const fn = () => {}` matches both @definition.function and @definition.const).
+      // Multi-name declarations share the same definition node, so include the emitted name.
+      if (definitionNode) {
+        const definitionBaseKey = `${definitionNode.startIndex}`;
+        if (nodeLabel === 'Const' || nodeLabel === 'Static' || nodeLabel === 'Variable') {
+          const definitionNameKey = `${definitionBaseKey}:${nodeName}`;
+          if (
+            processedDefinitionNodes.has(definitionBaseKey) ||
+            processedDefinitionNodes.has(definitionNameKey)
+          ) {
+            continue;
+          }
+          processedDefinitionNodes.add(definitionNameKey);
+        } else {
+          processedDefinitionNodes.add(definitionBaseKey);
+        }
+      }
+
       const startLine = definitionNode
         ? definitionNode.startPosition.row + lineOffset
         : nameNode
@@ -1980,13 +1986,20 @@ const processFileGroup = (
         definitionNode &&
         provider.variableExtractor
       ) {
-        const varCtx: VariableExtractorContext = {
-          filePath: file.path,
-          language,
-        };
-        const varInfo = provider.variableExtractor
-          .extractAll(definitionNode, varCtx)
-          .find((info) => info.name === nodeName);
+        let variableInfoByName = variableInfoCache.get(definitionNode.startIndex);
+        if (!variableInfoByName) {
+          const varCtx: VariableExtractorContext = {
+            filePath: file.path,
+            language,
+          };
+          variableInfoByName = new Map(
+            provider.variableExtractor
+              .extractAll(definitionNode, varCtx)
+              .map((info) => [info.name, info]),
+          );
+          variableInfoCache.set(definitionNode.startIndex, variableInfoByName);
+        }
+        const varInfo = variableInfoByName.get(nodeName);
         if (varInfo) {
           if (varInfo.type) declaredType = varInfo.type;
           methodProps.visibility = varInfo.visibility;

--- a/gitnexus/test/integration/go-multi-name-sequential-metadata.test.ts
+++ b/gitnexus/test/integration/go-multi-name-sequential-metadata.test.ts
@@ -45,17 +45,39 @@ describe('Go multi-name declaration metadata in sequential parsing', () => {
       scopeTreeCache,
     );
 
-    const metadata = new Map<string, string | undefined>();
+    const metadata = new Map<string, Record<string, unknown>>();
     graph.forEachNode((node) => {
       if (node.label === 'Const' || node.label === 'Variable') {
-        metadata.set(node.properties.name, node.properties.declaredType as string | undefined);
+        metadata.set(node.properties.name, node.properties);
       }
     });
 
-    expect(metadata.get('X')).toBe('int');
-    expect(metadata.get('Y')).toBe('int');
-    expect(metadata.get('a')).toBe('string');
-    expect(metadata.get('b')).toBe('string');
-    expect(metadata.get('c')).toBe('bool');
+    expect(metadata.get('X')).toMatchObject({
+      declaredType: 'int',
+      isConst: true,
+      isMutable: false,
+      scope: 'module',
+    });
+    expect(metadata.get('Y')).toMatchObject({
+      declaredType: 'int',
+      isConst: true,
+      isMutable: false,
+      scope: 'module',
+    });
+    expect(metadata.get('a')).toMatchObject({
+      declaredType: 'string',
+      isMutable: true,
+      scope: 'module',
+    });
+    expect(metadata.get('b')).toMatchObject({
+      declaredType: 'string',
+      isMutable: true,
+      scope: 'module',
+    });
+    expect(metadata.get('c')).toMatchObject({
+      declaredType: 'bool',
+      isMutable: true,
+      scope: 'module',
+    });
   });
 });

--- a/gitnexus/test/integration/go-multi-name-sequential-metadata.test.ts
+++ b/gitnexus/test/integration/go-multi-name-sequential-metadata.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createKnowledgeGraph } from '../../src/core/graph/graph.js';
+import { createASTCache } from '../../src/core/ingestion/ast-cache.js';
+import { createSymbolTable } from '../../src/core/ingestion/model/index.js';
+import { processParsingSequential } from '../../src/core/ingestion/parsing-processor.js';
+
+describe('Go multi-name declaration metadata in sequential parsing', () => {
+  it('enriches every const and var name when workers are skipped', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'go-multi-name-seq-'));
+    fs.writeFileSync(path.join(dir, 'go.mod'), 'module example.com/multi\n\ngo 1.22\n');
+    fs.writeFileSync(
+      path.join(dir, 'main.go'),
+      [
+        'package main',
+        '',
+        'const X, Y int = 1, 2',
+        '',
+        'var (',
+        '  a, b string',
+        '  c bool',
+        ')',
+        '',
+        'func main() {}',
+        '',
+      ].join('\n'),
+    );
+
+    const graph = createKnowledgeGraph();
+    const symbolTable = createSymbolTable();
+    const astCache = createASTCache();
+    const scopeTreeCache = createASTCache();
+    await processParsingSequential(
+      graph,
+      [
+        {
+          path: path.join(dir, 'main.go'),
+          content: fs.readFileSync(path.join(dir, 'main.go'), 'utf8'),
+        },
+      ],
+      symbolTable,
+      astCache,
+      scopeTreeCache,
+    );
+
+    const metadata = new Map<string, string | undefined>();
+    graph.forEachNode((node) => {
+      if (node.label === 'Const' || node.label === 'Variable') {
+        metadata.set(node.properties.name, node.properties.declaredType as string | undefined);
+      }
+    });
+
+    expect(metadata.get('X')).toBe('int');
+    expect(metadata.get('Y')).toBe('int');
+    expect(metadata.get('a')).toBe('string');
+    expect(metadata.get('b')).toBe('string');
+    expect(metadata.get('c')).toBe('bool');
+  });
+});

--- a/gitnexus/test/integration/go-multi-name-worker-metadata.test.ts
+++ b/gitnexus/test/integration/go-multi-name-worker-metadata.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runPipelineFromRepo } from './resolvers/helpers.js';
+import type { PipelineResult } from '../../src/types/pipeline.js';
+
+function createGoRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'go-multi-name-worker-'));
+  fs.writeFileSync(path.join(dir, 'go.mod'), 'module example.com/multi\n\ngo 1.22\n');
+  fs.writeFileSync(
+    path.join(dir, 'main.go'),
+    [
+      'package main',
+      '',
+      'const X, Y int = 1, 2',
+      'var a, b string',
+      '',
+      'var (',
+      '  c, d bool',
+      ')',
+      '',
+      'type Point struct { Px, py int }',
+      '',
+      'func main() {}',
+      '',
+    ].join('\n'),
+  );
+  return dir;
+}
+
+async function runMode(mode: 'worker' | 'sequential'): Promise<PipelineResult> {
+  return runPipelineFromRepo(createGoRepo(), () => {}, {
+    skipGraphPhases: true,
+    workerThresholdsForTest: { minFiles: 1, minBytes: 1 },
+    ...(mode === 'worker' ? { workerPoolSize: 2 } : { skipWorkers: true }),
+  });
+}
+
+function collectMetadata(result: PipelineResult): Map<string, Record<string, unknown>> {
+  const metadata = new Map<string, Record<string, unknown>>();
+  result.graph.forEachNode((node) => {
+    if (node.label === 'Const' || node.label === 'Variable' || node.label === 'Property') {
+      metadata.set(`${node.label}:${node.properties.name}`, node.properties);
+    }
+  });
+  return metadata;
+}
+
+describe('Go multi-name declaration metadata in worker parsing', () => {
+  it('emits every const and var name with metadata on the worker path', async () => {
+    const worker = await runMode('worker');
+    const sequential = await runMode('sequential');
+
+    expect(worker.usedWorkerPool).toBe(true);
+    expect(sequential.usedWorkerPool).toBe(false);
+
+    const workerMetadata = collectMetadata(worker);
+    const sequentialMetadata = collectMetadata(sequential);
+
+    expect([...workerMetadata.keys()].sort()).toEqual([...sequentialMetadata.keys()].sort());
+    expect(workerMetadata.get('Const:X')).toMatchObject({
+      declaredType: 'int',
+      isConst: true,
+      isMutable: false,
+      scope: 'module',
+    });
+    expect(workerMetadata.get('Const:Y')).toMatchObject({
+      declaredType: 'int',
+      isConst: true,
+      isMutable: false,
+      scope: 'module',
+    });
+    expect(workerMetadata.get('Variable:a')).toMatchObject({
+      declaredType: 'string',
+      isMutable: true,
+      scope: 'module',
+    });
+    expect(workerMetadata.get('Variable:b')).toMatchObject({
+      declaredType: 'string',
+      isMutable: true,
+      scope: 'module',
+    });
+    expect(workerMetadata.get('Variable:c')).toMatchObject({
+      declaredType: 'bool',
+      isMutable: true,
+      scope: 'module',
+    });
+    expect(workerMetadata.get('Variable:d')).toMatchObject({
+      declaredType: 'bool',
+      isMutable: true,
+      scope: 'module',
+    });
+    expect(workerMetadata.get('Property:Px')).toMatchObject({ declaredType: 'int' });
+    expect(workerMetadata.get('Property:py')).toMatchObject({ declaredType: 'int' });
+  });
+});

--- a/gitnexus/test/integration/tree-sitter-languages.test.ts
+++ b/gitnexus/test/integration/tree-sitter-languages.test.ts
@@ -128,6 +128,40 @@ describe('Tree-sitter multi-language parsing', () => {
       const defTypes = defs.map((d) => d.type);
       expect(defTypes).toContain('definition.function');
     });
+
+    it('captures every name in multi-name const, var, and field declarations', async () => {
+      await loadLanguage(SupportedLanguages.Go);
+      const provider = getProvider(SupportedLanguages.Go);
+      const code = `
+        package main
+        const X, Y,Z,A,B = 1, 2,3,4,5
+        var a, b int
+        var (
+          c, d string
+        )
+        const (
+          C, D = 3, 4
+        )
+        type Point struct { X, y int }
+      `;
+      const { matches } = parseAndQuery(parser, code, provider.treeSitterQueries);
+      const defs = extractDefinitions(matches);
+
+      const constNames = defs
+        .filter((def) => def.type === 'definition.const')
+        .map((def) => def.name);
+      expect(constNames.sort()).toEqual(['A', 'B', 'C', 'D', 'X', 'Y', 'Z']);
+
+      const variableNames = defs
+        .filter((def) => def.type === 'definition.variable')
+        .map((def) => def.name);
+      expect(variableNames.sort()).toEqual(['a', 'b', 'c', 'd']);
+
+      const propertyNames = defs
+        .filter((def) => def.type === 'definition.property')
+        .map((def) => def.name);
+      expect(propertyNames.sort()).toEqual(['X', 'y']);
+    });
   });
 
   describe('C', () => {

--- a/gitnexus/test/unit/field-extraction.test.ts
+++ b/gitnexus/test/unit/field-extraction.test.ts
@@ -703,6 +703,48 @@ describe('GenericFieldExtractor — Go', () => {
     expect(goConfig.extractType(xNode)).toBe('float64');
   });
 
+  it('extracts every name from Go multi-name struct fields', () => {
+    const { typeDecl } = findTypeSpec(`type Point struct {\n\tX, y int\n}`);
+
+    const result = extractor.extract(typeDecl, mockContext);
+    expect(result).not.toBeNull();
+    expect(result!.fields).toHaveLength(2);
+
+    const xField = result!.fields.find((field) => field.name === 'X');
+    expect(xField).toBeDefined();
+    expect(xField!.type).toBe('int');
+    expect(xField!.visibility).toBe('public');
+
+    const yField = result!.fields.find((field) => field.name === 'y');
+    expect(yField).toBeDefined();
+    expect(yField!.type).toBe('int');
+    expect(yField!.visibility).toBe('package');
+  });
+
+  it('extracts Go multi-name struct fields when called with the runtime struct_type owner', () => {
+    const { typeDecl } = findTypeSpec(`type Point struct {\n\tX, y int\n}`);
+    const typeSpec = typeDecl.namedChild(0)!;
+    const structType = typeSpec.namedChild(1)!;
+
+    expect(structType.type).toBe('struct_type');
+    expect(extractor.isTypeDeclaration(structType)).toBe(true);
+
+    const result = extractor.extract(structType, mockContext);
+    expect(result).not.toBeNull();
+    expect(result!.ownerFqn).toBe('Point');
+    expect(result!.fields).toHaveLength(2);
+
+    const xField = result!.fields.find((field) => field.name === 'X');
+    expect(xField).toBeDefined();
+    expect(xField!.type).toBe('int');
+    expect(xField!.visibility).toBe('public');
+
+    const yField = result!.fields.find((field) => field.name === 'y');
+    expect(yField).toBeDefined();
+    expect(yField!.type).toBe('int');
+    expect(yField!.visibility).toBe('package');
+  });
+
   it('reports isStatic and isReadonly as false for all fields', () => {
     const { typeDecl } = findTypeSpec(`type S struct {\n\tX int\n}`);
     const typeSpec = typeDecl.namedChild(0)!;

--- a/gitnexus/test/unit/scope-resolution/go/go-captures-smoke.test.ts
+++ b/gitnexus/test/unit/scope-resolution/go/go-captures-smoke.test.ts
@@ -63,6 +63,38 @@ func main() {
     expect(tags).toContain('@reference.write');
   });
 
+  it('emits every name from multi-name const, var, and field declarations', () => {
+    const src = `
+package main
+
+const X, Y,Z,A,B = 1, 2,3,4,5
+var a, b int
+var (
+  c, d string
+)
+const (
+  C, D = 3, 4
+)
+type Point struct { X, y int }
+`;
+    const matches = emitGoScopeCaptures(src, 'main.go');
+
+    const constNames = matches
+      .filter((m) => m['@declaration.const'] !== undefined)
+      .map((m) => m['@declaration.name']!.text);
+    expect(constNames.sort()).toEqual(['A', 'B', 'C', 'D', 'X', 'Y', 'Z']);
+
+    const variableNames = matches
+      .filter((m) => m['@declaration.variable'] !== undefined)
+      .map((m) => m['@declaration.name']!.text);
+    expect(variableNames.sort()).toEqual(['a', 'b', 'c', 'd']);
+
+    const fieldNames = matches
+      .filter((m) => m['@declaration.field'] !== undefined)
+      .map((m) => m['@declaration.name']!.text);
+    expect(fieldNames.sort()).toEqual(['X', 'y']);
+  });
+
   // ── Edge shapes the #1915 captured-node refactor reasons about but no
   //    lang-resolution fixture exercises (issue #1848 follow-up U2). ──
 

--- a/gitnexus/test/unit/variable-extraction.test.ts
+++ b/gitnexus/test/unit/variable-extraction.test.ts
@@ -267,6 +267,76 @@ describe('VariableExtractor — Go', () => {
     expect(info!.type).toBe('int');
   });
 
+  it('extracts every name from multi-name const declarations', () => {
+    parser.setLanguage(Go);
+    const tree = parser.parse('package main\nconst X, Y,Z,A,B = 1, 2,3,4,5');
+    const constNode = tree.rootNode.namedChildren.find(
+      (child) => child.type === 'const_declaration',
+    );
+    expect(constNode).toBeDefined();
+
+    const infos = extractor.extractAll(constNode!, ctx);
+    expect(infos.map((info) => info.name)).toEqual(['X', 'Y', 'Z', 'A', 'B']);
+    for (const info of infos) {
+      expect(info.isConst).toBe(true);
+      expect(info.isMutable).toBe(false);
+      expect(info.visibility).toBe('public');
+      expect(info.type).toBeNull();
+    }
+  });
+
+  it('extracts every name from multi-name var declarations with a shared type', () => {
+    parser.setLanguage(Go);
+    const tree = parser.parse('package main\nvar a, b int');
+    const varNode = tree.rootNode.namedChildren.find((child) => child.type === 'var_declaration');
+    expect(varNode).toBeDefined();
+
+    const infos = extractor.extractAll(varNode!, ctx);
+    expect(infos.map((info) => info.name)).toEqual(['a', 'b']);
+    for (const info of infos) {
+      expect(info.isConst).toBe(false);
+      expect(info.isMutable).toBe(true);
+      expect(info.visibility).toBe('package');
+      expect(info.type).toBe('int');
+    }
+  });
+
+  it('preserves per-spec types in grouped multi-name var declarations', () => {
+    parser.setLanguage(Go);
+    const tree = parser.parse('package main\nvar (\n  a, b int\n  c string\n)');
+    const varNode = tree.rootNode.namedChildren.find((child) => child.type === 'var_declaration');
+    expect(varNode).toBeDefined();
+
+    const infos = extractor.extractAll(varNode!, ctx);
+    expect(infos.map((info) => [info.name, info.type])).toEqual([
+      ['a', 'int'],
+      ['b', 'int'],
+      ['c', 'string'],
+    ]);
+
+    const cInfo = infos.find((info) => info.name === 'c');
+    expect(cInfo).toBeDefined();
+    expect(cInfo!.isConst).toBe(false);
+    expect(cInfo!.isMutable).toBe(true);
+    expect(cInfo!.visibility).toBe('package');
+  });
+
+  it('matches parse-worker nodeName selection for grouped multi-name vars', () => {
+    parser.setLanguage(Go);
+    const tree = parser.parse('package main\nvar (\n  a, b int\n  c string\n)');
+    const varNode = tree.rootNode.namedChildren.find((child) => child.type === 'var_declaration');
+    expect(varNode).toBeDefined();
+
+    const selected = extractor.extractAll(varNode!, ctx).find((info) => info.name === 'c');
+    expect(selected).toMatchObject({
+      name: 'c',
+      type: 'string',
+      visibility: 'package',
+      isConst: false,
+      isMutable: true,
+    });
+  });
+
   it('detects lowercase as package-private', () => {
     parser.setLanguage(Go);
     const tree = parser.parse('package main\nconst maxSize = 100');


### PR DESCRIPTION
## What changed

- Capture every identifier in Go multi-name `const`, `var`, grouped `var` / `const`, and struct field declarations.
- Extend the generic variable and field extractors so multi-name declarations can return per-name metadata while preserving existing single-name behavior by default.
- Select variable metadata by `nodeName` in both worker and sequential parsing paths via `extractAll(...).find(...)`.
- Allow Go field extraction to consume the runtime `struct_type` owner shape and split multi-field declarations with per-name visibility.
- Add regression coverage for query captures, scope captures, extractor metadata, exact capture sets, and sequential runtime metadata.

## Why

Go ingestion previously only captured or enriched the first name in declarations such as:

```go
const X, Y, Z = 1, 2, 3
var a, b int
type Point struct { X, y int }
```

That could produce missing symbols or incorrect metadata for later names in the same declaration.

Fixes #1927.

## How to verify

Passed:

```bash
cd gitnexus-shared && npm run build
cd gitnexus && npx tsc --noEmit
cd gitnexus && npm test -- go-multi-name-sequential-metadata.test.ts variable-extraction.test.ts field-extraction.test.ts tree-sitter-languages.test.ts scope-resolution/go/go-captures-smoke.test.ts grammar-literal-validation.test.ts
cd gitnexus && npx prettier --check src/core/ingestion/parsing-processor.ts test/integration/go-multi-name-sequential-metadata.test.ts src/core/ingestion/field-extractors/configs/go.ts src/core/ingestion/field-extractors/generic.ts src/core/ingestion/languages/go/query.ts src/core/ingestion/tree-sitter-queries.ts src/core/ingestion/variable-extractors/configs/go.ts src/core/ingestion/variable-extractors/generic.ts src/core/ingestion/variable-types.ts src/core/ingestion/workers/parse-worker.ts test/integration/tree-sitter-languages.test.ts test/unit/field-extraction.test.ts test/unit/scope-resolution/go/go-captures-smoke.test.ts test/unit/variable-extraction.test.ts
git diff --check
```

Additional GitNexus impact / scope checks:

```bash
cd gitnexus && ./node_modules/.bin/tsx src/cli/index.ts impact processParsingSequential --repo GitNexus --direction upstream
cd gitnexus && ./node_modules/.bin/tsx src/cli/index.ts detect-changes --scope all --repo GitNexus
```

Notes:

- `impact processParsingSequential`: risk `LOW`, direct upstream caller `processParsing`.
- `detect-changes` before commit: passed, risk `HIGH`, affected generic extractor plus worker/sequential ingestion flows.
- `detect-changes` after cutting the v2 branch reports `No changes detected` because the branch was created from the already committed fix.

Full-suite status:

```bash
cd gitnexus && npm test
```

This currently fails in local state with 3 non-F32 failures:

- `test/integration/cli-e2e.test.ts`: mini-repo fixture has an ignored `.gitignore` present locally, while the test expects it absent.
- `test/integration/pipeline-graph-golden.test.ts`: golden drift caused by the same local fixture pollution (`mini-repo` includes ignored docs / gitignore files), not by this Go change.
- `test/unit/wiki-flags.test.ts`: default OpenRouter model expectation mismatch (`minimax/minimax-m2.5` expected, `glm-5-turbo` received).

## Risk and rollback

Risk: high impact area. This touches shared generic extractors plus worker and sequential ingestion materialization paths.

Mitigations:

- Go-specific multi-name behavior is configured in Go query/extractor code.
- Generic extractor additions keep existing single-name extraction as the default behavior.
- Regression tests cover exact capture sets, per-name metadata, `struct_type` owner wiring, worker-style `nodeName` selection, and sequential runtime metadata.

Rollback: revert this PR to restore the previous Go declaration capture/extraction behavior.

## Documentation

No user-facing CLI, MCP, or web documentation changes are required. This is an ingestion correctness fix with test coverage.