### PR TITLE
fix(cli): preserve trailing spaces in git roots

### DIFF
--- a/gitnexus/src/storage/git.ts
+++ b/gitnexus/src/storage/git.ts
@@ -4,6 +4,8 @@ import path from 'path';
 
 // Git utilities for repository detection, commit tracking, and diff analysis
 
+const chompGitOutput = (value: Buffer): string => value.toString().replace(/\r?\n$/, '');
+
 export const isGitRepo = (repoPath: string): boolean => {
   try {
     execSync('git rev-parse --is-inside-work-tree', {
@@ -102,14 +104,14 @@ export const getRemoteUrl = (repoPath: string): string | undefined => {
  */
 export const getGitRoot = (fromPath: string): string | null => {
   try {
-    const raw = execSync('git rev-parse --show-toplevel', {
-      cwd: fromPath,
-      // Suppress stderr -- see getCurrentCommit comment and #1172.
-      stdio: ['ignore', 'pipe', 'ignore'],
-      windowsHide: true,
-    })
-      .toString()
-      .trim();
+    const raw = chompGitOutput(
+      execSync('git rev-parse --show-toplevel', {
+        cwd: fromPath,
+        // Suppress stderr -- see getCurrentCommit comment and #1172.
+        stdio: ['ignore', 'pipe', 'ignore'],
+        windowsHide: true,
+      }),
+    );
     // On Windows, git returns /d/Projects/Foo — path.resolve normalizes to D:\Projects\Foo
     return path.resolve(raw);
   } catch {
@@ -146,13 +148,13 @@ export const getGitRoot = (fromPath: string): string | null => {
  */
 export const getCanonicalRepoRoot = (fromPath: string): string | null => {
   try {
-    const commonDir = execSync('git rev-parse --path-format=absolute --git-common-dir', {
-      cwd: fromPath,
-      stdio: ['ignore', 'pipe', 'ignore'],
-      windowsHide: true,
-    })
-      .toString()
-      .trim();
+    const commonDir = chompGitOutput(
+      execSync('git rev-parse --path-format=absolute --git-common-dir', {
+        cwd: fromPath,
+        stdio: ['ignore', 'pipe', 'ignore'],
+        windowsHide: true,
+      }),
+    );
     if (!commonDir) return null;
     // Common dir is `<repo>/.git` for both the main checkout and all
     // linked worktrees. Its parent is the canonical repo root.

--- a/gitnexus/test/unit/git-utils.test.ts
+++ b/gitnexus/test/unit/git-utils.test.ts
@@ -146,6 +146,20 @@ describe('getGitRoot', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it('preserves a trailing-space repository directory name (#2190)', async () => {
+    const { getGitRoot } = await import('../../src/storage/git.js');
+    const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-space-root-'));
+    const repoDir = path.join(parentDir, 'repo ');
+    try {
+      fs.mkdirSync(repoDir);
+      execSync('git init -q', { cwd: repoDir });
+
+      expect(getGitRoot(repoDir)).toBe(path.resolve(repoDir));
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ─── getRemoteUrl ─────────────────────────────────────────────────────────

--- a/gitnexus/test/unit/git.test.ts
+++ b/gitnexus/test/unit/git.test.ts
@@ -159,11 +159,11 @@ describe('git utilities', () => {
       );
     });
 
-    it('trims output before resolving path', () => {
-      mockExecSync.mockReturnValueOnce(Buffer.from('  /repo  \n'));
+    it('preserves path whitespace while removing the trailing newline', () => {
+      mockExecSync.mockReturnValueOnce(Buffer.from('/repo \n'));
       const result = getGitRoot('/repo/src');
       expect(result).not.toBeNull();
-      expect(result!.trim()).toBe(result);
+      expect(result).toBe(path.resolve('/repo '));
     });
   });
 


### PR DESCRIPTION
## What
- Preserve filesystem whitespace when reading `git rev-parse --show-toplevel` / `--git-common-dir` output.
- Strip only the trailing line break from git output before `path.resolve`.
- Add a regression for a repo directory whose name ends with a space.

## Why
Fixes #2190. A valid repo named like `repo ` was detected by git, but GitNexus trimmed the path to `repo` and reported `Not a git repository.`

## Verification
- `npx vitest run test/unit/git.test.ts test/unit/git-utils.test.ts`
- `npx tsc --noEmit`
