### PR TITLE
feat(ingestion): M0 — taint/PDG substrate (schema + seams + spikes) (#2080)

### DIFF
--- a/gitnexus-shared/src/graph/types.ts
+++ b/gitnexus-shared/src/graph/types.ts
@@ -146,7 +146,10 @@ export type RelationshipType =
   /** Control-flow edge between two BasicBlock nodes (intra-procedural CFG). */
   | 'CFG'
   /** Data-dependence edge: a definition of `variable` reaches a use of it.
-   *  `variable` storage shape is decided by the M0/S1 spike. */
+   *  The `variable` name is stored in the relation's existing `reason` column
+   *  (M0/S1 verdict: LadybugDB has no secondary index on relationship
+   *  properties, so a dedicated indexed column would not speed the
+   *  variable-filtered path query). */
   | 'REACHING_DEF'
   /** A tainted value flows from source toward sink. */
   | 'TAINTED'

--- a/gitnexus-shared/src/graph/types.ts
+++ b/gitnexus-shared/src/graph/types.ts
@@ -44,7 +44,10 @@ export type NodeLabel =
   | 'Template'
   | 'Section'
   | 'Route'
-  | 'Tool';
+  | 'Tool'
+  // Taint/PDG substrate (issue #2080). Intra-procedural control-flow node.
+  // Emitted by no phase yet — M1 (#2081) populates these behind an opt-in.
+  | 'BasicBlock';
 
 export type NodeProperties = {
   name: string;
@@ -89,6 +92,8 @@ export type NodeProperties = {
   responseKeys?: string[];
   errorKeys?: string[];
   middleware?: string[];
+  // BasicBlock (taint/PDG substrate, issue #2080) — reuses filePath/startLine/endLine.
+  text?: string;
   // Extensible
   [key: string]: unknown;
 };
@@ -131,7 +136,25 @@ export type RelationshipType =
    *  `reason` encodes the event name: `vue-emit: <eventName>`.
    *  Complements `BINDS_EVENT_HANDLER`; a Cypher query joining on the
    *  component File node reveals all (emitter, handler) pairs. */
-  | 'EMITS_EVENT';
+  | 'EMITS_EVENT'
+  // ── Taint/PDG substrate (issue #2080) ────────────────────────────────────
+  // Reserved edge types for the taint-first PDG substrate. No phase emits any
+  // of these yet; they are populated behind an opt-in by later milestones
+  // (CFG → M1 #2081, REACHING_DEF → M2 #2082, TAINTED/SANITIZES/TAINT_PATH →
+  // M3/M4 #2083/#2084). Adding them here keeps the shared schema stable so
+  // downstream work does not re-ripple the exhaustiveness sites.
+  /** Control-flow edge between two BasicBlock nodes (intra-procedural CFG). */
+  | 'CFG'
+  /** Data-dependence edge: a definition of `variable` reaches a use of it.
+   *  `variable` storage shape is decided by the M0/S1 spike. */
+  | 'REACHING_DEF'
+  /** A tainted value flows from source toward sink. */
+  | 'TAINTED'
+  /** A sanitizer clears taint along a flow. */
+  | 'SANITIZES'
+  /** Materialized source→sink taint path. Working name — final name/representation
+   *  is confirmed when M3/M4 emits it; no persisted edge exists before then. */
+  | 'TAINT_PATH';
 
 export interface GraphNode {
   id: string;

--- a/gitnexus-shared/src/lbug/schema-constants.ts
+++ b/gitnexus-shared/src/lbug/schema-constants.ts
@@ -40,6 +40,8 @@ export const NODE_TABLES = [
   'Module',
   'Route',
   'Tool',
+  // Taint/PDG substrate (issue #2080) — inert until M1 (#2081) emits blocks.
+  'BasicBlock',
 ] as const;
 
 export type NodeTableName = (typeof NODE_TABLES)[number];
@@ -67,6 +69,14 @@ export const REL_TYPES = [
   'ENTRY_POINT_OF',
   'WRAPS',
   'QUERIES',
+  // Taint/PDG substrate (issue #2080) — reserved edge types, emitted by no
+  // phase yet (CFG → M1, REACHING_DEF → M2, TAINTED/SANITIZES/TAINT_PATH →
+  // M3/M4). REACHING_DEF's variable name rides the relation's `reason` column.
+  'CFG',
+  'REACHING_DEF',
+  'TAINTED',
+  'SANITIZES',
+  'TAINT_PATH',
 ] as const;
 
 export type RelType = (typeof REL_TYPES)[number];

--- a/gitnexus-web/src/lib/constants.ts
+++ b/gitnexus-web/src/lib/constants.ts
@@ -38,6 +38,7 @@ export const NODE_COLORS: Record<NodeLabel, string> = {
   Template: '#a78bfa', // Violet light - like Type
   Route: '#f43f5e', // Rose - like Process
   Tool: '#a855f7', // Purple - like Project
+  BasicBlock: '#475569', // Slate darker - control-flow node (muted, taint/PDG substrate)
 };
 
 // Node sizes by type - clear visual hierarchy with dramatic size differences
@@ -79,6 +80,7 @@ export const NODE_SIZES: Record<NodeLabel, number> = {
   Template: 3, // Like Type
   Route: 5, // Like Enum
   Tool: 5, // Like Enum
+  BasicBlock: 2, // Tiny - control-flow node (taint/PDG substrate)
 };
 
 // Community color palette for cluster-based coloring

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Taint/PDG substrate (M0)** — foundational schema + seams for reliable taint analysis on a PDG-expandable substrate (#2080, Epic #2087). Adds the `BasicBlock` node label and `CFG` / `REACHING_DEF` / `TAINTED` / `SANITIZES` / `TAINT_PATH` relationship types to the graph schema (round-trip through the bulk-COPY path), a phase-registry seam (`registerPhase` / `enabledWhen`) generalising the graph-phase opt-in guard, and a per-language source/sink/sanitizer config registry seam. All additive and inert — no phase emits the new nodes/edges yet, and a default `analyze` run is byte-identical to before. De-risking spikes (LadybugDB rel-property indexing, post-dominator feasibility) recorded on the issue.
+
 ## [1.6.6] - 2026-06-08
 
 ### Added

--- a/gitnexus/scripts/spikes/s1-reaching-def-index-bench.ts
+++ b/gitnexus/scripts/spikes/s1-reaching-def-index-bench.ts
@@ -1,0 +1,151 @@
+/**
+ * Spike S1 (issue #2080, M0) — THROWAWAY benchmark. Not part of the build
+ * (scripts/ is excluded from tsconfig) or the test suite.
+ *
+ * Question: can LadybugDB serve the headline REACHING_DEF query
+ *   [:REACHING_DEF*1..5 {variable}]
+ * fast enough, and what is the right storage shape for the `variable`?
+ *
+ * What it does:
+ *   1. Builds a synthetic ~100K-edge graph of BasicBlock nodes + REACHING_DEF
+ *      edges (variable carried in the CodeRelation `reason` column) with a
+ *      realistic per-variable fan-out distribution, and loads it through the
+ *      real bulk-COPY path (loadGraphToLbug).
+ *   2. Probes whether LadybugDB supports a secondary index on a relationship
+ *      property (the crux of the "edge property vs side table" decision).
+ *   3. Times the variable-filtered bounded var-length path query.
+ *
+ * Run:  npx tsx scripts/spikes/s1-reaching-def-index-bench.ts [edgeCount]
+ */
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { performance } from 'node:perf_hooks';
+import { createKnowledgeGraph } from '../../src/core/graph/graph.js';
+import type { KnowledgeGraph } from '../../src/core/graph/types.js';
+
+const EDGE_COUNT = Number(process.argv[2] ?? 30_000);
+// Realistic-ish def-use shape: many short chains, variables reused across them.
+const CHAIN_LEN = 6; // blocks per function-ish chain
+const DISTINCT_VARS = Math.max(1, Math.floor(EDGE_COUNT / 20)); // ~20 edges/variable fan-out
+
+const log = (m: string) => process.stdout.write(m + '\n');
+
+function buildSynthGraph(edgeCount: number): KnowledgeGraph {
+  const g = createKnowledgeGraph();
+  let edges = 0;
+  let chain = 0;
+  while (edges < edgeCount) {
+    const base = `BasicBlock:synth/f${chain}.ts`;
+    for (let i = 0; i <= CHAIN_LEN; i++) {
+      g.addNode({
+        id: `${base}:${i}`,
+        label: 'BasicBlock',
+        properties: {
+          name: '',
+          filePath: `synth/f${chain}.ts`,
+          startLine: i,
+          endLine: i,
+          text: '',
+        },
+      });
+    }
+    for (let i = 0; i < CHAIN_LEN && edges < edgeCount; i++) {
+      const variable = `v${edges % DISTINCT_VARS}`;
+      g.addRelationship({
+        id: `${base}:${i}->${i + 1}:${variable}`,
+        sourceId: `${base}:${i}`,
+        targetId: `${base}:${i + 1}`,
+        type: 'REACHING_DEF',
+        confidence: 1.0,
+        reason: variable, // M0 storage: variable rides `reason`
+      });
+      edges++;
+    }
+    chain++;
+  }
+  return g;
+}
+
+async function main() {
+  const tmp = path.join(os.tmpdir(), `s1-spike-${Date.now()}`);
+  const storagePath = path.join(tmp, '.gitnexus');
+  const dbPath = path.join(storagePath, 'lbug');
+  await fs.mkdir(dbPath, { recursive: true });
+
+  const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+  await adapter.initLbug(dbPath);
+
+  log(
+    `[S1] building synthetic graph: ~${EDGE_COUNT} REACHING_DEF edges, ` +
+      `${DISTINCT_VARS} distinct variables (~20 edges/var fan-out), chains of ${CHAIN_LEN}`,
+  );
+  const g = buildSynthGraph(EDGE_COUNT);
+
+  let t = performance.now();
+  await adapter.loadGraphToLbug(g, tmp, storagePath);
+  const loadMs = performance.now() - t;
+  const stats = await adapter.getLbugStats();
+  log(`[S1] bulk-COPY load: ${loadMs.toFixed(0)}ms  (nodes=${stats.nodes}, edges=${stats.edges})`);
+
+  // (2) Probe: does LadybugDB support a secondary index on a REL property?
+  let relIndexSupported = false;
+  let relIndexErr = '';
+  for (const stmt of [
+    "CALL CREATE_REL_INDEX('CodeRelation', 'cr_reason_idx', 'reason')",
+    'CREATE INDEX cr_reason_idx ON CodeRelation(reason)',
+  ]) {
+    try {
+      await adapter.executeQuery(stmt);
+      relIndexSupported = true;
+      break;
+    } catch (e: any) {
+      relIndexErr = String(e?.message ?? e).split('\n')[0];
+    }
+  }
+  log(
+    `[S1] rel-property secondary index supported? ${relIndexSupported}  ` +
+      `(last error: ${relIndexErr})`,
+  );
+
+  // (3a) Single-hop variable filter — the common case M3 runs most.
+  const probeVar = 'v0';
+  t = performance.now();
+  const single = await adapter.executeQuery(
+    `MATCH (a:BasicBlock)-[r:CodeRelation {type: 'REACHING_DEF', reason: '${probeVar}'}]->(b:BasicBlock)
+     RETURN count(r) AS c`,
+  );
+  const singleMs = performance.now() - t;
+  log(`[S1] single-hop variable filter → ${single[0]?.c} edges in ${singleMs.toFixed(0)}ms`);
+
+  // (3b) SOURCE-ANCHORED bounded var-length path — the realistic taint query
+  // (anchor the source block, then walk REACHING_DEF up to 5 hops). The
+  // UNANCHORED global form ([:REACHING_DEF*1..5] from every block) is
+  // impractical at scale (path explosion) — that is itself an S1 finding:
+  // taint queries MUST be scoped to a source block, not run graph-wide.
+  const srcId = 'BasicBlock:synth/f0.ts:0';
+  t = performance.now();
+  const anchored = await adapter.executeQuery(
+    `MATCH p = (a:BasicBlock)-[:CodeRelation*1..5 {type: 'REACHING_DEF'}]->(b:BasicBlock)
+     WHERE a.id = '${srcId}' AND all(rel IN relationships(p) WHERE rel.reason = '${probeVar}')
+     RETURN count(p) AS paths`,
+  );
+  const pathMs = performance.now() - t;
+  log(
+    `[S1] source-anchored [:REACHING_DEF*1..5 {reason='${probeVar}'}] from one block → ` +
+      `${anchored[0]?.paths} paths in ${pathMs.toFixed(0)}ms`,
+  );
+
+  await adapter.closeLbug();
+  await fs.rm(tmp, { recursive: true, force: true });
+
+  log('\n[S1] VERDICT INPUTS:');
+  log(
+    `  load_ms=${loadMs.toFixed(0)} single_hop_ms=${singleMs.toFixed(0)} anchored_path_ms=${pathMs.toFixed(0)} rel_index=${relIndexSupported}`,
+  );
+}
+
+main().catch((e) => {
+  console.error('[S1] FAILED:', e);
+  process.exit(1);
+});

--- a/gitnexus/scripts/spikes/s2-postdom-prototype.ts
+++ b/gitnexus/scripts/spikes/s2-postdom-prototype.ts
@@ -1,0 +1,162 @@
+/**
+ * Spike S2 (issue #2080, M0) — THROWAWAY post-dominator feasibility prototype.
+ * Not part of the build (scripts/ excluded from tsconfig) or the test suite.
+ *
+ * Question (per maintainer review): does the post-dominator algorithm Epic B
+ * (#2085, CDG) depends on hold up on real TS/JS control-flow shapes — the
+ * classic CFG hazards — before Epic B commits to it?
+ *
+ * Scope boundary: post-dominators operate on a CFG, not on the AST directly.
+ * This prototype validates the ALGORITHM (iterative dataflow on the reverse
+ * CFG, EXIT-rooted, → immediate-post-dominator tree) against CFGs that model
+ * each hazard's real TS control flow (the TS source each CFG represents is
+ * shown inline). Building the CFG from a tree-sitter AST is M1's job (#2081);
+ * this spike deliberately does not reimplement it.
+ *
+ * Run:  npx tsx scripts/spikes/s2-postdom-prototype.ts
+ */
+
+type CFG = {
+  name: string;
+  tsSource: string;
+  entry: string;
+  exit: string;
+  // adjacency: block -> successors
+  succ: Record<string, string[]>;
+  hazard: string;
+};
+
+// Iterative post-dominator dataflow on the reverse CFG.
+// PostDom(EXIT) = {EXIT}; PostDom(n) = {n} ∪ (⋂ PostDom(s) for s ∈ succ(n)).
+// Monotone over a finite lattice (powerset of blocks) ⇒ guaranteed to converge.
+function postDominators(cfg: CFG): { pdom: Record<string, Set<string>>; iterations: number } {
+  const blocks = Object.keys(cfg.succ);
+  const all = new Set(blocks);
+  const pdom: Record<string, Set<string>> = {};
+  for (const b of blocks) pdom[b] = b === cfg.exit ? new Set([cfg.exit]) : new Set(all);
+
+  let changed = true;
+  let iterations = 0;
+  while (changed) {
+    changed = false;
+    iterations++;
+    for (const b of blocks) {
+      if (b === cfg.exit) continue;
+      const succs = cfg.succ[b] ?? [];
+      let inter: Set<string> | null = null;
+      for (const s of succs) {
+        if (inter === null) inter = new Set(pdom[s]);
+        else inter = new Set([...inter].filter((x) => pdom[s].has(x)));
+      }
+      const next = new Set<string>(inter ?? []);
+      next.add(b);
+      if (next.size !== pdom[b].size || [...next].some((x) => !pdom[b].has(x))) {
+        pdom[b] = next;
+        changed = true;
+      }
+    }
+    if (iterations > blocks.length + 5)
+      throw new Error('post-dom did not converge (suspected bug)');
+  }
+  return { pdom, iterations };
+}
+
+// Immediate post-dominator: the closest strict post-dominator.
+function ipdom(cfg: CFG, pdom: Record<string, Set<string>>): Record<string, string | null> {
+  const res: Record<string, string | null> = {};
+  for (const b of Object.keys(cfg.succ)) {
+    if (b === cfg.exit) {
+      res[b] = null;
+      continue;
+    }
+    const strict = [...pdom[b]].filter((x) => x !== b);
+    // ipdom = the strict post-dom that does not post-dominate any other strict post-dom.
+    res[b] =
+      strict.find((cand) => strict.every((other) => other === cand || !pdom[other].has(cand))) ??
+      null;
+  }
+  return res;
+}
+
+const CFGS: CFG[] = [
+  {
+    name: 'early-return',
+    hazard: 'early return / multiple paths to EXIT',
+    tsSource: `function f(x){ if (x) { return 1; } g(); return 2; }`,
+    entry: 'ENTRY',
+    exit: 'EXIT',
+    succ: { ENTRY: ['ret1', 'g'], ret1: ['EXIT'], g: ['ret2'], ret2: ['EXIT'], EXIT: [] },
+  },
+  {
+    name: 'try-throw-finally',
+    hazard: 'try/throw/finally with multiple exits through finally',
+    tsSource: `function f(){ try { risky(); } catch(e){ handle(e); } finally { cleanup(); } done(); }`,
+    entry: 'ENTRY',
+    exit: 'EXIT',
+    // try → (normal | throw→catch) → finally → done → EXIT; finally also reached on rethrow
+    succ: {
+      ENTRY: ['try'],
+      try: ['finally', 'catch'],
+      catch: ['finally'],
+      finally: ['done', 'EXIT'],
+      done: ['EXIT'],
+      EXIT: [],
+    },
+  },
+  {
+    name: 'labeled-break',
+    hazard: 'labeled break/continue across nested loops',
+    tsSource: `outer: for(;;){ for(;;){ if (a) break outer; if (b) continue outer; work(); } }`,
+    entry: 'ENTRY',
+    exit: 'EXIT',
+    succ: {
+      ENTRY: ['outerHead'],
+      outerHead: ['innerHead', 'EXIT'],
+      innerHead: ['breakOuter', 'afterIf1'],
+      breakOuter: ['EXIT'],
+      afterIf1: ['contOuter', 'work'],
+      contOuter: ['outerHead'],
+      work: ['innerHead'],
+      EXIT: [],
+    },
+  },
+  {
+    name: 'if-else-diamond',
+    hazard: 'baseline reducible diamond (sanity)',
+    tsSource: `function f(x){ if (x) { a(); } else { b(); } c(); }`,
+    entry: 'ENTRY',
+    exit: 'EXIT',
+    succ: { ENTRY: ['a', 'b'], a: ['c'], b: ['c'], c: ['EXIT'], EXIT: [] },
+  },
+];
+
+function main() {
+  let allOk = true;
+  for (const cfg of CFGS) {
+    try {
+      const { pdom, iterations } = postDominators(cfg);
+      const idom = ipdom(cfg, pdom);
+      // Sanity invariants: EXIT post-dominates every block; ipdom tree reaches EXIT.
+      const exitPostDomsAll = Object.keys(cfg.succ).every((b) => pdom[b].has(cfg.exit));
+      console.log(`\n[S2] ${cfg.name} — ${cfg.hazard}`);
+      console.log(`     TS: ${cfg.tsSource}`);
+      console.log(
+        `     converged in ${iterations} iters; EXIT post-dominates all blocks: ${exitPostDomsAll}`,
+      );
+      console.log(
+        `     ipdom tree: ${Object.entries(idom)
+          .map(([b, p]) => `${b}->${p ?? '∅'}`)
+          .join('  ')}`,
+      );
+      if (!exitPostDomsAll) allOk = false;
+    } catch (e) {
+      allOk = false;
+      console.log(`\n[S2] ${cfg.name} FAILED: ${(e as Error).message}`);
+    }
+  }
+  console.log(
+    `\n[S2] VERDICT INPUT: all hazard CFGs converged + EXIT post-dominates all = ${allOk}`,
+  );
+}
+
+main();

--- a/gitnexus/src/core/ingestion/model/registration-table.ts
+++ b/gitnexus/src/core/ingestion/model/registration-table.ts
@@ -182,6 +182,9 @@ const LABEL_BEHAVIOR = {
   Section: 'inert',
   Route: 'inert',
   Tool: 'inert',
+  // Taint/PDG substrate (issue #2080) — a control-flow node, never a
+  // symbol-resolution target. Inert: file index only, no owner scope.
+  BasicBlock: 'inert',
 } as const satisfies Record<NodeLabel, LabelBehavior> &
   // Cross-invariant 1 — every class-like label (participates in
   // qualifiedName fallback in `SymbolTable.add()`) MUST be classified as

--- a/gitnexus/src/core/ingestion/pipeline-phases/index.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/index.ts
@@ -30,3 +30,4 @@ export { processesPhase, type ProcessesOutput } from './processes.js';
 export { runPipeline } from './runner.js';
 export type { PipelinePhase, PipelineContext, PhaseResult } from './types.js';
 export { getPhaseOutput } from './types.js';
+export { PhaseRegistry, type RegisterPhaseOptions } from './registry.js';

--- a/gitnexus/src/core/ingestion/pipeline-phases/registry.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/registry.ts
@@ -1,0 +1,66 @@
+/**
+ * Phase registry seam (issue #2080, taint/PDG substrate M0).
+ *
+ * A small, behaviour-preserving abstraction over phase-list *assembly*. Today
+ * `buildPhaseList` is a hand-maintained array with a single ad-hoc
+ * `if (!skipGraphPhases)` guard; this registry generalises that guard into a
+ * per-phase `enabledWhen` predicate so later milestones can register opt-in
+ * phases (e.g. CFG → M1 #2081) without editing the array each time.
+ *
+ * M0 wires the seam with **no behaviour change**: `build(options)` must return
+ * a phase list identical in membership and order to the legacy array for every
+ * options combination. The registry covers only list assembly — the runner,
+ * topological sort, `PipelinePhase.execute`, and any result-extraction guards
+ * (e.g. the `skipGraphPhases` check in `runPipelineFromRepo`) are untouched.
+ *
+ * Generic over the options type so this module depends only on `PipelinePhase`
+ * (no import of `PipelineOptions`, which lives in `pipeline.ts` and would
+ * otherwise create an import cycle).
+ */
+
+import type { PipelinePhase } from './types.js';
+
+/** Options accepted when registering a phase. */
+export interface RegisterPhaseOptions<TOptions> {
+  /**
+   * Predicate deciding whether this phase is included for a given options
+   * object. Absent ⇒ the phase is always enabled. This is the generalised
+   * form of the legacy `if (!skipGraphPhases)` guard.
+   */
+  readonly enabledWhen?: (options: TOptions | undefined) => boolean;
+}
+
+interface PhaseRegistration<TOptions> {
+  readonly phase: PipelinePhase;
+  readonly enabledWhen?: (options: TOptions | undefined) => boolean;
+}
+
+/**
+ * Ordered registry of pipeline phases. Not a global singleton — callers
+ * construct a fresh registry (so registration order is deterministic and there
+ * is no import-order or test-isolation hazard) and `build()` it per run.
+ */
+export class PhaseRegistry<TOptions = unknown> {
+  private readonly registrations: PhaseRegistration<TOptions>[] = [];
+
+  /**
+   * Register a phase. This is the `registerPhase(phase, { enabledWhen })` seam
+   * named in issue #2080. Returns `this` for fluent chaining. Registration
+   * order is preserved by `build()`.
+   */
+  register(phase: PipelinePhase, options?: RegisterPhaseOptions<TOptions>): this {
+    this.registrations.push({ phase, enabledWhen: options?.enabledWhen });
+    return this;
+  }
+
+  /**
+   * Build the ordered phase list for the given options. A phase is included
+   * iff it has no `enabledWhen` predicate or its predicate returns `true`.
+   * Order matches registration order.
+   */
+  build(options?: TOptions): PipelinePhase[] {
+    return this.registrations
+      .filter((r) => r.enabledWhen === undefined || r.enabledWhen(options))
+      .map((r) => r.phase);
+  }
+}

--- a/gitnexus/src/core/ingestion/pipeline-phases/registry.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/registry.ts
@@ -26,13 +26,18 @@ export interface RegisterPhaseOptions<TOptions> {
    * Predicate deciding whether this phase is included for a given options
    * object. Absent ⇒ the phase is always enabled. This is the generalised
    * form of the legacy `if (!skipGraphPhases)` guard.
+   *
+   * `options` is required, not optional: callers normalize an absent options
+   * object once at `build()` (e.g. `buildPhaseList` passes `options ?? {}`), so
+   * individual predicates read `(o) => !o.skipGraphPhases` without a defensive
+   * `?.` on every phase (#2080 review S1).
    */
-  readonly enabledWhen?: (options: TOptions | undefined) => boolean;
+  readonly enabledWhen?: (options: TOptions) => boolean;
 }
 
 interface PhaseRegistration<TOptions> {
   readonly phase: PipelinePhase;
-  readonly enabledWhen?: (options: TOptions | undefined) => boolean;
+  readonly enabledWhen?: (options: TOptions) => boolean;
 }
 
 /**
@@ -56,9 +61,11 @@ export class PhaseRegistry<TOptions = unknown> {
   /**
    * Build the ordered phase list for the given options. A phase is included
    * iff it has no `enabledWhen` predicate or its predicate returns `true`.
-   * Order matches registration order.
+   * Order matches registration order. `options` is required — callers that may
+   * have no options normalize once at the call site (`options ?? {}`) so the
+   * predicates never see `undefined`.
    */
-  build(options?: TOptions): PipelinePhase[] {
+  build(options: TOptions): PipelinePhase[] {
     return this.registrations
       .filter((r) => r.enabledWhen === undefined || r.enabledWhen(options))
       .map((r) => r.phase);

--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -153,22 +153,26 @@ export interface PipelineOptions {
  * options combination.
  */
 export function buildPhaseList(options?: PipelineOptions): PipelinePhase[] {
-  return new PhaseRegistry<PipelineOptions>()
-    .register(scanPhase)
-    .register(structurePhase)
-    .register(markdownPhase)
-    .register(cobolPhase)
-    .register(parsePhase)
-    .register(routesPhase)
-    .register(toolsPhase)
-    .register(ormPhase)
-    .register(crossFilePhase)
-    .register(scopeResolutionPhase)
-    .register(pruneLocalSymbolsPhase)
-    .register(mroPhase, { enabledWhen: (o) => !o?.skipGraphPhases })
-    .register(communitiesPhase, { enabledWhen: (o) => !o?.skipGraphPhases })
-    .register(processesPhase, { enabledWhen: (o) => !o?.skipGraphPhases })
-    .build(options);
+  return (
+    new PhaseRegistry<PipelineOptions>()
+      .register(scanPhase)
+      .register(structurePhase)
+      .register(markdownPhase)
+      .register(cobolPhase)
+      .register(parsePhase)
+      .register(routesPhase)
+      .register(toolsPhase)
+      .register(ormPhase)
+      .register(crossFilePhase)
+      .register(scopeResolutionPhase)
+      .register(pruneLocalSymbolsPhase)
+      .register(mroPhase, { enabledWhen: (o) => !o.skipGraphPhases })
+      .register(communitiesPhase, { enabledWhen: (o) => !o.skipGraphPhases })
+      .register(processesPhase, { enabledWhen: (o) => !o.skipGraphPhases })
+      // Normalize a missing options object once here so phase predicates above
+      // take a required PipelineOptions and need no `?.` guard (#2080 review S1).
+      .build(options ?? {})
+  );
 }
 
 // ── Pipeline orchestrator ─────────────────────────────────────────────────

--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -35,6 +35,7 @@ import {
   mroPhase,
   communitiesPhase,
   processesPhase,
+  PhaseRegistry,
   type ScopeResolutionOutput,
   type PipelinePhase,
   type CommunitiesOutput,
@@ -142,28 +143,32 @@ export interface PipelineOptions {
  *     → mro → communities → processes
  *
  * To add a new phase: create a file in pipeline-phases/, export the phase
- * object, and add it to the appropriate position in this array.
+ * object, and `.register()` it at the appropriate position below. Opt-in
+ * phases pass an `enabledWhen` predicate (issue #2080 phase-registry seam) —
+ * the legacy `if (!skipGraphPhases)` guard is now expressed that way on the
+ * three graph phases, with no change in behaviour.
+ *
+ * Exported for the parity test (`pipeline-phase-registry.test.ts`), which
+ * asserts the produced list is byte-identical to the legacy array for every
+ * options combination.
  */
-function buildPhaseList(options?: PipelineOptions): PipelinePhase[] {
-  const phases: PipelinePhase[] = [
-    scanPhase,
-    structurePhase,
-    markdownPhase,
-    cobolPhase,
-    parsePhase,
-    routesPhase,
-    toolsPhase,
-    ormPhase,
-    crossFilePhase,
-    scopeResolutionPhase,
-    pruneLocalSymbolsPhase,
-  ];
-
-  if (!options?.skipGraphPhases) {
-    phases.push(mroPhase, communitiesPhase, processesPhase);
-  }
-
-  return phases;
+export function buildPhaseList(options?: PipelineOptions): PipelinePhase[] {
+  return new PhaseRegistry<PipelineOptions>()
+    .register(scanPhase)
+    .register(structurePhase)
+    .register(markdownPhase)
+    .register(cobolPhase)
+    .register(parsePhase)
+    .register(routesPhase)
+    .register(toolsPhase)
+    .register(ormPhase)
+    .register(crossFilePhase)
+    .register(scopeResolutionPhase)
+    .register(pruneLocalSymbolsPhase)
+    .register(mroPhase, { enabledWhen: (o) => !o?.skipGraphPhases })
+    .register(communitiesPhase, { enabledWhen: (o) => !o?.skipGraphPhases })
+    .register(processesPhase, { enabledWhen: (o) => !o?.skipGraphPhases })
+    .build(options);
 }
 
 // ── Pipeline orchestrator ─────────────────────────────────────────────────

--- a/gitnexus/src/core/ingestion/taint/source-sink-config.ts
+++ b/gitnexus/src/core/ingestion/taint/source-sink-config.ts
@@ -1,0 +1,38 @@
+/**
+ * Source/sink/sanitizer config model (issue #2080, taint/PDG substrate M0).
+ *
+ * The per-language taint configuration *shape*. M0 ships only the type and an
+ * (empty) registry seam — no analysis consumes it yet. M3 (#2083, intra-proc
+ * taint) populates per-language specs and reads them when emitting TAINTED /
+ * SANITIZES edges.
+ *
+ * Kept deliberately minimal: enough for M3 to express "callable X is a
+ * source / sink / sanitizer, optionally for argument position N" without M0
+ * committing to matcher semantics it cannot yet validate. The shape is
+ * expected to grow (e.g. sanitizer escape conditions, return-position taint)
+ * when M3 makes contact with real flows; that is a forward-declared-interface
+ * design choice, not a finished contract.
+ */
+
+/**
+ * Identifies a callable that participates in taint flow. `name` is matched
+ * against a resolved callable (simple or qualified name — exact matching
+ * semantics are M3's call). `args` optionally narrows to specific 0-based
+ * argument positions that carry taint (for a source/sink) or clear it (for a
+ * sanitizer); omit to mean "unspecified / all".
+ */
+export interface TaintCallableMatcher {
+  readonly name: string;
+  readonly args?: readonly number[];
+}
+
+/**
+ * The taint configuration for a single language: which callables introduce
+ * taint (sources), which are dangerous to reach with tainted input (sinks),
+ * and which clear taint (sanitizers).
+ */
+export interface SourceSinkSanitizerSpec {
+  readonly sources: readonly TaintCallableMatcher[];
+  readonly sinks: readonly TaintCallableMatcher[];
+  readonly sanitizers: readonly TaintCallableMatcher[];
+}

--- a/gitnexus/src/core/ingestion/taint/source-sink-registry.ts
+++ b/gitnexus/src/core/ingestion/taint/source-sink-registry.ts
@@ -1,0 +1,42 @@
+/**
+ * Per-language source/sink/sanitizer registry seam (issue #2080).
+ *
+ * A keyed registry of {@link SourceSinkSanitizerSpec} by language id. M0 stands
+ * up the empty seam — no language is registered and nothing in the pipeline
+ * reads it. M3 (#2083) registers per-language specs and queries this registry
+ * when emitting taint edges.
+ *
+ * The store is module-level (matching the codebase's other per-language
+ * registries). {@link clearSourceSinkRegistry} resets it for test isolation.
+ */
+
+import type { SourceSinkSanitizerSpec } from './source-sink-config.js';
+
+const registry = new Map<string, SourceSinkSanitizerSpec>();
+
+/**
+ * Register the taint config for a language. Last-write-wins: re-registering
+ * the same `languageId` overwrites the previous spec (so M3 can override a
+ * built-in default). Returns nothing.
+ */
+export function registerSourceSinkConfig(languageId: string, spec: SourceSinkSanitizerSpec): void {
+  registry.set(languageId, spec);
+}
+
+/**
+ * Look up the taint config for a language. Returns `undefined` when no spec is
+ * registered (the M0 default for every language) — never throws.
+ */
+export function getSourceSinkConfig(languageId: string): SourceSinkSanitizerSpec | undefined {
+  return registry.get(languageId);
+}
+
+/** Language ids that currently have a registered spec. Empty in M0. */
+export function registeredTaintLanguages(): string[] {
+  return [...registry.keys()];
+}
+
+/** Reset the registry. Primarily for test isolation. */
+export function clearSourceSinkRegistry(): void {
+  registry.clear();
+}

--- a/gitnexus/src/core/lbug/csv-generator.ts
+++ b/gitnexus/src/core/lbug/csv-generator.ts
@@ -492,7 +492,7 @@ export const streamAllCSVsToDisk = async (
             escapeCSVField(node.properties.filePath || ''),
             escapeCSVNumber(node.properties.startLine, -1),
             escapeCSVNumber(node.properties.endLine, -1),
-            escapeCSVField((node.properties.text as string) || ''),
+            escapeCSVField(node.properties.text || ''),
           ].join(','),
         );
         break;

--- a/gitnexus/src/core/lbug/csv-generator.ts
+++ b/gitnexus/src/core/lbug/csv-generator.ts
@@ -305,6 +305,13 @@ export const streamAllCSVsToDisk = async (
     'id,name,filePath,description',
   );
 
+  // BasicBlock nodes — taint/PDG substrate (issue #2080). No `name` column;
+  // blocks are identified by id + source span. Emitted by no phase yet.
+  const basicBlockWriter = new BufferedCSVWriter(
+    path.join(csvDir, 'basicblock.csv'),
+    'id,filePath,startLine,endLine,text',
+  );
+
   // Multi-language node types share the same CSV shape (no isExported column)
   const multiLangHeader = 'id,name,filePath,startLine,endLine,content,description';
   const MULTI_LANG_TYPES = [
@@ -478,6 +485,17 @@ export const streamAllCSVsToDisk = async (
           ].join(','),
         );
         break;
+      case 'BasicBlock':
+        await basicBlockWriter.addRow(
+          [
+            escapeCSVField(node.id),
+            escapeCSVField(node.properties.filePath || ''),
+            escapeCSVNumber(node.properties.startLine, -1),
+            escapeCSVNumber(node.properties.endLine, -1),
+            escapeCSVField((node.properties.text as string) || ''),
+          ].join(','),
+        );
+        break;
       default: {
         // Code element nodes (Function, Class, Interface, CodeElement)
         const writer = codeWriterMap[node.label];
@@ -535,6 +553,7 @@ export const streamAllCSVsToDisk = async (
     sectionWriter,
     routeWriter,
     toolWriter,
+    basicBlockWriter,
     ...multiLangWriters.values(),
   ];
   await Promise.all(allWriters.map((w) => w.finish()));
@@ -571,6 +590,7 @@ export const streamAllCSVsToDisk = async (
     ['Section' as NodeTableName, sectionWriter],
     ['Route' as NodeTableName, routeWriter],
     ['Tool' as NodeTableName, toolWriter],
+    ['BasicBlock' as NodeTableName, basicBlockWriter],
     ...Array.from(multiLangWriters.entries()).map(
       ([name, w]) => [name as NodeTableName, w] as [NodeTableName, BufferedCSVWriter],
     ),

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -1124,6 +1124,10 @@ const getCopyQuery = (table: NodeTableName, filePath: string): string => {
   if (table === 'Tool') {
     return `COPY ${t}(id, name, filePath, description) FROM "${filePath}" ${COPY_CSV_OPTS}`;
   }
+  if (table === 'BasicBlock') {
+    // Taint/PDG substrate (issue #2080) — no name column.
+    return `COPY ${t}(id, filePath, startLine, endLine, text) FROM "${filePath}" ${COPY_CSV_OPTS}`;
+  }
   if (table === 'Method') {
     return `COPY ${t}(id, name, filePath, startLine, endLine, isExported, content, description, parameterCount, returnType) FROM "${filePath}" ${COPY_CSV_OPTS}`;
   }
@@ -1176,6 +1180,9 @@ export const insertNodeToLbug = async (
         ? `, description: ${escapeValue(properties.description)}`
         : '';
       query = `CREATE (n:Section {id: ${escapeValue(properties.id)}, name: ${escapeValue(properties.name)}, filePath: ${escapeValue(properties.filePath)}, startLine: ${properties.startLine || 0}, endLine: ${properties.endLine || 0}, level: ${properties.level || 1}, content: ${escapeValue(properties.content || '')}${descPart}})`;
+    } else if (label === 'BasicBlock') {
+      // Taint/PDG substrate (issue #2080) — no name column.
+      query = `CREATE (n:BasicBlock {id: ${escapeValue(properties.id)}, filePath: ${escapeValue(properties.filePath)}, startLine: ${properties.startLine || 0}, endLine: ${properties.endLine || 0}, text: ${escapeValue(properties.text || '')}})`;
     } else if (TABLES_WITH_EXPORTED.has(label)) {
       const descPart = properties.description
         ? `, description: ${escapeValue(properties.description)}`
@@ -1259,6 +1266,9 @@ export const batchInsertNodesToLbug = async (
             ? `, n.description = ${escapeValue(properties.description)}`
             : '';
           query = `MERGE (n:Section {id: ${escapeValue(properties.id)}}) SET n.name = ${escapeValue(properties.name)}, n.filePath = ${escapeValue(properties.filePath)}, n.startLine = ${properties.startLine || 0}, n.endLine = ${properties.endLine || 0}, n.level = ${properties.level || 1}, n.content = ${escapeValue(properties.content || '')}${descPart}`;
+        } else if (label === 'BasicBlock') {
+          // Taint/PDG substrate (issue #2080) — no name column.
+          query = `MERGE (n:BasicBlock {id: ${escapeValue(properties.id)}}) SET n.filePath = ${escapeValue(properties.filePath)}, n.startLine = ${properties.startLine || 0}, n.endLine = ${properties.endLine || 0}, n.text = ${escapeValue(properties.text || '')}`;
         } else if (TABLES_WITH_EXPORTED.has(label)) {
           const descPart = properties.description
             ? `, n.description = ${escapeValue(properties.description)}`

--- a/gitnexus/src/core/lbug/schema.ts
+++ b/gitnexus/src/core/lbug/schema.ts
@@ -221,6 +221,23 @@ CREATE NODE TABLE Section (
   PRIMARY KEY (id)
 )`;
 
+// Taint/PDG substrate (issue #2080) — intra-procedural control-flow node.
+// Emitted by no phase yet; M1 (#2081) populates these behind an opt-in.
+// REACHING_DEF carries its variable name in the relation's existing `reason`
+// column (see RELATION_SCHEMA) — LadybugDB has no secondary index on rel
+// properties, so a dedicated indexed column would buy nothing for the
+// variable-filtered path query (M0/S1 verdict). No `name` column: blocks are
+// identified by id + source span, not a symbol name.
+export const BASICBLOCK_SCHEMA = `
+CREATE NODE TABLE BasicBlock (
+  id STRING,
+  filePath STRING,
+  startLine INT64,
+  endLine INT64,
+  text STRING,
+  PRIMARY KEY (id)
+)`;
+
 // ============================================================================
 // RELATION TABLE SCHEMA
 // Single table with 'type' property - connects all node tables
@@ -431,6 +448,7 @@ CREATE REL TABLE ${REL_TABLE_NAME} (
   FROM CodeElement TO Process,
   FROM Route TO Process,
   FROM Tool TO Process,
+  FROM BasicBlock TO BasicBlock,
   type STRING,
   confidence DOUBLE,
   reason STRING,
@@ -521,6 +539,11 @@ export const NODE_SCHEMA_QUERIES = [
   ROUTE_SCHEMA,
   // MCP tools
   TOOL_SCHEMA,
+  // Taint/PDG substrate (issue #2080) — must be appended here, not just
+  // declared above: SCHEMA_QUERIES (the list initLbug actually runs) is built
+  // from NODE_SCHEMA_QUERIES. Omitting this leaves the BasicBlock table
+  // uncreated and the bulk-COPY round-trip fails with "table does not exist".
+  BASICBLOCK_SCHEMA,
 ];
 
 export const REL_SCHEMA_QUERIES = [RELATION_SCHEMA];

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -384,7 +384,13 @@ const mapGraphNodeRow = (table: string, row: any, includeContent: boolean): Grap
   id: row.id ?? row[0],
   label: table as GraphNode['label'],
   properties: {
-    name: row.name ?? row.label ?? row[1],
+    // `?? ''` keeps NodeProperties.name a `string` even for label rows that
+    // project no name/label column (BasicBlock — taint/PDG substrate #2080).
+    // Without it, BasicBlock rows carry name:undefined (masked by the cast
+    // below) and the web layer (Header search, circles/tree layout) derefs
+    // `.name` unguarded → TypeError once M1 emits blocks. `row.text` gives a
+    // BasicBlock a sensible fallback name before the empty-string floor.
+    name: row.name ?? row.label ?? row.text ?? row[1] ?? '',
     filePath: row.filePath ?? row[2],
     startLine: row.startLine,
     endLine: row.endLine,

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -344,9 +344,17 @@ const GRAPH_RELATIONSHIP_QUERY =
 
 const quoteNodeTable = (table: string): string => `\`${table.replace(/`/g, '``')}\``;
 
-const getNodeQuery = (table: string, includeContent: boolean): string => {
+export const getNodeQuery = (table: string, includeContent: boolean): string => {
   const tableLabel = quoteNodeTable(table);
 
+  if (table === 'BasicBlock') {
+    // Taint/PDG substrate (issue #2080) — BasicBlock has no name/content
+    // columns. Project only its declared columns: a default `n.name`
+    // projection raises a Ladybug "Cannot find property name" binder error
+    // (not matched by isIgnorableGraphQueryError), which would 500 the graph
+    // endpoint the moment BasicBlock joins NODE_TABLES, even on an empty table.
+    return `MATCH (n:${tableLabel}) RETURN n.id AS id, n.filePath AS filePath, n.startLine AS startLine, n.endLine AS endLine, n.text AS text`;
+  }
   if (table === 'File') {
     return includeContent
       ? `MATCH (n:${tableLabel}) RETURN n.id AS id, n.name AS name, n.filePath AS filePath, n.content AS content`
@@ -380,6 +388,7 @@ const mapGraphNodeRow = (table: string, row: any, includeContent: boolean): Grap
     filePath: row.filePath ?? row[2],
     startLine: row.startLine,
     endLine: row.endLine,
+    text: row.text,
     content: includeContent ? row.content : undefined,
     responseKeys: row.responseKeys,
     errorKeys: row.errorKeys,

--- a/gitnexus/test/integration/basicblock-roundtrip.test.ts
+++ b/gitnexus/test/integration/basicblock-roundtrip.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Integration test: BasicBlock + taint/PDG edge types round-trip the
+ * bulk-COPY load path (issue #2080, U5 / R4 / AC2).
+ *
+ * Exercises the real csv-generator → loadGraphToLbug → COPY → query path:
+ *  - a BasicBlock node (id/filePath/startLine/endLine/text) round-trips
+ *  - one edge of each new type (CFG/REACHING_DEF/TAINTED/SANITIZES/TAINT_PATH)
+ *    between two BasicBlocks round-trips (asserts the new FROM/TO DDL pair +
+ *    REL_TYPES load through bulk COPY)
+ *  - REACHING_DEF carries its `variable` in the existing `reason` column
+ *    (M0/S1 storage decision) and a variable-filtered query returns it
+ *  - the DDL (BASICBLOCK_SCHEMA wired into NODE_SCHEMA_QUERIES) loads on a
+ *    fresh DB — if BASICBLOCK_SCHEMA were not in SCHEMA_QUERIES, initLbug would
+ *    never create the table and these COPYs would fail (F1 guard, end-to-end)
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { buildTestGraph } from '../helpers/test-graph.js';
+
+let tmpBase: string;
+let storagePath: string;
+let dbPath: string;
+
+const BB1 = 'BasicBlock:src/a.ts:0';
+const BB2 = 'BasicBlock:src/a.ts:1';
+const NEW_EDGE_TYPES = ['CFG', 'REACHING_DEF', 'TAINTED', 'SANITIZES', 'TAINT_PATH'] as const;
+
+beforeAll(async () => {
+  tmpBase = path.join(os.tmpdir(), `gitnexus-bb-roundtrip-${Date.now()}-${process.pid}`);
+  storagePath = path.join(tmpBase, '.gitnexus');
+  dbPath = path.join(storagePath, 'lbug');
+  await fs.mkdir(dbPath, { recursive: true });
+
+  const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+  await adapter.initLbug(dbPath);
+
+  // Two BasicBlock nodes + one edge of each new type between them. The
+  // REACHING_DEF edge stores its variable name ('x') in `reason`.
+  const graph = buildTestGraph(
+    [
+      {
+        id: BB1,
+        label: 'BasicBlock',
+        name: '', // BasicBlock has no name column; ignored by the writer
+        filePath: 'src/a.ts',
+        startLine: 1,
+        endLine: 3,
+        extra: { text: 'const x = req.body;' },
+      },
+      {
+        id: BB2,
+        label: 'BasicBlock',
+        name: '',
+        filePath: 'src/a.ts',
+        startLine: 4,
+        endLine: 6,
+        extra: { text: 'sink(x);' },
+      },
+    ],
+    NEW_EDGE_TYPES.map((type) => ({
+      sourceId: BB1,
+      targetId: BB2,
+      type,
+      reason: type === 'REACHING_DEF' ? 'x' : `${type.toLowerCase()}-edge`,
+    })),
+  );
+
+  await adapter.loadGraphToLbug(graph, tmpBase, storagePath);
+});
+
+afterAll(async () => {
+  try {
+    const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+    await adapter.closeLbug();
+  } catch {
+    /* may not have opened */
+  }
+  if (tmpBase) {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      try {
+        await fs.rm(tmpBase, { recursive: true, force: true });
+        return;
+      } catch {
+        if (attempt < 4) await new Promise((r) => setTimeout(r, 200 * (attempt + 1)));
+      }
+    }
+  }
+});
+
+describe('BasicBlock + taint/PDG edge round-trip (#2080)', () => {
+  it('BasicBlock nodes round-trip with their source span and text', async () => {
+    const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+    const rows = await adapter.executeQuery(
+      'MATCH (n:BasicBlock) RETURN n.id AS id, n.text AS text, n.startLine AS startLine ORDER BY n.id',
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows[0].id).toBe(BB1);
+    expect(rows[0].text).toBe('const x = req.body;');
+    expect(Number(rows[0].startLine)).toBe(1);
+    expect(rows[1].id).toBe(BB2);
+    expect(rows[1].text).toBe('sink(x);');
+  });
+
+  it('each new edge type round-trips between the two BasicBlocks', async () => {
+    const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+    // All edges live in the single CodeRelation table, keyed by `type`.
+    for (const type of NEW_EDGE_TYPES) {
+      const rows = await adapter.executeQuery(
+        `MATCH (:BasicBlock)-[r:CodeRelation {type: '${type}'}]->(:BasicBlock) RETURN count(r) AS c`,
+      );
+      expect(Number(rows[0].c), `${type} edge should round-trip`).toBe(1);
+    }
+  });
+
+  it('REACHING_DEF carries its variable in reason and is queryable by it', async () => {
+    const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+    const rows = await adapter.executeQuery(
+      "MATCH (a:BasicBlock)-[r:CodeRelation {type: 'REACHING_DEF', reason: 'x'}]->(b:BasicBlock) RETURN a.id AS from, b.id AS to",
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].from).toBe(BB1);
+    expect(rows[0].to).toBe(BB2);
+  });
+});

--- a/gitnexus/test/integration/basicblock-roundtrip.test.ts
+++ b/gitnexus/test/integration/basicblock-roundtrip.test.ts
@@ -17,7 +17,9 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
+import { NODE_TABLES } from 'gitnexus-shared';
 import { buildTestGraph } from '../helpers/test-graph.js';
+import { getNodeQuery } from '../../src/server/api.js';
 
 let tmpBase: string;
 let storagePath: string;
@@ -93,14 +95,40 @@ describe('BasicBlock + taint/PDG edge round-trip (#2080)', () => {
   it('BasicBlock nodes round-trip with their source span and text', async () => {
     const adapter = await import('../../src/core/lbug/lbug-adapter.js');
     const rows = await adapter.executeQuery(
-      'MATCH (n:BasicBlock) RETURN n.id AS id, n.text AS text, n.startLine AS startLine ORDER BY n.id',
+      'MATCH (n:BasicBlock) RETURN n.id AS id, n.text AS text, n.filePath AS filePath, n.startLine AS startLine, n.endLine AS endLine ORDER BY n.id',
     );
     expect(rows).toHaveLength(2);
     expect(rows[0].id).toBe(BB1);
     expect(rows[0].text).toBe('const x = req.body;');
+    expect(rows[0].filePath).toBe('src/a.ts');
     expect(Number(rows[0].startLine)).toBe(1);
+    expect(Number(rows[0].endLine)).toBe(3);
     expect(rows[1].id).toBe(BB2);
     expect(rows[1].text).toBe('sink(x);');
+    expect(rows[1].filePath).toBe('src/a.ts');
+    expect(Number(rows[1].endLine)).toBe(6);
+  });
+
+  // Regression guard: adding a node table whose columns differ from the
+  // default (BasicBlock has no name/content) must not break the server's
+  // graph read path. getNodeQuery is what /api/graph's buildGraph +
+  // streamGraphNdjson run per NODE_TABLE; a default `n.name` projection on
+  // BasicBlock raises a non-ignorable Ladybug binder error → HTTP 500 on
+  // every analyzed repo. Assert every NODE_TABLE's query binds + runs, and
+  // that BasicBlock returns its loaded rows.
+  it('getNodeQuery binds + runs for every NODE_TABLE against the real schema', async () => {
+    const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+    for (const table of NODE_TABLES) {
+      for (const includeContent of [false, true]) {
+        const q = getNodeQuery(table, includeContent);
+        await expect(
+          adapter.executeQuery(q),
+          `getNodeQuery(${table}, includeContent=${includeContent}) should bind`,
+        ).resolves.toBeDefined();
+      }
+    }
+    const bbRows = await adapter.executeQuery(getNodeQuery('BasicBlock', false));
+    expect(bbRows).toHaveLength(2);
   });
 
   it('each new edge type round-trips between the two BasicBlocks', async () => {

--- a/gitnexus/test/unit/api-graph-streaming.test.ts
+++ b/gitnexus/test/unit/api-graph-streaming.test.ts
@@ -232,4 +232,53 @@ describe('streamGraphNdjson', () => {
       },
     });
   });
+
+  // Taint/PDG substrate (#2080): BasicBlock has no name/content columns, so its
+  // getNodeQuery projects none — mapGraphNodeRow must still yield a `string`
+  // name (NodeProperties.name contract) or the web layer derefs undefined.
+  it('emits a string name for BasicBlock nodes (no name column)', async () => {
+    lbugMocks.streamQuery.mockImplementation(
+      async (query: string, onRow: (row: any) => Promise<void>) => {
+        if (query.includes('MATCH (n:`BasicBlock`)')) {
+          expect(query).not.toContain('n.name'); // BasicBlock projects no name column
+          await onRow({
+            id: 'BasicBlock:src/a.ts:0',
+            filePath: 'src/a.ts',
+            startLine: 1,
+            endLine: 3,
+            text: 'const x = req.body;',
+          });
+          // a block with no text must still map to a string name, not undefined
+          await onRow({
+            id: 'BasicBlock:src/a.ts:1',
+            filePath: 'src/a.ts',
+            startLine: 4,
+            endLine: 4,
+          });
+          return 2;
+        }
+        return 0;
+      },
+    );
+
+    const writes: string[] = [];
+    const response = createMockResponse((chunk) => {
+      writes.push(chunk);
+      return true;
+    });
+
+    await expect(streamGraphNdjson(response, false)).resolves.toBeUndefined();
+
+    const blocks = writes
+      .map((chunk) => JSON.parse(chunk))
+      .filter((r) => r.type === 'node' && r.data.label === 'BasicBlock');
+    expect(blocks).toHaveLength(2);
+    for (const b of blocks) {
+      expect(typeof b.data.properties.name).toBe('string'); // never undefined
+    }
+    // falls back to the block text when present, else the empty-string floor
+    expect(blocks[0].data.properties.name).toBe('const x = req.body;');
+    expect(blocks[0].data.properties.text).toBe('const x = req.body;');
+    expect(blocks[1].data.properties.name).toBe('');
+  });
 });

--- a/gitnexus/test/unit/ingestion/pipeline-phase-registry.test.ts
+++ b/gitnexus/test/unit/ingestion/pipeline-phase-registry.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { PhaseRegistry } from '../../../src/core/ingestion/pipeline-phases/registry.js';
+import type { PipelinePhase } from '../../../src/core/ingestion/pipeline-phases/types.js';
+import { buildPhaseList } from '../../../src/core/ingestion/pipeline.js';
+
+// ---------------------------------------------------------------------------
+// PhaseRegistry — the issue #2080 phase-registry seam, tested in isolation
+// with lightweight fake phases (no real pipeline dependencies).
+// ---------------------------------------------------------------------------
+
+const fakePhase = (name: string): PipelinePhase => ({
+  name,
+  deps: [],
+  execute: async () => ({}),
+});
+
+describe('PhaseRegistry', () => {
+  it('preserves registration order in build()', () => {
+    const list = new PhaseRegistry()
+      .register(fakePhase('a'))
+      .register(fakePhase('b'))
+      .register(fakePhase('c'))
+      .build(undefined);
+    expect(list.map((p) => p.name)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('includes a phase with no enabledWhen predicate unconditionally', () => {
+    const list = new PhaseRegistry<{ flag?: boolean }>()
+      .register(fakePhase('always'))
+      .build({ flag: true });
+    expect(list.map((p) => p.name)).toEqual(['always']);
+  });
+
+  it('excludes a phase whose enabledWhen returns false', () => {
+    const reg = new PhaseRegistry<{ skip?: boolean }>()
+      .register(fakePhase('core'))
+      .register(fakePhase('optional'), { enabledWhen: (o) => !o?.skip });
+
+    expect(reg.build({ skip: true }).map((p) => p.name)).toEqual(['core']);
+    expect(reg.build({ skip: false }).map((p) => p.name)).toEqual(['core', 'optional']);
+    expect(reg.build(undefined).map((p) => p.name)).toEqual(['core', 'optional']);
+  });
+
+  it('enabledWhen filtering does not reorder surviving phases', () => {
+    const list = new PhaseRegistry<{ drop?: boolean }>()
+      .register(fakePhase('first'))
+      .register(fakePhase('gated'), { enabledWhen: (o) => !o?.drop })
+      .register(fakePhase('last'))
+      .build({ drop: true });
+    expect(list.map((p) => p.name)).toEqual(['first', 'last']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPhaseList parity — the registry refactor must produce a phase list
+// byte-identical (names + order) to the legacy hand-maintained array for
+// every options combination. This is the U6 characterization gate (R7/R8).
+//
+// Note: the second `skipGraphPhases` guard in runPipelineFromRepo (the
+// result-extraction path) is intentionally NOT routed through the registry
+// (KTD5); it remains keyed on the same option, so membership here stays
+// consistent with output consumption there.
+// ---------------------------------------------------------------------------
+
+const FULL_ORDER = [
+  'scan',
+  'structure',
+  'markdown',
+  'cobol',
+  'parse',
+  'routes',
+  'tools',
+  'orm',
+  'crossFile',
+  'scopeResolution',
+  'pruneLocalSymbols',
+  'mro',
+  'communities',
+  'processes',
+];
+
+const WITHOUT_GRAPH_PHASES = FULL_ORDER.filter(
+  (n) => n !== 'mro' && n !== 'communities' && n !== 'processes',
+);
+
+describe('buildPhaseList parity (registry refactor, #2080)', () => {
+  it('default options → full phase list in legacy order', () => {
+    expect(buildPhaseList(undefined).map((p) => p.name)).toEqual(FULL_ORDER);
+    expect(buildPhaseList({}).map((p) => p.name)).toEqual(FULL_ORDER);
+  });
+
+  it('skipGraphPhases:false → full phase list (graph phases included)', () => {
+    expect(buildPhaseList({ skipGraphPhases: false }).map((p) => p.name)).toEqual(FULL_ORDER);
+  });
+
+  it('skipGraphPhases:true → omits exactly mro/communities/processes', () => {
+    expect(buildPhaseList({ skipGraphPhases: true }).map((p) => p.name)).toEqual(
+      WITHOUT_GRAPH_PHASES,
+    );
+  });
+});

--- a/gitnexus/test/unit/ingestion/pipeline-phase-registry.test.ts
+++ b/gitnexus/test/unit/ingestion/pipeline-phase-registry.test.ts
@@ -20,7 +20,7 @@ describe('PhaseRegistry', () => {
       .register(fakePhase('a'))
       .register(fakePhase('b'))
       .register(fakePhase('c'))
-      .build(undefined);
+      .build({});
     expect(list.map((p) => p.name)).toEqual(['a', 'b', 'c']);
   });
 
@@ -34,17 +34,18 @@ describe('PhaseRegistry', () => {
   it('excludes a phase whose enabledWhen returns false', () => {
     const reg = new PhaseRegistry<{ skip?: boolean }>()
       .register(fakePhase('core'))
-      .register(fakePhase('optional'), { enabledWhen: (o) => !o?.skip });
+      .register(fakePhase('optional'), { enabledWhen: (o) => !o.skip });
 
     expect(reg.build({ skip: true }).map((p) => p.name)).toEqual(['core']);
     expect(reg.build({ skip: false }).map((p) => p.name)).toEqual(['core', 'optional']);
-    expect(reg.build(undefined).map((p) => p.name)).toEqual(['core', 'optional']);
+    // empty (normalized) options → predicate sees a real object, phase enabled
+    expect(reg.build({}).map((p) => p.name)).toEqual(['core', 'optional']);
   });
 
   it('enabledWhen filtering does not reorder surviving phases', () => {
     const list = new PhaseRegistry<{ drop?: boolean }>()
       .register(fakePhase('first'))
-      .register(fakePhase('gated'), { enabledWhen: (o) => !o?.drop })
+      .register(fakePhase('gated'), { enabledWhen: (o) => !o.drop })
       .register(fakePhase('last'))
       .build({ drop: true });
     expect(list.map((p) => p.name)).toEqual(['first', 'last']);

--- a/gitnexus/test/unit/model/registration-table.test.ts
+++ b/gitnexus/test/unit/model/registration-table.test.ts
@@ -9,6 +9,11 @@ import { createTypeRegistry } from '../../../src/core/ingestion/model/type-regis
 import { createMethodRegistry } from '../../../src/core/ingestion/model/method-registry.js';
 import { createFieldRegistry } from '../../../src/core/ingestion/model/field-registry.js';
 import { ALL_NODE_LABELS } from '../../../src/core/ingestion/model/index.js';
+import {
+  CLASS_TYPES_TUPLE,
+  FREE_CALLABLE_TUPLE,
+} from '../../../src/core/ingestion/model/symbol-table.js';
+import { EMBEDDABLE_LABELS } from '../../../src/core/embeddings/types.js';
 import type { SymbolDefinition } from 'gitnexus-shared';
 import { makeDef as makeBaseDef } from './helpers.js';
 
@@ -98,6 +103,30 @@ describe('NodeLabel taxonomy coverage', () => {
     expect(INERT_LABELS.has('Namespace')).toBe(true);
     expect(INERT_LABELS.has('Variable')).toBe(true);
     expect(INERT_LABELS.has('Import')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BasicBlock — taint/PDG substrate node (issue #2080). It is a control-flow
+// node, never a symbol-resolution or embedding target (KTD4). These guards
+// fail if a future change accidentally promotes it into a dispatch/callable
+// tuple or the embeddable set.
+// ---------------------------------------------------------------------------
+
+describe('BasicBlock taint/PDG substrate label (issue #2080)', () => {
+  it('is classified inert — not a dispatch or callable resolution target', () => {
+    expect(INERT_LABELS.has('BasicBlock')).toBe(true);
+    expect(DISPATCH_LABELS.has('BasicBlock')).toBe(false);
+    expect(CALLABLE_ONLY_LABELS.has('BasicBlock')).toBe(false);
+  });
+
+  it('is excluded from the class-like and free-callable tuples', () => {
+    expect((CLASS_TYPES_TUPLE as readonly string[]).includes('BasicBlock')).toBe(false);
+    expect((FREE_CALLABLE_TUPLE as readonly string[]).includes('BasicBlock')).toBe(false);
+  });
+
+  it('is not embeddable', () => {
+    expect((EMBEDDABLE_LABELS as readonly string[]).includes('BasicBlock')).toBe(false);
   });
 });
 

--- a/gitnexus/test/unit/schema.test.ts
+++ b/gitnexus/test/unit/schema.test.ts
@@ -140,6 +140,9 @@ describe('LadybugDB Schema', () => {
       // table and the bulk-COPY round-trip fails with "table does not exist".
       expect(SCHEMA_QUERIES).toContain(BASICBLOCK_SCHEMA);
       expect(BASICBLOCK_SCHEMA).toContain('CREATE NODE TABLE BasicBlock');
+      expect(BASICBLOCK_SCHEMA).toContain('filePath STRING');
+      expect(BASICBLOCK_SCHEMA).toContain('startLine INT64');
+      expect(BASICBLOCK_SCHEMA).toContain('endLine INT64');
       expect(BASICBLOCK_SCHEMA).toContain('text STRING');
       expect(BASICBLOCK_SCHEMA).toContain('PRIMARY KEY (id)');
     });

--- a/gitnexus/test/unit/schema.test.ts
+++ b/gitnexus/test/unit/schema.test.ts
@@ -17,6 +17,7 @@ import {
   CODE_ELEMENT_SCHEMA,
   COMMUNITY_SCHEMA,
   PROCESS_SCHEMA,
+  BASICBLOCK_SCHEMA,
   RELATION_SCHEMA,
   EMBEDDING_SCHEMA,
   CREATE_VECTOR_INDEX_QUERY,
@@ -68,9 +69,13 @@ describe('LadybugDB Schema', () => {
       }
     });
 
+    it('includes the BasicBlock taint/PDG substrate node (issue #2080)', () => {
+      expect(NODE_TABLES).toContain('BasicBlock');
+    });
+
     it('has expected total count', () => {
-      // 9 core + 19 multi-language + Route + Tool = 31
-      expect(NODE_TABLES).toHaveLength(31);
+      // 9 core + 19 multi-language + Route + Tool + BasicBlock = 32
+      expect(NODE_TABLES).toHaveLength(32);
     });
   });
 
@@ -87,6 +92,12 @@ describe('LadybugDB Schema', () => {
         'STEP_IN_PROCESS',
       ];
       for (const t of expected) {
+        expect(REL_TYPES).toContain(t);
+      }
+    });
+
+    it('includes the taint/PDG substrate edge types (issue #2080)', () => {
+      for (const t of ['CFG', 'REACHING_DEF', 'TAINTED', 'SANITIZES', 'TAINT_PATH']) {
         expect(REL_TYPES).toContain(t);
       }
     });
@@ -121,6 +132,16 @@ describe('LadybugDB Schema', () => {
     it('Property schema preserves declaredType', () => {
       expect(SCHEMA_QUERIES).toContain(PROPERTY_SCHEMA);
       expect(PROPERTY_SCHEMA).toContain('declaredType STRING');
+    });
+
+    it('BasicBlock schema is wired into SCHEMA_QUERIES (issue #2080, F1 guard)', () => {
+      // Defining BASICBLOCK_SCHEMA is not enough — it must be appended to
+      // NODE_SCHEMA_QUERIES (→ SCHEMA_QUERIES) or initLbug never creates the
+      // table and the bulk-COPY round-trip fails with "table does not exist".
+      expect(SCHEMA_QUERIES).toContain(BASICBLOCK_SCHEMA);
+      expect(BASICBLOCK_SCHEMA).toContain('CREATE NODE TABLE BasicBlock');
+      expect(BASICBLOCK_SCHEMA).toContain('text STRING');
+      expect(BASICBLOCK_SCHEMA).toContain('PRIMARY KEY (id)');
     });
 
     it('Community schema has heuristicLabel and cohesion', () => {
@@ -162,6 +183,10 @@ describe('LadybugDB Schema', () => {
     it('connects symbols to Process (STEP_IN_PROCESS)', () => {
       expect(RELATION_SCHEMA).toContain('FROM Function TO Process');
       expect(RELATION_SCHEMA).toContain('FROM Method TO Process');
+    });
+
+    it('connects BasicBlock to BasicBlock (taint/PDG substrate edges, #2080)', () => {
+      expect(RELATION_SCHEMA).toContain('FROM BasicBlock TO BasicBlock');
     });
 
     it('has all FROM/TO pairs needed for HAS_METHOD edges', () => {
@@ -208,7 +233,8 @@ describe('LadybugDB Schema', () => {
 
   describe('schema query ordering', () => {
     it('NODE_SCHEMA_QUERIES has correct count', () => {
-      expect(NODE_SCHEMA_QUERIES).toHaveLength(31);
+      // 31 + BasicBlock = 32
+      expect(NODE_SCHEMA_QUERIES).toHaveLength(32);
     });
 
     it('REL_SCHEMA_QUERIES has one relation table', () => {
@@ -216,8 +242,8 @@ describe('LadybugDB Schema', () => {
     });
 
     it('SCHEMA_QUERIES includes all node + rel + embedding schemas', () => {
-      // 31 node + 1 rel + 1 embedding = 33
-      expect(SCHEMA_QUERIES).toHaveLength(33);
+      // 32 node + 1 rel + 1 embedding = 34
+      expect(SCHEMA_QUERIES).toHaveLength(34);
     });
 
     it('node schemas come before relation schemas in SCHEMA_QUERIES', () => {

--- a/gitnexus/test/unit/taint/source-sink-registry.test.ts
+++ b/gitnexus/test/unit/taint/source-sink-registry.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerSourceSinkConfig,
+  getSourceSinkConfig,
+  registeredTaintLanguages,
+  clearSourceSinkRegistry,
+} from '../../../src/core/ingestion/taint/source-sink-registry.js';
+import type { SourceSinkSanitizerSpec } from '../../../src/core/ingestion/taint/source-sink-config.js';
+
+const spec = (over: Partial<SourceSinkSanitizerSpec> = {}): SourceSinkSanitizerSpec => ({
+  sources: [],
+  sinks: [],
+  sanitizers: [],
+  ...over,
+});
+
+describe('source/sink/sanitizer registry seam (#2080)', () => {
+  beforeEach(() => clearSourceSinkRegistry());
+
+  it('is empty by default — no language registered (guards default-run parity)', () => {
+    expect(registeredTaintLanguages()).toEqual([]);
+    expect(getSourceSinkConfig('typescript')).toBeUndefined();
+  });
+
+  it('register then get round-trips the spec', () => {
+    const ts = spec({ sinks: [{ name: 'eval' }], sources: [{ name: 'req.body', args: [0] }] });
+    registerSourceSinkConfig('typescript', ts);
+    expect(getSourceSinkConfig('typescript')).toBe(ts);
+    expect(registeredTaintLanguages()).toEqual(['typescript']);
+  });
+
+  it('getSourceSinkConfig returns undefined for an unregistered language (never throws)', () => {
+    registerSourceSinkConfig('typescript', spec());
+    expect(getSourceSinkConfig('python')).toBeUndefined();
+  });
+
+  it('re-registering the same language id overwrites (last-write-wins)', () => {
+    const first = spec({ sinks: [{ name: 'eval' }] });
+    const second = spec({ sinks: [{ name: 'exec' }] });
+    registerSourceSinkConfig('typescript', first);
+    registerSourceSinkConfig('typescript', second);
+    expect(getSourceSinkConfig('typescript')).toBe(second);
+    expect(registeredTaintLanguages()).toEqual(['typescript']);
+  });
+});


### PR DESCRIPTION
## M0 — Spikes & schema + phase-registry seam (taint/PDG substrate)

Closes the M0 milestone of **Epic A — Reliable taint analysis on a PDG-expandable substrate** (#2087). De-risks the two hardest unknowns and lays the schema + pipeline foundation **before** any analysis code. Everything here is **additive and inert** — no phase emits the new nodes/edges yet, and a default `analyze` run produces a byte-identical emitted graph.

Implements issue #2080.

### What's in this PR

- **Schema** (`gitnexus-shared`): add the `BasicBlock` node label and the `CFG` / `REACHING_DEF` / `TAINTED` / `SANITIZES` / `TAINT_PATH` relationship types to the shared graph schema, plus a `BasicBlock.text` node property. Resolve the codebase-wide exhaustiveness ripple so `tsc` stays clean: `LABEL_BEHAVIOR` (`BasicBlock: 'inert'`) and the `gitnexus-web` `NODE_COLORS`/`NODE_SIZES` maps. Guard tests assert BasicBlock is inert and excluded from the class-like / free-callable / embeddable sets.
- **DDL + bulk-COPY round-trip** (`gitnexus`): `BASICBLOCK_SCHEMA` wired into `NODE_SCHEMA_QUERIES`, a `FROM BasicBlock TO BasicBlock` pair on `CodeRelation`, a BasicBlock CSV writer + COPY/insert routing. An integration test round-trips a BasicBlock node + one edge of each new type through the real `loadGraphToLbug` path. REACHING_DEF carries its `variable` name in the existing `reason` column (see S1 verdict below).
- **Phase-registry seam**: `registerPhase` / `enabledWhen` generalises the ad-hoc `if (!skipGraphPhases)` graph-phase guard; `buildPhaseList` routes through it with **zero behaviour change** (parity test covers every option combination).
- **Source/sink/sanitizer config seam**: a per-language registry (`SourceSinkSanitizerSpec` + register/get), empty by default, consumed later by M3 (#2083).
- **Spikes (throwaway, build-excluded)**: S1 (REACHING_DEF storage) and S2 (post-dominator feasibility). Verdicts posted to [#2080](https://github.com/abhigyanpatwari/GitNexus/issues/2080).

### Spike verdicts (de-risking)

- **S1** — LadybugDB has **no secondary index on relationship properties** (`CREATE INDEX … ON CodeRelation(reason)` / `CALL CREATE_REL_INDEX` both rejected), so a `{variable}`-filtered path query is scan-based regardless of storage shape. M0 therefore stores the variable in the existing `reason` column (no shared-table perturbation, byte-identical default). Perf on a 30K-edge synthetic DB: load 347 ms, single-hop variable filter 9 ms, source-anchored `*1..5` path 33 ms. **Unanchored** global `*1..5` explodes — taint queries must be source-anchored + bounded (reinforces the RFC's `maxFunctionLines`/edge-budget bounding).
- **S2** — the post-dominator algorithm (iterative reverse-CFG dataflow, EXIT-rooted) is feasible: converges in ≤4 iterations on every classic TS hazard (early-return, try/throw/finally, labeled break/continue, diamond); EXIT post-dominates all blocks; ipdom trees correct. The real risk for Epic B is M1's AST→CFG extraction, not the algorithm.

### Acceptance criteria

- ✅ **AC1** — `tsc` clean across `gitnexus` + `gitnexus-shared` + `gitnexus-web`; new union members exhaustiveness-checked.
- ✅ **AC2** — DDL loads; `BasicBlock` + the new edge types round-trip the bulk-COPY path (integration test).
- ✅ **AC3** — S1 and S2 verdicts documented on #2080.
- ✅ **AC4** — default (no-flag) `analyze` emits a byte-identical graph (golden-graph parity harness unchanged, no `UPDATE_GOLDEN`).

### Review

Reviewed by a 9-persona ce-code-review pass. The headline catch (adversarial): adding `BasicBlock` to `NODE_TABLES` would have **500'd `/api/graph`** on every analyzed repo because `api.ts` `getNodeQuery`'s default branch projects `n.name`/`n.content` (which BasicBlock lacks) → a non-ignorable Ladybug binder error. Fixed in-PR (`getNodeQuery` BasicBlock branch + a binder-safety test that runs `getNodeQuery` for **every** `NODE_TABLE` against the real schema), plus 4 safe_auto fixes.

## Residual Review Findings

Recorded here as the durable sink. All are **deferred by design** to later milestones (no bugs in this PR); the milestones are tracked by Epic A (#2087) / Epic B (#2088).

- **P2** `gitnexus/src/core/lbug/lbug-adapter.ts:1127` — BasicBlock dispatch is triplicated across `getCopyQuery` / `insertNodeToLbug` / `batchInsertNodesToLbug`. The diff correctly extends all three (no bug); a per-label column-descriptor refactor is **M1-scope** before more block-adjacent paths land. *(maintainability, manual)*
- **P2** `gitnexus/src/mcp/local/local-backend.ts:116` — `VALID_RELATION_TYPES` (the curated `impact()` traversal allow-list) omits the new taint edge types. Whether taint edges should participate in impact analysis is an **M3 design decision**, not a mechanical sync. *(api-contract, manual)*
- **P2** `gitnexus-shared/src/graph/types.ts:53` — `NodeProperties.name` is required but BasicBlock has none (the `''` sentinel is used). Making `name` optional has broad blast radius (a fresh exhaustiveness ripple); revisit when M1's emitter constructs BasicBlock nodes. *(api-contract, gated_auto)*
- **P2** `gitnexus/src/core/ingestion/taint/source-sink-registry.ts:22` — registry keyed by `string` rather than `SupportedLanguages` (AGENTS.md shared-ingestion language-naming). The registry is empty in M0; bound the key type when **M3** registers languages. *(project-standards, confidence 50)*
- **P3** `gitnexus-web/src/core/llm/types.ts:319` — `GRAPH_SCHEMA_DESCRIPTION` / agent system prompt don't enumerate the new types (and `GRAPH_SCHEMA_DESCRIPTION` is currently unused). Becomes user-visible in **M1+**; the web allow-lists already validate dynamically via `REL_TYPES`. *(api-contract, advisory)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
