### PR TITLE
fix(api): skip traversal guard for bare root paths in /api/fs/list

### DIFF
--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -569,7 +569,10 @@ export const handleFsListRequest = async (
       res.status(400).json({ error: '"dir" must be an absolute path' });
       return;
     }
-    if (path.normalize(dir) !== path.resolve(dir)) {
+    // Skip the traversal guard for bare root directories (/ on Linux, C:\ on
+    // Windows) where path.normalize and path.resolve diverge on Windows.
+    const isRoot = dir === path.parse(dir).root;
+    if (!isRoot && path.normalize(dir) !== path.resolve(dir)) {
       res.status(400).json({ error: '"dir" must not contain traversal sequences' });
       return;
     }

--- a/gitnexus/test/unit/api-fs-list.test.ts
+++ b/gitnexus/test/unit/api-fs-list.test.ts
@@ -54,11 +54,10 @@ describe('GET /api/fs/list — handleFsListRequest', () => {
 
   it('defaults to / when dir is omitted (linux server)', async () => {
     const { status } = await invoke({});
-    if (process.platform === 'win32') {
-      expect(status).toBe(400);
-    } else {
-      expect(status).toBe(200);
-    }
+    // On Linux root / is the filesystem root; on Windows path.normalize('/')
+    // normalizes to \ while path.resolve('/') resolves to the CWD drive root.
+    // Our guard skips the traversal check for bare root paths.
+    expect(status).toBe(200);
   });
 
   it('returns 400 for a relative path', async () => {


### PR DESCRIPTION
Fixes a Windows path bug: `GET /api/fs/list?dir=/` (or no dir param)
returned 400 on Windows because path.normalize("/") !== path.resolve("/")
there, but they match on Linux.

Fix: skip the traversal guard for bare root directories, where the
normalize-vs-resolve divergence is expected behavior.

9/9 unit tests pass.