### PR TITLE
Feat/azure devops server support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ WEB_HOST_PORT=4173
 # Optional read-only mount, exposed to the server as /workspace.
 # Override with the directory that contains the repos you want to index.
 WORKSPACE_DIR=./
+
+# Azure DevOps Server Integration (passed to the server container)
+# AZURE_DEVOPS_URL=http://azuredevops.example.com
+# AZURE_DEVOPS_PAT=your-pat-here

--- a/gitnexus-web/src/components/AnalyzeOnboarding.tsx
+++ b/gitnexus-web/src/components/AnalyzeOnboarding.tsx
@@ -3,7 +3,7 @@
  *
  * The "empty state" card rendered inside DropZone's Crossfade when the server
  * is connected but zero repos are indexed. Replaces the generic error message
- * with a first-class GitHub URL input flow.
+ * with a first-class repository URL input flow.
  *
  * Rendering context:
  *   DropZone (Crossfade, phase="analyze")
@@ -15,7 +15,7 @@
  * the app to the graph explorer.
  */
 
-import { Sparkles, Github } from '@/lib/lucide-icons';
+import { Sparkles, GitBranch } from '@/lib/lucide-icons';
 import { RepoAnalyzer } from './RepoAnalyzer';
 import { useTranslation } from 'react-i18next';
 
@@ -46,7 +46,7 @@ export const AnalyzeOnboarding = ({ onComplete }: AnalyzeOnboardingProps) => {
 
           {/* Icon */}
           <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-accent/30 bg-gradient-to-br from-accent/20 to-accent-dim/10 shadow-glow-soft">
-            <Github className="h-7 w-7 text-accent" />
+            <GitBranch className="h-7 w-7 text-accent" />
           </div>
 
           <h2 className="text-lg leading-snug font-semibold text-text-primary">

--- a/gitnexus-web/src/components/RepoAnalyzer.tsx
+++ b/gitnexus-web/src/components/RepoAnalyzer.tsx
@@ -10,6 +10,7 @@ import { useState, useRef, useEffect, useId } from 'react';
 import {
   Github,
   Gitlab,
+  AzureDevops,
   FolderOpen,
   Loader2,
   Check,
@@ -30,10 +31,11 @@ import { useTranslation } from 'react-i18next';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-type InputMode = 'github' | 'gitlab' | 'local';
+type InputMode = 'github' | 'gitlab' | 'azure' | 'local';
 
 const GITHUB_RE = /^https?:\/\/(www\.)?github\.com\/[^/\s]+\/[^/\s]+/i;
 const GITLAB_RE = /^https?:\/\/[^/\s]+\/[^/\s]+\/[^/\s]+(\/.*)?$/i;
+const AZURE_RE = /^https?:\/\/[^/\s]+\/[^/\s]+\/[^/\s]+\/_git\/[^/\s]+/i;
 const IS_WINDOWS = navigator.userAgent.toLowerCase().includes('win');
 
 function isValidGithubUrl(value: string): boolean {
@@ -42,6 +44,10 @@ function isValidGithubUrl(value: string): boolean {
 
 function isValidGitlabUrl(value: string): boolean {
   return GITLAB_RE.test(value.trim());
+}
+
+function isValidAzureUrl(value: string): boolean {
+  return AZURE_RE.test(value.trim());
 }
 
 // ── Mode tabs ────────────────────────────────────────────────────────────────
@@ -80,6 +86,19 @@ function ModeTabs({ mode, onChange }: { mode: InputMode; onChange: (m: InputMode
       >
         <Gitlab className="h-3 w-3" />
         {t('repoAnalyzer.gitlabUrl')}
+      </button>
+      <button
+        role="tab"
+        aria-selected={mode === 'azure'}
+        onClick={() => onChange('azure')}
+        className={`flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all duration-150 ${
+          mode === 'azure'
+            ? 'bg-accent text-white shadow-sm'
+            : 'text-text-muted hover:text-text-secondary'
+        } `}
+      >
+        <AzureDevops className="h-3 w-3" />
+        {t('repoAnalyzer.azureDevOpsUrl')}
       </button>
       <button
         role="tab"
@@ -174,6 +193,7 @@ export const RepoAnalyzer = ({ variant, onComplete, onCancel }: RepoAnalyzerProp
   );
   const [githubUrl, setGithubUrl] = useState('');
   const [gitlabUrl, setGitlabUrl] = useState('');
+  const [azureUrl, setAzureUrl] = useState('');
   const [localPath, setLocalPath] = useState('');
   const [phase, setPhase] = useState<InternalPhase>('input');
   const [validationError, setValidationError] = useState<string | null>(null);
@@ -240,6 +260,7 @@ export const RepoAnalyzer = ({ variant, onComplete, onCancel }: RepoAnalyzerProp
     setMode(m);
     setGithubUrl('');
     setGitlabUrl('');
+    setAzureUrl('');
     setLocalPath('');
     setValidationError(null);
     setUploadSummary(null);
@@ -259,7 +280,9 @@ export const RepoAnalyzer = ({ variant, onComplete, onCancel }: RepoAnalyzerProp
       ? isValidGithubUrl(githubUrl) && (phase === 'input' || phase === 'error')
       : mode === 'gitlab'
         ? isValidGitlabUrl(gitlabUrl) && (phase === 'input' || phase === 'error')
-        : localPath.trim().length > 1 && (phase === 'input' || phase === 'error');
+        : mode === 'azure'
+          ? isValidAzureUrl(azureUrl) && (phase === 'input' || phase === 'error')
+          : localPath.trim().length > 1 && (phase === 'input' || phase === 'error');
 
   const handleAnalyze = async () => {
     if (mode === 'github' && !isValidGithubUrl(githubUrl)) {
@@ -268,6 +291,10 @@ export const RepoAnalyzer = ({ variant, onComplete, onCancel }: RepoAnalyzerProp
     }
     if (mode === 'gitlab' && !isValidGitlabUrl(gitlabUrl)) {
       setValidationError('Please enter a valid GitLab repository URL.');
+      return;
+    }
+    if (mode === 'azure' && !isValidAzureUrl(azureUrl)) {
+      setValidationError(t('errors:invalidAzureDevOpsUrl'));
       return;
     }
     if (mode === 'local' && localPath.trim().length < 2) {
@@ -288,7 +315,9 @@ export const RepoAnalyzer = ({ variant, onComplete, onCancel }: RepoAnalyzerProp
           ? { url: githubUrl.trim() }
           : mode === 'gitlab'
             ? { url: gitlabUrl.trim() }
-            : { path: localPath.trim() };
+            : mode === 'azure'
+              ? { url: azureUrl.trim() }
+              : { path: localPath.trim() };
       const { jobId } = await startAnalyze(request);
       // Stale resolution: return without cancelling — URL jobIds may be
       // dedup-aliased to a job another session owns (see cancelStaleUploadJob).
@@ -299,7 +328,9 @@ export const RepoAnalyzer = ({ variant, onComplete, onCancel }: RepoAnalyzerProp
           ? githubUrl.trim()
           : mode === 'gitlab'
             ? gitlabUrl.trim()
-            : localPath.trim();
+            : mode === 'azure'
+              ? azureUrl.trim()
+              : localPath.trim();
       trackJob(jobId, nameSource);
     } catch (err) {
       // Unmount aborts the controller, so this also covers the unmounted case.
@@ -513,6 +544,59 @@ export const RepoAnalyzer = ({ variant, onComplete, onCancel }: RepoAnalyzerProp
             )}
           </div>
           <p className="text-xs text-text-muted">{t('onboarding:repoAnalyzer.gitlabSupported')}</p>
+        </div>
+      )}
+
+      {/* Azure DevOps URL input */}
+      {showInput && mode === 'azure' && (
+        <div className="space-y-2">
+          <label
+            htmlFor={inputId}
+            className="block text-xs font-medium tracking-wider text-text-secondary uppercase"
+          >
+            {t('onboarding:repoAnalyzer.azureDevOpsRepositoryUrl')}
+          </label>
+          <div
+            className={`flex items-center gap-3 rounded-xl border bg-void px-4 py-3.5 transition-all duration-200 ${
+              validationError && phase === 'error'
+                ? 'border-red-500/50'
+                : isValidAzureUrl(azureUrl)
+                  ? 'border-accent/50 shadow-[0_0_0_3px_rgba(124,58,237,0.08)]'
+                  : 'border-border-default focus-within:border-accent/40'
+            } `}
+          >
+            <AzureDevops className="h-4 w-4 shrink-0 text-text-muted" />
+            <input
+              id={inputId}
+              type="url"
+              value={azureUrl}
+              onChange={(e) => {
+                setAzureUrl(e.target.value);
+                if (validationError) setValidationError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && canSubmit && !isLoading) {
+                  e.preventDefault();
+                  handleAnalyze();
+                }
+              }}
+              disabled={isLoading}
+              placeholder="http://azuredevops.example.com/Collection/Project/_git/Repo"
+              autoComplete="url"
+              spellCheck={false}
+              className="flex-1 border-none bg-transparent font-mono text-sm text-text-primary outline-none placeholder:text-text-muted disabled:opacity-50"
+            />
+            {azureUrl.length > 10 && (
+              <div className="shrink-0">
+                {isValidAzureUrl(azureUrl) ? (
+                  <Check className="h-3.5 w-3.5 text-emerald-400" />
+                ) : (
+                  <AlertCircle className="h-3.5 w-3.5 text-text-muted" />
+                )}
+              </div>
+            )}
+          </div>
+          <p className="text-xs text-text-muted">{t('onboarding:repoAnalyzer.azureDevOpsSupported')}</p>
         </div>
       )}
 

--- a/gitnexus-web/src/lib/lucide-icons.tsx
+++ b/gitnexus-web/src/lib/lucide-icons.tsx
@@ -185,6 +185,41 @@ export const Gitlab = forwardRef<SVGSVGElement, LucideProps>(function Gitlab(
   );
 });
 
+/**
+ * Azure DevOps mark — SVG path data from simple-icons (CC0-1.0).
+ *
+ * The Azure DevOps logo is a registered trademark of Microsoft Corporation.
+ * We use it here only to indicate Azure DevOps source-repo integration.
+ *
+ * API-compatible with `lucide-react` icons (`LucideProps`).
+ */
+export const AzureDevops = forwardRef<SVGSVGElement, LucideProps>(function AzureDevops(
+  {
+    size = 24,
+    color = 'currentColor',
+    className,
+    strokeWidth: _strokeWidth,
+    absoluteStrokeWidth: _absoluteStrokeWidth,
+    ...rest
+  },
+  ref,
+) {
+  return (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={color}
+      className={className}
+      {...rest}
+    >
+      <path d="M0 8.877L2.247 5.91l8.405-3.416V.022l7.37 5.393L2.966 8.338v8.225L0 15.707zm24-4.45v14.651l-5.753 4.9-9.303-3.057v3.056l-5.978-7.416 15.057 1.798V5.415z" />
+    </svg>
+  );
+});
+
 export const Github = forwardRef<SVGSVGElement, LucideProps>(function Github(
   {
     size = 24,

--- a/gitnexus-web/src/locales/en/errors.json
+++ b/gitnexus-web/src/locales/en/errors.json
@@ -6,6 +6,7 @@
   "analysisFailed": "Analysis failed. Check server logs.",
   "startAnalysisFailed": "Failed to start analysis",
   "invalidGithubUrl": "Please enter a valid GitHub repository URL.",
+  "invalidAzureDevOpsUrl": "Please enter a valid Azure DevOps repository URL.",
   "missingFolderPath": "Please enter a folder path.",
   "backend": {
     "reconnecting": "Server connection lost. Reconnecting…",

--- a/gitnexus-web/src/locales/en/onboarding.json
+++ b/gitnexus-web/src/locales/en/onboarding.json
@@ -31,7 +31,7 @@
   },
   "analyzeFirst": {
     "title": "Analyze your first repository",
-    "description": "Paste a GitHub URL and GitNexus will clone it, parse the code, and build a live knowledge graph — right in your browser.",
+    "description": "Paste a repository URL and GitNexus will clone it, parse the code, and build a live knowledge graph — right in your browser.",
     "footer": "Public repos only · Cloned locally by the server · No data leaves your machine"
   },
   "landing": {

--- a/gitnexus-web/src/locales/en/onboarding.json
+++ b/gitnexus-web/src/locales/en/onboarding.json
@@ -51,6 +51,7 @@
     "inputType": "Input type",
     "githubUrl": "GitHub URL",
     "gitlabUrl": "GitLab URL",
+    "azureDevOpsUrl": "Azure DevOps",
     "localFolder": "Local Folder",
     "starting": "Starting analysis...",
     "analyzeRepository": "Analyze Repository",
@@ -60,6 +61,8 @@
     "githubRepositoryUrl": "GitHub Repository URL",
     "gitlabRepositoryUrl": "GitLab Repository URL",
     "gitlabSupported": "Supports GitLab.com and self-hosted GitLab instances.",
+    "azureDevOpsRepositoryUrl": "Azure DevOps Repository URL",
+    "azureDevOpsSupported": "Format: https://dev.azure.com/organization/project/_git/repository",
     "localFolderPath": "Local Folder Path",
     "hideBackground": "Hide (analysis continues in background)",
     "upload": {

--- a/gitnexus-web/src/locales/zh-CN/errors.json
+++ b/gitnexus-web/src/locales/zh-CN/errors.json
@@ -6,6 +6,7 @@
   "analysisFailed": "分析失败，请检查服务器日志。",
   "startAnalysisFailed": "启动分析失败",
   "invalidGithubUrl": "请输入有效的 GitHub 仓库 URL。",
+  "invalidAzureDevOpsUrl": "请输入有效的 Azure DevOps 仓库 URL。",
   "missingFolderPath": "请输入文件夹路径。",
   "backend": {
     "reconnecting": "服务器连接已断开，正在重连…",

--- a/gitnexus-web/src/locales/zh-CN/onboarding.json
+++ b/gitnexus-web/src/locales/zh-CN/onboarding.json
@@ -31,7 +31,7 @@
   },
   "analyzeFirst": {
     "title": "分析你的第一个仓库",
-    "description": "粘贴 GitHub URL，GitNexus 会克隆仓库、解析代码，并直接在浏览器中构建实时知识图谱。",
+    "description": "粘贴仓库 URL，GitNexus 会克隆仓库、解析代码，并直接在浏览器中构建实时知识图谱。",
     "footer": "仅支持公开仓库 · 服务器本地克隆 · 数据不会离开你的机器"
   },
   "landing": {
@@ -51,6 +51,7 @@
     "inputType": "输入类型",
     "githubUrl": "GitHub URL",
     "gitlabUrl": "GitLab URL",
+    "azureDevOpsUrl": "Azure DevOps",
     "localFolder": "本地文件夹",
     "starting": "正在启动分析...",
     "analyzeRepository": "分析仓库",
@@ -60,6 +61,8 @@
     "githubRepositoryUrl": "GitHub 仓库 URL",
     "gitlabRepositoryUrl": "GitLab 仓库 URL",
     "gitlabSupported": "支持 GitLab.com 和自托管 GitLab 实例。",
+    "azureDevOpsRepositoryUrl": "Azure DevOps 仓库 URL",
+    "azureDevOpsSupported": "格式: http://server/Collection/Project/_git/Repository",
     "localFolderPath": "本地文件夹路径",
     "hideBackground": "隐藏（分析继续在后台进行）",
     "upload": {

--- a/gitnexus/.env.example
+++ b/gitnexus/.env.example
@@ -10,3 +10,11 @@
 
 # Works with Infinity, vLLM, TEI, llama.cpp, Ollama, LM Studio, or OpenAI.
 # See README for details.
+
+# Azure DevOps Server (Self-Hosted) Integration
+# Base URL of your Azure DevOps Server instance.
+# AZURE_DEVOPS_URL=http://azuredevops.example.com
+
+# Personal Access Token with Code (Read) scope for cloning private repos.
+# Used for both self-hosted and cloud (dev.azure.com) Azure DevOps.
+# AZURE_DEVOPS_PAT=your-pat-here

--- a/gitnexus/src/server/git-clone.ts
+++ b/gitnexus/src/server/git-clone.ts
@@ -236,6 +236,55 @@ export interface CloneProgress {
  *
  * Exported so the separator placement is testable without mocking spawn.
  */
+/**
+ * Detect Azure DevOps URLs — both self-hosted (via AZURE_DEVOPS_URL env)
+ * and cloud (dev.azure.com / *.visualstudio.com).
+ *
+ * Self-hosted Azure DevOps Server instances use arbitrary hostnames
+ * (e.g. `http://tfs.corp.example/Collection/Project/_git/Repo`), so the
+ * function checks `AZURE_DEVOPS_URL` first. Cloud addresses are a
+ * hardcoded fallback so PAT injection works out-of-the-box for
+ * dev.azure.com without extra configuration.
+ */
+export function isAzureDevOpsUrl(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+
+    // Self-hosted: match against the configured base URL.
+    const configuredBase = process.env.AZURE_DEVOPS_URL;
+    if (configuredBase) {
+      try {
+        const baseHost = new URL(configuredBase).hostname.toLowerCase();
+        if (host === baseHost) return true;
+      } catch {
+        /* invalid AZURE_DEVOPS_URL — fall through to cloud check */
+      }
+    }
+
+    // Cloud fallback.
+    return host === 'dev.azure.com' || host.endsWith('.visualstudio.com');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build git `-c http.extraHeader=...` arguments that inject a Basic Auth
+ * header when the URL targets an Azure DevOps instance and
+ * `AZURE_DEVOPS_PAT` is set.  Returns an empty array otherwise.
+ *
+ * The `-c` args are prepended to the git command so they appear before
+ * the `--` separator (option territory), and the PAT is never written to
+ * `.git/config` — it is scoped to the single git invocation.
+ */
+function buildAuthArgs(url: string): string[] {
+  if (!isAzureDevOpsUrl(url)) return [];
+  const pat = process.env.AZURE_DEVOPS_PAT;
+  if (!pat) return [];
+  const base64 = Buffer.from(`:${pat}`).toString('base64');
+  return ['-c', `http.extraHeader=Authorization: Basic ${base64}`];
+}
+
 export function buildCloneArgs(url: string, targetDir: string): string[] {
   return ['clone', '--depth', '1', '--', url, targetDir];
 }
@@ -413,19 +462,20 @@ export async function cloneOrPull(
     // whatever remote the dir was originally cloned from.
     await assertRemoteMatchesRequestedUrl(safeTarget, url);
     onProgress?.({ phase: 'pulling', message: 'Pulling latest changes...' });
-    await runGit(['pull', '--ff-only'], safeTarget);
+    await runGit(['pull', '--ff-only'], safeTarget, url);
   } else {
     await fs.mkdir(path.dirname(safeTarget), { recursive: true });
     onProgress?.({ phase: 'cloning', message: `Cloning ${url}...` });
-    await runGit(buildCloneArgs(url, safeTarget));
+    await runGit(buildCloneArgs(url, safeTarget), undefined, url);
   }
 
   return safeTarget;
 }
 
-function runGit(args: string[], cwd?: string): Promise<void> {
+function runGit(args: string[], cwd?: string, url?: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const proc = spawn('git', args, {
+    const authArgs = url ? buildAuthArgs(url) : [];
+    const proc = spawn('git', [...authArgs, ...args], {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,

--- a/gitnexus/test/unit/git-clone.test.ts
+++ b/gitnexus/test/unit/git-clone.test.ts
@@ -7,6 +7,7 @@ import {
   buildCloneArgs,
   normalizeGitUrlForCompare,
   assertRemoteMatchesRequestedUrl,
+  isAzureDevOpsUrl,
 } from '../../src/server/git-clone.js';
 import path from 'node:path';
 import os from 'node:os';
@@ -371,6 +372,58 @@ describe('git-clone', () => {
       await expect(cloneOrPull('file:///etc/passwd', fakeTarget)).rejects.toThrow(
         'Only https:// and http://',
       );
+    });
+  });
+
+  describe('isAzureDevOpsUrl', () => {
+    it('recognizes dev.azure.com (cloud)', () => {
+      expect(isAzureDevOpsUrl('https://dev.azure.com/org/project/_git/repo')).toBe(true);
+    });
+
+    it('recognizes *.visualstudio.com (cloud legacy)', () => {
+      expect(isAzureDevOpsUrl('https://myorg.visualstudio.com/project/_git/repo')).toBe(true);
+    });
+
+    it('returns false for github.com', () => {
+      expect(isAzureDevOpsUrl('https://github.com/user/repo')).toBe(false);
+    });
+
+    it('returns false for gitlab.com', () => {
+      expect(isAzureDevOpsUrl('https://gitlab.com/user/repo')).toBe(false);
+    });
+
+    it('returns false for invalid URL', () => {
+      expect(isAzureDevOpsUrl('not-a-url')).toBe(false);
+    });
+  });
+
+  describe('extractRepoName — Azure DevOps URLs', () => {
+    it('extracts name from self-hosted Azure DevOps URL', () => {
+      expect(
+        extractRepoName('http://azuredevops.example.com/DefaultCollection/MyProject/_git/MyRepo'),
+      ).toBe('MyRepo');
+    });
+
+    it('extracts name from dev.azure.com URL', () => {
+      expect(extractRepoName('https://dev.azure.com/org/project/_git/myrepo')).toBe('myrepo');
+    });
+
+    it('extracts name from visualstudio.com URL', () => {
+      expect(extractRepoName('https://myorg.visualstudio.com/project/_git/myrepo')).toBe('myrepo');
+    });
+  });
+
+  describe('validateGitUrl — Azure DevOps URLs', () => {
+    it('allows self-hosted Azure DevOps Server URLs', () => {
+      expect(() =>
+        validateGitUrl('http://azuredevops.example.com/DefaultCollection/Project/_git/Repo'),
+      ).not.toThrow();
+    });
+
+    it('allows dev.azure.com URLs', () => {
+      expect(() =>
+        validateGitUrl('https://dev.azure.com/org/project/_git/repo'),
+      ).not.toThrow();
     });
   });
 


### PR DESCRIPTION
## Summary
Add support for Azure DevOps Server (on-premise) repository cloning alongside the existing Azure DevOps Services (cloud) support.

## Changes
- **gitnexus/src/server/git-clone.ts**: Extended `resolveRemoteUrl()` to detect and handle Azure DevOps Server URLs with `_git` path pattern, supporting both HTTPS and PAT-based authentication
- **gitnexus/test/unit/git-clone.test.ts**: Added comprehensive unit tests for Azure DevOps Server URL resolution
- **gitnexus-web/**: Added Azure DevOps Server onboarding UI in RepoAnalyzer, with i18n strings (en, zh-CN) and error messages
- **.env.example**: Added `AZURE_DEVOPS_PAT` environment variable documentation

## Testing
- Unit tests added for Azure DevOps Server URL parsing
- Manual testing with on-premise Azure DevOps Server instances