### PR TITLE
fix(ci): drop broken `-t 22` from prebuildify in build-tree-sitter-prebuilds

### DIFF
--- a/.github/workflows/build-tree-sitter-prebuilds.yml
+++ b/.github/workflows/build-tree-sitter-prebuilds.yml
@@ -320,9 +320,12 @@ jobs:
 
           test -f "$pkgdir/binding.gyp" || { echo "::error::no binding.gyp for $NAME@$REF"; exit 1; }
 
-          # N-API, stripped, single ABI-stable binary for THIS host's arch.
-          # prebuildify emits prebuilds/<platform>-<arch>/<something>.node.
-          ( cd "$pkgdir" && npx --no-install prebuildify --napi --strip -t 22 )
+          # N-API, stripped, single ABI-stable binary for THIS host's arch. No
+          # `-t <node-version>`: an N-API prebuild is Node-version-agnostic, and
+          # prebuildify parses a bare `-t 22` as the NUMBER 22 and crashes
+          # (`v.indexOf is not a function`). prebuildify emits
+          # prebuilds/<platform>-<arch>/<something>.node.
+          ( cd "$pkgdir" && npx --no-install prebuildify --napi --strip )
 
           out=$(find "$pkgdir/prebuilds" -name '*.node' -print -quit)
           test -n "$out" || { echo "::error::prebuildify produced no .node"; exit 1; }


### PR DESCRIPTION
## Problem
The first real run of `build-tree-sitter-prebuilds` (dispatched on `main` after #2113 merged) failed on **every** matrix job — e.g. [`c linux-arm64`](https://github.com/abhigyanpatwari/GitNexus/actions/runs/27223491621/job/80384394389):

```
TypeError: v.indexOf is not a function
    at resolveTargets (prebuildify/index.js:317:21)
```

The build step ran `prebuildify --napi --strip -t 22`. prebuildify parses the bare `-t 22` as the **number** `22`, then calls `.indexOf` (a string method) on it in `resolveTargets` → crash. The workflow had never actually run before (swift's prebuilds were upstream-copied), so this was latent.

## Fix
Drop `-t 22`. An **N-API** prebuild is Node-version-agnostic, so targeting a Node version is both unnecessary and the cause.

## Verification
Reproduced + verified locally against the vendored `tree-sitter-c` source:
- `prebuildify --napi --strip -t 22` → the exact `v.indexOf is not a function` crash.
- `prebuildify --napi --strip` (no `-t`) → exit 0, produces `prebuilds/linux-x64/tree-sitter-c.node`, which exports `napi_register_module_v1` (confirmed N-API).

After this merges, re-dispatch `build-tree-sitter-prebuilds` (grammars=all, force=true) to populate c/dart/proto/kotlin prebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)