### PR TITLE
perf(cfg): SSA-sparse reaching-defs to replace the dense-set worklist (#2201)

### DIFF
--- a/gitnexus/bench/cfg/baselines.json
+++ b/gitnexus/bench/cfg/baselines.json
@@ -37,8 +37,17 @@
     "scaling_budget": 1.8,
     "disk_bytes_budget": 1.2,
     "rd_scaling_budget": 2.0,
-    "facts_large_min": 100,
-    "_note": "#2201: N nested loops carrying ONE variable end-to-end (depth 40->160) -- the pathology the dense worklist is superlinear on and whose block-visit total drives it past the blocks×64 ceiling (it would TRUNCATE to empty). rd is measured under the PRODUCTION blocks×64 budget (rdProductionBudget) to prove the ceiling stops firing: the depth-INDEPENDENT SSA solver (phi-nodes capture loop merges statically; no fixpoint iteration) computes the full facts (164 at large; floor 100 catches a regression to truncation/zero) with rd_scaling ~0.90 (linear in depth; measured ~0.42ms at depth 160). rd_scaling_budget 2.0 catches a regression back to superlinear. No heap_budget -- the deep-nest CFG payload is tiny and the retained-heap delta is GC-noise-dominated. Re-baseline the fingerprint only on an intentional CFG/visitor change."
+    "facts_large_min": 150,
+    "_note": "#2201: N nested loops carrying ONE variable end-to-end (depth 40->160) -- the pathology the dense worklist is superlinear on and whose block-visit total drives it past the blocks×64 ceiling (it would TRUNCATE to empty). rd is measured under the PRODUCTION blocks×64 budget (rdProductionBudget) to prove the ceiling stops firing: the depth-INDEPENDENT SSA solver (phi-nodes capture loop merges statically; no fixpoint iteration) computes the full facts (measured 164 at large) with rd_scaling ~0.68 (linear in depth; measured ~0.57ms at depth 160). facts_large_min tightened 100->150 (#2201 review R7): a partial-truncation regression that still cleared the old floor of 100 (but lost facts of the measured 164) now fails, with ~9% headroom under 164 for noise; the companion rd_all_computed gate also catches any non-'computed' status. rd_scaling_budget 2.0 catches a regression back to superlinear. No heap_budget -- the deep-nest CFG payload is tiny and the retained-heap delta is GC-noise-dominated. Re-baseline the fingerprint only on an intentional CFG/visitor change."
+  },
+  "wide-merge": {
+    "fingerprint": "7a66a844ee3994bd930c1e34bad3d7b410a762220e927c94fb3787f38d745280",
+    "scaling_budget": 1.8,
+    "disk_bytes_budget": 1.2,
+    "heap_budget": 1.3,
+    "rd_scaling_budget": 2.0,
+    "facts_large_min": 24000,
+    "_note": "#2201 review R7: N bindings, EACH assigned in a 3-way branch (a wide multi-operand phi per binding) inside a loop, then all used after the merge. Distinct from dense-bindings (one CHAINED redef per `if`): every binding fans into its OWN wide phi, so this exercises phi-placement + renaming + the reachByScc condensation across MANY independent wide merges. N bindings x constant arms => O(N) facts (measured 26008 at the large size), so the gate is rd_scaling LINEARITY: measured ~1.07 (time 9.3->39.8ms over the 4x size step); budget 2.0 catches a regression to the per-binding-rescan O(N^2) class -- the recurring solver antipattern the reachByScc alias fast path (review R2) guards against. rd is measured under the PRODUCTION blocks×64 budget (rdProductionBudget): all functions report 'computed' (the SSA path does not truncate here), and facts_large_min 24000 (measured 26008, ~7% headroom) + the rd_all_computed gate assert the wide merges compute fully. fp_blocks 82 / fp_edges 112 at FP_SIZE=15. Re-baseline the fingerprint only on an intentional CFG/harvest-shape change."
   },
   "fact-fanout": {
     "fingerprint": "83a8243a8aff117f69aeecb39d02a483e6cca70439d75f63e433f4e4ac85578f",

--- a/gitnexus/bench/cfg/baselines.json
+++ b/gitnexus/bench/cfg/baselines.json
@@ -29,8 +29,16 @@
     "scaling_budget": 1.8,
     "disk_bytes_budget": 1.2,
     "heap_budget": 1.3,
-    "rd_scaling_budget": 10.0,
-    "_note": "#2082 M2: N bindings live across ~N blocks in one loop -- bindings x blocks scale JOINTLY (the solver-lattice stressor). The overlay design measures rd ~5.2 normalized: the OUT spine copy on genning blocks is O(V) per block, which is quadratic when V scales with B (bounded in prod by maxFunctionLines; real functions have V~10-40). Budget 10 deliberately tolerates that known shape and exists to catch the repo's recurring per-item-rescan class (a per-use scan over all defs is O(n^3) here, ratio >=16). If rd drops well below 5, tighten."
+    "rd_scaling_budget": 2.0,
+    "_note": "#2082 M2 / #2201 SSA: N bindings live across ~N blocks in one loop -- bindings x blocks scale JOINTLY (the solver-lattice stressor). The dense GEN/KILL worklist measured rd ~5.2 normalized here (the OUT spine copy is O(V) per block, quadratic when V scales with B). The #2201 SSA-sparse solver answers each use's reaching set from the def-use graph WITHOUT a per-block dense lattice, dropping rd to ~0.86 (linear; measured 5-23x faster absolute). Budget tightened 10->2: still absorbs noise + catches a regression to the per-item-rescan class (a per-use scan over all defs is O(n^3) here, ratio >=16), but now also catches a fall-back to the dense quadratic. Fingerprint unchanged -- CFG construction is untouched."
+  },
+  "deep-nest": {
+    "fingerprint": "c0ca870487abc6ff379304c3162003e9e4f9b44aeb2fc29adfcf8d2179c7613a",
+    "scaling_budget": 1.8,
+    "disk_bytes_budget": 1.2,
+    "rd_scaling_budget": 2.0,
+    "facts_large_min": 100,
+    "_note": "#2201: N nested loops carrying ONE variable end-to-end (depth 40->160) -- the pathology the dense worklist is superlinear on and whose block-visit total drives it past the blocks×64 ceiling (it would TRUNCATE to empty). rd is measured under the PRODUCTION blocks×64 budget (rdProductionBudget) to prove the ceiling stops firing: the depth-INDEPENDENT SSA solver (phi-nodes capture loop merges statically; no fixpoint iteration) computes the full facts (164 at large; floor 100 catches a regression to truncation/zero) with rd_scaling ~0.90 (linear in depth; measured ~0.42ms at depth 160). rd_scaling_budget 2.0 catches a regression back to superlinear. No heap_budget -- the deep-nest CFG payload is tiny and the retained-heap delta is GC-noise-dominated. Re-baseline the fingerprint only on an intentional CFG/visitor change."
   },
   "fact-fanout": {
     "fingerprint": "83a8243a8aff117f69aeecb39d02a483e6cca70439d75f63e433f4e4ac85578f",

--- a/gitnexus/bench/cfg/measure.mjs
+++ b/gitnexus/bench/cfg/measure.mjs
@@ -199,6 +199,33 @@ const SCENARIOS = [
     },
   },
   {
+    name: 'wide-merge',
+    // #2201 review R7: N bindings, each assigned in a 3-way branch (a WIDE φ
+    // merge per binding) inside a loop, then all used after the merge. Unlike
+    // dense-bindings (one chained redef per `if`), every binding here fans into
+    // its own multi-operand φ — so the scenario stresses φ-placement + renaming +
+    // the reachByScc condensation across MANY independent wide merges. N bindings
+    // × constant arms ⇒ O(N) facts, so the gate is rd_scaling LINEARITY: a
+    // regression to the per-binding-rescan class (O(N²), the recurring solver
+    // antipattern reachByScc's alias fast path guards against) blows the ratio.
+    // >=16 blocks + a reachable loop ⇒ the production SSA path.
+    rdMaxFacts: 0, // measure the algorithm, not the cap
+    rdProductionBudget: true, // prove the SSA path computes under blocks×64
+    gen: (n) => {
+      let s = 'function f(c: number) {\n';
+      for (let i = 0; i < n; i++) s += `  let v${i} = ${i};\n`;
+      s += '  while (c > 0) {\n';
+      for (let i = 0; i < n; i++) {
+        s +=
+          `    if (c > ${i}) { v${i} = ${i} + c; }` +
+          ` else if (c < ${i}) { v${i} = ${i} - c; }` +
+          ` else { v${i} = c; }\n`;
+      }
+      for (let i = 0; i < n; i++) s += `    use(v${i});\n`;
+      return s + '    c = c - 1;\n  }\n  return v0;\n}\n';
+    },
+  },
+  {
     name: 'fact-fanout',
     // #2082 M2: N parallel case-arm defs of one variable + N later uses —
     // facts are O(defs×uses) BY SPEC, so a linearity ratio gate is the wrong

--- a/gitnexus/bench/cfg/measure.mjs
+++ b/gitnexus/bench/cfg/measure.mjs
@@ -626,6 +626,15 @@ if (!CHECK) {
           (r.rd_all_computed ? '' : ` [status != computed]`),
       );
     }
+    // Independent of the fact-count floor: under the production budget every
+    // function in a facts_large_min scenario must report status 'computed'. This
+    // catches a partial-truncation regression that still clears the count floor.
+    if (base.facts_large_min !== undefined && r.rd_all_computed === false) {
+      failures.push(
+        `${r.scenario}: a function did not reach status 'computed' under the production ` +
+          `block-visit budget — the SSA solver truncated where it must compute`,
+      );
+    }
     if (base.disk_bytes_large_max !== undefined && r.disk_bytes_large > base.disk_bytes_large_max) {
       failures.push(
         `${r.scenario}: cfgSideChannel absolute size ${r.disk_bytes_large} > ceiling ` +

--- a/gitnexus/bench/cfg/measure.mjs
+++ b/gitnexus/bench/cfg/measure.mjs
@@ -44,7 +44,10 @@ import { fileURLToPath } from 'node:url';
 import Parser from 'tree-sitter';
 import { collectFunctionCfgs } from '../../src/core/ingestion/cfg/collect.ts';
 import { computeReachingDefs } from '../../src/core/ingestion/cfg/reaching-defs.ts';
-import { DEFAULT_PDG_MAX_REACHING_DEF_FACTS_PER_FUNCTION } from '../../src/core/ingestion/cfg/emit.ts';
+import {
+  DEFAULT_PDG_MAX_REACHING_DEF_FACTS_PER_FUNCTION,
+  DEFAULT_PDG_MAX_REACHING_DEF_BLOCK_REVISITS,
+} from '../../src/core/ingestion/cfg/emit.ts';
 import { getTreeSitterBufferSize } from '../../src/core/ingestion/constants.ts';
 import { getLanguageGrammar } from '../../src/core/tree-sitter/parser-loader.ts';
 import { getProvider } from '../../src/core/ingestion/languages/index.ts';
@@ -173,6 +176,29 @@ const SCENARIOS = [
     },
   },
   {
+    name: 'deep-nest',
+    // #2201: N nested loops carrying one variable end-to-end — the pathology the
+    // dense GEN/KILL worklist is superlinear on and that drives its block-visit
+    // total past the blocks×64 ceiling (it would truncate to an empty result).
+    // The production SSA solver is depth-INDEPENDENT (φ-nodes capture the loop
+    // merges statically; no fixpoint iteration), so rd time scales ~linearly
+    // with depth and the ceiling never fires. Two gates: rd_scaling_budget
+    // catches a regression back to superlinear, and facts_large_min asserts the
+    // solver still COMPUTES full facts under the PRODUCTION blocks×64 budget
+    // (rdProductionBudget) — a dense worklist would report zero facts here.
+    small: 40,
+    large: 160, // 4×, well under the visitor's recursive-nesting depth guard
+    rdMaxFacts: 0, // measure the algorithm, not the cap
+    rdProductionBudget: true, // pass blocks×64 — the SSA solver must still compute
+    gen: (n) => {
+      let s = 'function f(c: number) {\n  let x = 0;\n';
+      for (let i = 0; i < n; i++) s += '  '.repeat(i + 1) + `while (c > ${i}) {\n`;
+      s += '  '.repeat(n + 1) + 'x = x + 1;\n';
+      for (let i = n - 1; i >= 0; i--) s += '  '.repeat(i + 1) + '}\n';
+      return s + '  return x;\n}\n';
+    },
+  },
+  {
     name: 'fact-fanout',
     // #2082 M2: N parallel case-arm defs of one variable + N later uses —
     // facts are O(defs×uses) BY SPEC, so a linearity ratio gate is the wrong
@@ -296,17 +322,32 @@ function measureCollect(tk, src, file, reps) {
 // the scope-resolution emit loop adds per file on a --pdg run). `maxFacts`
 // mirrors the per-scenario production posture: 0 (unlimited) measures the
 // algorithm; the production default exercises the boundedness contract.
-function measureReachingDefs(cfgs, reps, maxFacts) {
-  for (const c of cfgs) computeReachingDefs(c, { maxFacts }); // warm JIT
+// When `blockVisitsMul` > 0 each call also passes the PRODUCTION per-function
+// maxBlockVisits budget (blocks × mul). On the deep-nest scenario this is how
+// "the ceiling stops firing" (#2201) is measured: the dense worklist would
+// truncate to an empty result under this budget, whereas the production SSA
+// solver computes the full facts — so a nonzero `facts` under the budget is the
+// gate (see facts_large_min in baselines.json).
+function measureReachingDefs(cfgs, reps, maxFacts, blockVisitsMul = 0) {
+  const limitsFor = (c) =>
+    blockVisitsMul > 0
+      ? { maxFacts, maxBlockVisits: c.blocks.length * blockVisitsMul }
+      : { maxFacts };
+  for (const c of cfgs) computeReachingDefs(c, limitsFor(c)); // warm JIT
   const samples = [];
   let facts = 0;
+  let allComputed = true;
   for (let i = 0; i < reps; i++) {
     const start = process.hrtime.bigint();
     facts = 0;
-    for (const c of cfgs) facts += computeReachingDefs(c, { maxFacts }).facts.length;
+    for (const c of cfgs) {
+      const r = computeReachingDefs(c, limitsFor(c));
+      facts += r.facts.length;
+      if (r.status !== 'computed') allComputed = false;
+    }
     samples.push(Number(process.hrtime.bigint() - start) / 1e6);
   }
-  return { ms: median(samples), facts };
+  return { ms: median(samples), facts, allComputed };
 }
 
 // ---- taint pass cost (#2083 M3 U7) ----
@@ -441,10 +482,14 @@ function measureScenario(scenario) {
       ? heapLarge / heapSmall / sizeRatio
       : null;
 
-  // #2082 M2: reaching-defs solve cost over the same CFGs.
+  // #2082 M2: reaching-defs solve cost over the same CFGs. #2201: scenarios
+  // marked `rdProductionBudget` also pass the per-function blocks×64 ceiling, to
+  // prove the production SSA solver still COMPUTES where the dense worklist would
+  // truncate (the deep-nest ceiling-stops-firing acceptance).
   const rdMaxFacts = scenario.rdMaxFacts ?? 0;
-  const rdSmall = measureReachingDefs(small.cfgs, REPS, rdMaxFacts);
-  const rdLarge = measureReachingDefs(large.cfgs, REPS, rdMaxFacts);
+  const rdBudgetMul = scenario.rdProductionBudget ? DEFAULT_PDG_MAX_REACHING_DEF_BLOCK_REVISITS : 0;
+  const rdSmall = measureReachingDefs(small.cfgs, REPS, rdMaxFacts, rdBudgetMul);
+  const rdLarge = measureReachingDefs(large.cfgs, REPS, rdMaxFacts, rdBudgetMul);
   // Clamp the denominator: a 0.000ms small-N median would otherwise yield
   // ratio 0 and the gate would self-disable exactly when the solver is fast.
   const rdRatio = rdLarge.ms / Math.max(rdSmall.ms, 0.001) / sizeRatio;
@@ -506,6 +551,7 @@ function measureScenario(scenario) {
     rd_scaling_ratio: Number(rdRatio.toFixed(3)),
     facts_small: rdSmall.facts,
     facts_large: rdLarge.facts,
+    rd_all_computed: rdLarge.allComputed,
     ...fingerprint(tk, scenario),
   };
 }
@@ -568,6 +614,16 @@ if (!CHECK) {
       failures.push(
         `${r.scenario}: fact materialization ${r.facts_large} > bound ${base.facts_large_max} ` +
           `(the maxFacts early-stop is the boundedness contract)`,
+      );
+    }
+    // #2201 deep-nest: under the PRODUCTION blocks×64 budget the SSA solver must
+    // still COMPUTE full facts (a nonzero floor) where the dense worklist would
+    // truncate to empty — "the ceiling stops firing".
+    if (base.facts_large_min !== undefined && r.facts_large < base.facts_large_min) {
+      failures.push(
+        `${r.scenario}: only ${r.facts_large} facts < floor ${base.facts_large_min} under the ` +
+          `production block-visit budget — the ceiling fired (SSA should not truncate here)` +
+          (r.rd_all_computed ? '' : ` [status != computed]`),
       );
     }
     if (base.disk_bytes_large_max !== undefined && r.disk_bytes_large > base.disk_bytes_large_max) {

--- a/gitnexus/src/core/ingestion/cfg/emit.ts
+++ b/gitnexus/src/core/ingestion/cfg/emit.ts
@@ -108,10 +108,16 @@ export const DEFAULT_PDG_MAX_REACHING_DEF_FACTS_PER_FUNCTION =
  * never fires). Truncation degrades to a sound empty REACHING_DEF for that one
  * function (status `truncated`), never wrong facts.
  *
- * This ceiling is the SOUND backstop, not a perf fix: WTO / loop-aware iteration
- * ordering was benchmarked and rejected (0% faster — the cost is dense-set
- * propagation, not visitation order; see the no-go note in reaching-defs.ts at
- * the RPO-order site). SSA-sparse reaching-defs is the deferred real fix.
+ * As of #2201 this ceiling is an adversarial-only backstop that effectively
+ * never fires on real code: the production solver auto-selects the SSA-sparse
+ * path for the looping functions that would breach it, and the SSA path has no
+ * fixpoint iteration (it answers reaching queries from the def-use graph in one
+ * pass) so it computes the full facts where the dense worklist would have
+ * truncated. The budget is still consulted on the dense fallback path (small /
+ * loop-free functions, and throw-edge / unreachable-block functions the SSA path
+ * does not model). WTO / loop-aware iteration ordering was benchmarked and
+ * rejected (0% faster — the cost was dense-set propagation, not visitation
+ * order); SSA-sparse was the real fix. See reaching-defs.ts.
  */
 export const DEFAULT_PDG_MAX_REACHING_DEF_BLOCK_REVISITS = 64;
 

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs-graph.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs-graph.ts
@@ -1,0 +1,318 @@
+/**
+ * Pure graph sub-stages for the reaching-definitions solvers (#2201 review R4).
+ *
+ * Extracted from reaching-defs.ts to keep that module focused on the
+ * orchestrator, the dense oracle, the statement sweep, and the dispatcher.
+ * Everything here is a pure function of plain arrays — no CFG, no harvest, no
+ * solver state — so this module has NO dependency on reaching-defs.ts (a strict
+ * one-way import) and each stage is independently testable. The SSA pipeline
+ * (dominators → dominance frontiers → Tarjan SCC → reach-set condensation)
+ * implements Cooper-Harvey-Kennedy + Cytron + Tarjan; reverse-post-order, the
+ * loop-reachability check, and the def-set/lattice primitives are shared with
+ * the dense GEN/KILL solver and the dispatcher.
+ *
+ * These are held byte-identical to their former inline form by the differential
+ * equivalence fuzz (test/unit/cfg/reaching-defs-equivalence.test.ts) — any diff
+ * after extraction is an extraction bug, never the oracle.
+ */
+
+/** def-site keys reaching a program point (see reaching-defs.ts). */
+type DefSet = Set<number>;
+/** bindingIdx → def-site keys (the dense solver's per-block lattice). */
+type Lattice = Map<number, DefSet>;
+
+/**
+ * RPO over blocks reachable from `entry`; unreachable blocks appended by index.
+ * Returns the order AND the reachability bitmap the DFS already computed, so a
+ * caller needing "is every block reachable?" reuses this pass instead of a
+ * separate BFS (#2201 review R8 — the SSA path's reachability gate).
+ *
+ * @internal
+ */
+export function reversePostOrder(
+  entry: number,
+  succs: readonly number[][],
+  n: number,
+): { order: number[]; visited: boolean[] } {
+  const visited = new Array<boolean>(n).fill(false);
+  const post: number[] = [];
+  // Iterative DFS with an explicit phase stack (children pushed in reverse so
+  // they pop in sorted order — determinism).
+  const stack: { node: number; childIdx: number }[] = [{ node: entry, childIdx: 0 }];
+  visited[entry] = true;
+  while (stack.length) {
+    const top = stack[stack.length - 1];
+    const children = succs[top.node];
+    if (top.childIdx < children.length) {
+      const next = children[top.childIdx];
+      top.childIdx += 1;
+      if (!visited[next]) {
+        visited[next] = true;
+        stack.push({ node: next, childIdx: 0 });
+      }
+    } else {
+      post.push(top.node);
+      stack.pop();
+    }
+  }
+  const order = post.reverse();
+  for (let b = 0; b < n; b++) if (!visited[b]) order.push(b);
+  return { order, visited };
+}
+
+/**
+ * Immediate dominators (Cooper-Harvey-Kennedy; correct on irreducible CFGs).
+ * `rpo` is the reverse-post-order rooted at the synthetic start `S`, `dPredsX`
+ * the dominator-graph predecessors (incl. S→entry). Returns idom[b] for every
+ * node in [0, nx); idom[S] === S.
+ *
+ * @internal
+ */
+export function buildDominators(
+  rpo: readonly number[],
+  dPredsX: readonly number[][],
+  S: number,
+  nx: number,
+): number[] {
+  const rpoIdx = new Array<number>(nx);
+  rpo.forEach((b, i) => (rpoIdx[b] = i));
+  const idom = new Array<number>(nx).fill(-1);
+  idom[S] = S;
+  const intersect = (a: number, b: number): number => {
+    while (a !== b) {
+      while (rpoIdx[a] > rpoIdx[b]) a = idom[a];
+      while (rpoIdx[b] > rpoIdx[a]) b = idom[b];
+    }
+    return a;
+  };
+  for (let changed = true; changed; ) {
+    changed = false;
+    for (const b of rpo) {
+      if (b === S) continue;
+      let nd = -1;
+      for (const p of dPredsX[b]) if (idom[p] !== -1) nd = nd === -1 ? p : intersect(nd, p);
+      if (nd !== -1 && idom[b] !== nd) {
+        idom[b] = nd;
+        changed = true;
+      }
+    }
+  }
+  return idom;
+}
+
+/**
+ * Dominance frontiers (Cytron). df[b] is the set of nodes where b's dominance
+ * ends — the φ-placement targets for any binding defined in b.
+ *
+ * @internal
+ */
+export function buildDominanceFrontiers(
+  dPredsX: readonly number[][],
+  idom: readonly number[],
+  nx: number,
+): Set<number>[] {
+  const df: Set<number>[] = Array.from({ length: nx }, () => new Set<number>());
+  for (let b = 0; b < nx; b++) {
+    const dp = dPredsX[b];
+    if (dp.length < 2) continue;
+    for (const p of dp) {
+      let runner = p;
+      while (runner !== idom[b] && runner !== -1) {
+        df[runner].add(b);
+        runner = idom[runner];
+      }
+    }
+  }
+  return df;
+}
+
+/**
+ * Tarjan strongly-connected components over the value-graph operand edges
+ * (`nodeOps[node]` = operand node ids). Iterative (explicit work stack — the
+ * graph can be deep). SCCs are emitted in REVERSE topological order, so an
+ * SCC's operand SCCs are numbered before it — the property
+ * {@link condenseReachingSets} relies on for its single forward pass.
+ *
+ * @internal
+ */
+export function tarjanScc(nodeOps: readonly number[][]): {
+  sccOf: number[];
+  sccMembers: number[][];
+} {
+  const N = nodeOps.length;
+  const sccOf = new Array<number>(N).fill(-1);
+  const sccMembers: number[][] = [];
+  const index = new Array<number>(N).fill(-1);
+  const low = new Array<number>(N).fill(0);
+  const onStk = new Array<boolean>(N).fill(false);
+  const tarjanStk: number[] = [];
+  let counter = 0;
+  for (let start = 0; start < N; start++) {
+    if (index[start] !== -1) continue;
+    const work: { node: number; oi: number }[] = [{ node: start, oi: 0 }];
+    index[start] = low[start] = counter++;
+    tarjanStk.push(start);
+    onStk[start] = true;
+    while (work.length) {
+      const top = work[work.length - 1];
+      const ops = nodeOps[top.node];
+      if (top.oi < ops.length) {
+        const w = ops[top.oi++];
+        if (index[w] === -1) {
+          index[w] = low[w] = counter++;
+          tarjanStk.push(w);
+          onStk[w] = true;
+          work.push({ node: w, oi: 0 });
+        } else if (onStk[w] && index[w] < low[top.node]) {
+          low[top.node] = index[w];
+        }
+      } else {
+        if (low[top.node] === index[top.node]) {
+          const members: number[] = [];
+          let w: number;
+          do {
+            w = tarjanStk.pop()!;
+            onStk[w] = false;
+            sccOf[w] = sccMembers.length;
+            members.push(w);
+          } while (w !== top.node);
+          sccMembers.push(members);
+        }
+        work.pop();
+        if (work.length) {
+          const par = work[work.length - 1].node;
+          if (low[top.node] < low[par]) low[par] = low[top.node];
+        }
+      }
+    }
+  }
+  return { sccOf, sccMembers };
+}
+
+/**
+ * Reaching def-key set per SCC via condensation (cycle-safe union). Tarjan emits
+ * SCCs in reverse topological order, so a single forward pass over SCCs resolves
+ * every union: an SCC's reaching set is its members' own leaf keys plus the
+ * already-computed reaching sets of its cross-SCC operands.
+ *
+ * Alias fast path (#2201 review R2): an SCC with NO own leaf keys whose cross-SCC
+ * operands all resolve to a SINGLE source SCC has exactly that source's reaching
+ * set — share it BY REFERENCE instead of copying element-by-element (the O(defs²)
+ * cost at wide-fan-in φ merges). Safe: the returned sets are read-only after this
+ * pass, and contents are identical (set iteration order is irrelevant — the
+ * sweep sorts each use's keys before emission, KTD6).
+ *
+ * @internal
+ */
+export function condenseReachingSets(
+  sccMembers: readonly number[][],
+  sccOf: readonly number[],
+  nodeKeys: readonly (DefSet | null)[],
+  nodeOps: readonly number[][],
+): DefSet[] {
+  const reachByScc: DefSet[] = new Array(sccMembers.length);
+  for (let s = 0; s < sccMembers.length; s++) {
+    const members = sccMembers[s];
+    let aliasTarget = -1; // the unique cross-SCC source SCC, or -1 if none/many
+    let hasOwnKeys = false;
+    let multiSource = false;
+    for (const node of members) {
+      if (nodeKeys[node]) {
+        hasOwnKeys = true;
+        break;
+      }
+      for (const w of nodeOps[node]) {
+        const ws = sccOf[w];
+        if (ws === s) continue; // intra-SCC operand: same set being built, adds nothing
+        if (aliasTarget === -1) aliasTarget = ws;
+        else if (aliasTarget !== ws) {
+          multiSource = true;
+          break;
+        }
+      }
+      if (multiSource) break;
+    }
+    if (!hasOwnKeys && !multiSource && aliasTarget !== -1) {
+      reachByScc[s] = reachByScc[aliasTarget]; // zero-copy share
+      continue;
+    }
+    // General case: union own leaf keys + every distinct cross-SCC operand set.
+    const set: DefSet = new Set();
+    for (const node of members) {
+      const keys = nodeKeys[node];
+      if (keys) for (const k of keys) set.add(k);
+      for (const w of nodeOps[node]) {
+        const ws = sccOf[w];
+        if (ws !== s) for (const k of reachByScc[ws]) set.add(k);
+      }
+    }
+    reachByScc[s] = set;
+  }
+  return reachByScc;
+}
+
+/**
+ * True iff a cycle is reachable from `entry` (the CFG has a loop). Iterative DFS
+ * with a gray/black coloring; a gray successor is a back-edge. O(V+E). Used by
+ * the production dispatcher to decide SSA-vs-dense.
+ *
+ * @internal
+ */
+export function hasReachableLoop(entry: number, succs: readonly number[][], n: number): boolean {
+  const color = new Uint8Array(n); // 0 white, 1 gray, 2 black
+  const stack: { node: number; i: number }[] = [{ node: entry, i: 0 }];
+  color[entry] = 1;
+  while (stack.length) {
+    const top = stack[stack.length - 1];
+    const ss = succs[top.node];
+    if (top.i < ss.length) {
+      const next = ss[top.i++];
+      if (color[next] === 1) return true;
+      if (color[next] === 0) {
+        color[next] = 1;
+        stack.push({ node: next, i: 0 });
+      }
+    } else {
+      color[top.node] = 2;
+      stack.pop();
+    }
+  }
+  return false;
+}
+
+/**
+ * Order-stable union of two def-sets (shares `a` when `b` adds nothing).
+ *
+ * @internal
+ */
+export function unionSets(a: DefSet, b: DefSet): DefSet {
+  let target = a;
+  let copied = false;
+  for (const key of b) {
+    if (!target.has(key)) {
+      if (!copied) {
+        target = new Set(a);
+        copied = true;
+      }
+      target.add(key);
+    }
+  }
+  return target;
+}
+
+/**
+ * Per-binding lattice equality with a reference fast path (sets only ever grow).
+ *
+ * @internal
+ */
+export function latticeEquals(a: Lattice, b: Lattice): boolean {
+  if (a === b) return true;
+  if (a.size !== b.size) return false;
+  for (const [k, bSet] of b) {
+    const aSet = a.get(k);
+    if (aSet === bSet) continue;
+    if (!aSet || aSet.size !== bSet.size) return false;
+    for (const v of bSet) if (!aSet.has(v)) return false;
+  }
+  return true;
+}

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -576,10 +576,21 @@ function computeInSetsSparse(
   succsX[S] = [entry];
   const dPredsX: number[][] = new Array(nx);
   for (let b = 0; b < n; b++) {
-    const set = new Set<number>();
-    for (const p of preds[b]) set.add(p.from);
-    if (b === entry) set.add(S);
-    dPredsX[b] = [...set].sort((a, c) => a - c);
+    // preds[b] is pre-sorted by `from` (buildAdjacency), so duplicate `from`
+    // values (a throw + non-throw edge to the same handler, or parallel edges)
+    // are ADJACENT — dedup by skipping consecutive equals instead of a per-block
+    // Set + spread + sort (#2201 review R9). S = n exceeds every block index, so
+    // appending it for the entry keeps the list ascending without a re-sort.
+    const list: number[] = [];
+    let last = -1;
+    for (const p of preds[b]) {
+      if (p.from !== last) {
+        list.push(p.from);
+        last = p.from;
+      }
+    }
+    if (b === entry) list.push(S);
+    dPredsX[b] = list;
   }
   dPredsX[S] = [];
 
@@ -968,6 +979,10 @@ function sweepFacts(
 ): { facts: DefUseFact[]; truncated: boolean } {
   const facts: DefUseFact[] = [];
   let truncated = false;
+  // Scratch buffer for one use's reaching def-keys, reused across every use to
+  // avoid a per-use array allocation (#2201 review R9). Cleared per use; the
+  // KTD6 sort below operates on it in place.
+  const useKeys: number[] = [];
 
   outer: for (const b of blocks) {
     const stmts = b.statements;
@@ -988,16 +1003,21 @@ function sweepFacts(
       // self-fact on compound assignments is harmless; missing the
       // assign-and-test def→use (the most common JS idiom) would be a taint
       // false negative. May-defs join the self-key set the same way.
-      const sameStmtDefs =
-        s.defs.length > 0 || s.mayDefs?.length ? new Set([...s.defs, ...(s.mayDefs ?? [])]) : null;
+      // def/mayDef arrays are tiny (1–3 entries), so a membership scan over them
+      // is cheaper than the old per-statement `new Set([...defs, ...mayDefs])`
+      // (#2201 review R9). `hasSelfDefs` short-circuits pure-use statements.
+      const hasSelfDefs = s.defs.length > 0 || (s.mayDefs?.length ?? 0) > 0;
       for (const u of s.uses) {
         const reaching = overlay.get(u) ?? reachingAt(b.index, u);
-        const selfKey = sameStmtDefs?.has(u) ? defKey(b.index, i) : undefined;
+        const selfKey =
+          hasSelfDefs && (s.defs.includes(u) || (s.mayDefs?.includes(u) ?? false))
+            ? defKey(b.index, i)
+            : undefined;
         if (!reaching && selfKey === undefined) continue;
-        const keys =
-          selfKey !== undefined && !reaching?.has(selfKey)
-            ? [...(reaching ?? []), selfKey]
-            : [...(reaching ?? [])];
+        // Reuse the scratch buffer instead of spreading a fresh array per use.
+        useKeys.length = 0;
+        if (reaching) for (const k of reaching) useKeys.push(k);
+        if (selfKey !== undefined && !reaching?.has(selfKey)) useKeys.push(selfKey);
         // Canonical emission order (#2201 KTD6): sort each use's reaching
         // def-sites by defKey (= def block, then def stmt) BEFORE the maxFacts
         // cutoff. The full (untruncated) fact array is re-sorted identically at
@@ -1007,8 +1027,8 @@ function sweepFacts(
         // bindings (dense RPO vs sparse change-driven seed different keys
         // first), so a pre-sort cutoff is what keeps the two solvers'
         // truncated results byte-identical.
-        keys.sort((a, b) => a - b);
-        for (const key of keys) {
+        useKeys.sort((a, b) => a - b);
+        for (const key of useKeys) {
           if (facts.length >= maxFacts) {
             truncated = true;
             break outer;

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -823,8 +823,42 @@ function computeInSetsSparse(
   }
   const reachByScc: DefSet[] = new Array(sccMembers.length);
   for (let s = 0; s < sccMembers.length; s++) {
+    const members = sccMembers[s];
+    // Alias fast path (#2201 review R2): an SCC with NO own leaf keys whose
+    // cross-SCC operands all resolve to a SINGLE source SCC has exactly that
+    // source's reaching set — share it BY REFERENCE instead of copying it
+    // element-by-element. This is the common shape (a pass-through φ / single-
+    // operand value node), and the copy it avoids is the O(defs²) cost at
+    // wide-fan-in merges (a φ over many predecessors each carrying a large set).
+    // Contents are identical, and reachByScc sets are read-only after this pass
+    // (operand SCCs are numbered before s — Tarjan's reverse-topo order — and
+    // are only iterated, never mutated), so sharing is safe.
+    let aliasTarget = -1; // the unique cross-SCC source SCC, or -1 if none/many
+    let hasOwnKeys = false;
+    let multiSource = false;
+    for (const node of members) {
+      if (nodeKeys[node]) {
+        hasOwnKeys = true;
+        break;
+      }
+      for (const w of nodeOps[node]) {
+        const ws = sccOf[w];
+        if (ws === s) continue; // intra-SCC operand: same set being built, adds nothing
+        if (aliasTarget === -1) aliasTarget = ws;
+        else if (aliasTarget !== ws) {
+          multiSource = true;
+          break;
+        }
+      }
+      if (multiSource) break;
+    }
+    if (!hasOwnKeys && !multiSource && aliasTarget !== -1) {
+      reachByScc[s] = reachByScc[aliasTarget]; // zero-copy share
+      continue;
+    }
+    // General case: union own leaf keys + every distinct cross-SCC operand set.
     const set: DefSet = new Set();
-    for (const node of sccMembers[s]) {
+    for (const node of members) {
       const keys = nodeKeys[node];
       if (keys) for (const k of keys) set.add(k);
       for (const w of nodeOps[node]) {

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -103,6 +103,19 @@ export interface ReachingDefsLimits {
    * a per-function budget).
    */
   readonly maxBlockVisits?: number;
+  /**
+   * Memory bound on the SSA-sparse solver's value-graph construction (#2201
+   * review R1). `maxFacts` bounds fact MATERIALIZATION (sweepFacts) but nothing
+   * bounds the φ/value-graph the sparse path builds first; a high-binding-density
+   * deep loop routed to SSA (≥ SSA_MIN_BLOCKS blocks + a reachable loop) builds an
+   * O(blocks×bindings) graph the dense path would have truncated at the
+   * `maxBlockVisits` ceiling (~1.5 GB measured on a 3000-block × 300-binding
+   * function). When the projected node count would exceed this, the sparse solver
+   * falls back to the dense oracle (byte-identical, and bounded — dense honors
+   * `maxBlockVisits`). Honored ONLY by the sparse path; the dense solver ignores
+   * it. `undefined`/0 ⇒ {@link DEFAULT_MAX_SSA_VALUE_GRAPH_NODES}.
+   */
+  readonly maxSsaValueGraphNodes?: number;
 }
 
 export interface FunctionDefUse {
@@ -664,6 +677,25 @@ function computeInSetsSparse(
     }
   }
 
+  // ── memory bound (#2201 review R1): cap the value graph, else fall back ──
+  // After φ-placement, nodeKeys.length == the φ-node count — the term that grows
+  // superlinearly with the input on the deep-loop / dense-binding pathology.
+  // Renaming below adds at most ~2 nodes per gen entry (already bounded by the
+  // def-site universe the STMT_STRIDE overflow guard caps). If the projected
+  // total would exceed the budget, fall back to the dense oracle here — BEFORE
+  // paying for renaming + Tarjan SCC on a blown-up graph. Byte-identical (dense
+  // is the equivalence oracle) and bounded (dense honors maxBlockVisits). Mirrors
+  // the throw-edge / unreachable / OOB-binding gates at the top of this function.
+  const nodeBudget =
+    limits?.maxSsaValueGraphNodes && limits.maxSsaValueGraphNodes > 0
+      ? limits.maxSsaValueGraphNodes
+      : DEFAULT_MAX_SSA_VALUE_GRAPH_NODES;
+  let projectedRenameNodes = 0;
+  for (let b = 0; b < n; b++) projectedRenameNodes += (gen[b]?.size ?? 0) * 2;
+  if (nodeKeys.length + projectedRenameNodes > nodeBudget) {
+    return computeInSetsDense(cfg, n, h, adj, limits);
+  }
+
   // ── renaming (iterative dominator-tree DFS, per-binding value stacks) ──
   const domChildren: number[][] = Array.from({ length: nx }, () => []);
   for (let b = 0; b < nx; b++) if (b !== S && idom[b] !== -1) domChildren[idom[b]].push(b);
@@ -824,6 +856,21 @@ function computeInSetsSparse(
  * always take the cheaper dense path regardless of size.
  */
 const SSA_MIN_BLOCKS = 16;
+
+/**
+ * Default ceiling on the SSA-sparse solver's value-graph node count (#2201
+ * review R1). Above this the sparse path falls back to the dense oracle (which
+ * bounds its own work via `maxBlockVisits`), trading the deep-loop full-facts
+ * win for bounded memory on pathological inputs. Sized FAR above any real or
+ * benchmarked function: the suite's densest SSA scenarios (`dense-bindings`,
+ * `deep-nest`) build well under 10⁴ nodes, while the pathology this guards
+ * (thousands of blocks × hundreds of bindings) builds 10⁶–10⁷. The
+ * `dense-bindings` / `deep-nest` `rd_scaling_budget` gates in
+ * bench/cfg/baselines.json fail if this is set so low it forces those scenarios
+ * onto the dense path. Overridable per-call via
+ * {@link ReachingDefsLimits.maxSsaValueGraphNodes}.
+ */
+const DEFAULT_MAX_SSA_VALUE_GRAPH_NODES = 1_000_000;
 
 /**
  * True iff a cycle is reachable from `entry` (the CFG has a loop). Iterative DFS

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -526,8 +526,28 @@ function computeInSetsSparse(
   const { preds, succs, throwSuccs } = adj;
   const entry = cfg.entryIndex;
 
-  // Gate to the dense oracle for the two shapes the SSA path does not model.
+  // Gate to the dense oracle for the shapes the SSA path does not model.
   for (const list of throwSuccs) if (list.length) return computeInSetsDense(cfg, n, h, adj, limits);
+  // Malformed-input guard: an out-of-range binding index (negative or
+  // ≥ nBindings — a corrupted/stale durable parsedfile store) would crash the
+  // SSA path's nBindings-sized arrays (defBlocks[v]/stacks[u]). The dense solver
+  // tolerates any index (its lattice is a Map), so fall back — keeping the two
+  // byte-identical AND preserving the graceful per-function degradation the
+  // dense path gave (a throw here would escape the unguarded taint/harvest call
+  // sites and lose the whole file's taint layer). See hasEmitSafeFacts (emit.ts).
+  for (const b of cfg.blocks) {
+    const stmts = b.statements;
+    if (!stmts) continue;
+    for (const s of stmts) {
+      for (const d of s.defs)
+        if (d < 0 || d >= nBindings) return computeInSetsDense(cfg, n, h, adj, limits);
+      for (const u of s.uses)
+        if (u < 0 || u >= nBindings) return computeInSetsDense(cfg, n, h, adj, limits);
+      if (s.mayDefs)
+        for (const d of s.mayDefs)
+          if (d < 0 || d >= nBindings) return computeInSetsDense(cfg, n, h, adj, limits);
+    }
+  }
   const reachable = new Array<boolean>(n).fill(false);
   {
     const q = [entry];

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -5,16 +5,22 @@
  * coalesced blocks WITHOUT re-splitting the CFG.
  *
  * ARCHITECTURE (#2201): the analysis is split into solver-INDEPENDENT stages
- * (shared by both solvers, so the byte-identical surface is maximal) and a
+ * (shared by every path, so the byte-identical surface is maximal) and a
  * swappable IN-set computation:
  *   - {@link harvestStatementFacts} — per-block GEN/allDefs + def/use telemetry.
  *   - {@link buildAdjacency} — throw-aware predecessor/successor adjacency.
- *   - the IN-set computer — produces per-block entry reaching lattices. Two
- *     exist: {@link computeInSetsSparse} (production, change-driven per binding)
- *     and {@link computeInSetsDense} (the original GEN/KILL worklist, RETAINED
- *     as the differential equivalence oracle). They MUST produce identical
- *     inSets, including set INSERTION order (the maxFacts-truncated subset
- *     depends on the sweep's pre-sort emission order — see {@link sweepFacts}).
+ *   - the IN-set computer — answers block-entry reaching-set queries. Two
+ *     implementations: {@link computeInSetsSparse} (SSA — CHK dominators →
+ *     Cytron dominance frontiers + φ-placement → stack renaming over a
+ *     synthetic entry, walked SCC-condensed) and {@link computeInSetsDense}
+ *     (the original GEN/KILL worklist). Production runs {@link
+ *     computeInSetsAuto}, which picks the SSA solver for looping functions large
+ *     enough to amortize construction (where it is asymptotically faster and
+ *     never hits the dense ceiling) and the dense worklist everywhere else; the
+ *     dense path also serves the throw-edge / unreachable-block cases the SSA
+ *     path does not model. The two are held byte-identical by the equivalence
+ *     fuzz — only set CONTENTS must match (the sweep sorts each use's keys
+ *     before the maxFacts cutoff, so iteration order is irrelevant).
  *   - {@link sweepFacts} — statement sweep + sort + maxFacts truncation.
  *
  * PURE AND DETERMINISTIC (load-bearing contract):
@@ -74,26 +80,27 @@ export interface ReachingDefsLimits {
    */
   readonly maxFacts?: number;
   /**
-   * Adversarial-only safety bound on solver work.
+   * Adversarial-only safety bound on the DENSE worklist's iteration.
    *
-   * The DENSE oracle reads this as a ceiling on total block dequeues: iterative
-   * reaching-defs on a reducible CFG converges in O(loop-nesting-depth) passes,
-   * but a pathologically deep loop nest drives the visit total — and thus the
-   * solver — to O(blocks²), seconds + GB of heap (`maxFacts` does not help: fact
-   * count stays linear).
+   * The dense GEN/KILL solver reads this as a ceiling on total block dequeues:
+   * iterative reaching-defs on a reducible CFG converges in O(loop-nesting-depth)
+   * passes, but a pathologically deep loop nest drives the visit total — and thus
+   * the solver — to O(blocks²), seconds + GB of heap (`maxFacts` does not help:
+   * fact count stays linear). Exceeding the budget means the fixpoint has NOT
+   * converged, so any facts would be unsound — the dense solver bails to a sound
+   * empty `status: 'truncated'` (like the `overflow` guard).
    *
-   * The SPARSE solver (#2201) reads it as a ceiling on total (block, binding)
-   * dequeues. Because the sparse solve is change-driven per binding, realistic
-   * deep nests (loop-local / shallow variables) cost ~O(blocks) and complete far
-   * under this budget — the ceiling that fired on the dense worklist effectively
-   * never fires on real code. A single variable threaded through every level of
-   * an adversarial deep nest is the one residual O(depth²) shape (a documented
-   * SSA follow-up); it still bails soundly here.
+   * The SSA solver (#2201) has NO fixpoint iteration — it answers reaching
+   * queries from the def-use graph in one pass — so it always converges and this
+   * budget never trips it. The production dispatcher ({@link computeInSetsAuto})
+   * routes the deep nests that would breach the dense ceiling to the SSA solver,
+   * which computes their full facts: the ceiling that fired on the dense worklist
+   * effectively never fires on real code (#2201 acceptance). The budget is still
+   * honored on the dense fallback path (small / loop-free functions, and the
+   * throw-edge / unreachable-block cases the SSA path does not model).
    *
-   * On either solver, exceeding the budget means the fixpoint has NOT converged,
-   * so any facts would be unsound — the solver bails to a sound empty
-   * `status: 'truncated'` (like the `overflow` guard). `undefined`/0 ⇒ unlimited
-   * (the default for direct callers; the emit path sets a per-function budget).
+   * `undefined`/0 ⇒ unlimited (the default for direct callers; the emit path sets
+   * a per-function budget).
    */
   readonly maxBlockVisits?: number;
 }
@@ -389,9 +396,9 @@ function buildAdjacency(cfg: FunctionCfg, n: number): Adjacency {
  * O(blocks²) deep-loop-nest blow-up and REJECTED (#2195): on the dense-loop
  * benchmark a faithful weak-topological-order solver was 104/104 byte-identical
  * but 0% faster — the cost is inherent to dense-set propagation + lattice
- * merges, not visitation order. The asymptotic fix is the sparse, change-driven
- * solver ({@link computeInSetsSparse}); this dense version is retained only as
- * the differential equivalence oracle.
+ * merges, not visitation order. The asymptotic fix shipped in #2201: the
+ * SSA-sparse solver ({@link computeInSetsSparse}). This dense version is retained
+ * only as the differential equivalence oracle the fuzz checks SSA against.
  *
  * @internal
  */

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -213,6 +213,21 @@ export function computeReachingDefsDense(
 }
 
 /**
+ * Sparse, change-driven reaching-defs (#2201) — the production solve, exposed
+ * directly so the equivalence fuzz can gate it against the dense oracle before
+ * {@link computeReachingDefs} is switched over to it (U5). See
+ * {@link computeInSetsSparse} for the algorithm and byte-identical contract.
+ *
+ * @internal exported only for the equivalence fuzz harness and the cfg bench.
+ */
+export function computeReachingDefsSparse(
+  cfg: FunctionCfg,
+  limits?: ReachingDefsLimits,
+): FunctionDefUse {
+  return solveReachingDefs(cfg, limits, computeInSetsSparse);
+}
+
+/**
  * Shared orchestrator: the no-facts / overflow guards, the harvest, the
  * adjacency build, the swappable IN-set computation, and the statement sweep.
  * Only `computeInSets` differs between the production (sparse) and oracle
@@ -439,6 +454,173 @@ function computeInSetsDense(
 }
 
 /**
+ * SPARSE IN-set computer (#2201) — the production solver. Computes the SAME
+ * per-block entry reaching lattices as {@link computeInSetsDense}, but via a
+ * change-driven worklist over (block, binding) PAIRS instead of dense per-block
+ * lattice merges over a multi-pass fixpoint. Reaching-defs is component-wise
+ * independent per binding (a binding's transfer never reads another binding's
+ * set), so the product-lattice least fixed point equals the product of the
+ * per-binding least fixed points — this solve is provably equal to the dense
+ * one, and the perf win is that a binding is only ever (re)visited when one of
+ * its own predecessors' contributions changed (no dense per-block spine copy,
+ * no re-merge of unrelated bindings, no loop-depth pass multiplier on the
+ * shallow/loop-local variables that dominate real code).
+ *
+ * BYTE-IDENTICAL DISCIPLINE: each visit RECOMPUTES in_v[b] from scratch using
+ * the exact dense merge order (sorted predecessors, first contributor shared,
+ * copy-on-extend) — see {@link mergePreds}. Because the merge rebuilds from the
+ * converged predecessor sets, the final set's INSERTION order is independent of
+ * worklist visit order and matches the dense solver, which is what makes a
+ * maxFacts-TRUNCATED result (whose surviving subset depends on the sweep's
+ * pre-sort emission order) byte-identical too.
+ *
+ * BUDGET (KTD5): the dense ceiling counts block dequeues; this counts (block,
+ * binding) dequeues. The budget is scaled by the binding count so it NEVER
+ * trips on a function the dense solver computes (no coverage regression) while
+ * still bounding the one adversarial residual — a single variable threaded
+ * through every level of a pathologically deep nest, which stays O(depth²) here
+ * (a documented full-SSA follow-up). On realistic deep nests the change-driven
+ * solve completes far under budget, so the dense ceiling effectively never
+ * fires (#2201 acceptance).
+ *
+ * @internal
+ */
+function computeInSetsSparse(
+  cfg: FunctionCfg,
+  n: number,
+  h: Harvest,
+  adj: Adjacency,
+  limits: ReachingDefsLimits | undefined,
+): InSetsResult {
+  const { gen, allDefsGen } = h;
+  const { preds, succs, throwSuccs } = adj;
+  const nBindings = cfg.bindings?.length ?? 0;
+  if (nBindings === 0) {
+    return { converged: true, inSets: new Array(n).fill(EMPTY_LATTICE) };
+  }
+
+  // Per-block IN/OUT lattices, populated incrementally per binding. Sets are
+  // either nonempty or absent (never empty), mirroring the dense maps so the
+  // sweep's `.get(u)` sees identical undefined-vs-set results.
+  const inSets: Lattice[] = Array.from({ length: n }, () => new Map());
+  const outSets: Lattice[] = Array.from({ length: n }, () => new Map());
+
+  // Budget scaled by binding count — never trips where dense converges (no
+  // regression), still bounds the single-deeply-carried-variable adversarial
+  // case. undefined/0 ⇒ unlimited.
+  const base =
+    limits?.maxBlockVisits && limits.maxBlockVisits > 0 ? limits.maxBlockVisits : Infinity;
+  const maxUpdates = base === Infinity ? Infinity : base * nBindings;
+  let updates = 0;
+
+  // (block, binding) worklist, deduped via a flat pending bitmap. Visit order
+  // does not affect the result (each visit recomputes from current state), so
+  // a LIFO stack is used to avoid O(n) array shifts.
+  const encode = (b: number, v: number): number => b * nBindings + v;
+  const pending = new Uint8Array(n * nBindings);
+  const stack: number[] = [];
+  const enqueue = (b: number, v: number): void => {
+    const k = encode(b, v);
+    if (!pending[k]) {
+      pending[k] = 1;
+      stack.push(k);
+    }
+  };
+
+  // Seed: every binding genned in a block (its OUT becomes nonempty), plus the
+  // THROW successors of every gen block — a throwing block delivers allDefs(v)
+  // to its handler even when the block's own IN of v never changes (so the
+  // inChanged-driven throw requeue below would otherwise miss the first, static
+  // allDefs contribution).
+  for (let b = 0; b < n; b++) {
+    const g = gen[b];
+    if (!g) continue;
+    for (const v of g.keys()) {
+      enqueue(b, v);
+      for (const s of throwSuccs[b]) enqueue(s, v);
+    }
+  }
+
+  // Recompute IN(v) at block b from scratch, in the exact dense merge order
+  // (sorted predecessors; first contributor's set shared; copy-on-extend on
+  // subsequent contributors — never mutate a shared set). Returns the set or
+  // undefined when nothing reaches.
+  const computeIn = (b: number, v: number): DefSet | undefined => {
+    const p = preds[b];
+    if (p.length === 0) return undefined;
+    if (p.length === 1 && !p[0].viaThrow) return outSets[p[0].from].get(v);
+    let merged: DefSet | undefined;
+    let owned = false; // true once `merged` is our private (mutable) copy
+    const mergeOne = (src: DefSet | undefined): void => {
+      if (!src || src.size === 0) return;
+      if (merged === undefined) {
+        merged = src; // share the first contributor's set
+        owned = false;
+        return;
+      }
+      if (merged === src) return;
+      for (const key of src) {
+        if (!merged.has(key)) {
+          if (!owned) {
+            merged = new Set(merged);
+            owned = true;
+          }
+          merged.add(key);
+        }
+      }
+    };
+    for (const pe of p) {
+      if (pe.viaThrow) {
+        mergeOne(inSets[pe.from].get(v)); // exception may fire pre-defs…
+        mergeOne(allDefsGen[pe.from]?.get(v)); // …or after ANY of the block's defs
+      } else {
+        mergeOne(outSets[pe.from].get(v));
+      }
+    }
+    return merged;
+  };
+
+  // OUT(v) at b = overlay(IN): a killing gen replaces the set; a may-def-only
+  // gen unions without killing; no gen ⇒ OUT aliases IN.
+  const computeOut = (b: number, v: number, inV: DefSet | undefined): DefSet | undefined => {
+    const entry = gen[b]?.get(v);
+    if (!entry) return inV;
+    if (entry.kills) return entry.set;
+    return inV ? unionSets(inV, entry.set) : entry.set;
+  };
+
+  const setEq = (a: DefSet | undefined, b: DefSet | undefined): boolean => {
+    if (a === b) return true;
+    if (!a || !b || a.size !== b.size) return false;
+    for (const v of b) if (!a.has(v)) return false;
+    return true;
+  };
+
+  while (stack.length > 0) {
+    if (++updates > maxUpdates) return { converged: false };
+    const k = stack.pop()!;
+    pending[k] = 0;
+    const b = (k / nBindings) | 0;
+    const v = k - b * nBindings;
+
+    const newIn = computeIn(b, v);
+    const oldIn = inSets[b].get(v);
+    const inChanged = !setEq(oldIn, newIn);
+    if (newIn !== undefined) inSets[b].set(v, newIn);
+
+    const newOut = computeOut(b, v, newIn);
+    const oldOut = outSets[b].get(v);
+    const outChanged = !setEq(oldOut, newOut);
+    if (newOut !== undefined) outSets[b].set(v, newOut);
+
+    if (outChanged) for (const s of succs[b]) enqueue(s, v);
+    if (inChanged) for (const s of throwSuccs[b]) enqueue(s, v);
+  }
+
+  return { converged: true, inSets };
+}
+
+/**
  * Statement sweep — recover statement-granular def→use facts from the per-block
  * entry reaching lattices, sort them, and apply the maxFacts truncation. SHARED
  * by both solvers: the truncated SUBSET depends on the pre-sort emission order
@@ -481,6 +663,16 @@ function sweepFacts(
           selfKey !== undefined && !reaching?.has(selfKey)
             ? [...(reaching ?? []), selfKey]
             : [...(reaching ?? [])];
+        // Canonical emission order (#2201 KTD6): sort each use's reaching
+        // def-sites by defKey (= def block, then def stmt) BEFORE the maxFacts
+        // cutoff. The full (untruncated) fact array is re-sorted identically at
+        // the end, so this is a no-op there; its purpose is to make the
+        // TRUNCATED subset schedule-independent — the reaching SET's insertion
+        // order is fixpoint-evaluation-order-dependent for loop-carried
+        // bindings (dense RPO vs sparse change-driven seed different keys
+        // first), so a pre-sort cutoff is what keeps the two solvers'
+        // truncated results byte-identical.
+        keys.sort((a, b) => a - b);
         for (const key of keys) {
           if (facts.length >= maxFacts) {
             truncated = true;

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -430,7 +430,7 @@ function computeInSetsDense(
 ): InSetsResult {
   const { gen, allDefsGen } = h;
   const { preds, succs, throwSuccs } = adj;
-  const order = reversePostOrder(cfg.entryIndex, succs, n);
+  const { order } = reversePostOrder(cfg.entryIndex, succs, n);
 
   const inSets: Lattice[] = new Array(n).fill(EMPTY_LATTICE);
   const outSets: Lattice[] = new Array(n).fill(EMPTY_LATTICE);
@@ -561,17 +561,6 @@ function computeInSetsSparse(
           if (d < 0 || d >= nBindings) return computeInSetsDense(cfg, n, h, adj, limits);
     }
   }
-  const reachable = new Array<boolean>(n).fill(false);
-  {
-    const q = [entry];
-    reachable[entry] = true;
-    while (q.length) {
-      const x = q.pop()!;
-      for (const s of succs[x]) if (!reachable[s]) ((reachable[s] = true), q.push(s));
-    }
-  }
-  for (let b = 0; b < n; b++) if (!reachable[b]) return computeInSetsDense(cfg, n, h, adj, limits);
-
   // Synthetic pre-entry block (#2201): textbook SSA construction assumes the
   // entry has no predecessors. A loop back-edge into the entry — or a self-loop
   // on it — makes the entry a merge that needs a φ, and the dominance-frontier
@@ -595,7 +584,14 @@ function computeInSetsSparse(
   dPredsX[S] = [];
 
   // ── dominators (Cooper-Harvey-Kennedy; correct on irreducible CFGs) ──
-  const rpo = reversePostOrder(S, succsX, nx); // rooted at the synthetic entry
+  // RPO rooted at the synthetic entry. `reachX` is the reachability the DFS
+  // already computed — reused for the unreachable-block gate below instead of a
+  // separate BFS (#2201 review R8). Because S→entry is S's only edge, reachX[b]
+  // (b<n) is exactly "reachable from entry", identical to the old BFS gate.
+  const { order: rpo, visited: reachX } = reversePostOrder(S, succsX, nx);
+  // The SSA path does not model propagation among unreachable blocks (KTD4) —
+  // fall back to the dense oracle if any block is unreachable from the entry.
+  for (let b = 0; b < n; b++) if (!reachX[b]) return computeInSetsDense(cfg, n, h, adj, limits);
   const rpoIdx = new Array<number>(nx);
   rpo.forEach((b, i) => (rpoIdx[b] = i));
   const idom = new Array<number>(nx).fill(-1);
@@ -1052,8 +1048,17 @@ function sweepFacts(
   return { facts, truncated };
 }
 
-/** RPO over blocks reachable from `entry`; unreachable blocks appended by index. */
-function reversePostOrder(entry: number, succs: readonly number[][], n: number): number[] {
+/**
+ * RPO over blocks reachable from `entry`; unreachable blocks appended by index.
+ * Returns the order AND the reachability bitmap the DFS already computed, so a
+ * caller needing "is every block reachable?" reuses this pass instead of a
+ * separate BFS (#2201 review R8 — the SSA path's reachability gate).
+ */
+function reversePostOrder(
+  entry: number,
+  succs: readonly number[][],
+  n: number,
+): { order: number[]; visited: boolean[] } {
   const visited = new Array<boolean>(n).fill(false);
   const post: number[] = [];
   // Iterative DFS with an explicit phase stack (children pushed in reverse so
@@ -1077,7 +1082,7 @@ function reversePostOrder(entry: number, succs: readonly number[][], n: number):
   }
   const order = post.reverse();
   for (let b = 0; b < n; b++) if (!visited[b]) order.push(b);
-  return order;
+  return { order, visited };
 }
 
 /**

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -127,8 +127,32 @@ const EMPTY_LATTICE: Lattice = new Map();
 /**
  * Compute reaching definitions for one function. See the module doc for the
  * purity/determinism/sharing contract.
+ *
+ * This is the production entry point. As of #2201 it delegates to the
+ * SSA-sparse solver ({@link computeReachingDefsSparse}); the dense GEN/KILL
+ * worklist ({@link computeReachingDefsDense}) is retained as the differential
+ * equivalence oracle the fuzz suite checks the sparse path against — the two
+ * MUST be byte-identical (status, bindings, sorted facts, def/use telemetry).
  */
 export function computeReachingDefs(cfg: FunctionCfg, limits?: ReachingDefsLimits): FunctionDefUse {
+  // #2201 U1: production still runs the dense solver; the swap to sparse lands
+  // in U5 once the differential fuzz is byte-identical green.
+  return computeReachingDefsDense(cfg, limits);
+}
+
+/**
+ * Dense GEN/KILL monotone worklist — the original (#2082 M2) reaching-defs
+ * solver. As of #2201 this is RETAINED AS A TEST/BENCH-ONLY DIFFERENTIAL
+ * ORACLE, not a production code path: {@link computeReachingDefs} runs the
+ * SSA-sparse solver, and the equivalence fuzz asserts the two are byte-identical
+ * across a random-CFG corpus. Keep it behavior-frozen — it is the ground truth.
+ *
+ * @internal exported only for the equivalence fuzz harness and the cfg bench.
+ */
+export function computeReachingDefsDense(
+  cfg: FunctionCfg,
+  limits?: ReachingDefsLimits,
+): FunctionDefUse {
   if (!cfg.bindings) {
     return { status: 'no-facts', bindings: [], facts: [], defCount: 0, useCount: 0 };
   }

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -966,10 +966,17 @@ function computeInSetsAuto(
 /**
  * Statement sweep — recover statement-granular def→use facts from the per-block
  * entry reaching lattices, sort them, and apply the maxFacts truncation. SHARED
- * by both solvers: the truncated SUBSET depends on the pre-sort emission order
- * here (block index, then statement index, then use order, then the reaching
- * set's INSERTION order), so producing identical inSets — insertion order
- * included — is what makes a truncated result byte-identical across solvers.
+ * by both solvers, and the maxFacts cutoff is where their (intentionally
+ * different) reaching-set INSERTION orders would otherwise leak into the output:
+ * the dense worklist seeds keys in RPO fixpoint order, the SSA solver in
+ * renaming/SCC order, so a loop-carried use's reaching set is the same SET in a
+ * different order. The byte-identity of a TRUNCATED result therefore does NOT
+ * come from matching insertion orders — it comes from the KTD6 per-use
+ * `useKeys.sort()` BELOW, which canonicalizes each use's keys by defKey before
+ * the cutoff. (The full, untruncated fact array is re-sorted at the end, so the
+ * pre-sort is a no-op there; its whole purpose is the truncated prefix.) Outer
+ * emission order — block index, then statement index, then use order — is shared
+ * structurally and needs no canonicalization.
  */
 function sweepFacts(
   blocks: FunctionCfg['blocks'],

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -46,6 +46,16 @@
  * as a per-function taint-coverage gap.
  */
 import type { BindingEntry, FunctionCfg } from './types.js';
+import {
+  buildDominanceFrontiers,
+  buildDominators,
+  condenseReachingSets,
+  hasReachableLoop,
+  latticeEquals,
+  reversePostOrder,
+  tarjanScc,
+  unionSets,
+} from './reaching-defs-graph.js';
 
 /** A statement-granular program point within one function's CFG. */
 export interface ProgramPoint {
@@ -603,43 +613,10 @@ function computeInSetsSparse(
   // The SSA path does not model propagation among unreachable blocks (KTD4) —
   // fall back to the dense oracle if any block is unreachable from the entry.
   for (let b = 0; b < n; b++) if (!reachX[b]) return computeInSetsDense(cfg, n, h, adj, limits);
-  const rpoIdx = new Array<number>(nx);
-  rpo.forEach((b, i) => (rpoIdx[b] = i));
-  const idom = new Array<number>(nx).fill(-1);
-  idom[S] = S;
-  const intersect = (a: number, b: number): number => {
-    while (a !== b) {
-      while (rpoIdx[a] > rpoIdx[b]) a = idom[a];
-      while (rpoIdx[b] > rpoIdx[a]) b = idom[b];
-    }
-    return a;
-  };
-  for (let changed = true; changed; ) {
-    changed = false;
-    for (const b of rpo) {
-      if (b === S) continue;
-      let nd = -1;
-      for (const p of dPredsX[b]) if (idom[p] !== -1) nd = nd === -1 ? p : intersect(nd, p);
-      if (nd !== -1 && idom[b] !== nd) {
-        idom[b] = nd;
-        changed = true;
-      }
-    }
-  }
+  const idom = buildDominators(rpo, dPredsX, S, nx);
 
   // ── dominance frontiers (Cytron) ──
-  const df: Set<number>[] = Array.from({ length: nx }, () => new Set<number>());
-  for (let b = 0; b < nx; b++) {
-    const dp = dPredsX[b];
-    if (dp.length < 2) continue;
-    for (const p of dp) {
-      let runner = p;
-      while (runner !== idom[b] && runner !== -1) {
-        df[runner].add(b);
-        runner = idom[runner];
-      }
-    }
-  }
+  const df = buildDominanceFrontiers(dPredsX, idom, nx);
 
   // ── per-binding def blocks (must- or may-def ⇒ block transfer touches v) ──
   const defBlocks: number[][] = Array.from({ length: nBindings }, () => []);
@@ -779,102 +756,12 @@ function computeInSetsSparse(
   }
 
   // ── reaching sets per node via SCC condensation (cycle-safe union) ──
-  // Tarjan emits SCCs in reverse topological order, so an SCC's operand SCCs
-  // are numbered before it ⇒ a single forward pass over SCCs resolves unions.
-  const N = nodeKeys.length;
-  const sccOf = new Array<number>(N).fill(-1);
-  const sccMembers: number[][] = [];
-  const index = new Array<number>(N).fill(-1);
-  const low = new Array<number>(N).fill(0);
-  const onStk = new Array<boolean>(N).fill(false);
-  const tarjanStk: number[] = [];
-  let counter = 0;
-  for (let start = 0; start < N; start++) {
-    if (index[start] !== -1) continue;
-    const work: { node: number; oi: number }[] = [{ node: start, oi: 0 }];
-    index[start] = low[start] = counter++;
-    tarjanStk.push(start);
-    onStk[start] = true;
-    while (work.length) {
-      const top = work[work.length - 1];
-      const ops = nodeOps[top.node];
-      if (top.oi < ops.length) {
-        const w = ops[top.oi++];
-        if (index[w] === -1) {
-          index[w] = low[w] = counter++;
-          tarjanStk.push(w);
-          onStk[w] = true;
-          work.push({ node: w, oi: 0 });
-        } else if (onStk[w] && index[w] < low[top.node]) {
-          low[top.node] = index[w];
-        }
-      } else {
-        if (low[top.node] === index[top.node]) {
-          const members: number[] = [];
-          let w: number;
-          do {
-            w = tarjanStk.pop()!;
-            onStk[w] = false;
-            sccOf[w] = sccMembers.length;
-            members.push(w);
-          } while (w !== top.node);
-          sccMembers.push(members);
-        }
-        work.pop();
-        if (work.length) {
-          const par = work[work.length - 1].node;
-          if (low[top.node] < low[par]) low[par] = low[top.node];
-        }
-      }
-    }
-  }
-  const reachByScc: DefSet[] = new Array(sccMembers.length);
-  for (let s = 0; s < sccMembers.length; s++) {
-    const members = sccMembers[s];
-    // Alias fast path (#2201 review R2): an SCC with NO own leaf keys whose
-    // cross-SCC operands all resolve to a SINGLE source SCC has exactly that
-    // source's reaching set — share it BY REFERENCE instead of copying it
-    // element-by-element. This is the common shape (a pass-through φ / single-
-    // operand value node), and the copy it avoids is the O(defs²) cost at
-    // wide-fan-in merges (a φ over many predecessors each carrying a large set).
-    // Contents are identical, and reachByScc sets are read-only after this pass
-    // (operand SCCs are numbered before s — Tarjan's reverse-topo order — and
-    // are only iterated, never mutated), so sharing is safe.
-    let aliasTarget = -1; // the unique cross-SCC source SCC, or -1 if none/many
-    let hasOwnKeys = false;
-    let multiSource = false;
-    for (const node of members) {
-      if (nodeKeys[node]) {
-        hasOwnKeys = true;
-        break;
-      }
-      for (const w of nodeOps[node]) {
-        const ws = sccOf[w];
-        if (ws === s) continue; // intra-SCC operand: same set being built, adds nothing
-        if (aliasTarget === -1) aliasTarget = ws;
-        else if (aliasTarget !== ws) {
-          multiSource = true;
-          break;
-        }
-      }
-      if (multiSource) break;
-    }
-    if (!hasOwnKeys && !multiSource && aliasTarget !== -1) {
-      reachByScc[s] = reachByScc[aliasTarget]; // zero-copy share
-      continue;
-    }
-    // General case: union own leaf keys + every distinct cross-SCC operand set.
-    const set: DefSet = new Set();
-    for (const node of members) {
-      const keys = nodeKeys[node];
-      if (keys) for (const k of keys) set.add(k);
-      for (const w of nodeOps[node]) {
-        const ws = sccOf[w];
-        if (ws !== s) for (const k of reachByScc[ws]) set.add(k);
-      }
-    }
-    reachByScc[s] = set;
-  }
+  // Tarjan condenses the value graph (operand cycles from loop φs collapse to a
+  // single SCC); a forward pass over the reverse-topo SCC order unions each
+  // SCC's reaching set from its operands' (alias fast path for single-source
+  // SCCs — #2201 review R2). Both stages are pure (reaching-defs-graph.ts).
+  const { sccOf, sccMembers } = tarjanScc(nodeOps);
+  const reachByScc = condenseReachingSets(sccMembers, sccOf, nodeKeys, nodeOps);
 
   return {
     converged: true,
@@ -912,32 +799,6 @@ const SSA_MIN_BLOCKS = 16;
  * {@link ReachingDefsLimits.maxSsaValueGraphNodes}.
  */
 const DEFAULT_MAX_SSA_VALUE_GRAPH_NODES = 1_000_000;
-
-/**
- * True iff a cycle is reachable from `entry` (the CFG has a loop). Iterative DFS
- * with a gray/black coloring; a gray successor is a back-edge. O(V+E).
- */
-function hasReachableLoop(entry: number, succs: readonly number[][], n: number): boolean {
-  const color = new Uint8Array(n); // 0 white, 1 gray, 2 black
-  const stack: { node: number; i: number }[] = [{ node: entry, i: 0 }];
-  color[entry] = 1;
-  while (stack.length) {
-    const top = stack[stack.length - 1];
-    const ss = succs[top.node];
-    if (top.i < ss.length) {
-      const next = ss[top.i++];
-      if (color[next] === 1) return true;
-      if (color[next] === 0) {
-        color[next] = 1;
-        stack.push({ node: next, i: 0 });
-      }
-    } else {
-      color[top.node] = 2;
-      stack.pop();
-    }
-  }
-  return false;
-}
 
 /**
  * Production solver dispatcher (#2201). The SSA solver beats the dense worklist
@@ -1076,43 +937,6 @@ function sweepFacts(
 }
 
 /**
- * RPO over blocks reachable from `entry`; unreachable blocks appended by index.
- * Returns the order AND the reachability bitmap the DFS already computed, so a
- * caller needing "is every block reachable?" reuses this pass instead of a
- * separate BFS (#2201 review R8 — the SSA path's reachability gate).
- */
-function reversePostOrder(
-  entry: number,
-  succs: readonly number[][],
-  n: number,
-): { order: number[]; visited: boolean[] } {
-  const visited = new Array<boolean>(n).fill(false);
-  const post: number[] = [];
-  // Iterative DFS with an explicit phase stack (children pushed in reverse so
-  // they pop in sorted order — determinism).
-  const stack: { node: number; childIdx: number }[] = [{ node: entry, childIdx: 0 }];
-  visited[entry] = true;
-  while (stack.length) {
-    const top = stack[stack.length - 1];
-    const children = succs[top.node];
-    if (top.childIdx < children.length) {
-      const next = children[top.childIdx];
-      top.childIdx += 1;
-      if (!visited[next]) {
-        visited[next] = true;
-        stack.push({ node: next, childIdx: 0 });
-      }
-    } else {
-      post.push(top.node);
-      stack.pop();
-    }
-  }
-  const order = post.reverse();
-  for (let b = 0; b < n; b++) if (!visited[b]) order.push(b);
-  return { order, visited };
-}
-
-/**
  * Union predecessor lattices, sharing sets where possible. A normal edge
  * contributes OUT(from). A THROW edge contributes IN(from) ∪ allDefs(from):
  * an exception may fire before, between, or after any of the block's defs, so
@@ -1162,31 +986,3 @@ function mergePreds(
   return merged;
 }
 
-/** Order-stable union of two def-sets (shares `a` when `b` adds nothing). */
-function unionSets(a: DefSet, b: DefSet): DefSet {
-  let target = a;
-  let copied = false;
-  for (const key of b) {
-    if (!target.has(key)) {
-      if (!copied) {
-        target = new Set(a);
-        copied = true;
-      }
-      target.add(key);
-    }
-  }
-  return target;
-}
-
-/** Per-binding equality with a reference fast path (sets only ever grow). */
-function latticeEquals(a: Lattice, b: Lattice): boolean {
-  if (a === b) return true;
-  if (a.size !== b.size) return false;
-  for (const [k, bSet] of b) {
-    const aSet = a.get(k);
-    if (aSet === bSet) continue;
-    if (!aSet || aSet.size !== bSet.size) return false;
-    for (const v of bSet) if (!aSet.has(v)) return false;
-  }
-  return true;
-}

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -201,11 +201,14 @@ type InSetsComputer = (
  * Compute reaching definitions for one function. See the module doc for the
  * purity/determinism/sharing contract.
  *
- * This is the production entry point. As of #2201 it runs the sparse, change-
- * driven solver ({@link computeInSetsSparse}); the dense GEN/KILL worklist
- * ({@link computeReachingDefsDense}) is retained as the differential
- * equivalence oracle the fuzz suite checks the sparse path against — the two
- * MUST be byte-identical (status, bindings, sorted facts, def/use telemetry).
+ * This is the production entry point. As of #2201 it auto-dispatches via
+ * {@link computeInSetsAuto} — the SSA-sparse solver ({@link computeInSetsSparse})
+ * for looping functions large enough to amortize construction, the dense
+ * GEN/KILL worklist ({@link computeInSetsDense}) everywhere else (and for the
+ * throw-edge / unreachable-block functions the SSA path does not model). The two
+ * solvers are held byte-identical by the equivalence fuzz (status, bindings,
+ * sorted facts, def/use telemetry), so the dispatch is a pure performance
+ * heuristic; the dense solver doubles as that differential oracle.
  */
 export function computeReachingDefs(cfg: FunctionCfg, limits?: ReachingDefsLimits): FunctionDefUse {
   // #2201: production auto-selects the solver per function (see
@@ -219,12 +222,14 @@ export function computeReachingDefs(cfg: FunctionCfg, limits?: ReachingDefsLimit
 
 /**
  * Dense GEN/KILL monotone worklist — the original (#2082 M2) reaching-defs
- * solver. As of #2201 this is RETAINED AS A TEST/BENCH-ONLY DIFFERENTIAL
- * ORACLE, not a production code path: {@link computeReachingDefs} runs the
- * sparse solver, and the equivalence fuzz asserts the two are byte-identical
- * across a random-CFG corpus. Keep it behavior-frozen — it is the ground truth.
+ * solver. As of #2201 it plays two roles: (1) the production dispatcher
+ * ({@link computeInSetsAuto}) routes small / loop-free functions, and the
+ * throw-edge / unreachable-block functions the SSA path does not model, to this
+ * dense solver; (2) it is the differential equivalence ORACLE the fuzz checks
+ * the SSA path against. Keep it behavior-frozen — it is the ground truth.
  *
- * @internal exported only for the equivalence fuzz harness and the cfg bench.
+ * @internal exported for the equivalence fuzz harness (direct dense-vs-sparse
+ * comparison); the bench drives the production {@link computeReachingDefs}.
  */
 export function computeReachingDefsDense(
   cfg: FunctionCfg,
@@ -234,12 +239,13 @@ export function computeReachingDefsDense(
 }
 
 /**
- * Sparse, change-driven reaching-defs (#2201) — the production solve, exposed
- * directly so the equivalence fuzz can gate it against the dense oracle before
- * {@link computeReachingDefs} is switched over to it (U5). See
- * {@link computeInSetsSparse} for the algorithm and byte-identical contract.
+ * SSA-sparse reaching-defs (#2201) — exposed directly so the equivalence fuzz
+ * can drive the SSA solver on every eligible CFG (bypassing the production
+ * size/loop dispatch heuristic in {@link computeInSetsAuto}) and assert
+ * byte-identity against the dense oracle. See {@link computeInSetsSparse} for
+ * the algorithm and byte-identical contract.
  *
- * @internal exported only for the equivalence fuzz harness and the cfg bench.
+ * @internal exported only for the equivalence fuzz harness.
  */
 export function computeReachingDefsSparse(
   cfg: FunctionCfg,
@@ -788,7 +794,15 @@ function computeInSetsSparse(
   };
 }
 
-/** Minimum block count below which SSA construction does not amortize. */
+/**
+ * Minimum block count below which SSA construction (dominators + dominance
+ * frontiers + φ-placement + renaming + SCC) does not amortize over the dense
+ * worklist's single-pass aliasing. Calibrated empirically (~14-block crossover
+ * for loop-heavy functions; 16 leaves headroom); the dense-bindings
+ * `rd_scaling_budget` gate in bench/cfg/baselines.json catches a regression if
+ * this is mistuned. Paired with a reachable-loop check — loop-free functions
+ * always take the cheaper dense path regardless of size.
+ */
 const SSA_MIN_BLOCKS = 16;
 
 /**
@@ -803,11 +817,11 @@ function hasReachableLoop(entry: number, succs: readonly number[][], n: number):
     const top = stack[stack.length - 1];
     const ss = succs[top.node];
     if (top.i < ss.length) {
-      const nx = ss[top.i++];
-      if (color[nx] === 1) return true;
-      if (color[nx] === 0) {
-        color[nx] = 1;
-        stack.push({ node: nx, i: 0 });
+      const next = ss[top.i++];
+      if (color[next] === 1) return true;
+      if (color[next] === 0) {
+        color[next] = 1;
+        stack.push({ node: next, i: 0 });
       }
     } else {
       color[top.node] = 2;

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -166,11 +166,21 @@ interface Adjacency {
 }
 
 /**
- * The swappable stage: per-block entry reaching lattices, or a non-convergence
- * signal (maxBlockVisits exceeded ⇒ sound empty `truncated`). The two
- * implementations MUST agree byte-for-byte, including set insertion order.
+ * Block-entry reaching-set accessor: the set of def-site keys of `binding`
+ * reaching `blockIndex`'s entry, or undefined when none reach. Both solvers
+ * expose their result through this accessor so the sweep is solver-agnostic;
+ * the dense oracle backs it with precomputed per-block lattices, the sparse
+ * solver computes it lazily from the SSA def-use graph. Because {@link
+ * sweepFacts} sorts each use's reaching keys before the maxFacts cutoff, only
+ * the set CONTENTS need to match across solvers — not iteration order.
  */
-type InSetsResult = { converged: true; inSets: Lattice[] } | { converged: false };
+type ReachingAt = (blockIndex: number, binding: number) => DefSet | undefined;
+
+/**
+ * The swappable stage: a block-entry reaching-set accessor, or a non-
+ * convergence signal (the work budget exceeded ⇒ sound empty `truncated`).
+ */
+type InSetsResult = { converged: true; reachingAt: ReachingAt } | { converged: false };
 
 type InSetsComputer = (
   cfg: FunctionCfg,
@@ -191,10 +201,13 @@ type InSetsComputer = (
  * MUST be byte-identical (status, bindings, sorted facts, def/use telemetry).
  */
 export function computeReachingDefs(cfg: FunctionCfg, limits?: ReachingDefsLimits): FunctionDefUse {
-  // #2201 U5: production runs the sparse, change-driven solver. The dense
-  // worklist ({@link computeReachingDefsDense}) is retained as the differential
-  // equivalence oracle the fuzz suite holds this byte-identical to.
-  return solveReachingDefs(cfg, limits, computeInSetsSparse);
+  // #2201: production auto-selects the solver per function (see
+  // {@link computeInSetsAuto}) — the SSA solver where it pays off (looping
+  // functions large enough to amortize construction, incl. the deep nests the
+  // dense ceiling used to truncate), the dense worklist everywhere else (small
+  // or loop-free functions, where it is faster). Both are held byte-identical
+  // by the equivalence fuzz, so the choice is a pure performance heuristic.
+  return solveReachingDefs(cfg, limits, computeInSetsAuto);
 }
 
 /**
@@ -274,7 +287,7 @@ function solveReachingDefs(
   }
 
   const maxFacts = limits?.maxFacts && limits.maxFacts > 0 ? limits.maxFacts : Infinity;
-  const { facts, truncated } = sweepFacts(blocks, solved.inSets, h.defLine, maxFacts);
+  const { facts, truncated } = sweepFacts(blocks, solved.reachingAt, h.defLine, maxFacts);
 
   return {
     status: truncated ? 'truncated' : 'computed',
@@ -451,38 +464,38 @@ function computeInSetsDense(
     }
   }
 
-  return { converged: true, inSets };
+  return { converged: true, reachingAt: (blockIndex, binding) => inSets[blockIndex]?.get(binding) };
 }
 
 /**
- * SPARSE IN-set computer (#2201) — the production solver. Computes the SAME
- * per-block entry reaching lattices as {@link computeInSetsDense}, but via a
- * change-driven worklist over (block, binding) PAIRS instead of dense per-block
- * lattice merges over a multi-pass fixpoint. Reaching-defs is component-wise
- * independent per binding (a binding's transfer never reads another binding's
- * set), so the product-lattice least fixed point equals the product of the
- * per-binding least fixed points — this solve is provably equal to the dense
- * one, and the perf win is that a binding is only ever (re)visited when one of
- * its own predecessors' contributions changed (no dense per-block spine copy,
- * no re-merge of unrelated bindings, no loop-depth pass multiplier on the
- * shallow/loop-local variables that dominate real code).
+ * SPARSE IN-set computer (#2201) — the production solver. Instead of the dense
+ * GEN/KILL worklist's per-block lattice fixpoint, it builds pruned SSA for the
+ * function (Cooper-Harvey-Kennedy dominators → Cytron dominance frontiers and
+ * φ-placement → stack-based renaming) and answers block-entry reaching-def
+ * queries by walking the SSA def-use graph. φ-nodes statically capture loop
+ * merges, so a use's reaching set is recovered without iterating the loop
+ * (depth-independent), and pass-through blocks carry the dominating definition
+ * via the rename stack rather than re-materializing a dense lattice at every
+ * block — the two effects that make it faster than the dense solver on the
+ * deep-nest and dense-bindings pathologies.
  *
- * BYTE-IDENTICAL DISCIPLINE: each visit RECOMPUTES in_v[b] from scratch using
- * the exact dense merge order (sorted predecessors, first contributor shared,
- * copy-on-extend) — see {@link mergePreds}. Because the merge rebuilds from the
- * converged predecessor sets, the final set's INSERTION order is independent of
- * worklist visit order and matches the dense solver, which is what makes a
- * maxFacts-TRUNCATED result (whose surviving subset depends on the sweep's
- * pre-sort emission order) byte-identical too.
+ * BYTE-IDENTICAL CONTRACT: it computes the same may-reaching-definition SET at
+ * each block entry as {@link computeInSetsDense}. Order does not matter — {@link
+ * sweepFacts} sorts each use's reaching keys before the maxFacts cutoff (#2201
+ * KTD6) — so only set CONTENTS must match; the equivalence fuzz holds the line.
  *
- * BUDGET (KTD5): the dense ceiling counts block dequeues; this counts (block,
- * binding) dequeues. The budget is scaled by the binding count so it NEVER
- * trips on a function the dense solver computes (no coverage regression) while
- * still bounding the one adversarial residual — a single variable threaded
- * through every level of a pathologically deep nest, which stays O(depth²) here
- * (a documented full-SSA follow-up). On realistic deep nests the change-driven
- * solve completes far under budget, so the dense ceiling effectively never
- * fires (#2201 acceptance).
+ * SCOPE (KTD4): the SSA path covers fully-reachable CFGs with kill/may-def
+ * transfers, reducible AND irreducible (CHK + Cytron are correct on irreducible
+ * graphs). It does NOT model throw edges' IN∪allDefs handler semantics or
+ * propagation among unreachable blocks; functions with either are routed to the
+ * dense oracle — byte-identical and correct, just not asymptotically faster.
+ * These are not the perf pathologies (deep nests / dense-bindings are
+ * throw-free and fully reachable), so the win lands where it matters.
+ *
+ * No fixpoint iteration ⇒ the solve always converges in O(program); the
+ * `maxBlockVisits` ceiling that fired on the dense worklist's deep nests never
+ * fires here (#2201 acceptance). The bound is honored only on the dense
+ * fallback path.
  *
  * @internal
  */
@@ -493,132 +506,332 @@ function computeInSetsSparse(
   adj: Adjacency,
   limits: ReachingDefsLimits | undefined,
 ): InSetsResult {
-  const { gen, allDefsGen } = h;
-  const { preds, succs, throwSuccs } = adj;
   const nBindings = cfg.bindings?.length ?? 0;
-  if (nBindings === 0) {
-    return { converged: true, inSets: new Array(n).fill(EMPTY_LATTICE) };
+  if (nBindings === 0) return { converged: true, reachingAt: () => undefined };
+
+  const { gen } = h;
+  const { preds, succs, throwSuccs } = adj;
+  const entry = cfg.entryIndex;
+
+  // Gate to the dense oracle for the two shapes the SSA path does not model.
+  for (const list of throwSuccs) if (list.length) return computeInSetsDense(cfg, n, h, adj, limits);
+  const reachable = new Array<boolean>(n).fill(false);
+  {
+    const q = [entry];
+    reachable[entry] = true;
+    while (q.length) {
+      const x = q.pop()!;
+      for (const s of succs[x]) if (!reachable[s]) ((reachable[s] = true), q.push(s));
+    }
+  }
+  for (let b = 0; b < n; b++) if (!reachable[b]) return computeInSetsDense(cfg, n, h, adj, limits);
+
+  // Synthetic pre-entry block (#2201): textbook SSA construction assumes the
+  // entry has no predecessors. A loop back-edge into the entry — or a self-loop
+  // on it — makes the entry a merge that needs a φ, and the dominance-frontier
+  // walk degenerates when idom[entry] === entry (it never lands the entry in its
+  // own frontier). A virtual start node S → entry (S itself has no preds)
+  // restores the invariant: idom[entry] = S, the entry joins {start ⊔
+  // back-edges}, and the implicit start operand contributes ⊥ (an empty rename
+  // stack). S carries no statements, gen, or uses and is never queried.
+  const S = n;
+  const nx = n + 1;
+  const succsX: number[][] = new Array(nx);
+  for (let b = 0; b < n; b++) succsX[b] = succs[b] as number[];
+  succsX[S] = [entry];
+  const dPredsX: number[][] = new Array(nx);
+  for (let b = 0; b < n; b++) {
+    const set = new Set<number>();
+    for (const p of preds[b]) set.add(p.from);
+    if (b === entry) set.add(S);
+    dPredsX[b] = [...set].sort((a, c) => a - c);
+  }
+  dPredsX[S] = [];
+
+  // ── dominators (Cooper-Harvey-Kennedy; correct on irreducible CFGs) ──
+  const rpo = reversePostOrder(S, succsX, nx); // rooted at the synthetic entry
+  const rpoIdx = new Array<number>(nx);
+  rpo.forEach((b, i) => (rpoIdx[b] = i));
+  const idom = new Array<number>(nx).fill(-1);
+  idom[S] = S;
+  const intersect = (a: number, b: number): number => {
+    while (a !== b) {
+      while (rpoIdx[a] > rpoIdx[b]) a = idom[a];
+      while (rpoIdx[b] > rpoIdx[a]) b = idom[b];
+    }
+    return a;
+  };
+  for (let changed = true; changed; ) {
+    changed = false;
+    for (const b of rpo) {
+      if (b === S) continue;
+      let nd = -1;
+      for (const p of dPredsX[b]) if (idom[p] !== -1) nd = nd === -1 ? p : intersect(nd, p);
+      if (nd !== -1 && idom[b] !== nd) {
+        idom[b] = nd;
+        changed = true;
+      }
+    }
   }
 
-  // Per-block IN/OUT lattices, populated incrementally per binding. Sets are
-  // either nonempty or absent (never empty), mirroring the dense maps so the
-  // sweep's `.get(u)` sees identical undefined-vs-set results.
-  const inSets: Lattice[] = Array.from({ length: n }, () => new Map());
-  const outSets: Lattice[] = Array.from({ length: n }, () => new Map());
-
-  // Budget scaled by binding count — never trips where dense converges (no
-  // regression), still bounds the single-deeply-carried-variable adversarial
-  // case. undefined/0 ⇒ unlimited.
-  const base =
-    limits?.maxBlockVisits && limits.maxBlockVisits > 0 ? limits.maxBlockVisits : Infinity;
-  const maxUpdates = base === Infinity ? Infinity : base * nBindings;
-  let updates = 0;
-
-  // (block, binding) worklist, deduped via a flat pending bitmap. Visit order
-  // does not affect the result (each visit recomputes from current state), so
-  // a LIFO stack is used to avoid O(n) array shifts.
-  const encode = (b: number, v: number): number => b * nBindings + v;
-  const pending = new Uint8Array(n * nBindings);
-  const stack: number[] = [];
-  const enqueue = (b: number, v: number): void => {
-    const k = encode(b, v);
-    if (!pending[k]) {
-      pending[k] = 1;
-      stack.push(k);
+  // ── dominance frontiers (Cytron) ──
+  const df: Set<number>[] = Array.from({ length: nx }, () => new Set<number>());
+  for (let b = 0; b < nx; b++) {
+    const dp = dPredsX[b];
+    if (dp.length < 2) continue;
+    for (const p of dp) {
+      let runner = p;
+      while (runner !== idom[b] && runner !== -1) {
+        df[runner].add(b);
+        runner = idom[runner];
+      }
     }
-  };
+  }
 
-  // Seed: every binding genned in a block (its OUT becomes nonempty), plus the
-  // THROW successors of every gen block — a throwing block delivers allDefs(v)
-  // to its handler even when the block's own IN of v never changes (so the
-  // inChanged-driven throw requeue below would otherwise miss the first, static
-  // allDefs contribution).
+  // ── per-binding def blocks (must- or may-def ⇒ block transfer touches v) ──
+  const defBlocks: number[][] = Array.from({ length: nBindings }, () => []);
   for (let b = 0; b < n; b++) {
     const g = gen[b];
-    if (!g) continue;
-    for (const v of g.keys()) {
-      enqueue(b, v);
-      for (const s of throwSuccs[b]) enqueue(s, v);
-    }
+    if (g) for (const v of g.keys()) defBlocks[v].push(b);
   }
 
-  // Recompute IN(v) at block b from scratch, in the exact dense merge order
-  // (sorted predecessors; first contributor's set shared; copy-on-extend on
-  // subsequent contributors — never mutate a shared set). Returns the set or
-  // undefined when nothing reaches.
-  const computeIn = (b: number, v: number): DefSet | undefined => {
-    const p = preds[b];
-    if (p.length === 0) return undefined;
-    if (p.length === 1 && !p[0].viaThrow) return outSets[p[0].from].get(v);
-    let merged: DefSet | undefined;
-    let owned = false; // true once `merged` is our private (mutable) copy
-    const mergeOne = (src: DefSet | undefined): void => {
-      if (!src || src.size === 0) return;
-      if (merged === undefined) {
-        merged = src; // share the first contributor's set
-        owned = false;
-        return;
-      }
-      if (merged === src) return;
-      for (const key of src) {
-        if (!merged.has(key)) {
-          if (!owned) {
-            merged = new Set(merged);
-            owned = true;
-          }
-          merged.add(key);
+  // ── value-graph nodes: leaves carry def-site keys; internal nodes (φ /
+  //    may-def union) carry operand node ids. reachingSet(node) = union of all
+  //    leaf keys reachable through operands (computed once, cycle-safe, below).
+  const nodeKeys: (DefSet | null)[] = [];
+  const nodeOps: number[][] = [];
+  const newLeaf = (keys: DefSet): number => (
+    nodeKeys.push(keys),
+    nodeOps.push([]),
+    nodeKeys.length - 1
+  );
+  const newInternal = (): number => (nodeKeys.push(null), nodeOps.push([]), nodeKeys.length - 1);
+
+  // ── φ-placement: φ for v at the iterated dominance frontier of v's defs ──
+  const phiNode: (Map<number, number> | null)[] = new Array(nx).fill(null);
+  for (let v = 0; v < nBindings; v++) {
+    const dB = defBlocks[v];
+    if (dB.length === 0) continue;
+    const placed = new Set<number>();
+    const inWork = new Set<number>(dB);
+    const work = [...dB];
+    while (work.length) {
+      const x = work.pop()!;
+      for (const y of df[x]) {
+        if (placed.has(y)) continue;
+        placed.add(y);
+        let m = phiNode[y];
+        if (!m) phiNode[y] = m = new Map();
+        m.set(v, newInternal());
+        if (!inWork.has(y)) {
+          inWork.add(y);
+          work.push(y);
         }
       }
-    };
-    for (const pe of p) {
-      if (pe.viaThrow) {
-        mergeOne(inSets[pe.from].get(v)); // exception may fire pre-defs…
-        mergeOne(allDefsGen[pe.from]?.get(v)); // …or after ANY of the block's defs
-      } else {
-        mergeOne(outSets[pe.from].get(v));
-      }
     }
-    return merged;
-  };
-
-  // OUT(v) at b = overlay(IN): a killing gen replaces the set; a may-def-only
-  // gen unions without killing; no gen ⇒ OUT aliases IN.
-  const computeOut = (b: number, v: number, inV: DefSet | undefined): DefSet | undefined => {
-    const entry = gen[b]?.get(v);
-    if (!entry) return inV;
-    if (entry.kills) return entry.set;
-    return inV ? unionSets(inV, entry.set) : entry.set;
-  };
-
-  const setEq = (a: DefSet | undefined, b: DefSet | undefined): boolean => {
-    if (a === b) return true;
-    if (!a || !b || a.size !== b.size) return false;
-    for (const v of b) if (!a.has(v)) return false;
-    return true;
-  };
-
-  while (stack.length > 0) {
-    if (++updates > maxUpdates) return { converged: false };
-    const k = stack.pop()!;
-    pending[k] = 0;
-    const b = (k / nBindings) | 0;
-    const v = k - b * nBindings;
-
-    const newIn = computeIn(b, v);
-    const oldIn = inSets[b].get(v);
-    const inChanged = !setEq(oldIn, newIn);
-    if (newIn !== undefined) inSets[b].set(v, newIn);
-
-    const newOut = computeOut(b, v, newIn);
-    const oldOut = outSets[b].get(v);
-    const outChanged = !setEq(oldOut, newOut);
-    if (newOut !== undefined) outSets[b].set(v, newOut);
-
-    if (outChanged) for (const s of succs[b]) enqueue(s, v);
-    if (inChanged) for (const s of throwSuccs[b]) enqueue(s, v);
   }
 
-  return { converged: true, inSets };
+  // ── renaming (iterative dominator-tree DFS, per-binding value stacks) ──
+  const domChildren: number[][] = Array.from({ length: nx }, () => []);
+  for (let b = 0; b < nx; b++) if (b !== S && idom[b] !== -1) domChildren[idom[b]].push(b);
+  for (const list of domChildren) list.sort((a, b) => a - b);
+
+  const stacks: number[][] = Array.from({ length: nBindings }, () => []);
+  const entryValue: (Map<number, number> | null)[] = new Array(nx).fill(null);
+
+  const enterBlock = (b: number): number[] => {
+    const pushed: number[] = [];
+    const pm = phiNode[b];
+    if (pm)
+      for (const [v, node] of pm) {
+        stacks[v].push(node);
+        pushed.push(v);
+      }
+    // record block-entry (IN) value for each binding USED here — after φ push,
+    // before this block's own gen (the sweep applies intra-block defs itself).
+    // The synthetic entry S has no block ⇒ no statements/gen/uses.
+    const stmts = cfg.blocks[b]?.statements;
+    if (stmts) {
+      let ev: Map<number, number> | null = null;
+      for (const s of stmts)
+        for (const u of s.uses) {
+          const st = stacks[u];
+          if (st.length) {
+            if (!ev) ev = new Map();
+            ev.set(u, st[st.length - 1]);
+          }
+        }
+      entryValue[b] = ev;
+    }
+    // apply block gen ⇒ OUT values that flow to successors
+    const g = gen[b];
+    if (g)
+      for (const [v, ge] of g) {
+        const st = stacks[v];
+        let node: number;
+        if (ge.kills) {
+          node = newLeaf(ge.set);
+        } else {
+          node = newInternal();
+          if (st.length) nodeOps[node].push(st[st.length - 1]); // prior reaching (may-def keeps it)
+          nodeOps[node].push(newLeaf(ge.set));
+        }
+        st.push(node);
+        pushed.push(v);
+      }
+    // fill successor φ operands with this block's current OUT for each φ binding
+    for (const s of succsX[b]) {
+      const sm = phiNode[s];
+      if (!sm) continue;
+      for (const [v, phi] of sm) {
+        const st = stacks[v];
+        if (st.length) nodeOps[phi].push(st[st.length - 1]);
+      }
+    }
+    return pushed;
+  };
+
+  const frames: { b: number; ci: number; pushed: number[] }[] = [
+    { b: S, ci: 0, pushed: enterBlock(S) },
+  ];
+  while (frames.length) {
+    const f = frames[frames.length - 1];
+    const kids = domChildren[f.b];
+    if (f.ci < kids.length) {
+      const c = kids[f.ci++];
+      frames.push({ b: c, ci: 0, pushed: enterBlock(c) });
+    } else {
+      for (const v of f.pushed) stacks[v].pop();
+      frames.pop();
+    }
+  }
+
+  // ── reaching sets per node via SCC condensation (cycle-safe union) ──
+  // Tarjan emits SCCs in reverse topological order, so an SCC's operand SCCs
+  // are numbered before it ⇒ a single forward pass over SCCs resolves unions.
+  const N = nodeKeys.length;
+  const sccOf = new Array<number>(N).fill(-1);
+  const sccMembers: number[][] = [];
+  const index = new Array<number>(N).fill(-1);
+  const low = new Array<number>(N).fill(0);
+  const onStk = new Array<boolean>(N).fill(false);
+  const tarjanStk: number[] = [];
+  let counter = 0;
+  for (let start = 0; start < N; start++) {
+    if (index[start] !== -1) continue;
+    const work: { node: number; oi: number }[] = [{ node: start, oi: 0 }];
+    index[start] = low[start] = counter++;
+    tarjanStk.push(start);
+    onStk[start] = true;
+    while (work.length) {
+      const top = work[work.length - 1];
+      const ops = nodeOps[top.node];
+      if (top.oi < ops.length) {
+        const w = ops[top.oi++];
+        if (index[w] === -1) {
+          index[w] = low[w] = counter++;
+          tarjanStk.push(w);
+          onStk[w] = true;
+          work.push({ node: w, oi: 0 });
+        } else if (onStk[w] && index[w] < low[top.node]) {
+          low[top.node] = index[w];
+        }
+      } else {
+        if (low[top.node] === index[top.node]) {
+          const members: number[] = [];
+          let w: number;
+          do {
+            w = tarjanStk.pop()!;
+            onStk[w] = false;
+            sccOf[w] = sccMembers.length;
+            members.push(w);
+          } while (w !== top.node);
+          sccMembers.push(members);
+        }
+        work.pop();
+        if (work.length) {
+          const par = work[work.length - 1].node;
+          if (low[top.node] < low[par]) low[par] = low[top.node];
+        }
+      }
+    }
+  }
+  const reachByScc: DefSet[] = new Array(sccMembers.length);
+  for (let s = 0; s < sccMembers.length; s++) {
+    const set: DefSet = new Set();
+    for (const node of sccMembers[s]) {
+      const keys = nodeKeys[node];
+      if (keys) for (const k of keys) set.add(k);
+      for (const w of nodeOps[node]) {
+        const ws = sccOf[w];
+        if (ws !== s) for (const k of reachByScc[ws]) set.add(k);
+      }
+    }
+    reachByScc[s] = set;
+  }
+
+  return {
+    converged: true,
+    reachingAt: (blockIndex, binding) => {
+      const node = entryValue[blockIndex]?.get(binding);
+      if (node === undefined) return undefined;
+      const set = reachByScc[sccOf[node]];
+      return set.size ? set : undefined;
+    },
+  };
+}
+
+/** Minimum block count below which SSA construction does not amortize. */
+const SSA_MIN_BLOCKS = 16;
+
+/**
+ * True iff a cycle is reachable from `entry` (the CFG has a loop). Iterative DFS
+ * with a gray/black coloring; a gray successor is a back-edge. O(V+E).
+ */
+function hasReachableLoop(entry: number, succs: readonly number[][], n: number): boolean {
+  const color = new Uint8Array(n); // 0 white, 1 gray, 2 black
+  const stack: { node: number; i: number }[] = [{ node: entry, i: 0 }];
+  color[entry] = 1;
+  while (stack.length) {
+    const top = stack[stack.length - 1];
+    const ss = succs[top.node];
+    if (top.i < ss.length) {
+      const nx = ss[top.i++];
+      if (color[nx] === 1) return true;
+      if (color[nx] === 0) {
+        color[nx] = 1;
+        stack.push({ node: nx, i: 0 });
+      }
+    } else {
+      color[top.node] = 2;
+      stack.pop();
+    }
+  }
+  return false;
+}
+
+/**
+ * Production solver dispatcher (#2201). The SSA solver beats the dense worklist
+ * only when there is enough work to amortize SSA construction — a loop (so the
+ * dense fixpoint pays the loop-depth pass multiplier, or truncates at the
+ * ceiling) AND a non-trivial block count. Small or loop-free functions, which
+ * dense solves in one or two cheap aliasing passes, stay on the dense path.
+ * Because the two solvers are byte-identical (held by the equivalence fuzz),
+ * this is a pure performance heuristic with no effect on results.
+ *
+ * @internal
+ */
+function computeInSetsAuto(
+  cfg: FunctionCfg,
+  n: number,
+  h: Harvest,
+  adj: Adjacency,
+  limits: ReachingDefsLimits | undefined,
+): InSetsResult {
+  if (n >= SSA_MIN_BLOCKS && hasReachableLoop(cfg.entryIndex, adj.succs, n)) {
+    return computeInSetsSparse(cfg, n, h, adj, limits);
+  }
+  return computeInSetsDense(cfg, n, h, adj, limits);
 }
 
 /**
@@ -631,7 +844,7 @@ function computeInSetsSparse(
  */
 function sweepFacts(
   blocks: FunctionCfg['blocks'],
-  inSets: readonly Lattice[],
+  reachingAt: ReachingAt,
   defLine: ReadonlyMap<number, number>,
   maxFacts: number,
 ): { facts: DefUseFact[]; truncated: boolean } {
@@ -641,9 +854,12 @@ function sweepFacts(
   outer: for (const b of blocks) {
     const stmts = b.statements;
     if (!stmts || stmts.length === 0) continue;
-    // Lazy overlay of IN — entries are replaced (never mutated) on def, so the
-    // shared sets stay intact.
-    let reach: Lattice | null = null;
+    // Sparse intra-block overlay: only the bindings REDEFINED within this block
+    // so far. A use's reaching set is the overlay's override if present, else
+    // the block-entry reaching set (reachingAt). This never materializes the
+    // full block lattice — the dense O(live-vars) per-block copy the sparse
+    // solver exists to avoid.
+    const overlay = new Map<number, DefSet>();
     for (let i = 0; i < stmts.length; i++) {
       const s = stmts[i];
       // A use's binding that the SAME statement also defines could be a
@@ -657,7 +873,7 @@ function sweepFacts(
       const sameStmtDefs =
         s.defs.length > 0 || s.mayDefs?.length ? new Set([...s.defs, ...(s.mayDefs ?? [])]) : null;
       for (const u of s.uses) {
-        const reaching = (reach ?? inSets[b.index]).get(u);
+        const reaching = overlay.get(u) ?? reachingAt(b.index, u);
         const selfKey = sameStmtDefs?.has(u) ? defKey(b.index, i) : undefined;
         if (!reaching && selfKey === undefined) continue;
         const keys =
@@ -690,16 +906,14 @@ function sweepFacts(
       }
       if (s.mayDefs?.length) {
         // Gen WITHOUT kill: the conditional def joins the binding's set.
-        if (!reach) reach = new Map(inSets[b.index]);
         const key = defKey(b.index, i);
         for (const d of s.mayDefs) {
-          const prior = reach.get(d);
-          reach.set(d, prior ? unionSets(prior, new Set([key])) : new Set([key]));
+          const prior = overlay.get(d) ?? reachingAt(b.index, d);
+          overlay.set(d, prior ? unionSets(prior, new Set([key])) : new Set([key]));
         }
       }
       if (s.defs.length > 0) {
-        if (!reach) reach = new Map(inSets[b.index]);
-        for (const d of s.defs) reach.set(d, new Set([defKey(b.index, i)])); // kill + gen
+        for (const d of s.defs) overlay.set(d, new Set([defKey(b.index, i)])); // kill + gen
       }
     }
   }

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -1,8 +1,21 @@
 /**
- * Reaching definitions (#2082 M2 U3) — classic GEN/KILL monotone fixpoint over
- * one function's CFG, plus the canonical intra-block statement sweep that
- * recovers statement-granular def→use facts from M1's coalesced blocks
- * WITHOUT re-splitting the CFG.
+ * Reaching definitions (#2082 M2 U3, SSA-sparse rewrite #2201) — per-function
+ * intraprocedural may-reaching-definitions, plus the canonical intra-block
+ * statement sweep that recovers statement-granular def→use facts from M1's
+ * coalesced blocks WITHOUT re-splitting the CFG.
+ *
+ * ARCHITECTURE (#2201): the analysis is split into solver-INDEPENDENT stages
+ * (shared by both solvers, so the byte-identical surface is maximal) and a
+ * swappable IN-set computation:
+ *   - {@link harvestStatementFacts} — per-block GEN/allDefs + def/use telemetry.
+ *   - {@link buildAdjacency} — throw-aware predecessor/successor adjacency.
+ *   - the IN-set computer — produces per-block entry reaching lattices. Two
+ *     exist: {@link computeInSetsSparse} (production, change-driven per binding)
+ *     and {@link computeInSetsDense} (the original GEN/KILL worklist, RETAINED
+ *     as the differential equivalence oracle). They MUST produce identical
+ *     inSets, including set INSERTION order (the maxFacts-truncated subset
+ *     depends on the sweep's pre-sort emission order — see {@link sweepFacts}).
+ *   - {@link sweepFacts} — statement sweep + sort + maxFacts truncation.
  *
  * PURE AND DETERMINISTIC (load-bearing contract):
  *  - Pure function of its inputs — no graph, no logger (warnings are the
@@ -14,17 +27,10 @@
  *    insertion-ordered Maps/Sets throughout, and the output fact array is
  *    explicitly sorted. Snapshot tests and content-derived edge ids rely on it.
  *
- * COMPLEXITY DISCIPLINE (the four-times-repeated repo bug shape is per-item
- * re-derivation inside the loop): def-sets are SHARED BY REFERENCE, never
- * deep-copied — a MUST def's kill is total per binding, so a transfer either
- * aliases the incoming set or replaces it; a MAY def (conditional context —
- * see StatementFacts.mayDefs) unions WITHOUT killing via a copy-on-extend.
- * Single-predecessor blocks alias the predecessor's OUT map outright;
- * multi-pred merges union only bindings whose incoming sets differ by
- * reference. Iteration is reverse post-order, seeded with every block
- * (unreachable blocks keep ⊥ IN — correct, their defs reach nothing).
- * Convergence: sets grow monotonically within the finite def-site universe ⇒
- * ≤ loop-depth+1 passes in practice.
+ * COMPLEXITY DISCIPLINE: def-sets are SHARED BY REFERENCE, never deep-copied —
+ * a MUST def's kill is total per binding, so a transfer either aliases the
+ * incoming set or replaces it; a MAY def (conditional context — see
+ * StatementFacts.mayDefs) unions WITHOUT killing via a copy-on-extend.
  *
  * `limits.maxFacts` bounds materialization: facts are O(defs×uses) BY SPEC in
  * merge-heavy code (N branch-arm defs × N later uses = N² facts), and a
@@ -68,14 +74,24 @@ export interface ReachingDefsLimits {
    */
   readonly maxFacts?: number;
   /**
-   * Maximum total block dequeues in the dataflow fixpoint. Iterative
+   * Adversarial-only safety bound on solver work.
+   *
+   * The DENSE oracle reads this as a ceiling on total block dequeues: iterative
    * reaching-defs on a reducible CFG converges in O(loop-nesting-depth) passes,
-   * so a worklist visits each block a small multiple of times for real code; a
-   * pathologically deep loop nest (machine-generated / obfuscated) drives the
-   * pass count — and thus the visit total — to O(blocks²) and the solver to
-   * seconds + GB of heap (`maxFacts` does not help: fact count stays linear).
-   * When the visit total exceeds this budget the fixpoint has NOT converged, so
-   * any facts would be unsound — the solver bails to a sound empty
+   * but a pathologically deep loop nest drives the visit total — and thus the
+   * solver — to O(blocks²), seconds + GB of heap (`maxFacts` does not help: fact
+   * count stays linear).
+   *
+   * The SPARSE solver (#2201) reads it as a ceiling on total (block, binding)
+   * dequeues. Because the sparse solve is change-driven per binding, realistic
+   * deep nests (loop-local / shallow variables) cost ~O(blocks) and complete far
+   * under this budget — the ceiling that fired on the dense worklist effectively
+   * never fires on real code. A single variable threaded through every level of
+   * an adversarial deep nest is the one residual O(depth²) shape (a documented
+   * SSA follow-up); it still bails soundly here.
+   *
+   * On either solver, exceeding the budget means the fixpoint has NOT converged,
+   * so any facts would be unsound — the solver bails to a sound empty
    * `status: 'truncated'` (like the `overflow` guard). `undefined`/0 ⇒ unlimited
    * (the default for direct callers; the emit path sets a per-function budget).
    */
@@ -111,7 +127,7 @@ export interface FunctionDefUse {
  * statements into one block, so an overflow would silently alias
  * (block b, stmt STRIDE+k) with (block b+1, stmt k) and fabricate wrong-block
  * facts. computeReachingDefs therefore range-checks up front and bails to a
- * sound empty `truncated` result instead of ever letting a key alias.
+ * sound empty `overflow` result instead of ever letting a key alias.
  * 2^21 statements per block × blocks ≤ 2^32 stays inside Number's 2^53.
  */
 const STMT_STRIDE = 1 << 21;
@@ -124,27 +140,67 @@ type Lattice = Map<number, DefSet>;
 
 const EMPTY_LATTICE: Lattice = new Map();
 
+/** A block's GEN entry for one binding: the genned set + whether it kills. */
+interface GenEntry {
+  set: DefSet;
+  kills: boolean;
+}
+
+/** Solver-independent per-block facts (shared by both IN-set computers). */
+interface Harvest {
+  /** gen[b]: bindingIdx → { set, kills }. A MUST def kills; a MAY def adds. */
+  readonly gen: readonly (Map<number, GenEntry> | null)[];
+  /** allDefsGen[b]: bindingIdx → EVERY def-site key in the block (throw edges). */
+  readonly allDefsGen: readonly (Lattice | null)[];
+  readonly defLine: ReadonlyMap<number, number>;
+  readonly defCount: number;
+  readonly useCount: number;
+}
+
+/** Throw-aware adjacency (shared by both IN-set computers). */
+interface Adjacency {
+  readonly preds: readonly { from: number; viaThrow: boolean }[][];
+  readonly succs: readonly number[][];
+  /** Handlers whose IN depends on a block's IN (throw edges). */
+  readonly throwSuccs: readonly number[][];
+}
+
+/**
+ * The swappable stage: per-block entry reaching lattices, or a non-convergence
+ * signal (maxBlockVisits exceeded ⇒ sound empty `truncated`). The two
+ * implementations MUST agree byte-for-byte, including set insertion order.
+ */
+type InSetsResult = { converged: true; inSets: Lattice[] } | { converged: false };
+
+type InSetsComputer = (
+  cfg: FunctionCfg,
+  n: number,
+  h: Harvest,
+  adj: Adjacency,
+  limits: ReachingDefsLimits | undefined,
+) => InSetsResult;
+
 /**
  * Compute reaching definitions for one function. See the module doc for the
  * purity/determinism/sharing contract.
  *
- * This is the production entry point. As of #2201 it delegates to the
- * SSA-sparse solver ({@link computeReachingDefsSparse}); the dense GEN/KILL
- * worklist ({@link computeReachingDefsDense}) is retained as the differential
+ * This is the production entry point. As of #2201 it runs the sparse, change-
+ * driven solver ({@link computeInSetsSparse}); the dense GEN/KILL worklist
+ * ({@link computeReachingDefsDense}) is retained as the differential
  * equivalence oracle the fuzz suite checks the sparse path against — the two
  * MUST be byte-identical (status, bindings, sorted facts, def/use telemetry).
  */
 export function computeReachingDefs(cfg: FunctionCfg, limits?: ReachingDefsLimits): FunctionDefUse {
-  // #2201 U1: production still runs the dense solver; the swap to sparse lands
-  // in U5 once the differential fuzz is byte-identical green.
-  return computeReachingDefsDense(cfg, limits);
+  // #2201: production still runs the dense solver until U5 flips this to
+  // computeInSetsSparse (once the differential fuzz is byte-identical green).
+  return solveReachingDefs(cfg, limits, computeInSetsDense);
 }
 
 /**
  * Dense GEN/KILL monotone worklist — the original (#2082 M2) reaching-defs
  * solver. As of #2201 this is RETAINED AS A TEST/BENCH-ONLY DIFFERENTIAL
  * ORACLE, not a production code path: {@link computeReachingDefs} runs the
- * SSA-sparse solver, and the equivalence fuzz asserts the two are byte-identical
+ * sparse solver, and the equivalence fuzz asserts the two are byte-identical
  * across a random-CFG corpus. Keep it behavior-frozen — it is the ground truth.
  *
  * @internal exported only for the equivalence fuzz harness and the cfg bench.
@@ -152,6 +208,21 @@ export function computeReachingDefs(cfg: FunctionCfg, limits?: ReachingDefsLimit
 export function computeReachingDefsDense(
   cfg: FunctionCfg,
   limits?: ReachingDefsLimits,
+): FunctionDefUse {
+  return solveReachingDefs(cfg, limits, computeInSetsDense);
+}
+
+/**
+ * Shared orchestrator: the no-facts / overflow guards, the harvest, the
+ * adjacency build, the swappable IN-set computation, and the statement sweep.
+ * Only `computeInSets` differs between the production (sparse) and oracle
+ * (dense) paths — everything else is identical, which is what makes the two
+ * byte-identical by construction.
+ */
+function solveReachingDefs(
+  cfg: FunctionCfg,
+  limits: ReachingDefsLimits | undefined,
+  computeInSets: InSetsComputer,
 ): FunctionDefUse {
   if (!cfg.bindings) {
     return { status: 'no-facts', bindings: [], facts: [], defCount: 0, useCount: 0 };
@@ -170,51 +241,46 @@ export function computeReachingDefsDense(
     }
   }
 
-  // ── adjacency (sorted for deterministic merges) ─────────────────────────
-  // A `throw` edge contributes IN(from) ∪ allDefs(from) to its handler, not
-  // OUT: an exception can fire BEFORE the block's defs complete (the seed def
-  // in `let x = seed(); try { x = risky(); } catch { sink(x) }` must reach the
-  // sink) AND between any two defs of a multi-def coalesced block (the parse
-  // def in `x = parse(a); x = normalize(x);` is live exactly when normalize
-  // throws — OUT's last-def-wins misses it). Sound over-approximation;
-  // monotone, so the fixpoint absorbs it. See mergePreds.
-  const preds: { from: number; viaThrow: boolean }[][] = Array.from({ length: n }, () => []);
-  const succs: number[][] = Array.from({ length: n }, () => []);
-  // Handlers whose IN depends on this block's IN (throw edges) — requeued on
-  // IN change, since a genned binding can absorb IN growth without changing
-  // OUT, which would otherwise leave the handler stale.
-  const throwSuccs: number[][] = Array.from({ length: n }, () => []);
-  for (const e of cfg.edges) {
-    // Optional-chained pushes drop out-of-range endpoints defensively — the
-    // emit path validates via isEmitSafeCfg, but this pure function also runs
-    // on hand-built CFGs.
-    succs[e.from]?.push(e.to);
-    preds[e.to]?.push({ from: e.from, viaThrow: e.kind === 'throw' });
-    if (e.kind === 'throw') throwSuccs[e.from]?.push(e.to);
+  const h = harvestStatementFacts(blocks, n);
+  const adj = buildAdjacency(cfg, n);
+  const solved = computeInSets(cfg, n, h, adj, limits);
+  if (!solved.converged) {
+    // Did NOT converge within the budget — the in-sets are not at the fixpoint,
+    // so any facts would be unsound. Bail to a sound empty `truncated` result
+    // (a coverage gap, not an error), carrying the def/use telemetry gathered.
+    return {
+      status: 'truncated',
+      bindings: cfg.bindings,
+      facts: [],
+      defCount: h.defCount,
+      useCount: h.useCount,
+    };
   }
-  for (const list of preds) {
-    list.sort((a, b) => a.from - b.from || Number(a.viaThrow) - Number(b.viaThrow));
-    // duplicate (from, throw+non-throw) pairs both survive — the throw leg
-    // adds IN(from); the merge dedups set-wise.
-  }
-  for (const list of succs) list.sort((a, b) => a - b);
 
-  // ── per-block GEN + def/use telemetry ────────────────────────────────────
-  // gen[b]: bindingIdx → { set, kills }. A MUST def resets the accumulated
-  // set (kill is total); a MAY def (conditionally-evaluated context — see
-  // StatementFacts.mayDefs) only ADDS: the binding's incoming defs survive,
-  // so the transfer is out[x] = kills ? set : in[x] ∪ set.
-  interface GenEntry {
-    set: DefSet;
-    kills: boolean;
-  }
+  const maxFacts = limits?.maxFacts && limits.maxFacts > 0 ? limits.maxFacts : Infinity;
+  const { facts, truncated } = sweepFacts(blocks, solved.inSets, h.defLine, maxFacts);
+
+  return {
+    status: truncated ? 'truncated' : 'computed',
+    bindings: cfg.bindings,
+    facts,
+    defCount: h.defCount,
+    useCount: h.useCount,
+  };
+}
+
+/**
+ * Per-block GEN + def/use telemetry. gen[b]: bindingIdx → { set, kills }. A
+ * MUST def resets the accumulated set (kill is total); a MAY def (conditionally-
+ * evaluated context — see StatementFacts.mayDefs) only ADDS: the binding's
+ * incoming defs survive, so the transfer is out[x] = kills ? set : in[x] ∪ set.
+ * allDefsGen[b] is what a throw edge delivers to its handler: an exception can
+ * fire between any two statements, so every intermediate def may be the live one
+ * at the handler — IN∪OUT alone misses defs overwritten later in the same
+ * coalesced block.
+ */
+function harvestStatementFacts(blocks: FunctionCfg['blocks'], n: number): Harvest {
   const gen: (Map<number, GenEntry> | null)[] = new Array(n).fill(null);
-  // allDefsGen[b]: bindingIdx → EVERY def-site key in the block (must + may).
-  // This is what a throw edge delivers to its handler: an exception can fire
-  // between any two statements, so every intermediate def may be the live one
-  // at the handler — IN∪OUT alone misses defs overwritten later in the same
-  // coalesced block (`try { x = parse(a); x = normalize(x); } catch { sink(x) }`
-  // — parse's value is exactly what sink sees when normalize throws).
   const allDefsGen: (Lattice | null)[] = new Array(n).fill(null);
   const defLine = new Map<number, number>(); // defKey → source line
   let defCount = 0;
@@ -249,31 +315,73 @@ export function computeReachingDefsDense(
     gen[b.index] = g;
     allDefsGen[b.index] = all;
   }
+  return { gen, allDefsGen, defLine, defCount, useCount };
+}
 
-  // ── iteration order: RPO over reachable blocks, then the rest by index ──
-  // WTO / loop-aware iteration (Bourdoncle 1993) was evaluated as a fix for the
-  // O(blocks²) deep-loop-nest blow-up and REJECTED: on the dense-loop benchmark a
-  // faithful weak-topological-order solver was 104/104 byte-identical to this RPO
-  // worklist but 0% faster. The cost is inherent to dense-set propagation +
-  // lattice merges on the iterated dominance frontier, not to visitation order, so
-  // re-ordering passes buys nothing; the "skip re-evaluating a loop body once its
-  // header stabilises" shortcut is additionally unsound on irreducible (goto)
-  // CFGs. The sound, shipped backstop is the maxBlockVisits ceiling below (a
-  // blocks×64 budget — see emit.ts DEFAULT_PDG_MAX_REACHING_DEF_BLOCK_REVISITS),
-  // which truncates the pathological nest to a sound-empty result. The only real
-  // asymptotic fix is SSA-sparse reaching-defs (propagate along def-use chains, not
-  // dense block sets) — deferred to a tracked follow-up, not a reordering tweak.
+/**
+ * Throw-aware predecessor/successor adjacency, sorted for deterministic merges.
+ * A `throw` edge contributes IN(from) ∪ allDefs(from) to its handler, not OUT:
+ * an exception may fire BEFORE the block's defs complete (the seed def in
+ * `let x = seed(); try { x = risky(); } catch { sink(x) }` must reach the sink)
+ * AND between any two defs of a multi-def coalesced block. Sound over-
+ * approximation; monotone, so the fixpoint absorbs it. See mergePreds.
+ */
+function buildAdjacency(cfg: FunctionCfg, n: number): Adjacency {
+  const preds: { from: number; viaThrow: boolean }[][] = Array.from({ length: n }, () => []);
+  const succs: number[][] = Array.from({ length: n }, () => []);
+  // Handlers whose IN depends on this block's IN (throw edges) — requeued on
+  // IN change, since a genned binding can absorb IN growth without changing
+  // OUT, which would otherwise leave the handler stale.
+  const throwSuccs: number[][] = Array.from({ length: n }, () => []);
+  for (const e of cfg.edges) {
+    // Optional-chained pushes drop out-of-range endpoints defensively — the
+    // emit path validates via isEmitSafeCfg, but this pure function also runs
+    // on hand-built CFGs.
+    succs[e.from]?.push(e.to);
+    preds[e.to]?.push({ from: e.from, viaThrow: e.kind === 'throw' });
+    if (e.kind === 'throw') throwSuccs[e.from]?.push(e.to);
+  }
+  for (const list of preds) {
+    list.sort((a, b) => a.from - b.from || Number(a.viaThrow) - Number(b.viaThrow));
+    // duplicate (from, throw+non-throw) pairs both survive — the throw leg
+    // adds IN(from); the merge dedups set-wise.
+  }
+  for (const list of succs) list.sort((a, b) => a - b);
+  return { preds, succs, throwSuccs };
+}
+
+/**
+ * DENSE IN-set computer — the original monotone GEN/KILL worklist. Iterates in
+ * reverse post-order, seeded with every block (unreachable blocks keep ⊥ IN —
+ * correct, their defs reach nothing). Convergence: sets grow monotonically
+ * within the finite def-site universe ⇒ ≤ loop-depth+1 passes in practice.
+ *
+ * WTO / loop-aware iteration (Bourdoncle 1993) was evaluated as a fix for the
+ * O(blocks²) deep-loop-nest blow-up and REJECTED (#2195): on the dense-loop
+ * benchmark a faithful weak-topological-order solver was 104/104 byte-identical
+ * but 0% faster — the cost is inherent to dense-set propagation + lattice
+ * merges, not visitation order. The asymptotic fix is the sparse, change-driven
+ * solver ({@link computeInSetsSparse}); this dense version is retained only as
+ * the differential equivalence oracle.
+ *
+ * @internal
+ */
+function computeInSetsDense(
+  cfg: FunctionCfg,
+  n: number,
+  h: Harvest,
+  adj: Adjacency,
+  limits: ReachingDefsLimits | undefined,
+): InSetsResult {
+  const { gen, allDefsGen } = h;
+  const { preds, succs, throwSuccs } = adj;
   const order = reversePostOrder(cfg.entryIndex, succs, n);
 
-  // ── fixpoint ────────────────────────────────────────────────────────────
   const inSets: Lattice[] = new Array(n).fill(EMPTY_LATTICE);
   const outSets: Lattice[] = new Array(n).fill(EMPTY_LATTICE);
 
   const inWorklist = new Array(n).fill(true);
   let pending = n;
-  // Fixpoint-iteration ceiling (see ReachingDefsLimits.maxBlockVisits): bound the
-  // total block dequeues so a pathologically deep loop nest can't drive the
-  // worklist to O(blocks²). undefined/0 ⇒ unlimited.
   const maxBlockVisits =
     limits?.maxBlockVisits && limits.maxBlockVisits > 0 ? limits.maxBlockVisits : Infinity;
   let blockVisits = 0;
@@ -282,13 +390,7 @@ export function computeReachingDefsDense(
       if (!inWorklist[b]) continue;
       inWorklist[b] = false;
       pending -= 1;
-      if (++blockVisits > maxBlockVisits) {
-        // Did NOT converge within the budget — the in/out sets are not at the
-        // fixpoint, so any facts would be unsound. Bail to a sound empty
-        // `truncated` result (a coverage gap, not an error), carrying the def/use
-        // telemetry already gathered.
-        return { status: 'truncated', bindings: cfg.bindings, facts: [], defCount, useCount };
-      }
+      if (++blockVisits > maxBlockVisits) return { converged: false };
 
       const p = preds[b];
       const inB: Lattice =
@@ -333,8 +435,23 @@ export function computeReachingDefsDense(
     }
   }
 
-  // ── statement sweep: recover statement-granular def→use facts ───────────
-  const maxFacts = limits?.maxFacts && limits.maxFacts > 0 ? limits.maxFacts : Infinity;
+  return { converged: true, inSets };
+}
+
+/**
+ * Statement sweep — recover statement-granular def→use facts from the per-block
+ * entry reaching lattices, sort them, and apply the maxFacts truncation. SHARED
+ * by both solvers: the truncated SUBSET depends on the pre-sort emission order
+ * here (block index, then statement index, then use order, then the reaching
+ * set's INSERTION order), so producing identical inSets — insertion order
+ * included — is what makes a truncated result byte-identical across solvers.
+ */
+function sweepFacts(
+  blocks: FunctionCfg['blocks'],
+  inSets: readonly Lattice[],
+  defLine: ReadonlyMap<number, number>,
+  maxFacts: number,
+): { facts: DefUseFact[]; truncated: boolean } {
   const facts: DefUseFact[] = [];
   let truncated = false;
 
@@ -403,13 +520,7 @@ export function computeReachingDefsDense(
       a.bindingIdx - b.bindingIdx,
   );
 
-  return {
-    status: truncated ? 'truncated' : 'computed',
-    bindings: cfg.bindings,
-    facts,
-    defCount,
-    useCount,
-  };
+  return { facts, truncated };
 }
 
 /** RPO over blocks reachable from `entry`; unreachable blocks appended by index. */

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -191,9 +191,10 @@ type InSetsComputer = (
  * MUST be byte-identical (status, bindings, sorted facts, def/use telemetry).
  */
 export function computeReachingDefs(cfg: FunctionCfg, limits?: ReachingDefsLimits): FunctionDefUse {
-  // #2201: production still runs the dense solver until U5 flips this to
-  // computeInSetsSparse (once the differential fuzz is byte-identical green).
-  return solveReachingDefs(cfg, limits, computeInSetsDense);
+  // #2201 U5: production runs the sparse, change-driven solver. The dense
+  // worklist ({@link computeReachingDefsDense}) is retained as the differential
+  // equivalence oracle the fuzz suite holds this byte-identical to.
+  return solveReachingDefs(cfg, limits, computeInSetsSparse);
 }
 
 /**

--- a/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
+++ b/gitnexus/src/core/ingestion/cfg/reaching-defs.ts
@@ -985,4 +985,3 @@ function mergePreds(
   }
   return merged;
 }
-

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -415,6 +415,14 @@ export const resolvePdgConfig = (options: PdgOptions): RepoMeta['pdg'] =>
         // outlive the model that produced them — ANY model-content change
         // ships as a new digest and repopulates the taint edges.
         taintModelVersion,
+        // #2201 review R3: reaching-defs solver identity. The SSA-sparse rewrite
+        // computes full facts for deep-loop functions the dense worklist used to
+        // truncate to empty, so an existing `--pdg` index carries stale-truncated
+        // REACHING_DEF rows. Absent on any pre-#2201 stamp → the key-union
+        // pdgModeMismatch trips on the first upgraded run and forces the full
+        // writeback that recomputes the fuller coverage (no `--force` needed).
+        // Bump this tag on any future change to which facts the solver emits.
+        reachingDefSolver: 'ssa-sparse-v1',
       }
     : undefined;
 

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -194,6 +194,19 @@ export interface RepoMeta {
      * without `--force`. Optional: absent on pre-M3 stamps.
      */
     taintModelVersion?: string;
+    /**
+     * Identity of the reaching-definitions solver the persisted REACHING_DEF
+     * rows were produced under (#2201 review R3). The SSA-sparse rewrite computes
+     * FULL facts for deep-loop functions the old dense worklist truncated to
+     * empty (the blocks×64 ceiling no longer fires) — but an existing `--pdg`
+     * index built under the old solver carries those truncated rows. ABSENT on
+     * any pre-#2201 stamp, so that absence trips `pdgModeMismatch` on the first
+     * upgraded run and forces the full writeback that recomputes the now-fuller
+     * REACHING_DEF coverage without `--force`. Bump the tag on any future change
+     * that alters which facts the solver emits. Optional for that upgrade reason;
+     * resolved (always present) on every post-#2201 write.
+     */
+    reachingDefSolver?: string;
   };
 }
 

--- a/gitnexus/test/unit/cfg/reaching-defs-equivalence.test.ts
+++ b/gitnexus/test/unit/cfg/reaching-defs-equivalence.test.ts
@@ -24,6 +24,7 @@ import { describe, it, expect } from 'vitest';
 import {
   computeReachingDefs,
   computeReachingDefsDense,
+  computeReachingDefsSparse,
   type FunctionDefUse,
   type ReachingDefsLimits,
 } from '../../../src/core/ingestion/cfg/reaching-defs.js';
@@ -393,7 +394,18 @@ interface CorpusResult {
   firstFailure: string | null;
 }
 
-function runCorpus(left: Solver, right: Solver, count: number, baseSeed: number): CorpusResult {
+function runCorpus(
+  left: Solver,
+  right: Solver,
+  count: number,
+  baseSeed: number,
+  // maxBlockVisits has DIFFERENT (intentional) semantics across the dense and
+  // sparse solvers — dense counts block dequeues, sparse counts (block,binding)
+  // dequeues — so a small budget truncates them at different points. Perturb it
+  // only when comparing a solver against ITSELF (same semantics); cross-solver
+  // byte-identity is asserted with the budget unlimited (both fully converge).
+  perturbBlockVisits = true,
+): CorpusResult {
   const flags: ShapeFlags = {
     hasLoop: false,
     hasThrow: false,
@@ -425,7 +437,7 @@ function runCorpus(left: Solver, right: Solver, count: number, baseSeed: number)
     check(cfg, undefined, `canon[${i}]`);
     check(cfg, { maxFacts: 1 }, `canon[${i}]/maxFacts=1`);
     check(cfg, { maxFacts: 2 }, `canon[${i}]/maxFacts=2`);
-    check(cfg, { maxBlockVisits: 2 }, `canon[${i}]/maxBlockVisits=2`);
+    if (perturbBlockVisits) check(cfg, { maxBlockVisits: 2 }, `canon[${i}]/maxBlockVisits=2`);
   }
 
   // random corpus
@@ -437,7 +449,9 @@ function runCorpus(left: Solver, right: Solver, count: number, baseSeed: number)
     // exercise truncation on ~1/4 of cases (small maxFacts) and the block-visit
     // ceiling on ~1/8 — both must match byte-for-byte (KTD6).
     if (i % 4 === 0) check(cfg, { maxFacts: 1 + (i % 3) }, `seed=${seed}/maxFacts`);
-    if (i % 8 === 0) check(cfg, { maxBlockVisits: 1 + (i % 4) }, `seed=${seed}/maxBlockVisits`);
+    if (perturbBlockVisits && i % 8 === 0) {
+      check(cfg, { maxBlockVisits: 1 + (i % 4) }, `seed=${seed}/maxBlockVisits`);
+    }
   }
 
   return { checked, flags, firstFailure };
@@ -474,11 +488,58 @@ describe('#2201 reaching-defs differential equivalence', () => {
     expect(a.flags).toEqual(b.flags);
   });
 
-  it('PRODUCTION computeReachingDefs is byte-identical to the dense oracle', () => {
-    // U1: computeReachingDefs still delegates to dense, so this is trivially
-    // green. U5 swaps it to the sparse solver — this becomes the real gate.
-    const r = runCorpus(computeReachingDefs, computeReachingDefsDense, CORPUS_N, 0x5eed);
+  it('the SPARSE solver is byte-identical to the dense oracle (#2201 gate)', () => {
+    // The load-bearing equivalence gate: sparse vs dense across the full corpus,
+    // budget unlimited so both fully converge. maxFacts truncation IS compared
+    // (it must match byte-for-byte — KTD6); maxBlockVisits is not (the two count
+    // different things on purpose — that contrast is the no-regression test).
+    const r = runCorpus(
+      computeReachingDefsSparse,
+      computeReachingDefsDense,
+      CORPUS_N,
+      0x2201,
+      /* perturbBlockVisits */ false,
+    );
     expect(r.firstFailure).toBeNull();
+    expect(r.flags.hadComputed && r.flags.hadTruncated).toBe(true);
+  });
+
+  it('PRODUCTION computeReachingDefs is byte-identical to the dense oracle', () => {
+    // U1: computeReachingDefs delegates to dense (trivially green). U5 swaps it
+    // to the sparse solver — this stays the production-entry gate.
+    const r = runCorpus(
+      computeReachingDefs,
+      computeReachingDefsDense,
+      CORPUS_N,
+      0x5eed,
+      /* perturbBlockVisits */ false,
+    );
+    expect(r.firstFailure).toBeNull();
+  });
+
+  it('sparse never regresses coverage under the production block-visit budget', () => {
+    // Production posture: emit passes maxBlockVisits = blocks × 64. The contract
+    // is one-directional — wherever the dense solver COMPUTES, the sparse solver
+    // must also compute and produce identical facts (no lost REACHING_DEF
+    // coverage). The reverse is allowed and desired: sparse may compute deep
+    // nests the dense solver truncates (the #2201 ceiling-stops-firing win).
+    let regressions = 0;
+    let firstRegression: string | null = null;
+    for (let i = 0; i < CORPUS_N; i++) {
+      const cfg = genCfg(0xc0de + i);
+      const budget = { maxBlockVisits: cfg.blocks.length * 64 };
+      const dense = computeReachingDefsDense(cfg, budget);
+      const sparse = computeReachingDefsSparse(cfg, budget);
+      if (dense.status === 'computed') {
+        const d = diffDefUse(dense, sparse);
+        if (d) {
+          regressions++;
+          if (!firstRegression) firstRegression = `seed=${0xc0de + i}: ${d}`;
+        }
+      }
+    }
+    expect(firstRegression).toBeNull();
+    expect(regressions).toBe(0);
   });
 });
 

--- a/gitnexus/test/unit/cfg/reaching-defs-equivalence.test.ts
+++ b/gitnexus/test/unit/cfg/reaching-defs-equivalence.test.ts
@@ -76,7 +76,13 @@ interface GenOpts {
 }
 
 const DEFAULT_GEN: GenOpts = {
-  maxBlocks: 14,
+  // Span both sides of the production SSA dispatch threshold (SSA_MIN_BLOCKS=16):
+  // CFGs below it route the auto-dispatcher (computeReachingDefs) to dense, those
+  // above with a reachable loop route it to the SSA path — so the corpus
+  // differentially exercises BOTH branches of computeInSetsAuto, not just the
+  // forced-SSA computeReachingDefsSparse entry. See the hadLargeLoop coverage
+  // guard below.
+  maxBlocks: 36,
   maxBindings: 8,
   maxStmtsPerBlock: 4,
   pNoBindings: 0.03,
@@ -295,6 +301,22 @@ function canonicalHardCfgs(): FunctionCfg[] {
     ),
   );
 
+  // (6) Back-edge into the ENTRY block: 0 (def+use x) → 1 (def+use x) → 0 (loop
+  // back to entry) and 1 → 2 (exit, use x). The SSA solver's synthetic pre-entry
+  // node exists precisely for this — the entry is a loop header, so x's loop-
+  // carried def must reach the entry's own use. Pins that path deterministically.
+  out.push(
+    mk(
+      [blk(0, [st(1, [0], [0])]), blk(1, [st(2, [0], [0])]), blk(2, [st(3, [], [0])])],
+      [
+        { from: 0, to: 1, kind: 'seq' },
+        { from: 1, to: 0, kind: 'loop-back' },
+        { from: 1, to: 2, kind: 'cond-false' },
+      ],
+      [bind('x', 1)],
+    ),
+  );
+
   return out;
 }
 
@@ -333,6 +355,10 @@ interface ShapeFlags {
   hasShadow: boolean;
   hasMultiPred: boolean;
   hasUnreachable: boolean;
+  // ≥16-block CFG (SSA_MIN_BLOCKS) with a loop reachable from entry — the exact
+  // shape the production dispatcher (computeInSetsAuto) sends to the SSA solver.
+  // Asserting it proves the auto-dispatcher's SSA branch is differentially fuzzed.
+  hadLargeLoop: boolean;
   hadComputed: boolean;
   hadTruncated: boolean;
   hadNoFacts: boolean;
@@ -385,6 +411,22 @@ function classify(cfg: FunctionCfg, flags: ShapeFlags): void {
     for (const y of succ[x]) if (!seen[y]) ((seen[y] = true), q.push(y));
   }
   if (seen.some((v, i) => !v && i < n)) flags.hasUnreachable = true;
+
+  // loop reachable from entry (matches the dispatcher's hasReachableLoop) +
+  // ≥16 blocks ⇒ the production auto-dispatcher routes this CFG to the SSA path.
+  const c2 = new Array(n).fill(0);
+  let entryLoop = false;
+  const st2: { node: number; idx: number }[] = [{ node: cfg.entryIndex, idx: 0 }];
+  c2[cfg.entryIndex] = 1;
+  while (st2.length && !entryLoop) {
+    const top = st2[st2.length - 1];
+    if (top.idx < succ[top.node].length) {
+      const v = succ[top.node][top.idx++];
+      if (c2[v] === 1) entryLoop = true;
+      else if (c2[v] === 0) ((c2[v] = 1), st2.push({ node: v, idx: 0 }));
+    } else ((c2[top.node] = 2), st2.pop());
+  }
+  if (n >= 16 && entryLoop) flags.hadLargeLoop = true;
 }
 
 // ── corpus runner ──────────────────────────────────────────────────────────
@@ -399,11 +441,13 @@ function runCorpus(
   right: Solver,
   count: number,
   baseSeed: number,
-  // maxBlockVisits has DIFFERENT (intentional) semantics across the dense and
-  // sparse solvers — dense counts block dequeues, sparse counts (block,binding)
-  // dequeues — so a small budget truncates them at different points. Perturb it
-  // only when comparing a solver against ITSELF (same semantics); cross-solver
-  // byte-identity is asserted with the budget unlimited (both fully converge).
+  // maxBlockVisits has DIFFERENT (intentional) semantics across the solvers: the
+  // dense worklist counts block dequeues against it; the SSA solver has no
+  // fixpoint iteration and ignores it in its main path (it only flows through to
+  // the dense fallback for throw-edge/unreachable functions). So a tight budget
+  // truncates them at different points. Perturb it only when comparing a solver
+  // against ITSELF (same semantics); cross-solver byte-identity is asserted with
+  // the budget unlimited (both fully converge).
   perturbBlockVisits = true,
 ): CorpusResult {
   const flags: ShapeFlags = {
@@ -411,6 +455,7 @@ function runCorpus(
     hasThrow: false,
     hasMayDef: false,
     hasShadow: false,
+    hadLargeLoop: false,
     hasMultiPred: false,
     hasUnreachable: false,
     hadComputed: false,
@@ -476,6 +521,7 @@ describe('#2201 reaching-defs differential equivalence', () => {
     expect(f.hasShadow, 'shadowed bindings').toBe(true);
     expect(f.hasMultiPred, 'multi-pred joins').toBe(true);
     expect(f.hasUnreachable, 'unreachable blocks').toBe(true);
+    expect(f.hadLargeLoop, '≥16-block looping CFGs (production SSA dispatch path)').toBe(true);
     expect(f.hadComputed, 'computed results').toBe(true);
     expect(f.hadTruncated, 'truncated results').toBe(true);
     expect(f.hadNoFacts, 'no-facts results').toBe(true);

--- a/gitnexus/test/unit/cfg/reaching-defs-equivalence.test.ts
+++ b/gitnexus/test/unit/cfg/reaching-defs-equivalence.test.ts
@@ -317,6 +317,25 @@ function canonicalHardCfgs(): FunctionCfg[] {
     ),
   );
 
+  // (7) Malformed input: an OUT-OF-RANGE binding index (≥ nBindings, e.g. from a
+  // corrupted/stale durable store) in a looping CFG. The dense solver tolerates
+  // it (its lattice is a Map keyed by index); the SSA path must fall back to
+  // dense rather than crash its nBindings-sized arrays. Asserting byte-identity
+  // here pins that gate — without it, the SSA path throws and the differential
+  // comparison can never reach this divergent input (the generator only ever
+  // emits in-range indices).
+  out.push(
+    mk(
+      [blk(0, [st(1, [0], [])]), blk(1, [st(2, [3], [3])]), blk(2, [st(3, [], [0])])],
+      [
+        { from: 0, to: 1, kind: 'seq' },
+        { from: 1, to: 1, kind: 'loop-back' },
+        { from: 1, to: 2, kind: 'cond-false' },
+      ],
+      [bind('x', 1)], // nBindings = 1, so binding index 3 in block 1 is out of range
+    ),
+  );
+
   return out;
 }
 

--- a/gitnexus/test/unit/cfg/reaching-defs-equivalence.test.ts
+++ b/gitnexus/test/unit/cfg/reaching-defs-equivalence.test.ts
@@ -1,0 +1,487 @@
+/**
+ * #2201 — differential equivalence harness for the reaching-defs solvers.
+ *
+ * The SSA-sparse rewrite must be BYTE-IDENTICAL to the retained dense GEN/KILL
+ * oracle ({@link computeReachingDefsDense}). This file is the permanent gate:
+ * a seeded random-CFG generator drives both solvers and a structural comparator
+ * asserts identical status / bindings / sorted facts / def-use telemetry.
+ *
+ * In U1 both sides run the dense oracle (self-equivalence + corpus-coverage
+ * sanity); U5 flips the second solver to {@link computeReachingDefs} (sparse)
+ * — the single change that turns this into the real equivalence gate.
+ *
+ * The corpus deliberately covers the shapes where a may-reaching-defs rewrite
+ * is most likely to diverge: loops + irreducible (goto) topology, throw edges
+ * (IN∪allDefs handler semantics), may-defs (gen-without-kill), shadowed
+ * bindings, unreachable blocks, multi-predecessor joins, and the maxFacts /
+ * maxBlockVisits truncation postures (KTD6 — the truncated SUBSET depends on
+ * pre-sort emission order, so it must match too).
+ *
+ * Default corpus is CI-fast; GITNEXUS_RD_FUZZ_N raises it (the ≥1M run the
+ * plan calls for) for a deep local/CI-shard pass.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeReachingDefs,
+  computeReachingDefsDense,
+  type FunctionDefUse,
+  type ReachingDefsLimits,
+} from '../../../src/core/ingestion/cfg/reaching-defs.js';
+import type {
+  BindingEntry,
+  BasicBlockData,
+  CfgEdgeData,
+  CfgEdgeKind,
+  FunctionCfg,
+  StatementFacts,
+} from '../../../src/core/ingestion/cfg/types.js';
+
+type Solver = (cfg: FunctionCfg, limits?: ReachingDefsLimits) => FunctionDefUse;
+
+// ── deterministic PRNG (mulberry32) ───────────────────────────────────────
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const NON_THROW_KINDS: CfgEdgeKind[] = [
+  'seq',
+  'cond-true',
+  'cond-false',
+  'loop-back',
+  'break',
+  'continue',
+  'return',
+  'switch-case',
+  'fallthrough',
+];
+
+// ── random CFG generator ───────────────────────────────────────────────────
+interface GenOpts {
+  maxBlocks: number;
+  maxBindings: number;
+  maxStmtsPerBlock: number;
+  pNoBindings: number; // chance the whole CFG has bindings:undefined (→ no-facts)
+  pThrowEdge: number;
+  pMayDef: number;
+  pExtraEdge: number; // per-block chance of an extra random edge
+  pShadowName: number;
+}
+
+const DEFAULT_GEN: GenOpts = {
+  maxBlocks: 14,
+  maxBindings: 8,
+  maxStmtsPerBlock: 4,
+  pNoBindings: 0.03,
+  pThrowEdge: 0.12,
+  pMayDef: 0.18,
+  pExtraEdge: 0.9,
+  pShadowName: 0.4,
+};
+
+function genCfg(seed: number, opts: GenOpts = DEFAULT_GEN): FunctionCfg {
+  const rnd = mulberry32(seed);
+  const int = (n: number) => Math.floor(rnd() * n);
+  const n = 1 + int(opts.maxBlocks); // ≥1 block (entry)
+
+  // bindings — small name pool so shadowing collisions happen; distinct
+  // declLine/declColumn keep non-synthetic bindings' keys distinct.
+  const noBindings = rnd() < opts.pNoBindings;
+  const nBindings = noBindings ? 0 : int(opts.maxBindings + 1);
+  const namePool = ['a', 'b', 'c', 'd', 'e'];
+  const kinds: BindingEntry['kind'][] = ['var', 'let', 'const', 'param', 'catch'];
+  const bindings: BindingEntry[] = [];
+  for (let i = 0; i < nBindings; i++) {
+    const shadow = rnd() < opts.pShadowName;
+    bindings.push({
+      name: shadow ? namePool[int(namePool.length)] : `v${i}`,
+      declLine: 100 + i,
+      declColumn: i,
+      kind: kinds[int(kinds.length)],
+      ...(rnd() < 0.08 ? { synthetic: true } : {}),
+    });
+  }
+
+  const pickBindings = (max: number): number[] => {
+    if (nBindings === 0) return [];
+    const out: number[] = [];
+    const count = int(max + 1);
+    for (let k = 0; k < count; k++) out.push(int(nBindings));
+    return out;
+  };
+
+  // blocks (block 0 = entry; some blocks get no statements like synthetic
+  // ENTRY/EXIT to exercise the skip paths).
+  const blocks: BasicBlockData[] = [];
+  for (let b = 0; b < n; b++) {
+    const stmtCount = b === 0 && rnd() < 0.5 ? int(2) : int(opts.maxStmtsPerBlock + 1);
+    const statements: StatementFacts[] = [];
+    for (let i = 0; i < stmtCount; i++) {
+      const defs = pickBindings(2);
+      const uses = pickBindings(3);
+      const mayDefs = rnd() < opts.pMayDef ? pickBindings(1) : [];
+      statements.push({
+        line: b * 100 + i + 1,
+        defs,
+        uses,
+        ...(mayDefs.length ? { mayDefs } : {}),
+      });
+    }
+    blocks.push({
+      index: b,
+      startLine: b * 100,
+      endLine: b * 100 + stmtCount,
+      text: `B${b}`,
+      kind: b === 0 ? 'entry' : b === n - 1 ? 'exit' : 'normal',
+      // bindings:undefined ⇒ no-facts: drop statements entirely so it mirrors a
+      // pre-M2 CFG (the solver keys no-facts off cfg.bindings, but a realistic
+      // no-facts CFG also lacks statements).
+      ...(noBindings ? {} : { statements }),
+    });
+  }
+
+  // edges — a probabilistic spine (entry chain) for reachability + random
+  // extra edges that produce loops, irreducible topology, and unreachable
+  // blocks. Throw edges target a random handler block.
+  const edges: CfgEdgeData[] = [];
+  const addEdge = (from: number, to: number, kind: CfgEdgeKind) => {
+    if (from >= 0 && from < n && to >= 0 && to < n) edges.push({ from, to, kind });
+  };
+  for (let b = 0; b < n - 1; b++) {
+    if (rnd() < 0.75) addEdge(b, b + 1, 'seq');
+  }
+  for (let b = 0; b < n; b++) {
+    if (rnd() < opts.pExtraEdge) {
+      const to = int(n); // any target → forward / back / self / cross edges
+      const throwIt = rnd() < opts.pThrowEdge;
+      addEdge(b, to, throwIt ? 'throw' : NON_THROW_KINDS[int(NON_THROW_KINDS.length)]);
+    }
+  }
+
+  return {
+    filePath: 'fuzz.ts',
+    functionStartLine: 1,
+    functionEndLine: n * 100,
+    functionStartColumn: 0,
+    entryIndex: 0,
+    exitIndex: n - 1,
+    blocks,
+    edges,
+    ...(noBindings ? {} : { bindings }),
+  };
+}
+
+// ── hand-built canonical hard CFGs (guaranteed shape coverage) ─────────────
+// These pin the gnarly shapes the random generator hits only probabilistically.
+function canonicalHardCfgs(): FunctionCfg[] {
+  const mk = (
+    blocks: BasicBlockData[],
+    edges: CfgEdgeData[],
+    bindings: BindingEntry[],
+  ): FunctionCfg => ({
+    filePath: 'canon.ts',
+    functionStartLine: 1,
+    functionEndLine: 999,
+    functionStartColumn: 0,
+    entryIndex: 0,
+    exitIndex: blocks.length - 1,
+    blocks,
+    edges,
+    bindings,
+  });
+  const bind = (name: string, line: number): BindingEntry => ({
+    name,
+    declLine: line,
+    declColumn: 0,
+    kind: 'let',
+  });
+  const blk = (index: number, statements: StatementFacts[]): BasicBlockData => ({
+    index,
+    startLine: index * 10,
+    endLine: index * 10 + statements.length,
+    text: `B${index}`,
+    kind: index === 0 ? 'entry' : 'normal',
+    statements,
+  });
+  const st = (
+    line: number,
+    defs: number[],
+    uses: number[],
+    mayDefs?: number[],
+  ): StatementFacts => ({
+    line,
+    defs,
+    uses,
+    ...(mayDefs ? { mayDefs } : {}),
+  });
+
+  const out: FunctionCfg[] = [];
+
+  // (1) Irreducible two-entry loop: 0→1, 0→2, 1→2, 2→1. binding x def in 1, use in 2 & 1.
+  out.push(
+    mk(
+      [blk(0, [st(1, [0], [])]), blk(1, [st(2, [0], [0])]), blk(2, [st(3, [], [0])])],
+      [
+        { from: 0, to: 1, kind: 'cond-true' },
+        { from: 0, to: 2, kind: 'cond-false' },
+        { from: 1, to: 2, kind: 'seq' },
+        { from: 2, to: 1, kind: 'loop-back' },
+      ],
+      [bind('x', 1)],
+    ),
+  );
+
+  // (2) Self-loop with may-def: block 1 loops to itself; x may-def + use.
+  out.push(
+    mk(
+      [blk(0, [st(1, [0], [])]), blk(1, [st(2, [], [0], [0])])],
+      [
+        { from: 0, to: 1, kind: 'seq' },
+        { from: 1, to: 1, kind: 'loop-back' },
+      ],
+      [bind('x', 1)],
+    ),
+  );
+
+  // (3) try/catch throw edge: 0 (x=1), 1 (x=parse; x=normalize) -throw-> 2 (use x).
+  out.push(
+    mk(
+      [
+        blk(0, [st(1, [0], [])]),
+        blk(1, [st(2, [0], []), st(3, [0], [0])]),
+        blk(2, [st(4, [], [0])]),
+      ],
+      [
+        { from: 0, to: 1, kind: 'seq' },
+        { from: 1, to: 2, kind: 'seq' },
+        { from: 1, to: 2, kind: 'throw' },
+      ],
+      [bind('x', 1)],
+    ),
+  );
+
+  // (4) Diamond merge: both arm defs reach the join use.
+  out.push(
+    mk(
+      [
+        blk(0, [st(1, [], [])]),
+        blk(1, [st(2, [0], [])]),
+        blk(2, [st(3, [0], [])]),
+        blk(3, [st(4, [], [0])]),
+      ],
+      [
+        { from: 0, to: 1, kind: 'cond-true' },
+        { from: 0, to: 2, kind: 'cond-false' },
+        { from: 1, to: 3, kind: 'seq' },
+        { from: 2, to: 3, kind: 'seq' },
+      ],
+      [bind('x', 1)],
+    ),
+  );
+
+  // (5) Unreachable block carrying a def (block 2 not reachable from entry).
+  out.push(
+    mk(
+      [blk(0, [st(1, [0], [0])]), blk(1, [st(2, [], [0])]), blk(2, [st(3, [0], [0])])],
+      [{ from: 0, to: 1, kind: 'seq' }],
+      [bind('x', 1)],
+    ),
+  );
+
+  return out;
+}
+
+// ── structural comparator ──────────────────────────────────────────────────
+function serializeFact(f: FunctionDefUse['facts'][number]): string {
+  return (
+    `${f.def.blockIndex}:${f.def.stmtIndex}@${f.def.line}` +
+    `->${f.use.blockIndex}:${f.use.stmtIndex}@${f.use.line}#${f.bindingIdx}`
+  );
+}
+
+/** Returns null when byte-identical, else a human-readable first divergence. */
+function diffDefUse(a: FunctionDefUse, b: FunctionDefUse): string | null {
+  if (a.status !== b.status) return `status: ${a.status} vs ${b.status}`;
+  if (a.defCount !== b.defCount) return `defCount: ${a.defCount} vs ${b.defCount}`;
+  if (a.useCount !== b.useCount) return `useCount: ${a.useCount} vs ${b.useCount}`;
+  if (a.bindings.length !== b.bindings.length) {
+    return `bindings.length: ${a.bindings.length} vs ${b.bindings.length}`;
+  }
+  if (a.facts.length !== b.facts.length) {
+    return `facts.length: ${a.facts.length} vs ${b.facts.length}`;
+  }
+  for (let i = 0; i < a.facts.length; i++) {
+    const fa = serializeFact(a.facts[i]);
+    const fb = serializeFact(b.facts[i]);
+    if (fa !== fb) return `fact[${i}]: ${fa} vs ${fb}`;
+  }
+  return null;
+}
+
+// ── corpus shape classifier (coverage guard) ───────────────────────────────
+interface ShapeFlags {
+  hasLoop: boolean;
+  hasThrow: boolean;
+  hasMayDef: boolean;
+  hasShadow: boolean;
+  hasMultiPred: boolean;
+  hasUnreachable: boolean;
+  hadComputed: boolean;
+  hadTruncated: boolean;
+  hadNoFacts: boolean;
+}
+
+function classify(cfg: FunctionCfg, flags: ShapeFlags): void {
+  const n = cfg.blocks.length;
+  if (cfg.edges.some((e) => e.kind === 'throw')) flags.hasThrow = true;
+  if (cfg.blocks.some((b) => b.statements?.some((s) => s.mayDefs?.length))) flags.hasMayDef = true;
+  if (cfg.bindings) {
+    const names = cfg.bindings.map((b) => b.name);
+    if (new Set(names).size < names.length) flags.hasShadow = true;
+  }
+  const predCount = new Array(n).fill(0);
+  for (const e of cfg.edges) if (e.to >= 0 && e.to < n) predCount[e.to]++;
+  if (predCount.some((c) => c >= 2)) flags.hasMultiPred = true;
+
+  // cycle detection (DFS rec-stack) over the whole graph
+  const succ: number[][] = Array.from({ length: n }, () => []);
+  for (const e of cfg.edges)
+    if (e.from >= 0 && e.from < n && e.to >= 0 && e.to < n) succ[e.from].push(e.to);
+  const color = new Array(n).fill(0); // 0=white 1=gray 2=black
+  const hasCycleFrom = (start: number): boolean => {
+    const stack: { node: number; idx: number }[] = [{ node: start, idx: 0 }];
+    color[start] = 1;
+    while (stack.length) {
+      const top = stack[stack.length - 1];
+      if (top.idx < succ[top.node].length) {
+        const nx = succ[top.node][top.idx++];
+        if (color[nx] === 1) return true;
+        if (color[nx] === 0) {
+          color[nx] = 1;
+          stack.push({ node: nx, idx: 0 });
+        }
+      } else {
+        color[top.node] = 2;
+        stack.pop();
+      }
+    }
+    return false;
+  };
+  for (let s = 0; s < n; s++) if (color[s] === 0 && hasCycleFrom(s)) flags.hasLoop = true;
+
+  // reachability from entry
+  const seen = new Array(n).fill(false);
+  const q = [cfg.entryIndex];
+  seen[cfg.entryIndex] = true;
+  while (q.length) {
+    const x = q.pop()!;
+    for (const y of succ[x]) if (!seen[y]) ((seen[y] = true), q.push(y));
+  }
+  if (seen.some((v, i) => !v && i < n)) flags.hasUnreachable = true;
+}
+
+// ── corpus runner ──────────────────────────────────────────────────────────
+interface CorpusResult {
+  checked: number;
+  flags: ShapeFlags;
+  firstFailure: string | null;
+}
+
+function runCorpus(left: Solver, right: Solver, count: number, baseSeed: number): CorpusResult {
+  const flags: ShapeFlags = {
+    hasLoop: false,
+    hasThrow: false,
+    hasMayDef: false,
+    hasShadow: false,
+    hasMultiPred: false,
+    hasUnreachable: false,
+    hadComputed: false,
+    hadTruncated: false,
+    hadNoFacts: false,
+  };
+  let firstFailure: string | null = null;
+  let checked = 0;
+
+  const check = (cfg: FunctionCfg, limits: ReachingDefsLimits | undefined, label: string): void => {
+    const a = left(cfg, limits);
+    const b = right(cfg, limits);
+    const d = diffDefUse(a, b);
+    checked++;
+    if (a.status === 'computed') flags.hadComputed = true;
+    if (a.status === 'truncated') flags.hadTruncated = true;
+    if (a.status === 'no-facts') flags.hadNoFacts = true;
+    if (d && !firstFailure) firstFailure = `${label}: ${d}`;
+  };
+
+  // canonical hard CFGs first (under several limit postures)
+  for (const [i, cfg] of canonicalHardCfgs().entries()) {
+    classify(cfg, flags);
+    check(cfg, undefined, `canon[${i}]`);
+    check(cfg, { maxFacts: 1 }, `canon[${i}]/maxFacts=1`);
+    check(cfg, { maxFacts: 2 }, `canon[${i}]/maxFacts=2`);
+    check(cfg, { maxBlockVisits: 2 }, `canon[${i}]/maxBlockVisits=2`);
+  }
+
+  // random corpus
+  for (let i = 0; i < count; i++) {
+    const seed = baseSeed + i;
+    const cfg = genCfg(seed);
+    classify(cfg, flags);
+    check(cfg, undefined, `seed=${seed}`);
+    // exercise truncation on ~1/4 of cases (small maxFacts) and the block-visit
+    // ceiling on ~1/8 — both must match byte-for-byte (KTD6).
+    if (i % 4 === 0) check(cfg, { maxFacts: 1 + (i % 3) }, `seed=${seed}/maxFacts`);
+    if (i % 8 === 0) check(cfg, { maxBlockVisits: 1 + (i % 4) }, `seed=${seed}/maxBlockVisits`);
+  }
+
+  return { checked, flags, firstFailure };
+}
+
+const CORPUS_N = Number(process.env.GITNEXUS_RD_FUZZ_N ?? 1500);
+
+describe('#2201 reaching-defs differential equivalence', () => {
+  it('dense oracle is self-consistent and the comparator + generator are sound', () => {
+    // U1 baseline: dense-vs-dense MUST be byte-identical (proves the harness).
+    const r = runCorpus(computeReachingDefsDense, computeReachingDefsDense, CORPUS_N, 0x2201);
+    expect(r.firstFailure).toBeNull();
+    expect(r.checked).toBeGreaterThan(CORPUS_N);
+  });
+
+  it('the corpus exercises every divergence-prone shape (coverage guard)', () => {
+    const r = runCorpus(computeReachingDefsDense, computeReachingDefsDense, CORPUS_N, 0x2201);
+    const f = r.flags;
+    expect(f.hasLoop, 'loops').toBe(true);
+    expect(f.hasThrow, 'throw edges').toBe(true);
+    expect(f.hasMayDef, 'may-defs').toBe(true);
+    expect(f.hasShadow, 'shadowed bindings').toBe(true);
+    expect(f.hasMultiPred, 'multi-pred joins').toBe(true);
+    expect(f.hasUnreachable, 'unreachable blocks').toBe(true);
+    expect(f.hadComputed, 'computed results').toBe(true);
+    expect(f.hadTruncated, 'truncated results').toBe(true);
+    expect(f.hadNoFacts, 'no-facts results').toBe(true);
+  });
+
+  it('is deterministic — a fixed seed yields a byte-identical corpus across runs', () => {
+    const a = runCorpus(computeReachingDefsDense, computeReachingDefsDense, 200, 0xfeed);
+    const b = runCorpus(computeReachingDefsDense, computeReachingDefsDense, 200, 0xfeed);
+    expect(a.checked).toBe(b.checked);
+    expect(a.flags).toEqual(b.flags);
+  });
+
+  it('PRODUCTION computeReachingDefs is byte-identical to the dense oracle', () => {
+    // U1: computeReachingDefs still delegates to dense, so this is trivially
+    // green. U5 swaps it to the sparse solver — this becomes the real gate.
+    const r = runCorpus(computeReachingDefs, computeReachingDefsDense, CORPUS_N, 0x5eed);
+    expect(r.firstFailure).toBeNull();
+  });
+});
+
+// Re-exported for U5 and future harness reuse.
+export { genCfg, canonicalHardCfgs, diffDefUse, runCorpus, classify };
+export type { Solver, ShapeFlags, CorpusResult };

--- a/gitnexus/test/unit/cfg/reaching-defs.test.ts
+++ b/gitnexus/test/unit/cfg/reaching-defs.test.ts
@@ -425,6 +425,63 @@ describe('computeReachingDefs — determinism and convergence', () => {
     expect(prod!.status).toBe(dense.status);
     expect(render(prod!.facts)).toEqual(render(dense.facts)); // byte-identical to the tolerant dense path
   });
+
+  it('#2201 R1: an oversized SSA value graph falls back to the dense oracle (byte-identical)', () => {
+    // A ≥16-block looping multi-binding CFG → the production dispatcher routes it
+    // to the SSA-sparse path. `maxFacts` bounds only fact materialization, not the
+    // φ/value-graph the sparse path builds first; `maxSsaValueGraphNodes` caps that
+    // graph and falls back to the dense oracle when it would be too large. Because
+    // the fallback is byte-identical to dense, the routing flip is made OBSERVABLE
+    // via a tight `maxBlockVisits`: dense honors the ceiling (truncates), the SSA
+    // path ignores it (computes) — so the same budget yields different statuses
+    // depending on which solver ran.
+    const K = 4; // bindings
+    const blocks: BlockSpec[] = [{}, {}]; // 0 entry, 1 exit
+    const edges: [number, number][] = [[0, 2]];
+    const BODY = 18; // body blocks 2..19 → 20 blocks total (≥ SSA_MIN_BLOCKS)
+    for (let i = 0; i < BODY; i++) {
+      const b = 2 + i;
+      blocks[b] = { stmts: [stmt(b * 10, [i % K], [(i + 1) % K])] };
+      if (i < BODY - 1) edges.push([b, b + 1]);
+    }
+    edges.push([2 + BODY - 1, 2]); // back-edge → reachable loop (forces SSA dispatch)
+    edges.push([2, 1]); // exit
+    const bindings = Array.from({ length: K }, (_, i) => `v${i}`);
+    const mk = () => mkCfg(blocks, edges, bindings);
+    expect(mk().blocks.length).toBeGreaterThanOrEqual(16);
+
+    const denseFull = computeReachingDefsDense(mk());
+    expect(denseFull.status).toBe('computed');
+    expect(denseFull.facts.length).toBeGreaterThan(0);
+
+    // Tiny node cap, unbounded visits → falls back to dense → byte-identical.
+    const cappedUnbounded = computeReachingDefs(mk(), { maxSsaValueGraphNodes: 1 });
+    expect(cappedUnbounded.status).toBe(denseFull.status);
+    expect(render(cappedUnbounded.facts)).toEqual(render(denseFull.facts));
+
+    // Tiny node cap + tight block-visit budget → fallback to dense, whose ceiling
+    // then fires (truncated, empty). This is the observable proof the cap diverted
+    // the solve to the dense path.
+    const cappedBudgeted = computeReachingDefs(mk(), {
+      maxSsaValueGraphNodes: 1,
+      maxBlockVisits: 1,
+    });
+    expect(cappedBudgeted.status).toBe('truncated');
+    expect(cappedBudgeted.facts).toEqual([]);
+
+    // Default (huge) cap + the SAME tight budget → SSA path runs (no fixpoint
+    // iteration → ceiling never fires) and computes the full facts.
+    const uncapped = computeReachingDefs(mk(), { maxBlockVisits: 1 });
+    expect(uncapped.status).toBe('computed');
+    expect(render(uncapped.facts)).toEqual(render(denseFull.facts));
+
+    // Boundary monotonicity: a cap well above the graph stays on SSA (computes
+    // under the tight budget), a cap well below falls back (truncates).
+    const above = computeReachingDefs(mk(), { maxSsaValueGraphNodes: 100_000, maxBlockVisits: 1 });
+    expect(above.status).toBe('computed');
+    const below = computeReachingDefs(mk(), { maxSsaValueGraphNodes: 5, maxBlockVisits: 1 });
+    expect(below.status).toBe('truncated');
+  });
 });
 
 describe('computeReachingDefs — parser-direct acceptance (with U1/U2)', () => {

--- a/gitnexus/test/unit/cfg/reaching-defs.test.ts
+++ b/gitnexus/test/unit/cfg/reaching-defs.test.ts
@@ -8,6 +8,8 @@ import {
 } from '../../../src/core/ingestion/cfg/visitors/typescript.js';
 import {
   computeReachingDefs,
+  computeReachingDefsDense,
+  computeReachingDefsSparse,
   type DefUseFact,
 } from '../../../src/core/ingestion/cfg/reaching-defs.js';
 import type {
@@ -370,6 +372,33 @@ describe('computeReachingDefs — determinism and convergence', () => {
     expect(capped.status).toBe('truncated');
     expect(capped.facts).toEqual([]);
     expect(capped.defCount).toBe(full.defCount);
+  });
+
+  it('#2201 R5: the ceiling fires on the dense oracle but not on the SSA solver', () => {
+    // Contrast the two solvers on a looping CFG under a budget below the dense
+    // worklist's convergence: the dense oracle truncates to a sound-empty result
+    // (the ceiling fires), while the SSA solver — which has no fixpoint
+    // iteration — always converges (the ceiling that fired on the dense worklist
+    // effectively never fires). The facts the SSA solver computes are identical
+    // to the dense oracle's unbounded result. This is the #2201 acceptance: the
+    // blocks×64 ceiling stops firing on deep loops.
+    const blocks: BlockSpec[] = [{}, {}, { stmts: [stmt(3, [0], [0])] }];
+    const edges: [number, number][] = [
+      [0, 2],
+      [2, 2], // self-loop → the dense fixpoint must re-visit block 2
+      [2, 1],
+    ];
+    const denseFull = computeReachingDefsDense(mkCfg(blocks, edges, ['x']));
+    const denseCeiling = computeReachingDefsDense(mkCfg(blocks, edges, ['x']), {
+      maxBlockVisits: 1,
+    });
+    const sparse = computeReachingDefsSparse(mkCfg(blocks, edges, ['x']), { maxBlockVisits: 1 });
+
+    expect(denseFull.status).toBe('computed');
+    expect(denseFull.facts.length).toBeGreaterThan(0);
+    expect(denseCeiling.status).toBe('truncated'); // ceiling fires on the dense worklist
+    expect(sparse.status).toBe('computed'); // SSA ignores the ceiling — it never fires
+    expect(render(sparse.facts)).toEqual(render(denseFull.facts)); // and the facts match
   });
 });
 

--- a/gitnexus/test/unit/cfg/reaching-defs.test.ts
+++ b/gitnexus/test/unit/cfg/reaching-defs.test.ts
@@ -400,6 +400,31 @@ describe('computeReachingDefs — determinism and convergence', () => {
     expect(sparse.status).toBe('computed'); // SSA ignores the ceiling — it never fires
     expect(render(sparse.facts)).toEqual(render(denseFull.facts)); // and the facts match
   });
+
+  it('#2201: an out-of-range binding index in a ≥16-block loop does NOT crash the SSA path', () => {
+    // A corrupted/stale store can carry a binding index ≥ nBindings. The dense
+    // solver tolerates it (Map-keyed lattice); the SSA path's nBindings-sized
+    // arrays would throw. The production dispatcher routes ≥16-block looping
+    // functions to SSA, so without the malformed-input gate the throw would
+    // escape the (unguarded) taint/harvest callers and lose a whole file's taint
+    // layer. The gate falls back to dense — no throw, byte-identical to dense.
+    const blocks: BlockSpec[] = [{ stmts: [stmt(1, [0], [])] }];
+    const edges: [number, number][] = [];
+    for (let i = 1; i <= 18; i++) {
+      blocks.push({ stmts: [stmt(i + 1, i === 1 ? [5] : [0], [i === 1 ? 5 : 0])] }); // block 1 uses/defs OOB index 5
+      edges.push([i - 1, i]);
+    }
+    edges.push([18, 1]); // back-edge → loop; 19 blocks total, ≥16 → SSA dispatch
+    const cfg = mkCfg(blocks, edges, ['x']); // nBindings = 1; index 5 is out of range
+    expect(cfg.blocks.length).toBeGreaterThanOrEqual(16);
+    let prod: ReturnType<typeof computeReachingDefs> | undefined;
+    expect(() => {
+      prod = computeReachingDefs(cfg); // must NOT throw (gate → dense fallback)
+    }).not.toThrow();
+    const dense = computeReachingDefsDense(cfg);
+    expect(prod!.status).toBe(dense.status);
+    expect(render(prod!.facts)).toEqual(render(dense.facts)); // byte-identical to the tolerant dense path
+  });
 });
 
 describe('computeReachingDefs — parser-direct acceptance (with U1/U2)', () => {

--- a/gitnexus/test/unit/pdg-mode-flip.test.ts
+++ b/gitnexus/test/unit/pdg-mode-flip.test.ts
@@ -176,6 +176,42 @@ describe('pdgModeMismatch — pre-M5→M5 CDG-cap stamp upgrade (#2085 M5, pure)
   });
 });
 
+describe('pdgModeMismatch — pre-#2201→SSA reaching-defs solver upgrade (#2201 review R3, pure)', () => {
+  it('resolvePdgConfig stamps the reaching-defs solver identity', async () => {
+    const { resolvePdgConfig } = await import('../../src/core/run-analyze.js');
+    const stamp = resolvePdgConfig({ pdg: true });
+    expect(stamp?.reachingDefSolver).toBe('ssa-sparse-v1');
+  });
+
+  it('a pre-#2201 stamp (no solver key) mismatches the SSA request — upgrade recomputes truncated deep-loop facts', async () => {
+    const { pdgModeMismatch } = await import('../../src/core/run-analyze.js');
+    // What a pre-#2201 (M5-era) run wrote: every cap + model digest, but NO
+    // reachingDefSolver. The key-union comparator sees 'ssa-sparse-v1' !==
+    // undefined and trips the full writeback that recomputes the now-fuller
+    // REACHING_DEF coverage — the deep-loop functions the dense worklist
+    // truncated to empty at the blocks×64 ceiling now compute full facts.
+    const m5Stamp = {
+      maxFunctionLines: 2000,
+      maxEdgesPerFunction: 5000,
+      maxReachingDefEdgesPerFunction: 4000,
+      maxCdgEdgesPerFunction: 5000,
+      maxTaintFindingsPerFunction: 200,
+      maxTaintHops: 32,
+      maxInterprocFindings: 2000,
+      maxInterprocHops: 32,
+      maxInterprocEdges: 1000,
+      taintModelVersion,
+    };
+    expect(pdgModeMismatch(m5Stamp, { pdg: true })).toBe(true);
+  });
+
+  it('an identical post-#2201 stamp compares equal (no spurious re-analysis churn)', async () => {
+    const { pdgModeMismatch, resolvePdgConfig } = await import('../../src/core/run-analyze.js');
+    const stamp = resolvePdgConfig({ pdg: true });
+    expect(pdgModeMismatch(stamp, { pdg: true })).toBe(false);
+  });
+});
+
 describe('detect_changes BasicBlock exclusion (#2082 U7)', () => {
   it('the symbol-overlap id-prefix filter excludes exactly the BasicBlock rows', async () => {
     const repo = await setupMiniRepo();
@@ -258,6 +294,7 @@ describe('runFullAnalysis — pdg-mode flip (#2099 F1)', () => {
         maxInterprocHops: 32,
         maxInterprocEdges: 1000,
         taintModelVersion,
+        reachingDefSolver: 'ssa-sparse-v1',
       });
       expect(stamped!.incrementalInProgress).toBeUndefined(); // cleared on success
 
@@ -314,6 +351,7 @@ describe('runFullAnalysis — pdg-mode flip (#2099 F1)', () => {
         maxInterprocHops: 32,
         maxInterprocEdges: 1000,
         taintModelVersion,
+        reachingDefSolver: 'ssa-sparse-v1',
       });
       // The CFG layer survives a rebuild under a tighter edge cap (blocks are
       // never capped, only edges).

--- a/gitnexus/test/unit/run-analyze.test.ts
+++ b/gitnexus/test/unit/run-analyze.test.ts
@@ -349,6 +349,10 @@ describe('pdgModeMismatch / resolvePdgConfig (#2099 F1)', () => {
     // Content digest, not a tunable cap — pinned via the exported constant
     // (its VALUE changes whenever the built-in model changes, by design).
     taintModelVersion,
+    // Solver identity, not a tunable cap — always stamped on a pdg-on run
+    // (#2201 review R3). Bumps when the reaching-defs solver's emitted facts
+    // change; absence on a pre-#2201 stamp forces a re-analysis.
+    reachingDefSolver: 'ssa-sparse-v1',
   };
 
   it('resolvePdgConfig: pdg-off run resolves to undefined (the meta field is omitted)', async () => {
@@ -384,6 +388,7 @@ describe('pdgModeMismatch / resolvePdgConfig (#2099 F1)', () => {
       maxInterprocHops: 0,
       maxInterprocEdges: 0,
       taintModelVersion, // not a cap — always stamped on a pdg-on run
+      reachingDefSolver: 'ssa-sparse-v1', // solver identity — always stamped (#2201 R3)
     });
   });
 

--- a/gitnexus/tsconfig.json
+++ b/gitnexus/tsconfig.json
@@ -12,6 +12,7 @@
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
+    "stripInternal": true,
     "types": ["node"]
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## Summary

Replaces the dense GEN/KILL worklist reaching-definitions solver (`gitnexus/src/core/ingestion/cfg/reaching-defs.ts`) with an **SSA-sparse** formulation, resolving the WTO no-go deferral recorded in #2195/#2197. Closes #2201.

The dense worklist is superlinear (≈O(blocks²) work) on loop-heavy / many-binding functions because it re-materializes a dense per-block lattice and re-merges every binding on every fixpoint pass. The new solver builds pruned SSA — **Cooper-Harvey-Kennedy dominators → Cytron dominance frontiers + φ-placement → stack renaming over a synthetic entry → SCC-condensed φ-walkback** — and answers block-entry reaching-set queries from the def-use graph, skipping pass-through blocks and capturing loop merges statically (depth-independent).

## Approach (and an honest pivot)

External research first pointed at a **per-variable sparse worklist** as the lowest byte-identity risk. It was implemented and proven byte-identical — but measurement showed it was **2–4× slower** on the `dense-bindings` target (it still walks pass-through blocks per binding). The genuinely faster, asymptotically-better fix is true SSA, which is what shipped.

Production **auto-dispatches** (`computeInSetsAuto`): SSA for looping functions ≥16 blocks (where construction amortizes), the dense worklist everywhere else (small / loop-free) and for the throw-edge / unreachable-block shapes the SSA path does not model. The dense solver is retained as the differential **equivalence oracle**. Because both are held byte-identical, dispatch is a pure performance heuristic.

## Results (measured, `bench/cfg/measure.mjs --check`)

- **`dense-bindings` rd_scaling 5.2 → 0.86** (linear; **5×–23× faster** absolute, asymptotic in N). Budget tightened 10 → 2.
- **`deep-nest` (new scenario): the `blocks×64` ceiling stops firing** — under the production budget the SSA solver computes full facts (164 ≥ floor) where the dense worklist would truncate to empty.
- **Tiny / loop-free functions: ~1.0× (no regression)** — they take the dense path.

## Acceptance (#2201)

- ✅ **Byte-identical** REACHING_DEF projection: the committed snapshot oracle, taint (M3/M4) snapshots, summary-harvest, and the 13-language `--pdg` worker pipeline are all unchanged. Validated by a differential fuzz comparing SSA vs the dense oracle across **300k random CFGs (~1.2M comparisons)** + a 100k run that exercises the production auto-dispatcher's SSA branch at ≥16 blocks.
- ✅ **Measurable speedup** on `dense-bindings`.
- ✅ **Ceiling stops firing** on the deep-loop benchmark.

CFG fingerprints are unchanged — CFG construction is untouched; only the in-memory solve changed.

## Tests / validation

- `test/unit/cfg/reaching-defs-equivalence.test.ts` — permanent differential fuzz (dense oracle vs SSA + auto-dispatcher), shape-coverage guard incl. `hadLargeLoop` (the production SSA-dispatch path), canonical hard CFGs (irreducible, self-loop, throw, diamond, unreachable, back-edge-into-entry).
- `test/unit/cfg/reaching-defs.test.ts` — unit hazards + R5 contrast (dense ceiling fires, SSA converges).
- `reaching-defs-snapshot`, `taint`, `summary-harvest`, `pipeline-pdg` (13 langs, post-build), `bench --check` (8 scenarios) — all green. `tsc` clean.

## Notes

- `gitnexus/CHANGELOG.md` intentionally untouched (release-owned).
- The plan lives at `docs/plans/2026-06-15-001-perf-ssa-sparse-reaching-defs-plan.md` (the repo gitignores `docs/`, so it is a local decision artifact).

## Residual Review Findings

From the multi-agent code review (run `20260615-145253-4d86bad5`). None are merge-blockers; all are tracked follow-ups (the byte-identity contract is fuzz-proven and all oracles pass).

- **[P2] #7 (correctness/robustness)** `reaching-defs.ts` (~`computeInSetsSparse`): the SSA path is *less tolerant* than the dense solver of a corrupted/stale durable store — an out-of-range binding index in `defs`/`uses` throws (crashing the file's taint + summary-harvest layers) where dense tolerated it as a Map key. `taint/emit.ts` and `taint/summary-harvest-driver.ts` lack the `hasEmitSafeFacts` gate that `emitFileReachingDefs` has (pre-existing gap that SSA newly exposes). Fix: range-check binding indices in `solveReachingDefs` (fall back to dense/no-facts), or gate the taint/harvest call sites.
- **[P2] #8 (perf)** `computeInSetsAuto` dispatch: wide many-merge-point looping functions (≥16 blocks + loop + many bindings) can run ~2.7× slower / ~2× heavier under SSA while producing the identical truncated result (`maxFacts` does not bound SSA value-graph construction). Fix: gate SSA on an estimated-work signal beyond block-count+loop, or add a value-graph size cap that falls back to dense; add a bench scenario for the shape.
- **[P2] #9 (perf)** `reachByScc` unions copy full reaching-sets across SCC boundaries — potential O(defs²) at high-fan-out φ merge points (not covered by the one-binding `deep-nest` bench). Fix: flat sorted-array / lazy SCC reach sets; add a many-bindings-many-merges bench gate.
- **[P2] #10 (api-contract)** Deep-loop functions that previously truncated (empty REACHING_DEF) now compute full facts (the intended R5 win) — repos indexed on the prior version carry stale partial coverage until reindex. Verify the pdg/RepoMeta stamp forces a full writeback on solver-version change.
- **[P2] #11 (maintainability)** `reaching-defs.ts` grew ~496 → ~1050 lines; `computeInSetsSparse` bundles dominators + DF + φ-placement + renaming + SCC. Extract the sub-stages into helpers or split into `cfg/reaching-defs-sparse.ts`. (project-standards review found no hard line-count violation.)
- **[P3] #12 (perf)** Hot-path micro-allocations in the shared sweep / SSA setup (`keys.sort` per use, `sameStmtDefs` spread+Set per stmt, per-block Set in `dPredsX` dedup) — deliberately not auto-applied (hot-path, byte-identity-sensitive; marginal). Reuse scratch buffers; verify via the fuzz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
