### PR TITLE
ci: keep tree-sitter readiness summary counts current

### DIFF
--- a/.github/scripts/test_check_tree_sitter_upgrade_readiness.py
+++ b/.github/scripts/test_check_tree_sitter_upgrade_readiness.py
@@ -39,6 +39,13 @@ _spec.loader.exec_module(readiness)  # type: ignore[union-attr]
 # format change that would silently break change-detection fails here. Group 2 is
 # ONLY the Status cell ([^|]+? before the final `|$`).
 _ROW_DIFF_RE = re.compile(r"\| `(tree-sitter-[^`]+)` \|.*\| ([^|]+?) \|$", re.M)
+# Mirrors the scheduled issue-update summary extraction in
+# tree-sitter-upgrade-readiness.yml. If the report prose changes again, the issue
+# comment should not silently degrade to "?/? ready. ? blocker(s)".
+_ISSUE_READY_RE = re.compile(
+    r"- (\d+)/(\d+) npm-installed grammars already accept tree-sitter@"
+)
+_ISSUE_BLOCKER_RE = re.compile(r"\*\*Blocked\*\* — (\d+) grammars? ")
 
 
 def _physical_vendor_grammars() -> set[str]:
@@ -290,6 +297,15 @@ class ReportRendering(TestCase):
         self.assertEqual(self.rows["tree-sitter-c"], "Vendored — held")
         for status in self.rows.values():
             self.assertNotIn("|", status)
+
+    def test_issue_update_summary_regex_matches_current_report(self):
+        ready = _ISSUE_READY_RE.search(self.report)
+        blockers = _ISSUE_BLOCKER_RE.search(self.report)
+        self.assertIsNotNone(ready)
+        self.assertIsNotNone(blockers)
+        self.assertNotEqual(ready.group(1), "?")
+        self.assertNotEqual(ready.group(2), "?")
+        self.assertNotEqual(blockers.group(1), "?")
 
     def _matrix_row(self, name: str) -> str:
         for line in self.report.splitlines():

--- a/.github/scripts/test_check_tree_sitter_upgrade_readiness.py
+++ b/.github/scripts/test_check_tree_sitter_upgrade_readiness.py
@@ -303,9 +303,8 @@ class ReportRendering(TestCase):
         blockers = _ISSUE_BLOCKER_RE.search(self.report)
         self.assertIsNotNone(ready)
         self.assertIsNotNone(blockers)
-        self.assertNotEqual(ready.group(1), "?")
-        self.assertNotEqual(ready.group(2), "?")
-        self.assertNotEqual(blockers.group(1), "?")
+        self.assertEqual(ready.groups(), ("9", "10"))
+        self.assertEqual(blockers.group(1), "2")
 
     def _matrix_row(self, name: str) -> str:
         for line in self.report.splitlines():

--- a/.github/workflows/tree-sitter-upgrade-readiness.yml
+++ b/.github/workflows/tree-sitter-upgrade-readiness.yml
@@ -133,8 +133,8 @@ jobs:
             const existing = open.find(i => i.title === title);
             if (existing) {
               // Extract ready/total count for the changelog comment.
-              const readyMatch = report.match(/\*\*(\d+)\/(\d+)\*\* grammars ready/);
-              const blockerMatch = report.match(/\*\*(\d+) blocker/);
+              const readyMatch = report.match(/- (\d+)\/(\d+) npm-installed grammars already accept tree-sitter@/);
+              const blockerMatch = report.match(/\*\*Blocked\*\* — (\d+) grammars? /);
               const ready = readyMatch ? readyMatch[1] : '?';
               const total = readyMatch ? readyMatch[2] : '?';
               const blockers = blockerMatch ? blockerMatch[1] : '?';
@@ -165,7 +165,7 @@ jobs:
               }
 
               const today = new Date().toISOString().slice(0, 10);
-              let comment = `**${today}:** ${ready}/${total} ready. ${blockers} blocker(s) remaining.`;
+              let comment = `**${today}:** ${ready}/${total} npm-installed ready. ${blockers} blocker(s) remaining.`;
               if (changes.length > 0) {
                 comment += '\n\nChanges:\n' + changes.map(c => `- ${c}`).join('\n');
               } else {


### PR DESCRIPTION
## Summary
- update the scheduled tree-sitter readiness issue-comment parsing to match the current report format
- label the summary as npm-installed readiness so it matches the value being extracted
- add a unittest guard so future report prose changes do not silently produce `?/?` / `? blocker(s)` comments

## Verification
- `python3 -m unittest test_check_tree_sitter_upgrade_readiness -v` from `.github/scripts`
- `python3 .github/scripts/check-tree-sitter-upgrade-readiness.py --assert-current`
- `git diff --check`

## Risk
Low: this only affects the scheduled tracking-issue comment text. The readiness report generation and blocking behavior are unchanged.