### PR TITLE
feat(taint): add conservative Java source/sink model

### DIFF
--- a/gitnexus-shared/src/scope-resolution/types.ts
+++ b/gitnexus-shared/src/scope-resolution/types.ts
@@ -105,6 +105,13 @@ export type ParsedImport =
       readonly localName: string;
       readonly importedName: string;
       readonly targetRaw: string;
+      /**
+       * Set by providers when `targetRaw` already names the imported symbol
+       * rather than only its containing module. Consumers that compose
+       * `<local>.<member>` paths can then use `targetRaw.<member>` instead of
+       * duplicating `importedName`.
+       */
+      readonly targetIncludesImportedName?: boolean;
     }
   /**
    * Per-name import with rename.
@@ -119,6 +126,8 @@ export type ParsedImport =
       readonly importedName: string;
       readonly alias: string;
       readonly targetRaw: string;
+      /** See the same field on the `named` variant. */
+      readonly targetIncludesImportedName?: boolean;
     }
   /**
    * Qualified module handle, with or without rename. `importedName` is the

--- a/gitnexus/src/core/ingestion/languages/java/interpret.ts
+++ b/gitnexus/src/core/ingestion/languages/java/interpret.ts
@@ -30,6 +30,7 @@ export function interpretJavaImport(captures: CaptureMatch): ParsedImport | null
         localName: nameCap?.text ?? simpleName,
         importedName: simpleName,
         targetRaw: sourceCap.text,
+        targetIncludesImportedName: true,
       };
     }
     case 'wildcard': {

--- a/gitnexus/src/core/ingestion/taint/emit.ts
+++ b/gitnexus/src/core/ingestion/taint/emit.ts
@@ -232,7 +232,6 @@ export function emitFileTaint(
       const b = bindings[idx];
       return b === undefined ? `#${idx}` : bindingKey(b);
     };
-
     // SANITIZES — one edge per kill, REGARDLESS of findings (kills can and do
     // exist with zero findings: a fully-sanitized flow IS the kill evidence).
     for (const kill of flows.kills) {
@@ -263,13 +262,27 @@ export function emitFileTaint(
       // `exec(req.body, req.query)`'s two findings; `property` is free-text
       // (string-literal subscripts) and rides LAST so it cannot collide into
       // another component.
-      const id = generateId(
-        'TAINTED',
-        `${fnAnchor}:${finding.sinkKind}:` +
-          `${pointKey(source.point)}.${source.siteIndex}:${bKey(source.objectBindingIdx)}:` +
-          `${pointKey(sink.point)}.${sink.siteIndex}.${sink.argIndex}:${bKey(sink.bindingIdx)}:` +
-          `${sink.entryName}:${source.property}`,
-      );
+      const id =
+        source.type === 'member-read'
+          ? generateId(
+              'TAINTED',
+              `${fnAnchor}:${finding.sinkKind}:` +
+                `${pointKey(source.point)}.${source.siteIndex}:${bKey(source.objectBindingIdx)}:` +
+                `${pointKey(sink.point)}.${sink.siteIndex}.${sink.argIndex}:${bKey(
+                  sink.bindingIdx,
+                )}:` +
+                `${sink.entryName}:${source.property}`,
+            )
+          : generateId(
+              'TAINTED',
+              `${fnAnchor}:${finding.sinkKind}:` +
+                `${pointKey(source.point)}.${source.siteIndex}:call-result:` +
+                `${bKey(source.resultBindingIdx)}:${source.calleeName}:` +
+                `${pointKey(sink.point)}.${sink.siteIndex}.${sink.argIndex}:${bKey(
+                  sink.bindingIdx,
+                )}:` +
+                `${sink.entryName}`,
+            );
       if (seenEdgeIds.has(id)) continue;
       seenEdgeIds.add(id);
       // `kind` rides the reason's `;<kind>` header — the only persisted

--- a/gitnexus/src/core/ingestion/taint/java-model.ts
+++ b/gitnexus/src/core/ingestion/taint/java-model.ts
@@ -1,0 +1,24 @@
+/**
+ * Built-in Java taint model (#2261 first slice).
+ *
+ * This deliberately starts small. Servlet request input is modeled only when a
+ * conventional request receiver's call result is assigned to a binding. Sinks
+ * are limited to static-import-proven JDK filesystem operations that current
+ * harvested call-site/import data can identify without broad same-name matching.
+ * No sanitizers are registered in this slice.
+ */
+
+import type { SourceSinkSanitizerSpec } from './source-sink-config.js';
+
+export const JAVA_TAINT_MODEL: SourceSinkSanitizerSpec = {
+  sources: [
+    {
+      type: 'call-result',
+      kind: 'remote-input',
+      receivers: ['request', 'req'],
+      methods: ['getParameter', 'getHeader'],
+    },
+  ],
+  sinks: [{ name: 'readString', kind: 'path-traversal', args: [0], module: 'java.nio.file.Files' }],
+  sanitizers: [],
+};

--- a/gitnexus/src/core/ingestion/taint/match.ts
+++ b/gitnexus/src/core/ingestion/taint/match.ts
@@ -76,8 +76,10 @@
 import type { ParsedImport } from 'gitnexus-shared';
 import type { FunctionCfg, SiteRecord } from '../cfg/types.js';
 import type {
+  TaintCallResultSourceEntry,
   SourceSinkSanitizerSpec,
   TaintMemberSourceEntry,
+  TaintSourceEntry,
   TaintSanitizerEntry,
   TaintSinkEntry,
 } from './source-sink-config.js';
@@ -99,10 +101,23 @@ export type TaintImportIndex = ReadonlyMap<string, TaintImportBinding>;
 
 /** A member-read site matched as a taint source. */
 export interface MatchedSourceRead {
+  readonly type: 'member-read';
   /** Index into the owning statement's `sites` array. */
   readonly siteIndex: number;
   readonly entry: TaintMemberSourceEntry;
 }
+
+/** A call-result source matched on a call site with direct result definitions. */
+export interface MatchedSourceCall {
+  readonly type: 'call-result';
+  /** Index into the owning statement's `sites` array. */
+  readonly siteIndex: number;
+  readonly entry: TaintCallResultSourceEntry;
+  /** Bindings directly defined by this call result. Never empty. */
+  readonly resultDefs: readonly number[];
+}
+
+export type MatchedSource = MatchedSourceRead | MatchedSourceCall;
 
 /** A call/new site matched as a sink. */
 export interface MatchedSinkCall {
@@ -141,7 +156,7 @@ export interface StatementMatches {
   readonly blockIndex: number;
   readonly statementIndex: number;
   readonly line: number;
-  readonly sources: readonly MatchedSourceRead[];
+  readonly sources: readonly MatchedSource[];
   readonly sinks: readonly MatchedSinkCall[];
   readonly sanitizers: readonly MatchedSanitizerCall[];
 }
@@ -156,6 +171,9 @@ export interface FunctionSiteMatches {
 
 const stripNodeScheme = (specifier: string): string =>
   specifier.startsWith('node:') ? specifier.slice('node:'.length) : specifier;
+
+const isCallResultSource = (entry: TaintSourceEntry): entry is TaintCallResultSourceEntry =>
+  entry.type === 'call-result';
 
 /**
  * Build the local-name → module/member index from a file's `parsedImports`.
@@ -330,7 +348,7 @@ export function matchFunctionSites(
     block.statements?.forEach((stmt, statementIndex) => {
       const sites = stmt.sites;
       if (sites === undefined || sites.length === 0) return;
-      const sources: MatchedSourceRead[] = [];
+      const sources: MatchedSource[] = [];
       const sinks: MatchedSinkCall[] = [];
       const sanitizers: MatchedSanitizerCall[] = [];
 
@@ -340,8 +358,9 @@ export function matchFunctionSites(
           const objectName = bindings[site.object].name;
           const property = site.property;
           for (const entry of spec.sources) {
+            if (isCallResultSource(entry)) continue;
             if (entry.objects.includes(objectName) && entry.properties.includes(property)) {
-              sources.push({ siteIndex, entry });
+              sources.push({ type: 'member-read', siteIndex, entry });
             }
           }
           return;
@@ -349,6 +368,23 @@ export function matchFunctionSites(
         // call / new
         const resolved = resolveCallee(site);
         if (resolved === undefined) return;
+        if (site.kind === 'call' && (site.resultDefs?.length ?? 0) > 0) {
+          for (const entry of spec.sources) {
+            if (!isCallResultSource(entry)) continue;
+            if (
+              resolved.path.length === 2 &&
+              entry.receivers.includes(resolved.path[0]) &&
+              entry.methods.includes(resolved.path[1])
+            ) {
+              sources.push({
+                type: 'call-result',
+                siteIndex,
+                entry,
+                resultDefs: site.resultDefs as readonly number[],
+              });
+            }
+          }
+        }
         for (const entry of spec.sinks) {
           if (!sinkMechanismHit(entry, site, resolved)) continue;
           const argPositions: number[] = [];

--- a/gitnexus/src/core/ingestion/taint/match.ts
+++ b/gitnexus/src/core/ingestion/taint/match.ts
@@ -94,6 +94,12 @@ export interface TaintImportBinding {
    * CJS interop makes the default export ≈ the module object).
    */
   readonly member?: string;
+  /**
+   * True when the provider says `module` already includes `member`; used for
+   * class-like imports where a receiver call should resolve as
+   * `<module>.<method>`, not `<module>.<member>.<method>`.
+   */
+  readonly targetIncludesMember?: boolean;
 }
 
 /** Local name → import provenance for one file. Build once per file (U4). */
@@ -187,7 +193,13 @@ export function buildTaintImportIndex(imports: readonly ParsedImport[]): TaintIm
       const module = stripNodeScheme(imp.targetRaw);
       index.set(
         imp.localName,
-        imp.importedName === 'default' ? { module } : { module, member: imp.importedName },
+        imp.importedName === 'default'
+          ? { module }
+          : {
+              module,
+              member: imp.importedName,
+              ...(imp.targetIncludesImportedName === true ? { targetIncludesMember: true } : {}),
+            },
       );
     } else if (imp.kind === 'namespace') {
       index.set(imp.localName, { module: stripNodeScheme(imp.targetRaw) });
@@ -257,6 +269,10 @@ export function matchFunctionSites(
     const rest = path.slice(1);
     const canonical: string[] = [];
     let globalRoot = false;
+    const canonicalBase = (imp: TaintImportBinding): string[] =>
+      imp.member === undefined || imp.targetIncludesMember === true
+        ? [imp.module]
+        : [imp.module, imp.member];
 
     if (site.receiver !== undefined) {
       // Member chain with an identifier root — origin known by binding index.
@@ -264,8 +280,7 @@ export function matchFunctionSites(
       if (rb.synthetic === true) {
         const imp = imports.get(rb.name);
         if (imp !== undefined) {
-          const base = imp.member === undefined ? [imp.module] : [imp.module, imp.member];
-          canonical.push([...base, ...rest].join('.'));
+          canonical.push([...canonicalBase(imp), ...rest].join('.'));
         }
       } else {
         const module = requireByBinding.get(site.receiver);
@@ -286,7 +301,11 @@ export function matchFunctionSites(
         const imp = imports.get(root);
         if (imp !== undefined) {
           canonical.push(
-            imp.member === undefined ? `${imp.module}.default` : `${imp.module}.${imp.member}`,
+            imp.member === undefined
+              ? `${imp.module}.default`
+              : imp.targetIncludesMember === true
+                ? imp.module
+                : `${imp.module}.${imp.member}`,
           );
         } else {
           globalRoot = true;
@@ -368,20 +387,23 @@ export function matchFunctionSites(
         // call / new
         const resolved = resolveCallee(site);
         if (resolved === undefined) return;
-        if (site.kind === 'call' && (site.resultDefs?.length ?? 0) > 0) {
-          for (const entry of spec.sources) {
-            if (!isCallResultSource(entry)) continue;
-            if (
-              resolved.path.length === 2 &&
-              entry.receivers.includes(resolved.path[0]) &&
-              entry.methods.includes(resolved.path[1])
-            ) {
-              sources.push({
-                type: 'call-result',
-                siteIndex,
-                entry,
-                resultDefs: site.resultDefs as readonly number[],
-              });
+        if (site.kind === 'call') {
+          const resultDefs = site.resultDefs;
+          if (resultDefs !== undefined && resultDefs.length > 0) {
+            for (const entry of spec.sources) {
+              if (!isCallResultSource(entry)) continue;
+              if (
+                resolved.path.length === 2 &&
+                entry.receivers.includes(resolved.path[0]) &&
+                entry.methods.includes(resolved.path[1])
+              ) {
+                sources.push({
+                  type: 'call-result',
+                  siteIndex,
+                  entry,
+                  resultDefs,
+                });
+              }
             }
           }
         }

--- a/gitnexus/src/core/ingestion/taint/propagate.ts
+++ b/gitnexus/src/core/ingestion/taint/propagate.ts
@@ -161,14 +161,27 @@ export interface TaintHop {
  * occurrence itself — statement point + site index + object/property. For
  * worklist findings this is the ROOT source the taint chain was seeded from.
  */
-export interface TaintSourceOccurrence {
+interface BaseSourceOccurrence {
   readonly point: ProgramPoint;
   /** Index into the source statement's `sites` array. */
   readonly siteIndex: number;
-  readonly objectBindingIdx: number;
-  readonly property: string;
+  readonly type: 'member-read' | 'call-result';
   readonly kind: SourceKind;
 }
+
+interface MemberReadSourceOccurrence extends BaseSourceOccurrence {
+  readonly type: 'member-read';
+  readonly objectBindingIdx: number;
+  readonly property: string;
+}
+
+interface CallResultSourceOccurrence extends BaseSourceOccurrence {
+  readonly type: 'call-result';
+  readonly resultBindingIdx: number;
+  readonly calleeName: string;
+}
+
+export type TaintSourceOccurrence = MemberReadSourceOccurrence | CallResultSourceOccurrence;
 
 /** The sink side of a finding's identity: point + site + argument + binding. */
 export interface TaintSinkOccurrence {
@@ -514,18 +527,33 @@ export function computeTaintFlows(
     sinkKind: SinkKind,
     source: TaintSourceOccurrence,
     sink: Pick<TaintSinkOccurrence, 'point' | 'siteIndex' | 'argIndex' | 'bindingIdx'>,
-  ): string =>
-    [
+  ): string => {
+    if (source.type === 'member-read') {
+      return [
+        sinkKind,
+        pointKey(source.point),
+        source.siteIndex,
+        source.objectBindingIdx,
+        source.property,
+        pointKey(sink.point),
+        sink.siteIndex,
+        sink.argIndex,
+        sink.bindingIdx,
+      ].join('|');
+    }
+    return [
       sinkKind,
       pointKey(source.point),
       source.siteIndex,
-      source.objectBindingIdx,
-      source.property,
+      source.type,
+      source.resultBindingIdx,
+      source.calleeName,
       pointKey(sink.point),
       sink.siteIndex,
       sink.argIndex,
       sink.bindingIdx,
     ].join('|');
+  };
 
   const recordFinding = (
     sinkKind: SinkKind,
@@ -704,11 +732,28 @@ export function computeTaintFlows(
     const ctx = contextAt(sm.blockIndex, sm.statementIndex);
     if (!ctx) continue;
     for (const src of sm.sources) {
+      if (src.type === 'call-result') {
+        const srcSite = ctx.sites[src.siteIndex];
+        const calleeName = srcSite?.callee ?? src.entry.methods.join('|');
+        for (const d of src.resultDefs) {
+          const sourceOcc: CallResultSourceOccurrence = {
+            point: ctx.point,
+            siteIndex: src.siteIndex,
+            type: 'call-result',
+            resultBindingIdx: d,
+            calleeName,
+            kind: src.entry.kind,
+          };
+          deriveTaint(d, ctx.point, EMPTY_KINDS, undefined, sourceOcc, false);
+        }
+        continue;
+      }
       const srcSite = ctx.sites[src.siteIndex];
       if (srcSite?.object === undefined || srcSite.property === undefined) continue;
-      const sourceOcc: TaintSourceOccurrence = {
+      const sourceOcc: MemberReadSourceOccurrence = {
         point: ctx.point,
         siteIndex: src.siteIndex,
+        type: 'member-read',
         objectBindingIdx: srcSite.object,
         property: srcSite.property,
         kind: src.entry.kind,

--- a/gitnexus/src/core/ingestion/taint/propagate.ts
+++ b/gitnexus/src/core/ingestion/taint/propagate.ts
@@ -157,9 +157,10 @@ export interface TaintHop {
 }
 
 /**
- * The KTD6 rule-(b) source identity material: the matched member-read
- * occurrence itself — statement point + site index + object/property. For
- * worklist findings this is the ROOT source the taint chain was seeded from.
+ * The source identity material for a finding: either the matched member-read
+ * occurrence itself (statement point + site index + object/property) or an
+ * assigned call-result source. For worklist findings this is the ROOT source
+ * the taint chain was seeded from.
  */
 interface BaseSourceOccurrence {
   readonly point: ProgramPoint;
@@ -734,7 +735,8 @@ export function computeTaintFlows(
     for (const src of sm.sources) {
       if (src.type === 'call-result') {
         const srcSite = ctx.sites[src.siteIndex];
-        const calleeName = srcSite?.callee ?? src.entry.methods.join('|');
+        if (srcSite?.callee === undefined) continue;
+        const calleeName = srcSite.callee;
         for (const d of src.resultDefs) {
           const sourceOcc: CallResultSourceOccurrence = {
             point: ctx.point,

--- a/gitnexus/src/core/ingestion/taint/source-sink-config.ts
+++ b/gitnexus/src/core/ingestion/taint/source-sink-config.ts
@@ -100,20 +100,36 @@ export interface TaintSanitizerEntry {
  * table). One entry fans out over the objects × properties product.
  */
 export interface TaintMemberSourceEntry {
+  readonly type?: 'member-read';
   readonly kind: SourceKind;
   readonly objects: readonly string[];
   readonly properties: readonly string[];
 }
 
 /**
+ * A call-result taint source: the result of `<receiver>.<method>(...)` becomes
+ * tainted, but only when the call site records direct `resultDefs`. This keeps
+ * source seeding tied to proven data-flow destinations instead of treating an
+ * arbitrary nested call expression as a value occurrence.
+ */
+export interface TaintCallResultSourceEntry {
+  readonly type: 'call-result';
+  readonly kind: SourceKind;
+  readonly receivers: readonly string[];
+  readonly methods: readonly string[];
+}
+
+export type TaintSourceEntry = TaintMemberSourceEntry | TaintCallResultSourceEntry;
+
+/**
  * The taint configuration for a single language: which member reads introduce
  * taint (sources), which callables are dangerous to reach with tainted input
  * (sinks), and which callables clear it (sanitizers). M3 sources are
- * member-read entries only; call-result sources are a forward extension
- * (add a union variant), not a missing case.
+ * member-read entries for JS/TS/Python and call-result entries for languages
+ * whose request APIs return tainted values from calls.
  */
 export interface SourceSinkSanitizerSpec {
-  readonly sources: readonly TaintMemberSourceEntry[];
+  readonly sources: readonly TaintSourceEntry[];
   readonly sinks: readonly TaintSinkEntry[];
   readonly sanitizers: readonly TaintSanitizerEntry[];
 }

--- a/gitnexus/src/core/ingestion/taint/source-sink-config.ts
+++ b/gitnexus/src/core/ingestion/taint/source-sink-config.ts
@@ -97,7 +97,9 @@ export interface TaintSanitizerEntry {
  * the property is one of `properties` (`body`, `query`, …). Matching is
  * name-based on the harvested `member-read` site (Semgrep-convention, not
  * type-aware — the accepted M3 FP/FN trade recorded in the plan's risk
- * table). One entry fans out over the objects × properties product.
+ * table). One entry fans out over the objects × properties product. `type`
+ * remains optional so existing/custom model objects that predate the
+ * discriminant continue to load as member-read sources.
  */
 export interface TaintMemberSourceEntry {
   readonly type?: 'member-read';

--- a/gitnexus/src/core/ingestion/taint/summary-harvest.ts
+++ b/gitnexus/src/core/ingestion/taint/summary-harvest.ts
@@ -297,18 +297,27 @@ export function harvestFunctionSummary(
       stmtIndex: sm.statementIndex,
       line: facts.line,
     };
+    const memberSources = sm.sources.filter((src) => src.type === 'member-read');
     if (returnUseStmtKeys.has(stmtKey)) {
-      for (const src of sm.sources) sourceReturn.add(src.entry.kind);
+      for (const src of memberSources) sourceReturn.add(src.entry.kind);
     }
-    for (const d of [...facts.defs, ...(facts.mayDefs ?? [])]) {
-      enqueue({ bindingIdx: d, point, seedId: -1, exclusions: new Set() });
+    if (memberSources.length > 0) {
+      for (const d of [...facts.defs, ...(facts.mayDefs ?? [])]) {
+        enqueue({ bindingIdx: d, point, seedId: -1, exclusions: new Set() });
+      }
+    }
+    for (const src of sm.sources) {
+      if (src.type !== 'call-result') continue;
+      for (const d of src.resultDefs) {
+        enqueue({ bindingIdx: d, point, seedId: -1, exclusions: new Set() });
+      }
     }
     // DIRECT source-in-call-arg (`runIt(req.body)`): no intermediate binding is
     // defined, so the floor seed above records nothing. Climb the source
     // member-read's `parent` chain — each enclosing call/new site is a
     // `sourceToCallArg` (the cross-function fixpoint seed). A sink ancestor is
     // M3's intra-procedural concern and harmless to also record here.
-    for (const src of sm.sources) {
+    for (const src of memberSources) {
       let cur: SiteRecord | undefined = facts.sites?.[src.siteIndex];
       const guard = new Set<number>([src.siteIndex]);
       while (cur?.parent) {

--- a/gitnexus/src/core/ingestion/taint/typescript-model.ts
+++ b/gitnexus/src/core/ingestion/taint/typescript-model.ts
@@ -18,6 +18,7 @@
 import { createHash } from 'node:crypto';
 import { SupportedLanguages } from 'gitnexus-shared';
 import type { SourceSinkSanitizerSpec } from './source-sink-config.js';
+import { JAVA_TAINT_MODEL } from './java-model.js';
 import { PYTHON_TAINT_MODEL } from './python-model.js';
 import { registerSourceSinkConfig } from './source-sink-registry.js';
 
@@ -99,6 +100,7 @@ function canonicalJson(value: unknown): string {
 }
 
 export const BUILTIN_TAINT_MODELS = {
+  [SupportedLanguages.Java]: JAVA_TAINT_MODEL,
   [SupportedLanguages.JavaScript]: TS_JS_TAINT_MODEL,
   [SupportedLanguages.Python]: PYTHON_TAINT_MODEL,
   [SupportedLanguages.TypeScript]: TS_JS_TAINT_MODEL,
@@ -117,6 +119,7 @@ export const taintModelVersion: string = computeModelDigest(BUILTIN_TAINT_MODELS
  * until they have a dedicated model.
  */
 export function registerBuiltinTaintModels(): void {
+  registerSourceSinkConfig(SupportedLanguages.Java, JAVA_TAINT_MODEL);
   registerSourceSinkConfig(SupportedLanguages.TypeScript, TS_JS_TAINT_MODEL);
   registerSourceSinkConfig(SupportedLanguages.JavaScript, TS_JS_TAINT_MODEL);
   registerSourceSinkConfig(SupportedLanguages.Python, PYTHON_TAINT_MODEL);

--- a/gitnexus/src/core/ingestion/taint/typescript-model.ts
+++ b/gitnexus/src/core/ingestion/taint/typescript-model.ts
@@ -1,8 +1,8 @@
 /**
  * Built-in TS/JS taint model (#2083 M3 U2, plan KTD7).
  *
- * The canonical Express/Node source/sink/sanitizer set, registered for the
- * `typescript` and `javascript` language ids via the EXPLICIT
+ * The canonical Express/Node source/sink/sanitizer set plus the Java and
+ * Python models, registered for their language ids via the EXPLICIT
  * {@link registerBuiltinTaintModels} seam — deliberately not an import
  * side-effect, so the U4 emit path controls WHEN registration happens (call
  * it once before the pdg window runs; it is idempotent — the registry is
@@ -113,7 +113,7 @@ export const BUILTIN_TAINT_MODELS = {
 export const taintModelVersion: string = computeModelDigest(BUILTIN_TAINT_MODELS);
 
 /**
- * Register the built-in models for TypeScript, JavaScript, and Python.
+ * Register the built-in models for Java, TypeScript, JavaScript, and Python.
  * Explicit init seam for the U4 emit path (call before the pdg window
  * consumes the registry); idempotent. Other language ids remain unregistered
  * until they have a dedicated model.

--- a/gitnexus/test/unit/taint/java-model-match.test.ts
+++ b/gitnexus/test/unit/taint/java-model-match.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Java taint model (#2261) over real Java CFG and import capture output.
+ */
+
+import { createRequire } from 'node:module';
+import type { ParsedImport } from 'gitnexus-shared';
+import { describe, expect, it } from 'vitest';
+import { createJavaCfgVisitor } from '../../../src/core/ingestion/cfg/visitors/java.js';
+import { computeReachingDefs } from '../../../src/core/ingestion/cfg/reaching-defs.js';
+import type { FunctionCfg } from '../../../src/core/ingestion/cfg/types.js';
+import { emitJavaScopeCaptures } from '../../../src/core/ingestion/languages/java/captures.js';
+import { interpretJavaImport } from '../../../src/core/ingestion/languages/java/interpret.js';
+import { JAVA_TAINT_MODEL } from '../../../src/core/ingestion/taint/java-model.js';
+import { hasTaintSafeSites } from '../../../src/core/ingestion/taint/site-safety.js';
+import {
+  buildTaintImportIndex,
+  matchFunctionSites,
+  type FunctionSiteMatches,
+  type MatchedSinkCall,
+  type MatchedSource,
+} from '../../../src/core/ingestion/taint/match.js';
+import { computeTaintFlows } from '../../../src/core/ingestion/taint/propagate.js';
+import { makeCfgHarness, bindingIdx, type CfgHarness } from '../../helpers/cfg-harness.js';
+
+const javaGrammar = createRequire(import.meta.url)('tree-sitter-java') as Parameters<
+  typeof makeCfgHarness
+>[0];
+
+const java: CfgHarness = makeCfgHarness(javaGrammar, createJavaCfgVisitor(), 'fixture.java');
+
+function importsFor(src: string): ParsedImport[] {
+  return emitJavaScopeCaptures(src, 'fixture.java')
+    .filter((m) => m['@import.statement'] !== undefined)
+    .map((m) => interpretJavaImport(m))
+    .filter((p): p is ParsedImport => p !== null);
+}
+
+function cfgOf(code: string, fnIndex = 0): FunctionCfg {
+  const cfg = java.cfgOf(code, fnIndex);
+  expect(hasTaintSafeSites(cfg)).toBe(true);
+  return cfg;
+}
+
+function matchesOf(code: string, fnIndex = 0): { cfg: FunctionCfg; matches: FunctionSiteMatches } {
+  const cfg = cfgOf(code, fnIndex);
+  return {
+    cfg,
+    matches: matchFunctionSites(cfg, JAVA_TAINT_MODEL, buildTaintImportIndex(importsFor(code))),
+  };
+}
+
+function analyze(code: string, fnIndex = 0) {
+  const { cfg, matches } = matchesOf(code, fnIndex);
+  const defUse = computeReachingDefs(cfg);
+  return { cfg, matches, flows: computeTaintFlows(cfg, defUse, matches) };
+}
+
+const allSources = (m: FunctionSiteMatches): MatchedSource[] =>
+  m.statements.flatMap((s) => [...s.sources]);
+const allSinks = (m: FunctionSiteMatches): MatchedSinkCall[] =>
+  m.statements.flatMap((s) => [...s.sinks]);
+
+const wrap = (body: string, imports = ''): string => `${imports}
+class C {
+  void f(javax.servlet.http.HttpServletRequest request, Helper helper, String safe) {
+    ${body}
+  }
+}`;
+
+describe('Java taint model (#2261)', () => {
+  it('matches assigned request call results as remote-input sources', () => {
+    const { cfg, matches } = matchesOf(wrap(`String p = request.getParameter("id");`));
+    const sources = allSources(matches);
+    expect(sources).toHaveLength(1);
+    expect(sources[0].type).toBe('call-result');
+    expect(sources[0].entry.kind).toBe('remote-input');
+    expect(sources[0].type === 'call-result' ? [...sources[0].resultDefs] : []).toEqual([
+      bindingIdx(cfg, 'p'),
+    ]);
+    expect(matches.hasSource).toBe(true);
+  });
+
+  it('propagates an assigned request source into a static-import-proven file read sink', () => {
+    const { cfg, matches, flows } = analyze(
+      wrap(
+        `
+String p = request.getParameter("path");
+readString(of(p));
+`,
+        `
+import static java.nio.file.Files.readString;
+import static java.nio.file.Path.of;
+`,
+      ),
+    );
+    const p = bindingIdx(cfg, 'p');
+    const sink = allSinks(matches)[0];
+    expect(sink.entry.name).toBe('readString');
+    const sinkSite = matches.statements
+      .flatMap((stmt) => stmt.sinks.map((matched) => ({ stmt, matched })))
+      .find(({ matched }) => matched === sink);
+    if (sinkSite === undefined) throw new Error('expected readString sink site');
+    const site =
+      cfg.blocks[sinkSite.stmt.blockIndex].statements?.[sinkSite.stmt.statementIndex]?.sites?.[
+        sink.siteIndex
+      ];
+    expect(site?.callee).toBe('readString');
+    expect(site?.args?.[0]).toContainEqual([p, expect.any(Number)]);
+    expect(flows.status).toBe('computed');
+    expect(flows.findings).toHaveLength(1);
+    expect(flows.findings[0].sinkKind).toBe('path-traversal');
+    expect(flows.findings[0].source.type).toBe('call-result');
+  });
+
+  it('supports getHeader call-result sources', () => {
+    const { flows } = analyze(
+      wrap(
+        `
+String p = request.getHeader("X-Path");
+readString(of(p));
+`,
+        `
+import static java.nio.file.Files.readString;
+import static java.nio.file.Path.of;
+`,
+      ),
+    );
+    expect(flows.findings).toHaveLength(1);
+  });
+
+  it('does not seed an unassigned request call result', () => {
+    const { matches, flows } = analyze(
+      wrap(
+        `readString(request.getParameter("path"));`,
+        'import static java.nio.file.Files.readString;',
+      ),
+    );
+    expect(allSources(matches)).toHaveLength(0);
+    expect(flows.findings).toHaveLength(0);
+  });
+
+  it('does not treat unrelated same-named receivers as servlet sources', () => {
+    const { matches, flows } = analyze(
+      wrap(
+        `
+String p = helper.getParameter("path");
+readString(p);
+`,
+        'import static java.nio.file.Files.readString;',
+      ),
+    );
+    expect(allSources(matches)).toHaveLength(0);
+    expect(flows.findings).toHaveLength(0);
+  });
+
+  it('does not report a sink when the tainted value is not in the dangerous argument', () => {
+    const { cfg, matches, flows } = analyze(
+      wrap(
+        `
+String p = request.getParameter("path");
+String unused = p;
+readString(of(safe));
+`,
+        `
+import static java.nio.file.Files.readString;
+import static java.nio.file.Path.of;
+`,
+      ),
+    );
+    const p = bindingIdx(cfg, 'p');
+    const sink = allSinks(matches)[0];
+    expect(sink.entry.name).toBe('readString');
+    const sinkSite = matches.statements
+      .flatMap((stmt) => stmt.sinks.map((matched) => ({ stmt, matched })))
+      .find(({ matched }) => matched === sink);
+    if (sinkSite === undefined) throw new Error('expected readString sink site');
+    const site =
+      cfg.blocks[sinkSite.stmt.blockIndex].statements?.[sinkSite.stmt.statementIndex]?.sites?.[
+        sink.siteIndex
+      ];
+    expect(site?.callee).toBe('readString');
+    expect(site?.args?.[0]).not.toContainEqual([p, expect.any(Number)]);
+    expect(site?.args?.[0]).not.toContain(p);
+    expect(flows.status).toBe('computed');
+    expect(flows.findings).toHaveLength(0);
+  });
+
+  it('does not match same-named readString calls without static import provenance', () => {
+    const { matches, flows } = analyze(
+      wrap(`
+String p = request.getParameter("path");
+readString(p);
+helper.readString(p);
+`),
+    );
+    expect(allSinks(matches)).toHaveLength(0);
+    expect(flows.findings).toHaveLength(0);
+  });
+
+  it('does not report Paths.get or Path.of constructors as sinks', () => {
+    const { matches, flows } = analyze(
+      wrap(
+        `
+String p = request.getParameter("path");
+get(p);
+of(p);
+`,
+        `
+import static java.nio.file.Paths.get;
+import static java.nio.file.Path.of;
+`,
+      ),
+    );
+    expect(allSinks(matches)).toHaveLength(0);
+    expect(flows.findings).toHaveLength(0);
+  });
+
+  it('does not match unrelated static imports named readString', () => {
+    const { matches, flows } = analyze(
+      wrap(
+        `
+String p = request.getParameter("path");
+readString(p);
+`,
+        'import static com.example.Files.readString;',
+      ),
+    );
+    expect(allSinks(matches)).toHaveLength(0);
+    expect(flows.findings).toHaveLength(0);
+  });
+
+  it('does not report untainted input reaching the file read sink', () => {
+    const { matches, flows } = analyze(
+      wrap(
+        `readString(of(safe));`,
+        `
+import static java.nio.file.Files.readString;
+import static java.nio.file.Path.of;
+`,
+      ),
+    );
+    expect(allSinks(matches)).toHaveLength(1);
+    expect(flows.findings).toHaveLength(0);
+  });
+});

--- a/gitnexus/test/unit/taint/java-model-match.test.ts
+++ b/gitnexus/test/unit/taint/java-model-match.test.ts
@@ -4,7 +4,7 @@
 
 import { createRequire } from 'node:module';
 import type { ParsedImport } from 'gitnexus-shared';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import { createJavaCfgVisitor } from '../../../src/core/ingestion/cfg/visitors/java.js';
 import { computeReachingDefs } from '../../../src/core/ingestion/cfg/reaching-defs.js';
 import type { FunctionCfg } from '../../../src/core/ingestion/cfg/types.js';
@@ -60,9 +60,22 @@ const allSources = (m: FunctionSiteMatches): MatchedSource[] =>
 const allSinks = (m: FunctionSiteMatches): MatchedSinkCall[] =>
   m.statements.flatMap((s) => [...s.sinks]);
 
+function matchedSinkSite(cfg: FunctionCfg, matches: FunctionSiteMatches, sink: MatchedSinkCall) {
+  const sinkSite = matches.statements
+    .flatMap((stmt) => stmt.sinks.map((matched) => ({ stmt, matched })))
+    .find(({ matched }) => matched === sink);
+  assert(sinkSite !== undefined, 'expected matched sink site');
+  const site =
+    cfg.blocks[sinkSite.stmt.blockIndex].statements?.[sinkSite.stmt.statementIndex]?.sites?.[
+      sink.siteIndex
+    ];
+  assert(site !== undefined, 'expected concrete sink site');
+  return site;
+}
+
 const wrap = (body: string, imports = ''): string => `${imports}
 class C {
-  void f(javax.servlet.http.HttpServletRequest request, Helper helper, String safe) {
+  void f(javax.servlet.http.HttpServletRequest request, javax.servlet.http.HttpServletRequest req, Helper helper, String safe) {
     ${body}
   }
 }`;
@@ -96,14 +109,7 @@ import static java.nio.file.Path.of;
     const p = bindingIdx(cfg, 'p');
     const sink = allSinks(matches)[0];
     expect(sink.entry.name).toBe('readString');
-    const sinkSite = matches.statements
-      .flatMap((stmt) => stmt.sinks.map((matched) => ({ stmt, matched })))
-      .find(({ matched }) => matched === sink);
-    if (sinkSite === undefined) throw new Error('expected readString sink site');
-    const site =
-      cfg.blocks[sinkSite.stmt.blockIndex].statements?.[sinkSite.stmt.statementIndex]?.sites?.[
-        sink.siteIndex
-      ];
+    const site = matchedSinkSite(cfg, matches, sink);
     expect(site?.callee).toBe('readString');
     expect(site?.args?.[0]).toContainEqual([p, expect.any(Number)]);
     expect(flows.status).toBe('computed');
@@ -112,8 +118,32 @@ import static java.nio.file.Path.of;
     expect(flows.findings[0].source.type).toBe('call-result');
   });
 
+  it('propagates regular-import-proven Files.readString into a path-traversal finding', () => {
+    const { cfg, matches, flows } = analyze(
+      wrap(
+        `
+String p = request.getParameter("path");
+Files.readString(Path.of(p));
+`,
+        `
+import java.nio.file.Files;
+import java.nio.file.Path;
+`,
+      ),
+    );
+    const p = bindingIdx(cfg, 'p');
+    const sinks = allSinks(matches);
+    expect(sinks).toHaveLength(1);
+    expect(sinks[0].entry.kind).toBe('path-traversal');
+    const site = matchedSinkSite(cfg, matches, sinks[0]);
+    expect(site.callee).toBe('Files.readString');
+    expect(site.args?.[0]).toContainEqual([p, expect.any(Number)]);
+    expect(flows.findings).toHaveLength(1);
+    expect(flows.findings[0].sinkKind).toBe('path-traversal');
+  });
+
   it('supports getHeader call-result sources', () => {
-    const { flows } = analyze(
+    const { cfg, matches, flows } = analyze(
       wrap(
         `
 String p = request.getHeader("X-Path");
@@ -125,6 +155,36 @@ import static java.nio.file.Path.of;
 `,
       ),
     );
+    const p = bindingIdx(cfg, 'p');
+    const sources = allSources(matches);
+    expect(sources).toHaveLength(1);
+    assert(sources[0].type === 'call-result', 'expected getHeader to be a call-result source');
+    expect(sources[0].entry.kind).toBe('remote-input');
+    expect([...sources[0].resultDefs]).toEqual([p]);
+    const sinks = allSinks(matches);
+    expect(sinks).toHaveLength(1);
+    expect(sinks[0].entry.kind).toBe('path-traversal');
+    expect(flows.findings).toHaveLength(1);
+    expect(flows.findings[0].source.type).toBe('call-result');
+  });
+
+  it('supports the short req receiver for call-result sources', () => {
+    const { cfg, matches, flows } = analyze(
+      wrap(
+        `
+String p = req.getParameter("path");
+readString(of(p));
+`,
+        `
+import static java.nio.file.Files.readString;
+import static java.nio.file.Path.of;
+`,
+      ),
+    );
+    const p = bindingIdx(cfg, 'p');
+    const [source] = allSources(matches);
+    assert(source?.type === 'call-result', 'expected req.getParameter source');
+    expect([...source.resultDefs]).toEqual([p]);
     expect(flows.findings).toHaveLength(1);
   });
 
@@ -170,14 +230,7 @@ import static java.nio.file.Path.of;
     const p = bindingIdx(cfg, 'p');
     const sink = allSinks(matches)[0];
     expect(sink.entry.name).toBe('readString');
-    const sinkSite = matches.statements
-      .flatMap((stmt) => stmt.sinks.map((matched) => ({ stmt, matched })))
-      .find(({ matched }) => matched === sink);
-    if (sinkSite === undefined) throw new Error('expected readString sink site');
-    const site =
-      cfg.blocks[sinkSite.stmt.blockIndex].statements?.[sinkSite.stmt.statementIndex]?.sites?.[
-        sink.siteIndex
-      ];
+    const site = matchedSinkSite(cfg, matches, sink);
     expect(site?.callee).toBe('readString');
     expect(site?.args?.[0]).not.toContainEqual([p, expect.any(Number)]);
     expect(site?.args?.[0]).not.toContain(p);
@@ -229,6 +282,35 @@ readString(p);
     expect(flows.findings).toHaveLength(0);
   });
 
+  it('does not match unrelated regular imports named Files', () => {
+    const { matches, flows } = analyze(
+      wrap(
+        `
+String p = request.getParameter("path");
+Files.readString(p);
+`,
+        'import com.example.Files;',
+      ),
+    );
+    expect(allSinks(matches)).toHaveLength(0);
+    expect(flows.findings).toHaveLength(0);
+  });
+
+  it('does not let a local Files receiver inherit import provenance', () => {
+    const { matches, flows } = analyze(
+      wrap(
+        `
+String p = request.getParameter("path");
+Helper Files = helper;
+Files.readString(p);
+`,
+        'import java.nio.file.Files;',
+      ),
+    );
+    expect(allSinks(matches)).toHaveLength(0);
+    expect(flows.findings).toHaveLength(0);
+  });
+
   it('does not report untainted input reaching the file read sink', () => {
     const { matches, flows } = analyze(
       wrap(
@@ -240,6 +322,20 @@ import static java.nio.file.Path.of;
       ),
     );
     expect(allSinks(matches)).toHaveLength(1);
+    expect(flows.findings).toHaveLength(0);
+  });
+
+  it('does not report regular-import path constructors without a file sink', () => {
+    const { matches, flows } = analyze(
+      wrap(
+        `
+String p = request.getParameter("path");
+Path.of(p);
+`,
+        'import java.nio.file.Path;',
+      ),
+    );
+    expect(allSinks(matches)).toHaveLength(0);
     expect(flows.findings).toHaveLength(0);
   });
 });

--- a/gitnexus/test/unit/taint/model-match.test.ts
+++ b/gitnexus/test/unit/taint/model-match.test.ts
@@ -25,7 +25,7 @@ import {
   type FunctionSiteMatches,
   type MatchedSanitizerCall,
   type MatchedSinkCall,
-  type MatchedSourceRead,
+  type MatchedSource,
 } from '../../../src/core/ingestion/taint/match.js';
 import {
   getSourceSinkConfig,
@@ -47,7 +47,7 @@ function matchesOf(
 
 const allSinks = (m: FunctionSiteMatches): MatchedSinkCall[] =>
   m.statements.flatMap((s) => [...s.sinks]);
-const allSources = (m: FunctionSiteMatches): MatchedSourceRead[] =>
+const allSources = (m: FunctionSiteMatches): MatchedSource[] =>
   m.statements.flatMap((s) => [...s.sources]);
 const allSanitizers = (m: FunctionSiteMatches): MatchedSanitizerCall[] =>
   m.statements.flatMap((s) => [...s.sanitizers]);
@@ -276,7 +276,13 @@ describe('registry + model identity', () => {
   it('registerBuiltinTaintModels registers TS, JS, and Python (idempotent); others stay undefined', () => {
     registerBuiltinTaintModels();
     registerBuiltinTaintModels(); // idempotent — last-write-wins on the same ids
-    expect(registeredTaintLanguages().sort()).toEqual(['javascript', 'python', 'typescript']);
+    expect(registeredTaintLanguages().sort()).toEqual([
+      'java',
+      'javascript',
+      'python',
+      'typescript',
+    ]);
+    expect(getSourceSinkConfig('java')).toBe(BUILTIN_TAINT_MODELS.java);
     expect(getSourceSinkConfig('typescript')).toBe(TS_JS_TAINT_MODEL);
     expect(getSourceSinkConfig('javascript')).toBe(TS_JS_TAINT_MODEL);
     expect(getSourceSinkConfig('python')).toBe(BUILTIN_TAINT_MODELS.python);

--- a/gitnexus/test/unit/taint/model-match.test.ts
+++ b/gitnexus/test/unit/taint/model-match.test.ts
@@ -78,6 +78,21 @@ function f(c) { cp.exec(c); }`);
     expect(allSinks(m).map((s) => s.entry.name)).toEqual(['exec']);
   });
 
+  it('named import from a same-tail module is not canonicalized as a namespace handle', () => {
+    const spec: SourceSinkSanitizerSpec = {
+      sources: [],
+      sinks: [{ name: 'readString', kind: 'path-traversal', args: [0], module: 'pkg.Files' }],
+      sanitizers: [],
+    };
+    const m = matchesOf(
+      `import { Files } from 'pkg.Files';
+function f(p) { Files.readString(p); }`,
+      0,
+      spec,
+    );
+    expect(allSinks(m)).toHaveLength(0);
+  });
+
   it('node: scheme prefix is normalized — `from "node:child_process"` matches too', () => {
     const m = matchesOf(`import { execSync } from 'node:child_process';
 function f(c) { execSync(c); }`);

--- a/gitnexus/test/unit/taint/python-model-match.test.ts
+++ b/gitnexus/test/unit/taint/python-model-match.test.ts
@@ -15,7 +15,7 @@ import {
   matchFunctionSites,
   type FunctionSiteMatches,
   type MatchedSinkCall,
-  type MatchedSourceRead,
+  type MatchedSource,
 } from '../../../src/core/ingestion/taint/match.js';
 import { makeCfgHarness } from '../../helpers/cfg-harness.js';
 
@@ -36,7 +36,7 @@ function matchesOf(code: string, fnIndex = 0): FunctionSiteMatches {
 
 const allSinks = (m: FunctionSiteMatches): MatchedSinkCall[] =>
   m.statements.flatMap((s) => [...s.sinks]);
-const allSources = (m: FunctionSiteMatches): MatchedSourceRead[] =>
+const allSources = (m: FunctionSiteMatches): MatchedSource[] =>
   m.statements.flatMap((s) => [...s.sources]);
 
 describe('Python taint model (#2204)', () => {

--- a/gitnexus/test/unit/taint/python-model-match.test.ts
+++ b/gitnexus/test/unit/taint/python-model-match.test.ts
@@ -9,6 +9,7 @@ import { createPythonCfgVisitor } from '../../../src/core/ingestion/cfg/visitors
 import { emitPythonScopeCaptures } from '../../../src/core/ingestion/languages/python/captures.js';
 import { interpretPythonImport } from '../../../src/core/ingestion/languages/python/interpret.js';
 import { PYTHON_TAINT_MODEL } from '../../../src/core/ingestion/taint/python-model.js';
+import type { SourceSinkSanitizerSpec } from '../../../src/core/ingestion/taint/source-sink-config.js';
 import { hasTaintSafeSites } from '../../../src/core/ingestion/taint/site-safety.js';
 import {
   buildTaintImportIndex,
@@ -28,10 +29,14 @@ function importsFor(src: string): ParsedImport[] {
     .filter((p): p is ParsedImport => p !== null);
 }
 
-function matchesOf(code: string, fnIndex = 0): FunctionSiteMatches {
+function matchesOf(
+  code: string,
+  fnIndex = 0,
+  spec: SourceSinkSanitizerSpec = PYTHON_TAINT_MODEL,
+): FunctionSiteMatches {
   const cfg = harness.cfgOf(code, fnIndex);
   expect(hasTaintSafeSites(cfg)).toBe(true);
-  return matchFunctionSites(cfg, PYTHON_TAINT_MODEL, buildTaintImportIndex(importsFor(code)));
+  return matchFunctionSites(cfg, spec, buildTaintImportIndex(importsFor(code)));
 }
 
 const allSinks = (m: FunctionSiteMatches): MatchedSinkCall[] =>
@@ -73,6 +78,25 @@ def f(request):
     sp.run(request.args)
 `);
     expect(allSinks(m).map((s) => s.entry.name)).toEqual(['run']);
+  });
+
+  it('does not dedupe named imports from a same-tail module path', () => {
+    const spec: SourceSinkSanitizerSpec = {
+      sources: [],
+      sinks: [{ name: 'read_string', kind: 'path-traversal', args: [0], module: 'pkg.Files' }],
+      sanitizers: [],
+    };
+    const m = matchesOf(
+      `
+from pkg.Files import Files
+
+def f(p):
+    Files.read_string(p)
+`,
+      0,
+      spec,
+    );
+    expect(allSinks(m)).toHaveLength(0);
   });
 
   it('does not guess positional sink slots for keyword arguments', () => {

--- a/gitnexus/test/unit/taint/summary-harvest.test.ts
+++ b/gitnexus/test/unit/taint/summary-harvest.test.ts
@@ -190,6 +190,17 @@ describe('harvestFunctionSummary — source→return', () => {
     expect(f.sourceToReturn).toEqual([{ sourceKind: 'remote-input' }]);
   });
 
+  it('records an assigned call-result source returned via a local', () => {
+    const f = harvest(
+      `function f(request: { getParameter(name: string): string }) {
+        const u = request.getParameter('path');
+        return u;
+      }`,
+      CALL_RESULT_SOURCE_SPEC,
+    );
+    expect(f.sourceToReturn).toEqual([{ sourceKind: 'remote-input' }]);
+  });
+
   it('is empty when no source is present', () => {
     const f = harvest(`function f(x: string) { return x; }`);
     expect(f.sourceToReturn).toEqual([]);

--- a/gitnexus/test/unit/taint/summary-harvest.test.ts
+++ b/gitnexus/test/unit/taint/summary-harvest.test.ts
@@ -28,6 +28,19 @@ const SPEC: SourceSinkSanitizerSpec = {
   sanitizers: [{ name: 'escape', neutralizes: ['command-injection'], global: true }],
 };
 
+const CALL_RESULT_SOURCE_SPEC: SourceSinkSanitizerSpec = {
+  sources: [
+    {
+      type: 'call-result',
+      kind: 'remote-input',
+      receivers: ['request'],
+      methods: ['getParameter'],
+    },
+  ],
+  sinks: [],
+  sanitizers: [],
+};
+
 function harvest(code: string, spec: SourceSinkSanitizerSpec = SPEC, fnIndex = 0) {
   const cfg: FunctionCfg = cfgOf(code, fnIndex);
   const defUse = computeReachingDefs(cfg);
@@ -93,15 +106,15 @@ describe('harvestFunctionSummary — call-arg sanitizer exclusions (#2084 review
     // records that command-injection was neutralised on the path.
     const f = harvest(`function f(x: string) { const y = escape(x); helper(y); }`);
     const edge = f.paramToCallArg.find((c) => c.calleeName === 'helper');
-    expect(edge).toBeDefined();
-    expect(edge!.neutralized).toEqual(['command-injection']);
+    if (edge === undefined) throw new Error('expected helper call-arg edge');
+    expect(edge.neutralized).toEqual(['command-injection']);
   });
 
   it('records no neutralized when the param reaches the call directly', () => {
     const f = harvest(`function f(x: string) { helper(x); }`);
     const edge = f.paramToCallArg.find((c) => c.calleeName === 'helper');
-    expect(edge).toBeDefined();
-    expect(edge!.neutralized).toBeUndefined();
+    if (edge === undefined) throw new Error('expected helper call-arg edge');
+    expect(edge.neutralized).toBeUndefined();
   });
 });
 
@@ -114,6 +127,19 @@ describe('harvestFunctionSummary — source→callee-arg (fixpoint seed)', () =>
   it('records a source passed via a local into a callee argument', () => {
     const f = harvest(`function f() { const u = req.body; runIt(u); }`);
     expect(f.sourceToCallArg.some((s) => s.calleeName === 'runIt')).toBe(true);
+  });
+
+  it('records an assigned call-result source passed via a local into a callee argument', () => {
+    const f = harvest(
+      `function f(request: { getParameter(name: string): string }) {
+        const u = request.getParameter('path');
+        runIt(u);
+      }`,
+      CALL_RESULT_SOURCE_SPEC,
+    );
+    expect(f.sourceToCallArg).toEqual([
+      { sourceKind: 'remote-input', callLine: 3, argIndex: 0, calleeName: 'runIt' },
+    ]);
   });
 });
 
@@ -185,9 +211,9 @@ describe('harvestFunctionSummary — documented limitations', () => {
     // fix (formal-param index from the worker) is deferred.
     const f = harvest(`function f([a, b]: string[], x: string) { exec(x); }`);
     const xSink = f.paramToSink.find((s) => s.sinkKind === 'command-injection');
-    expect(xSink).toBeDefined();
+    if (xSink === undefined) throw new Error('expected command-injection param sink');
     // Current (limited) behaviour: ordinal index 2, NOT the formal index 1.
-    expect(xSink!.param).toBe(2);
+    expect(xSink.param).toBe(2);
   });
 });
 

--- a/gitnexus/test/unit/taint/taint-emit.test.ts
+++ b/gitnexus/test/unit/taint/taint-emit.test.ts
@@ -18,6 +18,7 @@
 import { describe, it, expect } from 'vitest';
 import { cfgsOf, importsFor } from '../../helpers/ts-cfg-harness.js';
 import { emitFileCfgs } from '../../../src/core/ingestion/cfg/emit.js';
+import type { FunctionCfg } from '../../../src/core/ingestion/cfg/types.js';
 import type { SourceSinkSanitizerSpec } from '../../../src/core/ingestion/taint/source-sink-config.js';
 import {
   emitFileTaint,
@@ -42,6 +43,19 @@ const MECH: SourceSinkSanitizerSpec = {
 const MECH_ALL_ARGS: SourceSinkSanitizerSpec = {
   ...MECH,
   sinks: [{ name: 'exec', kind: 'command-injection', global: true }],
+};
+
+const CALL_RESULT_SOURCE_SPEC: SourceSinkSanitizerSpec = {
+  sources: [
+    {
+      type: 'call-result',
+      kind: 'remote-input',
+      receivers: ['request'],
+      methods: ['getParameter'],
+    },
+  ],
+  sinks: [{ name: 'exec', kind: 'command-injection', args: [0], global: true }],
+  sanitizers: [],
 };
 
 interface RunResult {
@@ -98,6 +112,36 @@ function handler(req: { body: string }) {
     expect(ids.has(tainted[0].sourceId)).toBe(true);
     expect(ids.has(tainted[0].targetId)).toBe(true);
     expect(tainted[0].id.startsWith('TAINTED:fixture.ts:')).toBe(true);
+  });
+
+  it('preserves the legacy member-read TAINTED edge identity', () => {
+    const { tainted } = run(CODE);
+    expect(tainted[0].id).toBe(
+      'TAINTED:fixture.ts:2:0:command-injection:2:0.0:req:2:17:2:1.0.0:cmd:3:8:exec:body',
+    );
+  });
+
+  it('persists a call-result source TAINTED edge with deterministic identity', () => {
+    const { result, tainted } = run(
+      `
+function handler(request: { getParameter(name: string): string }) {
+  const cmd = request.getParameter('cmd');
+  exec(cmd);
+}`,
+      { spec: CALL_RESULT_SOURCE_SPEC },
+    );
+    expect(result.functionsAnalyzed).toBe(1);
+    expect(result.findingsEmitted).toBe(1);
+    expect(tainted).toHaveLength(1);
+    expect(tainted[0].id).toBe(
+      'TAINTED:fixture.ts:2:0:command-injection:2:0.0:call-result:cmd:3:8:request.getParameter:2:1.0.0:cmd:3:8:exec',
+    );
+    const decoded = decodeTaintPath(tainted[0].reason);
+    expect(decoded.ok).toBe(true);
+    if (decoded.ok) {
+      expect(decoded.kind).toBe('command-injection');
+      expect(decoded.hops.map((h) => `${h.variable}@${h.line}`)).toEqual(['cmd@3', 'cmd@4']);
+    }
   });
 
   it('the persisted reason decodes via the shared codec with ordered hops + variables', () => {


### PR DESCRIPTION
## Summary

- add a generic call-result taint-source variant that seeds only proven `resultDefs`
- register a conservative Java model for servlet `request`/`req` `getParameter` and `getHeader` results
- model only static-import-proven `java.nio.file.Files.readString` as the initial Java path sink
- preserve legacy member-read finding and `TAINTED` edge identities while adding deterministic call-result identities
- cover intra-procedural propagation, function-summary harvesting, emission, registry/version behavior, and negative provenance cases

## Conservative boundaries

- `Paths.get` and `Path.of` are path constructors, not sinks
- JDBC, broad `execute*`, `Runtime.exec`, and `ProcessBuilder` matching remain out of scope because current site data cannot prove their receiver types safely
- unassigned call results are not seeded
- unsupported or same-named calls without exact static-import provenance do not match
- no Java sanitizers are registered

## Validation

- `npx tsc --noEmit`
- affected suite: 16 files, 477 tests passed
- taint suite: 14 files, 237 tests passed
- Java resolver integration: 186 tests passed
- five subprocess-heavy CLI files rerun alone: 57 tests passed on both feature and clean current `upstream/main`
- `git diff --check`
- GitNexus `detect_changes`: LOW risk, 0 affected processes
- Solo production-readiness review: production-ready with minor follow-ups; no production-readiness issues found against the current DoD bar

Full `npm test` was run on Windows: 10,515 passed, 121 skipped, and 11 failed across eight unrelated environment/performance-sensitive files. The three persistent failures reproduce on a clean archive of current `upstream/main` (`git-utils` trailing-space path, literal collector, Swift scaling). The remaining five files pass standalone on both clean main and this branch and fail only under full-suite process/resource contention. No taint or Java resolver test failed.

Closes #2261
Refs #2204
