### PR TITLE
fix(ci): green the tree-sitter prebuild matrix (npm-bundled prebuilds + arm64 runtime)

### DIFF
--- a/.github/workflows/build-tree-sitter-prebuilds.yml
+++ b/.github/workflows/build-tree-sitter-prebuilds.yml
@@ -320,6 +320,15 @@ jobs:
 
           test -f "$pkgdir/binding.gyp" || { echo "::error::no binding.gyp for $NAME@$REF"; exit 1; }
 
+          # Drop any prebuilds the package shipped in its own tarball before we
+          # build. The tree-sitter-org npm grammars (e.g. tree-sitter-c) bundle
+          # prebuilds/ for all 6 tuples; left in place, the `find ... -print -quit`
+          # below would pick a non-host tuple (e.g. win32-x64 on a linux runner)
+          # and the assertion would wrongly fail. prebuildify rebuilds THIS host's
+          # tuple from the source the tarball also ships. (Vendored grammars are
+          # already cleaned above; this also covers the npm branch.)
+          rm -rf "$pkgdir/prebuilds"
+
           # N-API, stripped, single ABI-stable binary for THIS host's arch. No
           # `-t <node-version>`: an N-API prebuild is Node-version-agnostic, and
           # prebuildify parses a bare `-t 22` as the NUMBER 22 and crashes
@@ -352,7 +361,15 @@ jobs:
           cd "$probe"
           # Pin tree-sitter to the repo's exact runtime peer so an ABI mismatch
           # fails HERE, not in a user's install (mirrors the #1922 ABI gate).
-          npm install --no-audit --no-fund --ignore-scripts node-gyp-build@^4 tree-sitter@0.21.1
+          # NOT --ignore-scripts: tree-sitter@0.21.1's tarball ships prebuilds for
+          # the common tuples but NOT linux-arm64 / win32-arm64, so on the arm64
+          # runners node-gyp-build must source-build the runtime — give it node-gyp
+          # + node-addon-api to do so. Where tree-sitter ships a prebuild (x64,
+          # darwin-arm64) node-gyp-build uses it and nothing compiles. The grammar
+          # .node we built is still loaded as a prebuild; only the runtime peer may
+          # compile. The grammar-vs-runtime ABI check still fires at setLanguage.
+          npm install --no-audit --no-fund \
+            node-gyp-build@^4 node-gyp@^11 node-addon-api@^8 tree-sitter@0.21.1
           # The node script is single-quoted on purpose — its ${...} are JS
           # template literals read from the environment, not shell expansions.
           # shellcheck disable=SC2016


### PR DESCRIPTION
The first real dispatch of `build-tree-sitter-prebuilds` ([run 27225767097](https://github.com/abhigyanpatwari/GitNexus/actions/runs/27225767097)) failed every matrix job. Two **independent** root causes — confirmed from the job logs:

## 1. `c` fails at *Build* on every tuple except darwin-x64
`tree-sitter-c` is `kind:'npm'`, and the official tree-sitter-org package **ships its own `prebuilds/` for all 6 tuples inside its npm tarball**. After `prebuildify` builds the host tuple, the detection `find "$pkgdir/prebuilds" -name '*.node' -print -quit` grabs whatever `readdir` returns first — `win32-x64` on a linux runner — so the assertion fails:

```
##[error]built win32-x64, expected linux-x64
```

`c darwin-x64` passed only because `readdir` happened to return `darwin-x64` first. (`kotlin` is `npm` too but its community package ships no prebuilds, so it dodged this.)

**Fix:** `rm -rf "$pkgdir/prebuilds"` before `prebuildify`, so only the freshly-built host tuple remains. prebuildify rebuilds from the source the tarball also ships.

## 2. Every `linux-arm64` fails at *Validate*
Build succeeds; the **runtime** load throws. The stack is unambiguous — it's `require("tree-sitter")`, not the grammar:

```
Error: No native build was found for platform=linux arch=arm64 ... abi=127 node=22.22.3
    at Object.<anonymous> (.../node_modules/tree-sitter/index.js:1:42)
```

`tree-sitter@0.21.1`'s tarball ships **no `linux-arm64` prebuild**, and validate installed it with `--ignore-scripts`, so node-gyp-build couldn't source-build it on the `ubuntu-24.04-arm` runner. The grammar's own arm64 `.node` loaded fine (the throw is after it).

**Fix:** drop `--ignore-scripts` and add `node-gyp` + `node-addon-api` so the runtime peer source-builds where upstream ships no prebuild. On prebuild-covered tuples (x64, darwin-arm64) node-gyp-build still uses the prebuild and nothing compiles. The grammar-vs-runtime ABI check still fires at `setLanguage` (the #1922 gate is preserved).

## Coverage after these fixes
- `c` linux-x64 / linux-arm64 / darwin-arm64 / win32-x64 → build passes (fix 1); c linux-arm64 also needs fix 2 at validate.
- dart / kotlin / swift / proto linux-arm64 → validate passes (fix 2).
- `win32-arm64` (still running at time of writing) is the remaining watch item: tree-sitter likely ships no win32-arm64 prebuild either, but fix 2 + the existing "Ensure Python (arm64 Windows only)" step should let it source-build. Will confirm on re-dispatch.

Validated locally: `actionlint` clean, `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)