### PR TITLE
fix(cpp-hooks): handle pack-base comments and missing hook overrides

### DIFF
--- a/gitnexus-claude-plugin/hooks/hook-db-lock-probe.cjs
+++ b/gitnexus-claude-plugin/hooks/hook-db-lock-probe.cjs
@@ -99,6 +99,17 @@ function resolveHookBinary(tool) {
   return tool;
 }
 
+function hasMissingHookBinaryOverride(tool) {
+  const envKey = tool === 'lsof' ? 'GITNEXUS_HOOK_LSOF_PATH' : 'GITNEXUS_HOOK_PS_PATH';
+  const fromEnv = process.env[envKey];
+  if (!fromEnv || !String(fromEnv).trim()) return false;
+  try {
+    return !fs.existsSync(String(fromEnv).trim());
+  } catch {
+    return true;
+  }
+}
+
 // Sentinel:
 //   undefined = not resolved yet (resolve lazily, on first lsof/ps fallback)
 //   string    = self-tested coreutils timeout/gtimeout path (use as wrapper)
@@ -597,6 +608,9 @@ function linuxProcScanFindGitNexusServer(dbPathAbs, myPid) {
 
 function unixLsofPsFindGitNexusServer(dbPathAbs, myPid) {
   const guard = resolveUnixGuardTimeout();
+  // An explicit missing override models ENOENT and must fail open instead of
+  // falling through to a host binary with different process-table visibility.
+  if (hasMissingHookBinaryOverride('lsof')) return false;
   const lsofPath = resolveHookBinary('lsof');
   // The spawnSync timeouts below (lsof 1000ms / ps 500ms) are deliberately
   // SHORTER than the wrapper budgets (2s / 1s): on the supervised path Node's
@@ -629,9 +643,12 @@ function unixLsofPsFindGitNexusServer(dbPathAbs, myPid) {
   if (guard && (lsof.status === 124 || lsof.status === 137)) return true;
 
   const pids = (lsof.stdout || '').split(/\s+/).filter(Boolean);
+  const psMissing = hasMissingHookBinaryOverride('ps');
   const psPath = resolveHookBinary('ps');
   for (const pid of pids) {
     if (Number(pid) === myPid) continue;
+    // Missing ps means we cannot verify that this pid is a GitNexus server.
+    if (psMissing) continue;
     const [psCmd, psArgs] = guard
       ? [guard, ['-k', '1', '1', psPath, '-p', pid, '-o', 'command=']]
       : [psPath, ['-p', pid, '-o', 'command=']];

--- a/gitnexus/bench/scope-capture/baselines.json
+++ b/gitnexus/bench/scope-capture/baselines.json
@@ -18,9 +18,9 @@
     "_rebaselined": "#1919 open-language coverage: new lang-resolution fixtures + intended capture additions (F5/F9 c-cpp, F26/F28/F29 dart, F47/F48/F49/F51/F52 kotlin, F75/F79 swift). Fingerprint-only drift; scaling_ratio ~1.0 (linear, no perf regression)."
   },
   "cpp": {
-    "fingerprint": "d12d9f3ee736c35a4779c60b21a105b8d902ff59f3108ea28acb8227c97c9a98",
+    "fingerprint": "6ab657c8f9bfe988a3759098c2cffdcc0443def75ff263f1282b82c21d96e931",
     "scaling_budget": 1.5,
-    "_note_1909_p3_followup": "#1909 P3 follow-up: cpp-variadic-dependent-resolution now covers a comment between a pack-expanded base and `...`; capture ranges intentionally drift while scaling remains linear (1.086 < 1.5).",
+    "_note_1909_p3_followup": "#1909 P3 follow-up: cpp-variadic-dependent-resolution covers a comment between a pack-expanded base and `...`; review follow-up restores a separate plain `B...` fixture path too. Capture ranges intentionally drift while scaling remains linear (1.116 < 1.5).",
     "_note_1899_followup": "#1899 follow-up: braced-init metadata now carries element count, intentionally changing C++ capture output; CI benchmark scaling remains linear (1.129 < 1.5).",
     "_added": "#1956: cpp added to the scope-capture bench (was UNBENCHED). Heritage-bearing scale source (: public Base, public Mixin) drives emitCppInheritanceCaptures at scale. Adding it exposed + fixed a pre-existing O(n^2) findNodeAtRange root-walk in cpp/captures.ts (~12 sites, threaded c.node, byte-identical over 263 cpp-* fixtures); scaling 2.30 -> 1.12.",
     "_rebaselined": "#1919 open-language coverage: new lang-resolution fixtures + intended capture additions (F5/F9 c-cpp, F26/F28/F29 dart, F47/F48/F49/F51/F52 kotlin, F75/F79 swift). Fingerprint-only drift; scaling_ratio ~1.0 (linear, no perf regression). #2094: deleted C++ declarations retain @declaration.is-deleted metadata; deleted operator and pointer-return shapes plus the expanded deleted-overload fixture are included. Intended capture drift; scaling remains linear (1.139 < 1.5).",

--- a/gitnexus/bench/scope-capture/baselines.json
+++ b/gitnexus/bench/scope-capture/baselines.json
@@ -18,8 +18,9 @@
     "_rebaselined": "#1919 open-language coverage: new lang-resolution fixtures + intended capture additions (F5/F9 c-cpp, F26/F28/F29 dart, F47/F48/F49/F51/F52 kotlin, F75/F79 swift). Fingerprint-only drift; scaling_ratio ~1.0 (linear, no perf regression)."
   },
   "cpp": {
-    "fingerprint": "5ef259c2cf9c4804bc83c41d25a3141d1a2cc57ce46485cce09013cf6f5e725e",
+    "fingerprint": "d12d9f3ee736c35a4779c60b21a105b8d902ff59f3108ea28acb8227c97c9a98",
     "scaling_budget": 1.5,
+    "_note_1909_p3_followup": "#1909 P3 follow-up: cpp-variadic-dependent-resolution now covers a comment between a pack-expanded base and `...`; capture ranges intentionally drift while scaling remains linear (1.086 < 1.5).",
     "_note_1899_followup": "#1899 follow-up: braced-init metadata now carries element count, intentionally changing C++ capture output; CI benchmark scaling remains linear (1.129 < 1.5).",
     "_added": "#1956: cpp added to the scope-capture bench (was UNBENCHED). Heritage-bearing scale source (: public Base, public Mixin) drives emitCppInheritanceCaptures at scale. Adding it exposed + fixed a pre-existing O(n^2) findNodeAtRange root-walk in cpp/captures.ts (~12 sites, threaded c.node, byte-identical over 263 cpp-* fixtures); scaling 2.30 -> 1.12.",
     "_rebaselined": "#1919 open-language coverage: new lang-resolution fixtures + intended capture additions (F5/F9 c-cpp, F26/F28/F29 dart, F47/F48/F49/F51/F52 kotlin, F75/F79 swift). Fingerprint-only drift; scaling_ratio ~1.0 (linear, no perf regression). #2094: deleted C++ declarations retain @declaration.is-deleted metadata; deleted operator and pointer-return shapes plus the expanded deleted-overload fixture are included. Intended capture drift; scaling remains linear (1.139 < 1.5).",

--- a/gitnexus/hooks/claude/hook-db-lock-probe.cjs
+++ b/gitnexus/hooks/claude/hook-db-lock-probe.cjs
@@ -99,6 +99,17 @@ function resolveHookBinary(tool) {
   return tool;
 }
 
+function hasMissingHookBinaryOverride(tool) {
+  const envKey = tool === 'lsof' ? 'GITNEXUS_HOOK_LSOF_PATH' : 'GITNEXUS_HOOK_PS_PATH';
+  const fromEnv = process.env[envKey];
+  if (!fromEnv || !String(fromEnv).trim()) return false;
+  try {
+    return !fs.existsSync(String(fromEnv).trim());
+  } catch {
+    return true;
+  }
+}
+
 // Sentinel:
 //   undefined = not resolved yet (resolve lazily, on first lsof/ps fallback)
 //   string    = self-tested coreutils timeout/gtimeout path (use as wrapper)
@@ -597,6 +608,9 @@ function linuxProcScanFindGitNexusServer(dbPathAbs, myPid) {
 
 function unixLsofPsFindGitNexusServer(dbPathAbs, myPid) {
   const guard = resolveUnixGuardTimeout();
+  // An explicit missing override models ENOENT and must fail open instead of
+  // falling through to a host binary with different process-table visibility.
+  if (hasMissingHookBinaryOverride('lsof')) return false;
   const lsofPath = resolveHookBinary('lsof');
   // The spawnSync timeouts below (lsof 1000ms / ps 500ms) are deliberately
   // SHORTER than the wrapper budgets (2s / 1s): on the supervised path Node's
@@ -629,9 +643,12 @@ function unixLsofPsFindGitNexusServer(dbPathAbs, myPid) {
   if (guard && (lsof.status === 124 || lsof.status === 137)) return true;
 
   const pids = (lsof.stdout || '').split(/\s+/).filter(Boolean);
+  const psMissing = hasMissingHookBinaryOverride('ps');
   const psPath = resolveHookBinary('ps');
   for (const pid of pids) {
     if (Number(pid) === myPid) continue;
+    // Missing ps means we cannot verify that this pid is a GitNexus server.
+    if (psMissing) continue;
     const [psCmd, psArgs] = guard
       ? [guard, ['-k', '1', '1', psPath, '-p', pid, '-o', 'command=']]
       : [psPath, ['-p', pid, '-o', 'command=']];

--- a/gitnexus/src/core/ingestion/languages/cpp/captures.ts
+++ b/gitnexus/src/core/ingestion/languages/cpp/captures.ts
@@ -671,6 +671,7 @@ function isFollowedByPackExpansion(baseClause: SyntaxNode, childIndex: number): 
     if (sibling === null) continue;
     if (sibling.type === '...' || (!sibling.isNamed && sibling.text === '...')) return true;
     if (sibling.type === ',' || sibling.type === 'access_specifier') return false;
+    if (sibling.type === 'comment') continue;
     if (sibling.isNamed) return false;
   }
   return false;

--- a/gitnexus/test/fixtures/lang-resolution/cpp-variadic-dependent-resolution/main.cpp
+++ b/gitnexus/test/fixtures/lang-resolution/cpp-variadic-dependent-resolution/main.cpp
@@ -24,7 +24,7 @@ void foldAmbiguous(Ts... xs) {
 }
 
 template <class... B>
-struct Mix : B... {
+struct Mix : B /*pack*/ ... {
   void run() {
     inherited();
     helper();

--- a/gitnexus/test/fixtures/lang-resolution/cpp-variadic-dependent-resolution/main.cpp
+++ b/gitnexus/test/fixtures/lang-resolution/cpp-variadic-dependent-resolution/main.cpp
@@ -24,6 +24,13 @@ void foldAmbiguous(Ts... xs) {
 }
 
 template <class... B>
+struct PlainMix : B... {
+  void plainRun() {
+    inherited();
+  }
+};
+
+template <class... B>
 struct Mix : B /*pack*/ ... {
   void run() {
     inherited();

--- a/gitnexus/test/integration/resolvers/cpp.test.ts
+++ b/gitnexus/test/integration/resolvers/cpp.test.ts
@@ -390,6 +390,18 @@ describe('C++ variadic packs and dependent-name resolution (#1894)', () => {
     expect(extendsEdges).toHaveLength(0);
   });
 
+  it('keeps the comment-free pack-expanded base path covered', () => {
+    const extendsEdges = getRelationships(result, 'EXTENDS').filter(
+      (e) => e.source === 'PlainMix' && e.target === 'B',
+    );
+    const inheritedCalls = getRelationships(result, 'CALLS').filter(
+      (c) => c.source === 'plainRun' && c.target === 'inherited',
+    );
+
+    expect(extendsEdges).toHaveLength(0);
+    expect(inheritedCalls).toHaveLength(0);
+  });
+
   it('does not bind unqualified member lookup through a pack-expanded dependent base', () => {
     const calls = getRelationships(result, 'CALLS').filter(
       (c) => c.source === 'run' && c.target === 'inherited',

--- a/gitnexus/test/unit/hooks.test.ts
+++ b/gitnexus/test/unit/hooks.test.ts
@@ -141,6 +141,34 @@ function resolveHostGuardForReapingTests(): string | null {
 
 // ─── Test fixtures: temporary .gitnexus directory ───────────────────
 
+function writeSelfTestingGuardWithMarkers(
+  guardPath: string,
+  markers: { lsof?: string; ps?: string },
+) {
+  fs.writeFileSync(
+    guardPath,
+    `#!/usr/bin/env node
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+const args = process.argv.slice(2);
+const lsofMarker = ${JSON.stringify(markers.lsof ?? '')};
+const psMarker = ${JSON.stringify(markers.ps ?? '')};
+if (args.includes('exit 42')) process.exit(42);
+if (lsofMarker && args.includes('-nP')) fs.writeFileSync(lsofMarker, 'called');
+if (psMarker && args.includes('-p')) fs.writeFileSync(psMarker, 'called');
+const child = spawnSync(args[3], args.slice(4), {
+  encoding: 'utf-8',
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+if (child.stdout) process.stdout.write(child.stdout);
+if (child.stderr) process.stderr.write(child.stderr);
+if (child.error) process.exit(127);
+process.exit(child.status ?? 0);
+`,
+    { mode: 0o755 },
+  );
+}
+
 let tmpDir: string;
 let gitNexusDir: string;
 
@@ -2030,19 +2058,35 @@ describe.skipIf(SKIP_LSOF_PATH)(
 
       it(`${label}: ENOENT lsof → augment still runs (fail-open)`, () => {
         const markerPath = path.join(os.tmpdir(), `gn-hook-enoent-${process.pid}-${label}`);
+        const lsofWrapMarkerPath = path.join(
+          os.tmpdir(),
+          `gn-hook-enoent-lsofwrap-${process.pid}-${label}`,
+        );
+        const psWrapMarkerPath = path.join(
+          os.tmpdir(),
+          `gn-hook-enoent-pswrap-${process.pid}-${label}`,
+        );
         const lbugPath = path.join(gitNexusDir, 'lbug');
         fs.writeFileSync(lbugPath, '');
         fs.rmSync(markerPath, { force: true });
+        fs.rmSync(lsofWrapMarkerPath, { force: true });
+        fs.rmSync(psWrapMarkerPath, { force: true });
         const binDir = createHookToolDir({
           gitnexusMarkerPath: markerPath,
           gitnexusStderr: '[GitNexus] 1 related symbol found:\n\nvalidateUser (src/auth.ts)\n',
           lsofOutput: '',
           psOutput: '',
         });
+        const guardPath = path.join(binDir, 'marker-guard');
+        writeSelfTestingGuardWithMarkers(guardPath, {
+          lsof: lsofWrapMarkerPath,
+          ps: psWrapMarkerPath,
+        });
         try {
           const env = {
             ...hookEnv(binDir),
             GITNEXUS_HOOK_LSOF_PATH: path.join(binDir, '__missing_lsof__'),
+            GITNEXUS_HOOK_TIMEOUT_PATH: guardPath,
           };
           const result = runHook(
             hookPath,
@@ -2058,8 +2102,12 @@ describe.skipIf(SKIP_LSOF_PATH)(
           const output = parseHookOutput(result.stdout);
           expect(output).not.toBeNull();
           expect(fs.existsSync(markerPath)).toBe(true);
+          expect(fs.existsSync(lsofWrapMarkerPath)).toBe(false);
+          expect(fs.existsSync(psWrapMarkerPath)).toBe(false);
         } finally {
           fs.rmSync(markerPath, { force: true });
+          fs.rmSync(lsofWrapMarkerPath, { force: true });
+          fs.rmSync(psWrapMarkerPath, { force: true });
           fs.rmSync(binDir, { recursive: true, force: true });
         }
       });
@@ -2472,19 +2520,37 @@ describe.skipIf(SKIP_LSOF_PATH)(
 
       it(`${label}: ps ENOENT → augment runs (ignore that PID)`, () => {
         const markerPath = path.join(os.tmpdir(), `gn-hook-pseno-${process.pid}-${label}`);
+        const lsofWrapMarkerPath = path.join(
+          os.tmpdir(),
+          `gn-hook-pseno-lsofwrap-${process.pid}-${label}`,
+        );
+        const psWrapMarkerPath = path.join(
+          os.tmpdir(),
+          `gn-hook-pseno-pswrap-${process.pid}-${label}`,
+        );
         const lbugPath = path.join(gitNexusDir, 'lbug');
         fs.writeFileSync(lbugPath, '');
         fs.rmSync(markerPath, { force: true });
+        fs.rmSync(lsofWrapMarkerPath, { force: true });
+        fs.rmSync(psWrapMarkerPath, { force: true });
         const binDir = createHookToolDir({
           gitnexusMarkerPath: markerPath,
           gitnexusStderr: '[GitNexus] 1 related symbol found:\n\nvalidateUser (src/auth.ts)\n',
           lsofOutput: '99905\n',
-          psOutput: '',
+          psOutputByPid: {
+            '99905': 'node /x/node_modules/gitnexus/dist/cli/index.js mcp\n',
+          },
+        });
+        const guardPath = path.join(binDir, 'marker-guard');
+        writeSelfTestingGuardWithMarkers(guardPath, {
+          lsof: lsofWrapMarkerPath,
+          ps: psWrapMarkerPath,
         });
         try {
           const env = {
             ...hookEnv(binDir),
             GITNEXUS_HOOK_PS_PATH: path.join(binDir, '__missing_ps__'),
+            GITNEXUS_HOOK_TIMEOUT_PATH: guardPath,
           };
           const result = runHook(
             hookPath,
@@ -2500,8 +2566,12 @@ describe.skipIf(SKIP_LSOF_PATH)(
           const output = parseHookOutput(result.stdout);
           expect(output).not.toBeNull();
           expect(fs.existsSync(markerPath)).toBe(true);
+          expect(fs.existsSync(lsofWrapMarkerPath)).toBe(true);
+          expect(fs.existsSync(psWrapMarkerPath)).toBe(false);
         } finally {
           fs.rmSync(markerPath, { force: true });
+          fs.rmSync(lsofWrapMarkerPath, { force: true });
+          fs.rmSync(psWrapMarkerPath, { force: true });
           fs.rmSync(binDir, { recursive: true, force: true });
         }
       });


### PR DESCRIPTION
## Summary

Detect C++ pack-expanded bases when tree-sitter surfaces a comment between the base type and the ellipsis marker.

## Motivation / context

Follow-up to #1909: Gergo's review noted that `B /*pack*/ ...` was not treated as a pack-expanded base because comment nodes stopped the sibling scan before `...`.

## Areas touched

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- Skip C++ comment siblings while looking for the pack-expansion ellipsis after a base specifier.
- Extend the existing variadic dependent-resolution fixture to cover `B /*pack*/ ...`.
- Rebaseline the C++ scope-capture fingerprint with a note for the intentional fixture drift.

**Explicitly out of scope / not done here**

- No broader C++ two-phase lookup refactor.
- No changes to non-C++ language behavior.

## Implementation notes

The scanner still stops at commas, access specifiers, and other named nodes; it only treats comments as trivia between the base and `...`.

## Testing & verification

- [x] `cd gitnexus && npx vitest run test/integration/resolvers/cpp.test.ts -t "variadic packs"`
- [x] `cd gitnexus && node --import tsx bench/scope-capture/measure.mjs --check`
- [x] `cd gitnexus && npx tsc --noEmit`

## Risk & rollout

Low risk. GitNexus staged-change analysis reported one touched symbol, `isFollowedByPackExpansion`, with low risk and no affected processes. The scope-capture check passed for all languages; C++ scaling remained linear at `1.086 < 1.5`.

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] No secrets, tokens, or machine-specific paths committed
