### PR TITLE
feat(group): resolve inline HTTP provider handlers via call-site line (#2276)

### DIFF
--- a/gitnexus/src/core/group/cross-trace.ts
+++ b/gitnexus/src/core/group/cross-trace.ts
@@ -1036,12 +1036,13 @@ const FILE_BASENAME_RE =
 
 /**
  * A provider endpoint's display label. A resolved handler has a real function
- * name; the source-scan fallbacks leave a generic token (`'handler'`/`'fetch'`)
- * or a file basename. Those are treated as anonymous and shown as
+ * name; the source-scan fallbacks leave a generic token (`'handler'`/`'fetch'`,
+ * or `'route'` for an unresolved named-controller / closure Laravel route) or a
+ * file basename. Those are treated as anonymous and shown as
  * `<METHOD /path handler>` so the endpoint is still identifiable by route. When
  * the bridge row carries a resolved `providerUid`, the name IS a real symbol —
- * the `'handler'`/`'fetch'` sentinel check is suppressed so a function genuinely
- * named `handler` is not mislabeled anonymous.
+ * the sentinel check is suppressed so a function genuinely named `handler` (or,
+ * hypothetically, `route`) is not mislabeled anonymous.
  */
 function providerLabel(
   providerName: string,
@@ -1052,7 +1053,8 @@ function providerLabel(
   const generic =
     providerName === '' ||
     FILE_BASENAME_RE.test(providerName) ||
-    (!resolved && (providerName === 'handler' || providerName === 'fetch'));
+    (!resolved &&
+      (providerName === 'handler' || providerName === 'fetch' || providerName === 'route'));
   return generic
     ? { label: `<${contractId} handler>`, anon: true }
     : { label: providerName, anon: false };

--- a/gitnexus/src/core/group/extractors/http-patterns/go.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/go.ts
@@ -31,7 +31,7 @@ const FRAMEWORK_ROUTE_PATTERNS = compilePatterns({
             field: (field_identifier) @http_method (#match? @http_method "^(GET|POST|PUT|DELETE|PATCH)$"))
           arguments: (argument_list
             (interpreted_string_literal) @path
-            (identifier) @handler))
+            [(identifier) (func_literal)] @handler))
       `,
     },
   ],
@@ -51,7 +51,7 @@ const HANDLE_FUNC_PATTERNS = compilePatterns({
             field: (field_identifier) @fn (#eq? @fn "HandleFunc"))
           arguments: (argument_list
             (interpreted_string_literal) @path
-            (identifier) @handler))
+            [(identifier) (func_literal)] @handler))
       `,
     },
   ],
@@ -138,12 +138,18 @@ export const GO_HTTP_PLUGIN: HttpLanguagePlugin = {
       if (!methodNode || !pathNode) continue;
       const path = unquoteLiteral(pathNode.text);
       if (path === null) continue;
+      // An inline `func(){…}` handler has no name → emit `name: null` and a
+      // `line` so it resolves to its containing/closure symbol by line-span
+      // containment (like a consumer). A named identifier handler keeps its
+      // name and resolves by name; `line` is harmless there.
+      const isInlineHandler = handlerNode?.type === 'func_literal';
       out.push({
         role: 'provider',
         framework: 'go-framework',
         method: methodNode.text.toUpperCase(),
         path,
-        name: handlerNode?.text ?? null,
+        name: isInlineHandler ? null : (handlerNode?.text ?? null),
+        line: (handlerNode ?? pathNode).startPosition.row + 1,
         confidence: 0.8,
       });
     }
@@ -155,12 +161,16 @@ export const GO_HTTP_PLUGIN: HttpLanguagePlugin = {
       if (!pathNode) continue;
       const path = unquoteLiteral(pathNode.text);
       if (path === null) continue;
+      // Inline `func(){…}` handler → resolve by containment (see go-framework
+      // note above); a named handler resolves by name.
+      const isInlineHandler = handlerNode?.type === 'func_literal';
       out.push({
         role: 'provider',
         framework: 'go-stdlib',
         method: 'GET',
         path,
-        name: handlerNode?.text ?? null,
+        name: isInlineHandler ? null : (handlerNode?.text ?? null),
+        line: (handlerNode ?? pathNode).startPosition.row + 1,
         confidence: 0.8,
       });
     }

--- a/gitnexus/src/core/group/extractors/http-patterns/go.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/go.ts
@@ -17,8 +17,11 @@ import type { HttpDetection, HttpLanguagePlugin } from './types.js';
 
 // ─── Provider: framework routing ──────────────────────────────────────
 // Matches `\w+\.GET(...)` etc. (gin, echo, chi all share this shape).
-// Captures the HTTP method (field name), path literal, and handler
-// identifier passed as the second argument.
+// Captures the HTTP method (field name), path literal, and the handler —
+// anchored to the LAST argument (`@handler .`) so a variadic middleware
+// chain (`r.GET("/x", mw, handler)`, gin/echo/chi style) binds the real
+// handler, not a middleware identifier (which would otherwise over-match
+// and attach the route to the wrong symbol — see #2276 review).
 const FRAMEWORK_ROUTE_PATTERNS = compilePatterns({
   name: 'go-framework-route',
   language: Go,
@@ -31,7 +34,8 @@ const FRAMEWORK_ROUTE_PATTERNS = compilePatterns({
             field: (field_identifier) @http_method (#match? @http_method "^(GET|POST|PUT|DELETE|PATCH)$"))
           arguments: (argument_list
             (interpreted_string_literal) @path
-            [(identifier) (func_literal)] @handler))
+            [(identifier) (func_literal)] @handler
+            .))
       `,
     },
   ],
@@ -51,7 +55,8 @@ const HANDLE_FUNC_PATTERNS = compilePatterns({
             field: (field_identifier) @fn (#eq? @fn "HandleFunc"))
           arguments: (argument_list
             (interpreted_string_literal) @path
-            [(identifier) (func_literal)] @handler))
+            [(identifier) (func_literal)] @handler
+            .))
       `,
     },
   ],

--- a/gitnexus/src/core/group/extractors/http-patterns/java.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/java.ts
@@ -746,6 +746,11 @@ export const JAVA_HTTP_PLUGIN: HttpLanguagePlugin = {
           method: route.httpMethod,
           path: joinPath(prefix, route.rawPath),
           name: route.methodName,
+          // Spring providers are named controller methods resolved BY NAME;
+          // `line` is wired for parity with the consumer emits (and a future
+          // inline DSL) and is inert for current resolution — a named provider
+          // never falls through to line-span containment.
+          line: route.methodNode.startPosition.row + 1,
           confidence: 0.8,
         });
       }

--- a/gitnexus/src/core/group/extractors/http-patterns/java.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/java.ts
@@ -746,11 +746,13 @@ export const JAVA_HTTP_PLUGIN: HttpLanguagePlugin = {
           method: route.httpMethod,
           path: joinPath(prefix, route.rawPath),
           name: route.methodName,
-          // Spring providers are named controller methods resolved BY NAME;
-          // `line` is wired for parity with the consumer emits (and a future
-          // inline DSL) and is inert for current resolution — a named provider
-          // never falls through to line-span containment.
-          line: route.methodNode.startPosition.row + 1,
+          // Spring providers are named controller methods resolved BY NAME, so
+          // `line` is inert — a named provider never falls through to line-span
+          // containment. Gate it on a present name so a (grammar-impossible)
+          // nameless provider degrades to file-level rather than resolving by
+          // containment to the enclosing class. Wired for consumer-emit parity
+          // and a future inline DSL.
+          line: route.methodName ? route.methodNode.startPosition.row + 1 : undefined,
           confidence: 0.8,
         });
       }

--- a/gitnexus/src/core/group/extractors/http-patterns/kotlin.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/kotlin.ts
@@ -1019,11 +1019,13 @@ function buildKotlinPlugin(language: unknown): HttpLanguagePlugin {
             method: httpMethod,
             path: joinPath(prefix, rawPath),
             name: nameNode?.text ?? null,
-            // Spring providers are named controller methods resolved BY NAME;
-            // `line` is wired for parity with the consumer emits (and a future
-            // inline DSL) and is inert for current resolution — a named provider
-            // never falls through to line-span containment.
-            line: methodNode.startPosition.row + 1,
+            // Spring providers are named controller methods resolved BY NAME, so
+            // `line` is inert — a named provider never falls through to line-span
+            // containment. Gate it on a present name so a (grammar-impossible)
+            // nameless provider degrades to file-level rather than resolving by
+            // containment to the enclosing class. Wired for consumer-emit parity
+            // and a future inline DSL.
+            line: nameNode?.text ? methodNode.startPosition.row + 1 : undefined,
             confidence: 0.8,
           });
         }

--- a/gitnexus/src/core/group/extractors/http-patterns/kotlin.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/kotlin.ts
@@ -1019,6 +1019,11 @@ function buildKotlinPlugin(language: unknown): HttpLanguagePlugin {
             method: httpMethod,
             path: joinPath(prefix, rawPath),
             name: nameNode?.text ?? null,
+            // Spring providers are named controller methods resolved BY NAME;
+            // `line` is wired for parity with the consumer emits (and a future
+            // inline DSL) and is inert for current resolution — a named provider
+            // never falls through to line-span containment.
+            line: methodNode.startPosition.row + 1,
             confidence: 0.8,
           });
         }

--- a/gitnexus/src/core/group/extractors/http-patterns/php.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/php.ts
@@ -37,7 +37,9 @@ const LARAVEL_ROUTE_SPEC: PatternSpec<Record<string, never>> = {
     (scoped_call_expression
       scope: (name) @scope (#eq? @scope "Route")
       name: (name) @method (#match? @method "^(get|post|put|delete|patch)$")
-      arguments: (arguments . (argument (string) @path)))
+      arguments: (arguments
+        . (argument (string) @path)
+        (argument [(anonymous_function) (arrow_function)] @closure)?))
   `,
 };
 
@@ -150,12 +152,22 @@ export const PHP_HTTP_PLUGIN: HttpLanguagePlugin = {
       if (!methodNode || !pathNode) continue;
       const path = phpStringText(pathNode);
       if (path === null) continue;
+      // A closure handler (`Route::get('/x', function(){…})` / `fn() => …`) has
+      // no name → emit `name: null` + the registration line so it resolves to
+      // its containing symbol (e.g. a service-provider `boot()` or controller
+      // method) by line-span containment. A named-controller route keeps the
+      // `'route'` label — resolving its array/string handler to a real method is
+      // a separate, graph-backed concern. NOTE: a closure at FILE scope
+      // (routes/web.php) has no enclosing function and PHP closures are not yet
+      // indexed as symbols, so it still degrades to file-level (see #2276).
+      const closureNode = match.captures.closure;
       out.push({
         role: 'provider',
         framework: 'laravel',
         method: methodNode.text.toUpperCase(),
         path,
-        name: 'route',
+        name: closureNode ? null : 'route',
+        line: (closureNode ?? pathNode).startPosition.row + 1,
         confidence: 0.8,
       });
     }

--- a/gitnexus/src/core/group/extractors/http-patterns/python.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/python.ts
@@ -1057,6 +1057,12 @@ export const PYTHON_HTTP_PLUGIN: HttpLanguagePlugin = {
         method: httpMethod,
         path,
         name: null,
+        // The decorated handler has no captured name → resolve by line-span
+        // containment. Best-effort fallback: FastAPI routes are graph-backed
+        // (ingestion decorator routes) and the function span starts at `def`
+        // (decorators excluded), so this lands the single-decorator case and
+        // degrades to file-level for multi-decorator stacks.
+        line: pathNode.startPosition.row + 1,
         confidence: 0.8,
       });
     }
@@ -1101,6 +1107,8 @@ export const PYTHON_HTTP_PLUGIN: HttpLanguagePlugin = {
           method: httpMethod,
           path: p,
           name: null,
+          // Best-effort containment fallback — see the @app provider note above.
+          line: pathNode.startPosition.row + 1,
           confidence: 0.8,
         });
       }

--- a/gitnexus/test/integration/http-inline-handler-symbol-roundtrip.test.ts
+++ b/gitnexus/test/integration/http-inline-handler-symbol-roundtrip.test.ts
@@ -32,7 +32,9 @@ let storagePath: string;
 let dbPath: string;
 
 beforeAll(async () => {
-  tmpBase = path.join(os.tmpdir(), `gitnexus-http-inline-e2e-${Date.now()}-${process.pid}`);
+  // Atomic, unique temp dir (fs.mkdtemp) — avoids the predictable
+  // os.tmpdir()+name pattern CodeQL flags as an insecure temporary file.
+  tmpBase = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-http-inline-e2e-'));
   repoDir = path.join(tmpBase, 'repo');
   storagePath = path.join(tmpBase, '.gitnexus');
   dbPath = path.join(storagePath, 'lbug');

--- a/gitnexus/test/integration/http-inline-handler-symbol-roundtrip.test.ts
+++ b/gitnexus/test/integration/http-inline-handler-symbol-roundtrip.test.ts
@@ -1,0 +1,112 @@
+/**
+ * End-to-end validation of the INLINE provider source-scan containment path
+ * (#2276).
+ *
+ * The unit suite (`test/unit/group/http-route-extractor.test.ts`) proves the
+ * resolver logic by MOCKING `CONTAINING_QUERY` with hand-picked spans. That
+ * leaves one assumption unverified: that the REAL ingestion pipeline records a
+ * Go enclosing function with a 0-based span that actually contains the emitted
+ * call-site line. This test closes that gap.
+ *
+ * It runs the real pipeline over a Go file whose `http.HandleFunc` handler is an
+ * inline `func(){…}` (the issue's headline Go example), persists the resulting
+ * graph into a real LadybugDB, and runs the production `HttpRouteExtractor`
+ * against the real executor. The provider must resolve to the containing
+ * `main()` symbol via line-span containment (`source_scan_resolved`) — not the
+ * file-level fallback. Go does not index anonymous func literals as symbols
+ * (only `function_declaration`/`method_declaration`), so the innermost
+ * containing symbol is `main` itself.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { runPipelineFromRepo } from '../../src/core/ingestion/pipeline.js';
+import { HttpRouteExtractor } from '../../src/core/group/extractors/http-route-extractor.js';
+import type { CypherExecutor } from '../../src/core/group/contract-extractor.js';
+import type { RepoHandle } from '../../src/core/group/types.js';
+
+let tmpBase: string;
+let repoDir: string;
+let storagePath: string;
+let dbPath: string;
+
+beforeAll(async () => {
+  tmpBase = path.join(os.tmpdir(), `gitnexus-http-inline-e2e-${Date.now()}-${process.pid}`);
+  repoDir = path.join(tmpBase, 'repo');
+  storagePath = path.join(tmpBase, '.gitnexus');
+  dbPath = path.join(storagePath, 'lbug');
+  await fs.mkdir(path.join(repoDir, 'cmd'), { recursive: true });
+  await fs.mkdir(dbPath, { recursive: true });
+
+  // net/http inline handler INSIDE main() — the #2276 Go example. Before this
+  // change the func literal was not even captured; now it emits name:null + the
+  // call-site line so it resolves to main() by containment.
+  await fs.writeFile(
+    path.join(repoDir, 'cmd', 'server.go'),
+    `package main
+
+import "net/http"
+
+func main() {
+\thttp.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
+\t\tw.Write([]byte("ok"))
+\t})
+\thttp.ListenAndServe(":8080", nil)
+}
+`,
+  );
+
+  const result = await runPipelineFromRepo(repoDir, () => {}, {});
+  const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+  await adapter.initLbug(dbPath);
+  await adapter.loadGraphToLbug(result.graph, tmpBase, storagePath);
+}, 120_000);
+
+afterAll(async () => {
+  try {
+    const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+    await adapter.closeLbug();
+  } catch {
+    /* may not have opened */
+  }
+  if (tmpBase) {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      try {
+        await fs.rm(tmpBase, { recursive: true, force: true });
+        return;
+      } catch {
+        if (attempt < 4) await new Promise((r) => setTimeout(r, 200 * (attempt + 1)));
+      }
+    }
+  }
+});
+
+describe('inline Go provider handler resolves via real source-scan containment (#2276)', () => {
+  it('resolves an inline http.HandleFunc closure to the containing main() with a real symbolUid', async () => {
+    const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+    // Param-aware executor (CONTAINING_QUERY binds $filePath) — the same shape
+    // production passes to ContractExtractors.
+    const dbExecutor: CypherExecutor = (query, params = {}) =>
+      adapter.executePrepared(query, params);
+    const repo: RepoHandle = {
+      id: 'test-repo',
+      path: 'repo',
+      repoPath: repoDir,
+      storagePath,
+    };
+
+    const contracts = await new HttpRouteExtractor().extract(dbExecutor, repoDir, repo);
+    const provider = contracts.find(
+      (c) => c.role === 'provider' && c.contractId === 'http::GET::/api/health',
+    );
+
+    expect(provider).toBeDefined();
+    // The real pipeline indexed main() with its true 0-based span; the emitted
+    // call-site line lands inside it, so containment yields a real symbolUid
+    // rather than the empty file-level fallback.
+    expect(provider?.symbolUid).toBeTruthy();
+    expect(provider?.symbolName).toBe('main');
+    expect(provider?.meta.extractionStrategy).toBe('source_scan_resolved');
+  });
+});

--- a/gitnexus/test/unit/group/cross-trace.test.ts
+++ b/gitnexus/test/unit/group/cross-trace.test.ts
@@ -478,6 +478,73 @@ describe('runGroupTrace', () => {
     },
   );
 
+  itLbugReopen(
+    'destination trace anonymizes an unresolved Laravel `route` placeholder (#2276)',
+    async () => {
+      // A named-controller / closure Laravel provider that did not resolve keeps
+      // the synthetic `'route'` placeholder (never a real symbol name). It must
+      // be treated as anonymous — shown as `<route handler>` — exactly like the
+      // `'handler'`/`'fetch'` sentinels, not displayed as the literal `route`.
+      const consumer = makeContract({
+        repo: 'app/frontend',
+        role: 'consumer',
+        symbolUid: 'callUsers-uid',
+        symbolRef: { filePath: 'src/api.ts', name: 'callUsers' },
+        symbolName: 'callUsers',
+        contractId: 'http::GET::/api/users',
+      });
+      const provider = makeContract({
+        repo: 'app/backend',
+        role: 'provider',
+        symbolUid: '', // unresolved file-scope closure / named-controller route
+        symbolRef: { filePath: 'routes/web.php', name: 'route' },
+        symbolName: 'route',
+        contractId: 'http::GET::/api/users',
+      });
+      const link: CrossLink = {
+        from: { repo: 'app/frontend', symbolUid: 'callUsers-uid', symbolRef: consumer.symbolRef },
+        to: { repo: 'app/backend', symbolUid: '', symbolRef: provider.symbolRef },
+        type: 'http',
+        contractId: 'http::GET::/api/users',
+        matchType: 'exact',
+        confidence: 1,
+      };
+      await writeBridge(groupDir, {
+        contracts: [consumer, provider],
+        crossLinks: [link],
+        repoSnapshots: {},
+        missingRepos: [],
+      });
+
+      const port = makePort(
+        { 'reg-fe:callUsers': okSym('callUsers-uid', 'callUsers', 'src/api.ts', 3) },
+        {
+          'reg-fe:callUsers-uid->callUsers-uid': okTrace(
+            [{ name: 'callUsers', filePath: 'src/api.ts', startLine: 3 }],
+            [],
+          ),
+        },
+      );
+      const r = await runGroupTrace(
+        { port, gitnexusDir: tmpDir },
+        { name: 'g1', from: 'callUsers' },
+      );
+      expect(r).toMatchObject({
+        status: 'ok',
+        to: {
+          name: '<http::GET::/api/users handler>',
+          repo: 'app/backend',
+          filePath: 'routes/web.php',
+        },
+        hops: [
+          { name: 'callUsers', repo: 'app/frontend' },
+          { name: '<http::GET::/api/users handler>', repo: 'app/backend' },
+        ],
+        notes: expect.arrayContaining([expect.stringContaining('anonymous')]),
+      });
+    },
+  );
+
   itLbugReopen('destination trace not_found when no HTTP link leaves the repo', async () => {
     await writeUnlinkedBridge(groupDir);
     const port = makePort(

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -780,6 +780,131 @@ func registerRoutes(r *gin.Engine) {
       });
     });
 
+    it('binds the LAST arg as handler for a middleware + inline route, not the middleware (#2276)', async () => {
+      // `r.GET(path, mw, func(){})` — gin/echo variadic middleware before an
+      // inline handler. The trailing-anchor on @handler must select the closure
+      // (→ containment to the enclosing fn), NOT the middleware identifier. With
+      // the prior unanchored capture this emitted a second detection for `mw`
+      // that won the contractId merge and mis-attributed the route to it.
+      const dir = path.join(tmpDir, 'go-mw-inline-gin');
+      fs.mkdirSync(path.join(dir, 'cmd'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'cmd/server.go'),
+        `package main
+
+func authMiddleware(c *gin.Context) {}
+
+func registerRoutes(r *gin.Engine) {
+  r.GET("/api/guarded", authMiddleware, func(c *gin.Context) {
+    c.String(200, "ok")
+  })
+}
+`,
+      );
+      // Both the middleware and the enclosing registrar are indexed. The closure
+      // sits at line 6, contained by registerRoutes [5,9]; authMiddleware [3,3]
+      // does not contain it. The route must resolve to registerRoutes.
+      const mockDbExecutor = async (
+        query: string,
+        params?: Record<string, unknown>,
+      ): Promise<Record<string, unknown>[]> => {
+        if (query.includes('UNION ALL') && String(params?.filePath ?? '').includes('server.go')) {
+          return [
+            {
+              uid: 'fn-authMiddleware',
+              name: 'authMiddleware',
+              filePath: 'cmd/server.go',
+              startLine: 3,
+              endLine: 3,
+              labels: ['Function'],
+            },
+            {
+              uid: 'fn-registerRoutes',
+              name: 'registerRoutes',
+              filePath: 'cmd/server.go',
+              startLine: 5,
+              endLine: 9,
+              labels: ['Function'],
+            },
+          ];
+        }
+        return [];
+      };
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const providers = contracts.filter(
+        (c) => c.role === 'provider' && c.contractId === 'http::GET::/api/guarded',
+      );
+      // Exactly one provider (no middleware over-match), resolved by containment.
+      expect(providers).toHaveLength(1);
+      expect(providers[0]).toMatchObject({
+        symbolUid: 'fn-registerRoutes',
+        symbolName: 'registerRoutes',
+      });
+    });
+
+    it('binds the LAST arg as handler for a middleware + NAMED route, not the middleware (#2276)', async () => {
+      // `r.GET(path, mw, namedHandler)` — the named handler is the last arg and
+      // must resolve by name; the leading middleware identifier must not win.
+      const dir = path.join(tmpDir, 'go-mw-named-gin');
+      fs.mkdirSync(path.join(dir, 'cmd'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'cmd/server.go'),
+        `package main
+
+func authMiddleware(c *gin.Context) {}
+
+func listOrders(c *gin.Context) {}
+
+func registerRoutes(r *gin.Engine) {
+  r.GET("/api/orders", authMiddleware, listOrders)
+}
+`,
+      );
+      const mockDbExecutor = async (
+        query: string,
+        params?: Record<string, unknown>,
+      ): Promise<Record<string, unknown>[]> => {
+        if (query.includes('UNION ALL') && String(params?.filePath ?? '').includes('server.go')) {
+          return [
+            {
+              uid: 'fn-authMiddleware',
+              name: 'authMiddleware',
+              filePath: 'cmd/server.go',
+              startLine: 3,
+              endLine: 3,
+              labels: ['Function'],
+            },
+            {
+              uid: 'fn-listOrders',
+              name: 'listOrders',
+              filePath: 'cmd/server.go',
+              startLine: 5,
+              endLine: 5,
+              labels: ['Function'],
+            },
+            {
+              uid: 'fn-registerRoutes',
+              name: 'registerRoutes',
+              filePath: 'cmd/server.go',
+              startLine: 7,
+              endLine: 9,
+              labels: ['Function'],
+            },
+          ];
+        }
+        return [];
+      };
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const providers = contracts.filter(
+        (c) => c.role === 'provider' && c.contractId === 'http::GET::/api/orders',
+      );
+      expect(providers).toHaveLength(1);
+      expect(providers[0]).toMatchObject({
+        symbolUid: 'fn-listOrders',
+        symbolName: 'listOrders',
+      });
+    });
+
     it('resolves a Laravel closure route nested in a method to that method (#2276)', async () => {
       const dir = path.join(tmpDir, 'php-closure-in-method');
       fs.mkdirSync(path.join(dir, 'app'), { recursive: true });

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -833,6 +833,53 @@ Route::put('/api/named', [UserController::class, 'update']);
       expect(provider).toBeDefined();
       expect(provider?.symbolUid).toBe('');
     });
+
+    it('resolves a FastAPI @app provider to its decorated function (source-scan fallback) (#2276)', async () => {
+      const dir = path.join(tmpDir, 'py-fastapi-app');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'main.py'),
+        `from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/api/items")
+def list_items():
+    return []
+`,
+      );
+      // The decorator is on line 4 (row 3); `def list_items` is on line 5
+      // (row 4). tree-sitter records the function_definition span from `def`,
+      // so list_items spans 0-based [4,5]. The detection line is the decorator
+      // row + 1 = 5, and the resolver's direct `line` probe (row 4) lands in
+      // the def span. (Graph routes are authoritative; this is the fallback.)
+      const mockDbExecutor = async (
+        query: string,
+        params?: Record<string, unknown>,
+      ): Promise<Record<string, unknown>[]> => {
+        if (query.includes('UNION ALL') && String(params?.filePath ?? '').includes('main.py')) {
+          return [
+            {
+              uid: 'fn-list_items',
+              name: 'list_items',
+              filePath: 'main.py',
+              startLine: 4,
+              endLine: 5,
+              labels: ['Function'],
+            },
+          ];
+        }
+        return [];
+      };
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const provider = contracts.find(
+        (c) => c.role === 'provider' && c.contractId === 'http::GET::/api/items',
+      );
+      expect(provider).toMatchObject({
+        symbolUid: 'fn-list_items',
+        symbolName: 'list_items',
+        meta: { extractionStrategy: 'source_scan_resolved' },
+      });
+    });
   });
 
   describe('provider extraction — graph-first (Strategy A)', () => {

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -1133,6 +1133,100 @@ def list_items():
       expect(provider).toBeDefined();
       expect(provider?.symbolUid).toBe('');
     });
+
+    // The @router/APIRouter provider emit also carries `line` (#2276), but only
+    // @app was covered above. These pin the @router containment path: a
+    // single-decorator router handler resolves to its function, and a
+    // multi-decorator one degrades to file-level — same as @app.
+
+    it('resolves a FastAPI @router provider to its decorated function (source-scan fallback) (#2276)', async () => {
+      const dir = path.join(tmpDir, 'py-fastapi-router');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'main.py'),
+        `from fastapi import APIRouter
+router = APIRouter()
+
+@router.get("/api/items")
+def list_items():
+    return []
+`,
+      );
+      // Same shape as the @app case: @router.get is on line 4 (row 3), `def`
+      // on line 5 → list_items spans 0-based [4,5]; the `line` probe lands in
+      // the def span and resolves via source_scan_resolved. No include_router
+      // prefix in scope, so the unprefixed path is emitted.
+      const mockDbExecutor = async (
+        query: string,
+        params?: Record<string, unknown>,
+      ): Promise<Record<string, unknown>[]> => {
+        if (query.includes('UNION ALL') && String(params?.filePath ?? '').includes('main.py')) {
+          return [
+            {
+              uid: 'fn-list_items',
+              name: 'list_items',
+              filePath: 'main.py',
+              startLine: 4,
+              endLine: 5,
+              labels: ['Function'],
+            },
+          ];
+        }
+        return [];
+      };
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const provider = contracts.find(
+        (c) => c.role === 'provider' && c.contractId === 'http::GET::/api/items',
+      );
+      expect(provider).toMatchObject({
+        symbolUid: 'fn-list_items',
+        symbolName: 'list_items',
+        meta: { extractionStrategy: 'source_scan_resolved' },
+      });
+    });
+
+    it('leaves a module-scope multi-decorator @router handler at file-level (#2276)', async () => {
+      const dir = path.join(tmpDir, 'py-fastapi-router-multidecorator');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'main.py'),
+        `from fastapi import APIRouter
+router = APIRouter()
+
+@router.post("/api/items")
+@require_auth
+def create_item():
+    return {}
+`,
+      );
+      // With a second decorator the `def` is on line 6 → create_item spans
+      // 0-based [5,6]; the path-line probe falls ABOVE that span → no
+      // containment → file-level (symbolUid stays empty), matching @app.
+      const mockDbExecutor = async (
+        query: string,
+        params?: Record<string, unknown>,
+      ): Promise<Record<string, unknown>[]> => {
+        if (query.includes('UNION ALL') && String(params?.filePath ?? '').includes('main.py')) {
+          return [
+            {
+              uid: 'fn-create_item',
+              name: 'create_item',
+              filePath: 'main.py',
+              startLine: 5,
+              endLine: 6,
+              labels: ['Function'],
+            },
+          ];
+        }
+        return [];
+      };
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const provider = contracts.find(
+        (c) => c.role === 'provider' && c.contractId === 'http::POST::/api/items',
+      );
+      expect(provider).toBeDefined();
+      expect(provider?.symbolUid).toBe('');
+    });
   });
 
   describe('provider extraction — graph-first (Strategy A)', () => {

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -880,6 +880,78 @@ def list_items():
         meta: { extractionStrategy: 'source_scan_resolved' },
       });
     });
+
+    // Documented limitations pinned by tests (#2276): a closure with no
+    // enclosing function symbol, and a multi-decorator FastAPI handler whose
+    // detection line falls above the def-span, both degrade to file-level
+    // rather than mis-attributing. These lock the comments in php.ts/python.ts.
+
+    it('leaves a FILE-scope Laravel closure at file-level (no enclosing symbol) (#2276)', async () => {
+      const dir = path.join(tmpDir, 'php-closure-file-scope');
+      fs.mkdirSync(path.join(dir, 'routes'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'routes/web.php'),
+        `<?php
+Route::get('/api/home', function () {
+    return view('home');
+});
+`,
+      );
+      // No enclosing function/method at file scope, and PHP closures are not
+      // indexed as symbols → containment finds nothing → symbolUid stays empty.
+      const mockDbExecutor = async (): Promise<Record<string, unknown>[]> => [];
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const provider = contracts.find(
+        (c) => c.role === 'provider' && c.contractId === 'http::GET::/api/home',
+      );
+      expect(provider).toBeDefined();
+      expect(provider?.symbolUid).toBe('');
+    });
+
+    it('leaves a multi-decorator FastAPI handler at file-level (line above def-span) (#2276)', async () => {
+      const dir = path.join(tmpDir, 'py-fastapi-multidecorator');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'main.py'),
+        `from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/api/items")
+@require_auth
+def list_items():
+    return []
+`,
+      );
+      // The path literal is on line 4 (row 3) → detection line = row 3 + 1 = 4.
+      // With a second decorator the `def` is on line 6 (row 5), so list_items
+      // spans 0-based [5,6]. The resolver probes row 3 (line-1) then row 4
+      // (line); both fall ABOVE the [5,6] span → no containment → file-level.
+      // (Single-decorator resolves because there the def sits at the line probe.)
+      const mockDbExecutor = async (
+        query: string,
+        params?: Record<string, unknown>,
+      ): Promise<Record<string, unknown>[]> => {
+        if (query.includes('UNION ALL') && String(params?.filePath ?? '').includes('main.py')) {
+          return [
+            {
+              uid: 'fn-list_items',
+              name: 'list_items',
+              filePath: 'main.py',
+              startLine: 5,
+              endLine: 6,
+              labels: ['Function'],
+            },
+          ];
+        }
+        return [];
+      };
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const provider = contracts.find(
+        (c) => c.role === 'provider' && c.contractId === 'http::GET::/api/items',
+      );
+      expect(provider).toBeDefined();
+      expect(provider?.symbolUid).toBe('');
+    });
   });
 
   describe('provider extraction — graph-first (Strategy A)', () => {

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -723,6 +723,116 @@ func main() {
         symbolName: 'healthHandler',
       });
     });
+
+    it('resolves a Laravel closure route nested in a method to that method (#2276)', async () => {
+      const dir = path.join(tmpDir, 'php-closure-in-method');
+      fs.mkdirSync(path.join(dir, 'app'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'app/RouteServiceProvider.php'),
+        `<?php
+class RouteServiceProvider {
+    public function boot() {
+        Route::get('/api/closure', function () {
+            return 1;
+        });
+    }
+}
+`,
+      );
+      // boot() spans source lines 3-7 → 0-based [2,6]; the closure registration
+      // is on line 4 (row 3), inside boot's span.
+      const mockDbExecutor = async (
+        query: string,
+        params?: Record<string, unknown>,
+      ): Promise<Record<string, unknown>[]> => {
+        if (
+          query.includes('UNION ALL') &&
+          String(params?.filePath ?? '').includes('RouteServiceProvider.php')
+        ) {
+          return [
+            {
+              uid: 'method-boot',
+              name: 'boot',
+              filePath: 'app/RouteServiceProvider.php',
+              startLine: 2,
+              endLine: 6,
+              labels: ['Method'],
+            },
+          ];
+        }
+        return [];
+      };
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const provider = contracts.find(
+        (c) => c.role === 'provider' && c.contractId === 'http::GET::/api/closure',
+      );
+      expect(provider).toMatchObject({
+        symbolUid: 'method-boot',
+        symbolName: 'boot',
+        meta: { extractionStrategy: 'source_scan_resolved' },
+      });
+    });
+
+    it('resolves a Laravel arrow-fn closure route by containment (#2276)', async () => {
+      const dir = path.join(tmpDir, 'php-arrow-in-method');
+      fs.mkdirSync(path.join(dir, 'app'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'app/RouteServiceProvider.php'),
+        `<?php
+class RouteServiceProvider {
+    public function boot() {
+        Route::post('/api/arrow', fn() => response());
+    }
+}
+`,
+      );
+      const mockDbExecutor = async (
+        query: string,
+        params?: Record<string, unknown>,
+      ): Promise<Record<string, unknown>[]> => {
+        if (
+          query.includes('UNION ALL') &&
+          String(params?.filePath ?? '').includes('RouteServiceProvider.php')
+        ) {
+          return [
+            {
+              uid: 'method-boot',
+              name: 'boot',
+              filePath: 'app/RouteServiceProvider.php',
+              startLine: 2,
+              endLine: 4,
+              labels: ['Method'],
+            },
+          ];
+        }
+        return [];
+      };
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const provider = contracts.find(
+        (c) => c.role === 'provider' && c.contractId === 'http::POST::/api/arrow',
+      );
+      expect(provider).toMatchObject({ symbolUid: 'method-boot', symbolName: 'boot' });
+    });
+
+    it('leaves a Laravel NAMED-controller route at the prior behavior (no closure path) (#2276)', async () => {
+      const dir = path.join(tmpDir, 'php-named-controller');
+      fs.mkdirSync(path.join(dir, 'routes'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'routes/web.php'),
+        `<?php
+Route::put('/api/named', [UserController::class, 'update']);
+`,
+      );
+      // No closure → name stays 'route' (not null); the 'route' label resolves
+      // to no symbol, so symbolUid stays empty (file-level). Behavior unchanged.
+      const mockDbExecutor = async (): Promise<Record<string, unknown>[]> => [];
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const provider = contracts.find(
+        (c) => c.role === 'provider' && c.contractId === 'http::PUT::/api/named',
+      );
+      expect(provider).toBeDefined();
+      expect(provider?.symbolUid).toBe('');
+    });
   });
 
   describe('provider extraction — graph-first (Strategy A)', () => {

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -579,6 +579,150 @@ app.add_url_rule('/api/users', view_func=handle_users)
       expect(provider).toMatchObject({ symbolUid: 'fn-list_users', symbolName: 'list_users' });
       expect(queriedNames).not.toContain('module:handle_users');
     });
+
+    // ── Inline / closure provider handlers (#2276) ──────────────────────
+    // An inline provider handler has no name, so it must resolve by line-span
+    // containment to the symbol it lives in — exactly like a consumer. Mirrors
+    // the Node/Express inline-arrow behavior for the non-Node plugins.
+
+    it('resolves a Go inline http.HandleFunc closure to its containing function (#2276)', async () => {
+      const dir = path.join(tmpDir, 'go-inline-handlefunc');
+      fs.mkdirSync(path.join(dir, 'cmd'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'cmd/server.go'),
+        `package main
+
+func main() {
+  http.HandleFunc("/api/inline", func(w http.ResponseWriter, r *http.Request) {
+    w.Write([]byte("ok"))
+  })
+}
+`,
+      );
+      // main() spans source lines 3-7 → 0-based [2,6]; the HandleFunc
+      // registration and its anonymous func are on line 4 (row 3), inside span.
+      const mockDbExecutor = async (
+        query: string,
+        params?: Record<string, unknown>,
+      ): Promise<Record<string, unknown>[]> => {
+        if (query.includes('UNION ALL') && String(params?.filePath ?? '').includes('server.go')) {
+          return [
+            {
+              uid: 'fn-main',
+              name: 'main',
+              filePath: 'cmd/server.go',
+              startLine: 2,
+              endLine: 6,
+              labels: ['Function'],
+            },
+          ];
+        }
+        return [];
+      };
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const provider = contracts.find(
+        (c) => c.role === 'provider' && c.contractId === 'http::GET::/api/inline',
+      );
+      expect(provider).toMatchObject({
+        symbolUid: 'fn-main',
+        symbolName: 'main',
+        meta: { extractionStrategy: 'source_scan_resolved' },
+      });
+    });
+
+    it('resolves a Go inline gin framework-route closure to its containing function (#2276)', async () => {
+      const dir = path.join(tmpDir, 'go-inline-gin');
+      fs.mkdirSync(path.join(dir, 'cmd'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'cmd/server.go'),
+        `package main
+
+func registerRoutes(r *gin.Engine) {
+  r.GET("/api/ping", func(c *gin.Context) {
+    c.String(200, "pong")
+  })
+}
+`,
+      );
+      const mockDbExecutor = async (
+        query: string,
+        params?: Record<string, unknown>,
+      ): Promise<Record<string, unknown>[]> => {
+        if (query.includes('UNION ALL') && String(params?.filePath ?? '').includes('server.go')) {
+          return [
+            {
+              uid: 'fn-registerRoutes',
+              name: 'registerRoutes',
+              filePath: 'cmd/server.go',
+              startLine: 2,
+              endLine: 6,
+              labels: ['Function'],
+            },
+          ];
+        }
+        return [];
+      };
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const provider = contracts.find(
+        (c) => c.role === 'provider' && c.contractId === 'http::GET::/api/ping',
+      );
+      expect(provider).toMatchObject({
+        symbolUid: 'fn-registerRoutes',
+        symbolName: 'registerRoutes',
+      });
+    });
+
+    it('keeps Go NAMED HandleFunc handler resolving by name, not containment (#2276)', async () => {
+      const dir = path.join(tmpDir, 'go-named-handlefunc');
+      fs.mkdirSync(path.join(dir, 'cmd'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'cmd/server.go'),
+        `package main
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {}
+
+func main() {
+  http.HandleFunc("/api/health", healthHandler)
+}
+`,
+      );
+      // Both the named handler and the registrar main() are indexed. A named
+      // provider must resolve to the HANDLER by name, never to main by line.
+      const mockDbExecutor = async (
+        query: string,
+        params?: Record<string, unknown>,
+      ): Promise<Record<string, unknown>[]> => {
+        if (query.includes('UNION ALL') && String(params?.filePath ?? '').includes('server.go')) {
+          return [
+            {
+              uid: 'fn-healthHandler',
+              name: 'healthHandler',
+              filePath: 'cmd/server.go',
+              startLine: 2,
+              endLine: 2,
+              labels: ['Function'],
+            },
+            {
+              uid: 'fn-main',
+              name: 'main',
+              filePath: 'cmd/server.go',
+              startLine: 4,
+              endLine: 6,
+              labels: ['Function'],
+            },
+          ];
+        }
+        return [];
+      };
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const provider = contracts.find(
+        (c) => c.role === 'provider' && c.contractId === 'http::GET::/api/health',
+      );
+      expect(provider).toMatchObject({
+        symbolUid: 'fn-healthHandler',
+        symbolName: 'healthHandler',
+      });
+    });
   });
 
   describe('provider extraction — graph-first (Strategy A)', () => {

--- a/gitnexus/test/unit/group/http-route-extractor.test.ts
+++ b/gitnexus/test/unit/group/http-route-extractor.test.ts
@@ -724,6 +724,62 @@ func main() {
       });
     });
 
+    it('keeps a NAMED gin framework-route handler resolving by name, not its registrar (#2276)', async () => {
+      // The framework-route query was also widened to accept func literals; this
+      // pins that a NAMED identifier handler still resolves by name even though
+      // a `line` is now emitted and the enclosing registrar span covers it.
+      const dir = path.join(tmpDir, 'go-named-gin');
+      fs.mkdirSync(path.join(dir, 'cmd'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'cmd/server.go'),
+        `package main
+
+func listOrders(c *gin.Context) {}
+
+func registerRoutes(r *gin.Engine) {
+  r.GET("/api/orders", listOrders)
+}
+`,
+      );
+      // listOrders spans [2,2]; registerRoutes spans [4,6] and its span CONTAINS
+      // the r.GET line (row 5). A named provider must resolve to listOrders by
+      // name — never to registerRoutes by line-span containment.
+      const mockDbExecutor = async (
+        query: string,
+        params?: Record<string, unknown>,
+      ): Promise<Record<string, unknown>[]> => {
+        if (query.includes('UNION ALL') && String(params?.filePath ?? '').includes('server.go')) {
+          return [
+            {
+              uid: 'fn-listOrders',
+              name: 'listOrders',
+              filePath: 'cmd/server.go',
+              startLine: 2,
+              endLine: 2,
+              labels: ['Function'],
+            },
+            {
+              uid: 'fn-registerRoutes',
+              name: 'registerRoutes',
+              filePath: 'cmd/server.go',
+              startLine: 4,
+              endLine: 6,
+              labels: ['Function'],
+            },
+          ];
+        }
+        return [];
+      };
+      const contracts = await extractor.extract(mockDbExecutor, dir, makeRepo(dir));
+      const provider = contracts.find(
+        (c) => c.role === 'provider' && c.contractId === 'http::GET::/api/orders',
+      );
+      expect(provider).toMatchObject({
+        symbolUid: 'fn-listOrders',
+        symbolName: 'listOrders',
+      });
+    });
+
     it('resolves a Laravel closure route nested in a method to that method (#2276)', async () => {
       const dir = path.join(tmpDir, 'php-closure-in-method');
       fs.mkdirSync(path.join(dir, 'app'), { recursive: true });


### PR DESCRIPTION
## What & why

Closes #2276 (follow-up to #2269). #2269 wired the call-site `line` through every HTTP plugin's **consumer** detections so a consumer contract resolves to the function containing the `fetch`/client call. Provider detections were left behind: an **inline / closure provider handler** in the non-Node plugins (Go `http.HandleFunc("/x", func(){…})`, Laravel `Route::get('/x', function(){…})`) carried no `line`, so it could not resolve by line-span containment and degraded to a file-level `symbolUid` — leaving cross-repo trace/impact unable to attribute the route to a real symbol.

This PR wires `line` onto the provider emit sites across the five non-Node plugins so inline providers resolve to their containing / closure symbol, matching the consumer behavior and the Node/Express provider behavior already in place.

## The load-bearing detail

The resolver (`resolveDetectionSymbol` in `http-route-extractor.ts`) short-circuits: a provider with a **truthy `name`** is resolved **by name only** and never falls through to line-span containment (the guard that prevents a route attaching to its registrar). `line` is consulted only for consumers and for providers whose `name` is falsy. So "just set `line`" is necessary but **not sufficient** for the headline cases — inline handlers must emit **both** `name: null` **and** `line`.

## Per-language changes

| Plugin | Change |
|--------|--------|
| **Go** (`go.ts`) | Widened the HandleFunc + framework-route handler capture from `(identifier)` to `[(identifier) (func_literal)]`; an inline func literal now emits `name: null` + `line: (handlerNode ?? pathNode).startPosition.row + 1`. Named identifier handlers keep resolving by name. |
| **PHP** (`php.ts`) | The Laravel route query optionally captures the closure handler `(argument [(anonymous_function) (arrow_function)] @closure)?`; a closure emits `name: null` + line and resolves to its containing symbol (service-provider `boot()`, controller method). Named-controller routes are unchanged. |
| **Python** (`python.ts`) | FastAPI `@app`/`@router` providers (already `name: null`) gain `line`. Best-effort: FastAPI routes are graph-authoritative and the function span starts at `def`, so this lands the single-decorator source-scan fallback. Flask `add_url_rule` already carried `line`. |
| **Kotlin / Java** (`kotlin.ts`, `java.ts`) | Spring `@*Mapping` named-method providers gain `line` for parity with the consumer emits and a future inline DSL. Inert for current resolution (verified): a named Spring method resolves by name and never reaches containment. |

## Testing

`gitnexus/test/unit/group/http-route-extractor.test.ts` — 9 new tests via the existing mock-`dbExecutor` containment harness:
- Go inline `http.HandleFunc` + gin closure resolve to the containing function; named handler still resolves by name.
- Laravel closure (`function(){}` and `fn() =>`) nested in a method resolves to that method; named-controller route unchanged.
- FastAPI `@app` decorated handler resolves to the decorated function.
- Documented-limitation guards: a **file-scope** Laravel closure and a **multi-decorator** FastAPI handler both degrade to file-level (no mis-attribution) rather than resolving.

Full file: 182 tests pass. `tsc` clean. Broader group/route suites (consumer signals, multi-verb, graph-method, cross-trace, Spring parity): green.

## Scope boundaries / documented limitations

- **File-scope Laravel closures** (the common `routes/web.php` pattern) have no enclosing function, and PHP closures are not indexed as symbols, so they remain file-level. Method-nested closures resolve. Closure indexing is a separate ingestion concern.
- **Multi-decorator FastAPI** handlers degrade to file-level (the detection line sits above the `def`-span). FastAPI routes are graph-authoritative regardless.
- Named-controller Laravel routes (`[Controller::class, 'method']`) keep the `'route'` label — resolving them to a real method is graph-backed and out of scope here.

## Residual Review Findings

From the multi-engine `ce-code-review` pass (7 reviewers, 0 P0/P1):

- **[P3 · pre-existing · go.ts:34]** Go multi-argument routes with middleware before the handler (`r.GET("/x", mw, func(){})`) emit two provider detections — one for the middleware identifier and one for the inline closure — because the handler capture is unanchored. This is a pre-existing over-match (it already affected `r.GET("/x", mw, namedHandler)`); the func-literal widening compounds the inline case. **Deferred** per the plan's scope boundary (out of scope; pre-existing). Fix path: anchor `@handler` to the trailing argument.
- **[P3 · advisory · python.ts]** A FastAPI decorator nested inside an enclosing function resolves to the enclosing function rather than the inner handler. This is strictly better than file-level, matches the issue's "containing symbol" intent, and FastAPI is graph-authoritative anyway.
- **[P2 · advisory · http-route-extractor.test.ts]** The test file is ~7.2k lines (pre-existing); the inline-provider tests are a future extraction candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
