### PR TITLE
perf(group): skip redundant HTTP provider fallback

### DIFF
--- a/gitnexus/src/core/group/extractors/http-patterns/java.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/java.ts
@@ -675,6 +675,7 @@ function scanSpringProject(files: readonly HttpScanInput[]): HttpFileDetections[
 export const JAVA_HTTP_PLUGIN: HttpLanguagePlugin = {
   name: 'java-http',
   language: Java,
+  graphProviderCoverage: 'complete',
   scan(tree) {
     const out: HttpDetection[] = [];
 

--- a/gitnexus/src/core/group/extractors/http-patterns/php.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/php.ts
@@ -130,6 +130,7 @@ function isHttpUrlLiteral(path: string): boolean {
 export const PHP_HTTP_PLUGIN: HttpLanguagePlugin = {
   name: 'php-http',
   language: PHP.php_only,
+  graphProviderCoverage: 'complete',
   scan(tree) {
     const out: HttpDetection[] = [];
 

--- a/gitnexus/src/core/group/extractors/http-patterns/python.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/python.ts
@@ -795,6 +795,7 @@ function joinPrefix(prefix: string, route: string): string {
 export const PYTHON_HTTP_PLUGIN: HttpLanguagePlugin = {
   name: 'python-http',
   language: Python,
+  graphProviderCoverage: 'complete',
   prepareRepo({ files, parser, readFile, parseSource }): RepoContext {
     return buildPythonRepoContext(files, parser, readFile, parseSource);
   },

--- a/gitnexus/src/core/group/extractors/http-patterns/types.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/types.ts
@@ -79,6 +79,12 @@ export interface HttpLanguagePlugin {
   /** tree-sitter grammar object (passed to the shared parser). */
   language: unknown;
   /**
+   * The ingestion pipeline emits every provider route for this language as a
+   * Route/HANDLES_ROUTE graph entry. The orchestrator may skip source-provider
+   * emission for graph-covered files only when graph handlers also resolve.
+   */
+  graphProviderCoverage?: 'complete';
+  /**
    * Optional pre-pass: walk the relevant files in the repo and produce
    * an opaque context that `scan` can use to resolve cross-file facts.
    * Implementations must not throw — return undefined on any error so

--- a/gitnexus/src/core/group/extractors/http-route-extractor.ts
+++ b/gitnexus/src/core/group/extractors/http-route-extractor.ts
@@ -305,9 +305,7 @@ export class HttpRouteExtractor implements ContractExtractor {
       const graphKeys = new Set(graphContracts.map((contract) => contract.contractId));
       const sourceProviderKeys = (await getDetections(file))
         .filter((detection) => detection.role === 'provider')
-        .map((detection) =>
-          contractIdFor(detection.method, normalizeHttpPath(detection.path)),
-        );
+        .map((detection) => contractIdFor(detection.method, normalizeHttpPath(detection.path)));
       if (sourceProviderKeys.some((key) => !graphKeys.has(key))) {
         providerSourceFiles.push(file);
       }

--- a/gitnexus/src/core/group/extractors/http-route-extractor.ts
+++ b/gitnexus/src/core/group/extractors/http-route-extractor.ts
@@ -282,11 +282,39 @@ export class HttpRouteExtractor implements ContractExtractor {
 
     const graphProviders =
       dbExecutor != null ? await this.extractProvidersGraph(dbExecutor, getDetections) : [];
-    // Source scan always runs to capture routes in languages/files not covered
-    // by graph edges; the glob and per-file parse results are cached above.
+    const graphProvidersByFile = new Map<string, ExtractedContract[]>();
+    for (const contract of graphProviders) {
+      const fileContracts = graphProvidersByFile.get(contract.symbolRef.filePath) ?? [];
+      fileContracts.push(contract);
+      graphProvidersByFile.set(contract.symbolRef.filePath, fileContracts);
+    }
+    const providerSourceFiles: string[] = [];
+    for (const file of files) {
+      const plugin = getPluginForFile(file);
+      if (plugin?.graphProviderCoverage !== 'complete') {
+        providerSourceFiles.push(file);
+        continue;
+      }
+      const graphContracts = graphProvidersByFile.get(file);
+      // An empty or unresolved graph result is not proof of full coverage.
+      // Preserve source fallback for partial indexes and handler misses.
+      if (!graphContracts?.length || graphContracts.some((contract) => !contract.symbolUid)) {
+        providerSourceFiles.push(file);
+        continue;
+      }
+      const graphKeys = new Set(graphContracts.map((contract) => contract.contractId));
+      const sourceProviderKeys = (await getDetections(file))
+        .filter((detection) => detection.role === 'provider')
+        .map((detection) =>
+          contractIdFor(detection.method, normalizeHttpPath(detection.path)),
+        );
+      if (sourceProviderKeys.some((key) => !graphKeys.has(key))) {
+        providerSourceFiles.push(file);
+      }
+    }
     const providers = this.mergeGraphAndSourceContracts(
       graphProviders,
-      await this.extractProvidersSourceScan(files, getDetections),
+      await this.extractProvidersSourceScan(providerSourceFiles, getDetections),
     );
 
     const graphConsumers =

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -173,6 +173,59 @@ func main() {
       expect(sourceRoute?.symbolName).toBe('healthHandler');
       expect(sourceRoute?.meta.extractionStrategy).toBe('source_scan');
     });
+
+    it('preserves source fallback when a graph-covered file also has a source-only route', async () => {
+      const dir = path.join(tmpDir, 'graph-partial-provider-file');
+      fs.mkdirSync(path.join(dir, 'src/controller'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'src/controller/UserController.java'),
+        `
+@RestController
+@RequestMapping("/api")
+public class UserController {
+    @GetMapping("/users")
+    public List<User> list() { return service.findAll(); }
+
+    @PostMapping("/users")
+    public User create(@RequestBody User user) { return service.save(user); }
+}
+`,
+      );
+
+      const mockDbExecutor = async (query: string) => {
+        if (query.includes('HANDLES_ROUTE')) {
+          return [
+            {
+              fileId: 'file-uid-ctrl',
+              filePath: 'src/controller/UserController.java',
+              routePath: '/api/users',
+              routeId: 'route-uid-users',
+              routeSource: 'decorator-GetMapping',
+            },
+          ];
+        }
+        if (query.includes('CONTAINS')) {
+          return [
+            {
+              uid: 'method-uid-list',
+              name: 'list',
+              filePath: 'src/controller/UserController.java',
+              labels: ['Method'],
+            },
+          ];
+        }
+        if (query.includes('FETCHES')) return [];
+        return [];
+      };
+
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const providers = contracts.filter((contract) => contract.role === 'provider');
+
+      expect(providers.find((c) => c.contractId === 'http::GET::/api/users')).toBeDefined();
+      expect(providers.find((c) => c.contractId === 'http::POST::/api/users')).toMatchObject({
+        meta: expect.objectContaining({ extractionStrategy: 'source_scan' }),
+      });
+    });
   });
 
   describe('provider extraction — source-scan fallback (Strategy B)', () => {


### PR DESCRIPTION
## Summary
- mark Java, Python, and PHP HTTP plugins as having complete ingestion Route coverage
- skip source-provider emission only when graph contracts resolve and cover every cached source provider key
- preserve source fallback for empty, unresolved, and mixed graph/source coverage
- add a regression for a graph-covered file that still contains a source-only route

## Validation
- \
px tsc --noEmit\`n- \
px vitest run test/unit/group/http-route-extractor.test.ts --maxWorkers=2\ — 91 passed
- full suite: 10,922 passed; the sole failing literal-collector assertion is reproducible on unchanged main

Fixes #2138