### PR TITLE
fix(ci): make the prebuild PR push re-run-safe (--force-with-lease → --force)

### DIFF
--- a/.github/workflows/build-tree-sitter-prebuilds.yml
+++ b/.github/workflows/build-tree-sitter-prebuilds.yml
@@ -507,7 +507,13 @@ jobs:
             run(`git commit -m "chore(vendor): rebuild native prebuilds (${grammars})\n\nBuilt by ${process.env.RUN_URL}"`);
             const { owner, repo } = context.repo;
             const remote = `https://x-access-token:${process.env.GH_TOKEN}@github.com/${owner}/${repo}.git`;
-            run(`git push --force-with-lease "${remote}" "HEAD:${branch}"`);
+            // Plain --force, not --force-with-lease: the branch is ephemeral and
+            // unique per run (keyed by context.runId), written ONLY by this job, so
+            // there is no concurrent writer to protect against. --force-with-lease
+            // would compare against a remote-tracking ref this fresh checkout never
+            // fetched, so re-running the SAME run (branch already pushed by attempt
+            // 1) fails with "stale info" instead of overwriting.
+            run(`git push --force "${remote}" "HEAD:${branch}"`);
             const body = [
               `Rebuilt the vendored native prebuilds for: **${grammars}**.`,
               '',


### PR DESCRIPTION
## Problem
The `build-tree-sitter-prebuilds` aggregate job ("Vendor prebuilds + open PR") pushes the ephemeral prebuild branch with:

```js
run(`git push --force-with-lease "${remote}" "HEAD:${branch}"`);
```

The branch is unique per run (`chore/vendor-ts-prebuilds-<grammars>-<runId>`) and written **only** by this job, so there is no concurrent writer to protect against. `--force-with-lease` compares against a remote-tracking ref that the job's fresh checkout never fetched — so **re-running the same run** (where attempt 1 already pushed the branch) fails with:

```
! [rejected]  HEAD -> chore/vendor-ts-prebuilds-...-<runId> (stale info)
error: failed to push some refs
```

instead of overwriting. This is exactly what happened on [run 27227806817](https://github.com/abhigyanpatwari/GitNexus/actions/runs/27227806817) after the `pull_requests:write` App-permission fix cleared the earlier 403 — the *replay* then tripped the lease.

## Fix
Use plain `git push --force`. For an ephemeral, single-writer, per-`runId` branch that's the correct, re-run-idempotent idiom; there's no other writer for the lease to guard. Fresh dispatches were never affected (new `runId` → new branch).

One-line change + explanatory comment. `actionlint` clean, `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)