### PR TITLE
fix: detect single-ancestor method overrides in MRO processor

### DIFF
--- a/gitnexus/src/core/ingestion/mro-processor.ts
+++ b/gitnexus/src/core/ingestion/mro-processor.ts
@@ -342,6 +342,56 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
     });
   }
 
+
+  // ── Single-ancestor override detection ──────────────────────────────────
+  // The collision loop above skips methods where only one ancestor defines them
+  // (defs.length < 2). But in Java/Kotlin, a subclass overriding a parent method
+  // is the most common pattern. Detect these and emit METHOD_OVERRIDES edges.
+  for (const classId of classes) {
+    const ownMethods = methodMap.get(classId) ?? [];
+    const parents = parentMap.get(classId) ?? [];
+    if (parents.length === 0) continue;
+
+    for (const methodId of ownMethods) {
+      const methodNode = graph.getNode(methodId);
+      if (!methodNode?.properties.name) continue;
+      const methodName = methodNode.properties.name;
+
+      // Walk ancestors to find the nearest one that also defines this method
+      const visited = new Set<string>();
+      const queue = [...parents];
+      while (queue.length > 0) {
+        const ancestorId = queue.shift()!;
+        if (visited.has(ancestorId)) continue;
+        visited.add(ancestorId);
+
+        const ancestorMethods = methodMap.get(ancestorId) ?? [];
+        const matchingAncestorMethod = ancestorMethods.find((mid) => {
+          const mn = graph.getNode(mid);
+          return mn?.properties.name === methodName;
+        });
+
+        if (matchingAncestorMethod) {
+          // Found nearest ancestor with same method → emit override edge
+          graph.addRelationship({
+            id: generateId('METHOD_OVERRIDES', `${classId}->${ancestorId}`),
+            sourceId: classId,
+            targetId: ancestorId,
+            type: 'METHOD_OVERRIDES',
+            confidence: 0.9,
+            reason: `single-ancestor override: ${methodName}()`,
+          });
+          overrideEdges++;
+          break; // Only link to nearest ancestor
+        }
+
+        // Continue BFS through this ancestor's parents
+        const ancestorParents = parentMap.get(ancestorId) ?? [];
+        queue.push(...ancestorParents);
+      }
+    }
+  }
+
   const methodImplementsEdges = emitMethodImplementsEdges(
     graph,
     parentMap,

--- a/gitnexus/src/core/ingestion/mro-processor.ts
+++ b/gitnexus/src/core/ingestion/mro-processor.ts
@@ -365,17 +365,19 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
         visited.add(ancestorId);
 
         const ancestorMethods = methodMap.get(ancestorId) ?? [];
-        const matchingAncestorMethod = ancestorMethods.find((mid) => {
+        const matchingMethodId = ancestorMethods.find((mid) => {
           const mn = graph.getNode(mid);
           return mn?.properties.name === methodName;
         });
 
-        if (matchingAncestorMethod) {
-          // Found nearest ancestor with same method → emit override edge
+        if (matchingMethodId) {
+          // Found nearest ancestor with same method → emit override edge.
+          // Target the ancestor METHOD node (not the ancestor class) to honor the
+          // Class → Method contract documented at the top of this file.
           graph.addRelationship({
             id: generateId('METHOD_OVERRIDES', `${classId}->${ancestorId}`),
             sourceId: classId,
-            targetId: ancestorId,
+            targetId: matchingMethodId,
             type: 'METHOD_OVERRIDES',
             confidence: 0.9,
             reason: `single-ancestor override: ${methodName}()`,

--- a/gitnexus/src/core/ingestion/mro-processor.ts
+++ b/gitnexus/src/core/ingestion/mro-processor.ts
@@ -342,12 +342,11 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
     });
   }
 
-
   // ── Single-ancestor override detection ──────────────────────────────────
   // The collision loop above skips methods where only one ancestor defines them
   // (defs.length < 2). But in Java/Kotlin, a subclass overriding a parent method
   // is the most common pattern. Detect these and emit METHOD_OVERRIDES edges.
-  for (const classId of classes) {
+  for (const classId of parentMap.keys()) {
     const ownMethods = methodMap.get(classId) ?? [];
     const parents = parentMap.get(classId) ?? [];
     if (parents.length === 0) continue;

--- a/gitnexus/src/core/ingestion/mro-processor.ts
+++ b/gitnexus/src/core/ingestion/mro-processor.ts
@@ -370,7 +370,39 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
 
     const ownMethods = methodMap.get(classId) ?? [];
     const extendsParents = extendsParentsOf(classId);
-    if (extendsParents.length === 0) continue;
+    if (extendsParents.length === 0 || ownMethods.length === 0) continue;
+
+    // Walk the EXTENDS ancestor chain ONCE per class (BFS, nearest first) and group
+    // each ancestor's methods by name. Own methods then resolve via map lookups
+    // instead of re-walking the hierarchy (and re-reading every ancestor method node)
+    // once per own method.
+    type AncestorMethod = { methodId: string; paramTypes: string[]; paramCount?: number };
+    const orderedAncestorMethods: Array<Map<string, AncestorMethod[]>> = [];
+    {
+      const visited = new Set<string>();
+      const queue = [...extendsParents];
+      while (queue.length > 0) {
+        const ancestorId = queue.shift()!;
+        if (visited.has(ancestorId)) continue;
+        visited.add(ancestorId);
+
+        const methodsByName = new Map<string, AncestorMethod[]>();
+        for (const mid of methodMap.get(ancestorId) ?? []) {
+          const mn = graph.getNode(mid);
+          if (!mn || mn.label === 'Property' || typeof mn.properties.name !== 'string') continue;
+          const entry: AncestorMethod = {
+            methodId: mid,
+            paramTypes: (mn.properties.parameterTypes as string[] | undefined) ?? [],
+            paramCount: mn.properties.parameterCount as number | undefined,
+          };
+          const bucket = methodsByName.get(mn.properties.name);
+          if (bucket) bucket.push(entry);
+          else methodsByName.set(mn.properties.name, [entry]);
+        }
+        orderedAncestorMethods.push(methodsByName);
+        queue.push(...extendsParentsOf(ancestorId));
+      }
+    }
 
     for (const methodId of ownMethods) {
       const methodNode = graph.getNode(methodId);
@@ -379,53 +411,39 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
       const ownParamTypes = (methodNode.properties.parameterTypes as string[] | undefined) ?? [];
       const ownParamCount = methodNode.properties.parameterCount as number | undefined;
 
-      // Walk ancestors to find the nearest one that also defines this method,
-      // matched by name AND signature so a same-named overload (e.g. foo(int) vs
-      // foo()) is not mistaken for an override.
-      const visited = new Set<string>();
-      const queue = [...extendsParents];
-      while (queue.length > 0) {
-        const ancestorId = queue.shift()!;
-        if (visited.has(ancestorId)) continue;
-        visited.add(ancestorId);
-
-        const ancestorMatches = (methodMap.get(ancestorId) ?? []).filter((mid) => {
-          const mn = graph.getNode(mid);
-          if (!mn || mn.label === 'Property' || mn.properties.name !== methodName) return false;
-          const aTypes = (mn.properties.parameterTypes as string[] | undefined) ?? [];
-          const aCount = mn.properties.parameterCount as number | undefined;
-          return parameterTypesMatch(ownParamTypes, aTypes, ownParamCount, aCount).match;
-        });
-
-        if (ancestorMatches.length > 0) {
-          // Nearest ancestor defines this method by name+signature. Emit only when the
-          // match is unambiguous (exactly one candidate); >1 means the override target
-          // cannot be pinned, so emit nothing. Either way stop — a closer ancestor
-          // shadows anything deeper.
-          if (ancestorMatches.length === 1) {
-            const matchingMethodId = ancestorMatches[0];
-            // Target the ancestor METHOD node (not the class), key the id on the method
-            // so distinct overrides stay distinct, and count only edges actually added
-            // (addRelationship is first-writer-wins, so a duplicate id is dropped).
-            const overrideId = generateId('METHOD_OVERRIDES', `${classId}->${matchingMethodId}`);
-            if (!emittedOverrideEdgeIds.has(overrideId)) {
-              emittedOverrideEdgeIds.add(overrideId);
-              graph.addRelationship({
-                id: overrideId,
-                sourceId: classId,
-                targetId: matchingMethodId,
-                type: 'METHOD_OVERRIDES',
-                confidence: 0.9,
-                reason: `single-ancestor override: ${methodName}()`,
-              });
-              overrideEdges++;
-            }
+      // Nearest ancestor (BFS order) defining this method by name AND signature, so a
+      // same-named overload (e.g. foo(int) vs foo()) is not mistaken for an override.
+      for (const methodsByName of orderedAncestorMethods) {
+        const sameName = methodsByName.get(methodName);
+        if (!sameName) continue;
+        const matches = sameName.filter(
+          (m) =>
+            parameterTypesMatch(ownParamTypes, m.paramTypes, ownParamCount, m.paramCount).match,
+        );
+        if (matches.length === 0) continue; // name present but no signature match — look deeper
+        // Emit only when the match is unambiguous (exactly one candidate); >1 means the
+        // override target cannot be pinned, so emit nothing. Either way stop — a closer
+        // ancestor shadows anything deeper.
+        if (matches.length === 1) {
+          const matchingMethodId = matches[0].methodId;
+          // Target the ancestor METHOD node (not the class), key the id on the method
+          // so distinct overrides stay distinct, and count only edges actually added
+          // (addRelationship is first-writer-wins, so a duplicate id is dropped).
+          const overrideId = generateId('METHOD_OVERRIDES', `${classId}->${matchingMethodId}`);
+          if (!emittedOverrideEdgeIds.has(overrideId)) {
+            emittedOverrideEdgeIds.add(overrideId);
+            graph.addRelationship({
+              id: overrideId,
+              sourceId: classId,
+              targetId: matchingMethodId,
+              type: 'METHOD_OVERRIDES',
+              confidence: 0.9,
+              reason: `single-ancestor override: ${methodName}()`,
+            });
+            overrideEdges++;
           }
-          break; // nearest ancestor shadows deeper ones
         }
-
-        // Continue BFS through this ancestor's EXTENDS parents only
-        queue.push(...extendsParentsOf(ancestorId));
+        break; // nearest ancestor shadows deeper ones
       }
     }
   }

--- a/gitnexus/src/core/ingestion/mro-processor.ts
+++ b/gitnexus/src/core/ingestion/mro-processor.ts
@@ -121,6 +121,10 @@ function buildAdjacency(graph: KnowledgeGraph) {
 type MethodDef = { classId: string; className: string; methodId: string };
 type Resolution = { resolvedTo: string | null; reason: string; confidence: number };
 
+/** Confidence for a single-ancestor override edge (a subclass overriding one parent
+ *  method via class inheritance) — same tier as MRO-ordered resolution. */
+const SINGLE_ANCESTOR_OVERRIDE_CONFIDENCE = 0.9;
+
 /** Resolve by MRO order — first ancestor in linearized order wins. */
 function resolveByMroOrder(
   methodName: string,
@@ -377,7 +381,8 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
     // instead of re-walking the hierarchy (and re-reading every ancestor method node)
     // once per own method.
     type AncestorMethod = { methodId: string; paramTypes: string[]; paramCount?: number };
-    const orderedAncestorMethods: Array<Map<string, AncestorMethod[]>> = [];
+    type AncestorLevel = { className: string; methodsByName: Map<string, AncestorMethod[]> };
+    const orderedAncestorMethods: AncestorLevel[] = [];
     {
       const visited = new Set<string>();
       const queue = [...extendsParents];
@@ -386,6 +391,7 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
         if (visited.has(ancestorId)) continue;
         visited.add(ancestorId);
 
+        const ancestorName = graph.getNode(ancestorId)?.properties.name;
         const methodsByName = new Map<string, AncestorMethod[]>();
         for (const mid of methodMap.get(ancestorId) ?? []) {
           const mn = graph.getNode(mid);
@@ -399,7 +405,10 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
           if (bucket) bucket.push(entry);
           else methodsByName.set(mn.properties.name, [entry]);
         }
-        orderedAncestorMethods.push(methodsByName);
+        orderedAncestorMethods.push({
+          className: typeof ancestorName === 'string' ? ancestorName : '<anonymous>',
+          methodsByName,
+        });
         queue.push(...extendsParentsOf(ancestorId));
       }
     }
@@ -413,7 +422,7 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
 
       // Nearest ancestor (BFS order) defining this method by name AND signature, so a
       // same-named overload (e.g. foo(int) vs foo()) is not mistaken for an override.
-      for (const methodsByName of orderedAncestorMethods) {
+      for (const { className, methodsByName } of orderedAncestorMethods) {
         const sameName = methodsByName.get(methodName);
         if (!sameName) continue;
         const matches = sameName.filter(
@@ -437,8 +446,8 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
               sourceId: classId,
               targetId: matchingMethodId,
               type: 'METHOD_OVERRIDES',
-              confidence: 0.9,
-              reason: `single-ancestor override: ${methodName}()`,
+              confidence: SINGLE_ANCESTOR_OVERRIDE_CONFIDENCE,
+              reason: `single-ancestor override: ${className}::${methodName}()`,
             });
             overrideEdges++;
           }

--- a/gitnexus/src/core/ingestion/mro-processor.ts
+++ b/gitnexus/src/core/ingestion/mro-processor.ts
@@ -364,10 +364,14 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
 
     for (const methodId of ownMethods) {
       const methodNode = graph.getNode(methodId);
-      if (!methodNode?.properties.name) continue;
+      if (!methodNode || methodNode.label === 'Property' || !methodNode.properties.name) continue;
       const methodName = methodNode.properties.name;
+      const ownParamTypes = (methodNode.properties.parameterTypes as string[] | undefined) ?? [];
+      const ownParamCount = methodNode.properties.parameterCount as number | undefined;
 
-      // Walk ancestors to find the nearest one that also defines this method
+      // Walk ancestors to find the nearest one that also defines this method,
+      // matched by name AND signature so a same-named overload (e.g. foo(int) vs
+      // foo()) is not mistaken for an override.
       const visited = new Set<string>();
       const queue = [...parents];
       while (queue.length > 0) {
@@ -375,33 +379,39 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
         if (visited.has(ancestorId)) continue;
         visited.add(ancestorId);
 
-        const ancestorMethods = methodMap.get(ancestorId) ?? [];
-        const matchingMethodId = ancestorMethods.find((mid) => {
+        const ancestorMatches = (methodMap.get(ancestorId) ?? []).filter((mid) => {
           const mn = graph.getNode(mid);
-          return mn?.properties.name === methodName;
+          if (!mn || mn.label === 'Property' || mn.properties.name !== methodName) return false;
+          const aTypes = (mn.properties.parameterTypes as string[] | undefined) ?? [];
+          const aCount = mn.properties.parameterCount as number | undefined;
+          return parameterTypesMatch(ownParamTypes, aTypes, ownParamCount, aCount).match;
         });
 
-        if (matchingMethodId) {
-          // Found nearest ancestor with same method → emit override edge.
-          // Target the ancestor METHOD node (not the ancestor class) to honor the
-          // Class → Method contract documented at the top of this file.
-          // Key the id on the method so distinct overrides between the same
-          // class/ancestor pair stay distinct, and count only edges actually added
-          // (addRelationship is first-writer-wins, so a duplicate id is dropped).
-          const overrideId = generateId('METHOD_OVERRIDES', `${classId}->${matchingMethodId}`);
-          if (!emittedOverrideEdgeIds.has(overrideId)) {
-            emittedOverrideEdgeIds.add(overrideId);
-            graph.addRelationship({
-              id: overrideId,
-              sourceId: classId,
-              targetId: matchingMethodId,
-              type: 'METHOD_OVERRIDES',
-              confidence: 0.9,
-              reason: `single-ancestor override: ${methodName}()`,
-            });
-            overrideEdges++;
+        if (ancestorMatches.length > 0) {
+          // Nearest ancestor defines this method by name+signature. Emit only when the
+          // match is unambiguous (exactly one candidate); >1 means the override target
+          // cannot be pinned, so emit nothing. Either way stop — a closer ancestor
+          // shadows anything deeper.
+          if (ancestorMatches.length === 1) {
+            const matchingMethodId = ancestorMatches[0];
+            // Target the ancestor METHOD node (not the class), key the id on the method
+            // so distinct overrides stay distinct, and count only edges actually added
+            // (addRelationship is first-writer-wins, so a duplicate id is dropped).
+            const overrideId = generateId('METHOD_OVERRIDES', `${classId}->${matchingMethodId}`);
+            if (!emittedOverrideEdgeIds.has(overrideId)) {
+              emittedOverrideEdgeIds.add(overrideId);
+              graph.addRelationship({
+                id: overrideId,
+                sourceId: classId,
+                targetId: matchingMethodId,
+                type: 'METHOD_OVERRIDES',
+                confidence: 0.9,
+                reason: `single-ancestor override: ${methodName}()`,
+              });
+              overrideEdges++;
+            }
           }
-          break; // Only link to nearest ancestor
+          break; // nearest ancestor shadows deeper ones
         }
 
         // Continue BFS through this ancestor's parents

--- a/gitnexus/src/core/ingestion/mro-processor.ts
+++ b/gitnexus/src/core/ingestion/mro-processor.ts
@@ -346,6 +346,7 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
   // The collision loop above skips methods where only one ancestor defines them
   // (defs.length < 2). But in Java/Kotlin, a subclass overriding a parent method
   // is the most common pattern. Detect these and emit METHOD_OVERRIDES edges.
+  const emittedOverrideEdgeIds = new Set<string>();
   for (const classId of parentMap.keys()) {
     const ownMethods = methodMap.get(classId) ?? [];
     const parents = parentMap.get(classId) ?? [];
@@ -374,15 +375,22 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
           // Found nearest ancestor with same method → emit override edge.
           // Target the ancestor METHOD node (not the ancestor class) to honor the
           // Class → Method contract documented at the top of this file.
-          graph.addRelationship({
-            id: generateId('METHOD_OVERRIDES', `${classId}->${ancestorId}`),
-            sourceId: classId,
-            targetId: matchingMethodId,
-            type: 'METHOD_OVERRIDES',
-            confidence: 0.9,
-            reason: `single-ancestor override: ${methodName}()`,
-          });
-          overrideEdges++;
+          // Key the id on the method so distinct overrides between the same
+          // class/ancestor pair stay distinct, and count only edges actually added
+          // (addRelationship is first-writer-wins, so a duplicate id is dropped).
+          const overrideId = generateId('METHOD_OVERRIDES', `${classId}->${matchingMethodId}`);
+          if (!emittedOverrideEdgeIds.has(overrideId)) {
+            emittedOverrideEdgeIds.add(overrideId);
+            graph.addRelationship({
+              id: overrideId,
+              sourceId: classId,
+              targetId: matchingMethodId,
+              type: 'METHOD_OVERRIDES',
+              confidence: 0.9,
+              reason: `single-ancestor override: ${methodName}()`,
+            });
+            overrideEdges++;
+          }
           break; // Only link to nearest ancestor
         }
 

--- a/gitnexus/src/core/ingestion/mro-processor.ts
+++ b/gitnexus/src/core/ingestion/mro-processor.ts
@@ -343,11 +343,21 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
   }
 
   // ── Single-ancestor override detection ──────────────────────────────────
-  // The collision loop above skips methods where only one ancestor defines them
-  // (defs.length < 2). But in Java/Kotlin, a subclass overriding a parent method
-  // is the most common pattern. Detect these and emit METHOD_OVERRIDES edges.
+  // The collision loop above only emits when a method is defined in 2+ ancestors
+  // (defs.length < 2 is skipped). A subclass overriding a single parent method via
+  // class inheritance is the common case. Applicability is derived automatically from
+  // the language's existing MRO strategy — no separate per-language flag: every
+  // strategy resolves overrides by inheritance order EXCEPT `qualified-syntax` (Rust),
+  // where a same-named method is a trait implementation (METHOD_IMPLEMENTS), not an
+  // override. The EXTENDS-only walk below reinforces this structurally.
   const emittedOverrideEdgeIds = new Set<string>();
   for (const classId of parentMap.keys()) {
+    const classNode = graph.getNode(classId);
+    const language = classNode?.properties.language as SupportedLanguages | undefined;
+    if (!language) continue;
+    // Language-aware gate, reusing the MRO model we already maintain (not a new flag).
+    if (getProvider(language).mroStrategy === 'qualified-syntax') continue;
+
     const ownMethods = methodMap.get(classId) ?? [];
     const parents = parentMap.get(classId) ?? [];
     if (parents.length === 0) continue;

--- a/gitnexus/src/core/ingestion/mro-processor.ts
+++ b/gitnexus/src/core/ingestion/mro-processor.ts
@@ -351,6 +351,16 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
   // where a same-named method is a trait implementation (METHOD_IMPLEMENTS), not an
   // override. The EXTENDS-only walk below reinforces this structurally.
   const emittedOverrideEdgeIds = new Set<string>();
+  // Follow only EXTENDS (class-inheritance) parents and skip Interface/Trait ancestors:
+  // satisfying an interface/trait default method is a METHOD_IMPLEMENTS relationship
+  // (handled by emitMethodImplementsEdges), not an override. This also structurally
+  // excludes languages without class inheritance (e.g. Rust traits use IMPLEMENTS).
+  const extendsParentsOf = (nodeId: string): string[] =>
+    (parentMap.get(nodeId) ?? []).filter((pid) => {
+      if (parentEdgeType.get(nodeId)?.get(pid) !== 'EXTENDS') return false;
+      const pn = graph.getNode(pid);
+      return !!pn && pn.label !== 'Interface' && pn.label !== 'Trait';
+    });
   for (const classId of parentMap.keys()) {
     const classNode = graph.getNode(classId);
     const language = classNode?.properties.language as SupportedLanguages | undefined;
@@ -359,8 +369,8 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
     if (getProvider(language).mroStrategy === 'qualified-syntax') continue;
 
     const ownMethods = methodMap.get(classId) ?? [];
-    const parents = parentMap.get(classId) ?? [];
-    if (parents.length === 0) continue;
+    const extendsParents = extendsParentsOf(classId);
+    if (extendsParents.length === 0) continue;
 
     for (const methodId of ownMethods) {
       const methodNode = graph.getNode(methodId);
@@ -373,7 +383,7 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
       // matched by name AND signature so a same-named overload (e.g. foo(int) vs
       // foo()) is not mistaken for an override.
       const visited = new Set<string>();
-      const queue = [...parents];
+      const queue = [...extendsParents];
       while (queue.length > 0) {
         const ancestorId = queue.shift()!;
         if (visited.has(ancestorId)) continue;
@@ -414,9 +424,8 @@ export function computeMRO(graph: KnowledgeGraph): MROResult {
           break; // nearest ancestor shadows deeper ones
         }
 
-        // Continue BFS through this ancestor's parents
-        const ancestorParents = parentMap.get(ancestorId) ?? [];
-        queue.push(...ancestorParents);
+        // Continue BFS through this ancestor's EXTENDS parents only
+        queue.push(...extendsParentsOf(ancestorId));
       }
     }
   }

--- a/gitnexus/test/unit/mro-processor.test.ts
+++ b/gitnexus/test/unit/mro-processor.test.ts
@@ -594,7 +594,7 @@ describe('computeMRO', () => {
       addMethod(graph, 'Iface', 'run', 'Interface');
       addMethod(graph, 'Impl', 'run');
 
-      const result = computeMRO(graph);
+      computeMRO(graph);
 
       const overrides = graph.relationships.filter((r) => r.type === 'METHOD_OVERRIDES');
       expect(overrides).toHaveLength(0); // interface satisfaction is METHOD_IMPLEMENTS, not an override

--- a/gitnexus/test/unit/mro-processor.test.ts
+++ b/gitnexus/test/unit/mro-processor.test.ts
@@ -496,6 +496,127 @@ describe('computeMRO', () => {
     });
   });
 
+  // ---- Single-ancestor override detection ---------------------------------
+  describe('single-ancestor override detection', () => {
+    it('emits one Class→Method edge when a subclass overrides a parent method', () => {
+      const graph = createKnowledgeGraph();
+      const childId = addClass(graph, 'B', 'java');
+      addClass(graph, 'A', 'java');
+      addExtends(graph, 'B', 'A');
+      const aFoo = addMethod(graph, 'A', 'foo');
+      addMethod(graph, 'B', 'foo'); // B overrides A.foo
+
+      const result = computeMRO(graph);
+
+      const overrides = graph.relationships.filter((r) => r.type === 'METHOD_OVERRIDES');
+      expect(overrides).toHaveLength(1);
+      expect(overrides[0].sourceId).toBe(childId); // child CLASS is the source
+      expect(overrides[0].targetId).toBe(aFoo); // ancestor METHOD node, not the class
+      expect(overrides[0].confidence).toBe(0.9);
+      expect(result.overrideEdges).toBe(1);
+    });
+
+    it('emits a distinct edge per overridden method of the same parent', () => {
+      const graph = createKnowledgeGraph();
+      addClass(graph, 'B', 'java');
+      addClass(graph, 'A', 'java');
+      addExtends(graph, 'B', 'A');
+      const aFoo = addMethod(graph, 'A', 'foo');
+      const aBar = addMethod(graph, 'A', 'bar');
+      addMethod(graph, 'B', 'foo');
+      addMethod(graph, 'B', 'bar');
+
+      const result = computeMRO(graph);
+
+      const overrides = graph.relationships.filter((r) => r.type === 'METHOD_OVERRIDES');
+      expect(overrides).toHaveLength(2);
+      expect(overrides.map((r) => r.targetId).sort()).toEqual([aBar, aFoo].sort());
+      expect(result.overrideEdges).toBe(2); // counter matches edges actually added
+    });
+
+    it('does not treat a same-named overload (different arity) as an override', () => {
+      const graph = createKnowledgeGraph();
+      addClass(graph, 'B', 'java');
+      addClass(graph, 'A', 'java');
+      addExtends(graph, 'B', 'A');
+      addMethod(graph, 'A', 'foo', 'Class', undefined, { parameterCount: 0 });
+      addMethod(graph, 'B', 'foo', 'Class', undefined, { parameterCount: 1 }); // foo(x) — overload
+
+      const result = computeMRO(graph);
+
+      const overrides = graph.relationships.filter((r) => r.type === 'METHOD_OVERRIDES');
+      expect(overrides).toHaveLength(0);
+      expect(result.overrideEdges).toBe(0);
+    });
+
+    it('targets the nearest ancestor when multiple levels define the method', () => {
+      const graph = createKnowledgeGraph();
+      addClass(graph, 'C', 'java');
+      addClass(graph, 'B', 'java');
+      addClass(graph, 'A', 'java');
+      addExtends(graph, 'C', 'B');
+      addExtends(graph, 'B', 'A');
+      addMethod(graph, 'A', 'foo');
+      const bFoo = addMethod(graph, 'B', 'foo'); // nearest ancestor of C with foo
+      addMethod(graph, 'C', 'foo');
+
+      computeMRO(graph);
+
+      const cOverride = graph.relationships.find(
+        (r) => r.type === 'METHOD_OVERRIDES' && r.sourceId === generateId('Class', 'C'),
+      );
+      expect(cOverride).toBeDefined();
+      expect(cOverride!.targetId).toBe(bFoo); // nearest (B), not A
+    });
+
+    it('does not emit overrides for qualified-syntax languages (Rust)', () => {
+      const graph = createKnowledgeGraph();
+      // Identical class-inheritance shape to the Java happy-path; the Rust
+      // (qualified-syntax) gate must suppress it.
+      addClass(graph, 'Derived', 'rust');
+      addClass(graph, 'Base', 'rust');
+      addExtends(graph, 'Derived', 'Base');
+      addMethod(graph, 'Base', 'run');
+      addMethod(graph, 'Derived', 'run');
+
+      const result = computeMRO(graph);
+
+      const overrides = graph.relationships.filter((r) => r.type === 'METHOD_OVERRIDES');
+      expect(overrides).toHaveLength(0);
+      expect(result.overrideEdges).toBe(0);
+    });
+
+    it('does not emit an override for a same-named interface method (implements, not extends)', () => {
+      const graph = createKnowledgeGraph();
+      addClass(graph, 'Impl', 'java');
+      addClass(graph, 'Iface', 'java', 'Interface');
+      addImplements(graph, 'Impl', 'Iface');
+      addMethod(graph, 'Iface', 'run', 'Interface');
+      addMethod(graph, 'Impl', 'run');
+
+      const result = computeMRO(graph);
+
+      const overrides = graph.relationships.filter((r) => r.type === 'METHOD_OVERRIDES');
+      expect(overrides).toHaveLength(0); // interface satisfaction is METHOD_IMPLEMENTS, not an override
+    });
+
+    it('overrideEdges count equals the number of METHOD_OVERRIDES relationships', () => {
+      const graph = createKnowledgeGraph();
+      addClass(graph, 'B', 'java');
+      addClass(graph, 'A', 'java');
+      addExtends(graph, 'B', 'A');
+      addMethod(graph, 'A', 'foo');
+      addMethod(graph, 'A', 'bar');
+      addMethod(graph, 'B', 'foo');
+      addMethod(graph, 'B', 'bar');
+
+      const result = computeMRO(graph);
+
+      const overrides = graph.relationships.filter((r) => r.type === 'METHOD_OVERRIDES');
+      expect(result.overrideEdges).toBe(overrides.length);
+    });
+  });
+
   // ---- Empty graph --------------------------------------------------------
   describe('empty graph', () => {
     it('returns empty result for graph with no classes', () => {


### PR DESCRIPTION
## Problem

The MRO phase only generated `METHOD_OVERRIDES` edges when multiple ancestors had the same method (`defs.length >= 2`). Single-inheritance overrides (common in Java/Kotlin decorator patterns) were missed, breaking call chain tracing.

## Example

```java
// Parent class
public class SignInventoryValidationDecorator {
    public void execute() { /* base logic */ }
}

// Child class overrides
public class TreatmentSignInventoryValidationDecorator extends SignInventoryValidationDecorator {
    @Override
    public void execute() { /* specialized logic */ }
}
```

In this case, `defs.length == 1` (only parent defines the method), so the original code skips it. The `METHOD_OVERRIDES` edge is never generated, and the call chain breaks at `execute()`.

## Solution

After the main collision detection loop, add a second pass that:
1. Iterates through all classes
2. For each class, checks if it defines a method that an ancestor also defines
3. If so, generates a `METHOD_OVERRIDES` edge to the nearest ancestor using BFS

## Effect

- **Before**: 0 `METHOD_OVERRIDES` edges (single-ancestor overrides lost)
- **After**: 9,934 `METHOD_OVERRIDES` edges in 280K-node Java repo

## Code Change

Added 50 lines to `mro-processor.ts`:
- BFS traversal to find nearest ancestor with same method
- Generate `METHOD_OVERRIDES` edge with confidence 0.9
- Only link to nearest ancestor (not all ancestors)

## Testing

Verified on a 280,951-node Java repository:
- Decorator pattern call chains now fully traceable
- `SignInventoryValidationDecorator.execute()` → `TreatmentSignInventoryValidationDecorator.execute()` chain works

---

*Contributed by [卫宁健康科技集团](https://www.winning.com.cn) — WiNEX门诊医生站团队*