### PR TITLE
fix(ingestion): index generator function declarations

### DIFF
--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -27,6 +27,9 @@ export const TYPESCRIPT_QUERIES = `
 (function_declaration
   name: (identifier) @name) @definition.function
 
+(generator_function_declaration
+  name: (identifier) @name) @definition.function
+
 ; TypeScript overload signatures (function_signature is a separate node type from function_declaration)
 (function_signature
   name: (identifier) @name) @definition.function
@@ -372,6 +375,9 @@ export const JAVASCRIPT_QUERIES = `
   name: (identifier) @name) @definition.class
 
 (function_declaration
+  name: (identifier) @name) @definition.function
+
+(generator_function_declaration
   name: (identifier) @name) @definition.function
 
 (method_definition

--- a/gitnexus/test/integration/typescript-async-generator-functions.test.ts
+++ b/gitnexus/test/integration/typescript-async-generator-functions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { parseFilesWithWorkers } from '../helpers/worker-parse.js';
+
+describe('TypeScript async generator functions', () => {
+  it('indexes exported async function* declarations as Function nodes', async () => {
+    const { graph } = await parseFilesWithWorkers([
+      {
+        path: 'src/coach.ts',
+        content: `
+          export function userText(input: string): string {
+            return input.trim();
+          }
+
+          export async function* runCoachLoop(input: string): AsyncGenerator<string> {
+            yield userText(input);
+          }
+        `,
+      },
+    ]);
+
+    const functionNames = new Set(
+      graph.nodes.filter((node) => node.label === 'Function').map((node) => node.properties.name),
+    );
+
+    expect(functionNames).toContain('userText');
+    expect(functionNames).toContain('runCoachLoop');
+  });
+});

--- a/gitnexus/test/unit/tree-sitter-queries.test.ts
+++ b/gitnexus/test/unit/tree-sitter-queries.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import Parser from 'tree-sitter';
+import JavaScript from 'tree-sitter-javascript';
 import TypeScript from 'tree-sitter-typescript';
 import {
   TYPESCRIPT_QUERIES,
@@ -17,29 +18,30 @@ import {
   DART_QUERIES,
 } from '../../src/core/ingestion/tree-sitter-queries.js';
 
+function capturedDefinitionFunctionNames(
+  language: Parameters<Parser['setLanguage']>[0],
+  querySource: string,
+  src: string,
+): string[] {
+  const parser = new Parser();
+  parser.setLanguage(language);
+  const query = new Parser.Query(language, querySource);
+  const tree = parser.parse(src);
+  const names: string[] = [];
+  for (const match of query.matches(tree.rootNode)) {
+    let isFunction = false;
+    let name: string | undefined;
+    for (const capture of match.captures) {
+      if (capture.name === 'definition.function') isFunction = true;
+      if (capture.name === 'name') name = capture.node.text;
+    }
+    if (isFunction && name !== undefined) names.push(name);
+  }
+  return names;
+}
+
 describe('tree-sitter queries', () => {
   describe('TypeScript queries', () => {
-    function capturedDefinitionFunctionNames(src: string): string[] {
-      const parser = new Parser();
-      parser.setLanguage(TypeScript.typescript as Parameters<Parser['setLanguage']>[0]);
-      const query = new Parser.Query(
-        TypeScript.typescript as Parameters<Parser['setLanguage']>[0],
-        TYPESCRIPT_QUERIES,
-      );
-      const tree = parser.parse(src);
-      const names: string[] = [];
-      for (const match of query.matches(tree.rootNode)) {
-        let isFunction = false;
-        let name: string | undefined;
-        for (const capture of match.captures) {
-          if (capture.name === 'definition.function') isFunction = true;
-          if (capture.name === 'name') name = capture.node.text;
-        }
-        if (isFunction && name !== undefined) names.push(name);
-      }
-      return names;
-    }
-
     it('captures class declarations', () => {
       expect(TYPESCRIPT_QUERIES).toContain('class_declaration');
       expect(TYPESCRIPT_QUERIES).toContain('@definition.class');
@@ -56,12 +58,16 @@ describe('tree-sitter queries', () => {
     });
 
     it('captures async generator function declarations as function definitions', () => {
-      const names = capturedDefinitionFunctionNames(`
+      const names = capturedDefinitionFunctionNames(
+        TypeScript.typescript as Parameters<Parser['setLanguage']>[0],
+        TYPESCRIPT_QUERIES,
+        `
         export function userText() { return ''; }
         export async function* runCoachLoop(): AsyncGenerator<string> {
           yield 'ready';
         }
-      `);
+      `,
+      );
 
       expect(names).toContain('userText');
       expect(names).toContain('runCoachLoop');
@@ -96,6 +102,26 @@ describe('tree-sitter queries', () => {
 
     it('does not have interface declarations', () => {
       expect(JAVASCRIPT_QUERIES).not.toContain('interface_declaration');
+    });
+
+    it('captures generator function declarations as function definitions', () => {
+      const names = capturedDefinitionFunctionNames(
+        JavaScript as Parameters<Parser['setLanguage']>[0],
+        JAVASCRIPT_QUERIES,
+        `
+        export function userText() { return ''; }
+        export async function* runCoachLoop() {
+          yield 'ready';
+        }
+        export function* plainGen() {
+          yield 1;
+        }
+      `,
+      );
+
+      expect(names).toContain('userText');
+      expect(names).toContain('runCoachLoop');
+      expect(names).toContain('plainGen');
     });
   });
 

--- a/gitnexus/test/unit/tree-sitter-queries.test.ts
+++ b/gitnexus/test/unit/tree-sitter-queries.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import Parser from 'tree-sitter';
+import TypeScript from 'tree-sitter-typescript';
 import {
   TYPESCRIPT_QUERIES,
   JAVASCRIPT_QUERIES,
@@ -17,6 +19,27 @@ import {
 
 describe('tree-sitter queries', () => {
   describe('TypeScript queries', () => {
+    function capturedDefinitionFunctionNames(src: string): string[] {
+      const parser = new Parser();
+      parser.setLanguage(TypeScript.typescript as Parameters<Parser['setLanguage']>[0]);
+      const query = new Parser.Query(
+        TypeScript.typescript as Parameters<Parser['setLanguage']>[0],
+        TYPESCRIPT_QUERIES,
+      );
+      const tree = parser.parse(src);
+      const names: string[] = [];
+      for (const match of query.matches(tree.rootNode)) {
+        let isFunction = false;
+        let name: string | undefined;
+        for (const capture of match.captures) {
+          if (capture.name === 'definition.function') isFunction = true;
+          if (capture.name === 'name') name = capture.node.text;
+        }
+        if (isFunction && name !== undefined) names.push(name);
+      }
+      return names;
+    }
+
     it('captures class declarations', () => {
       expect(TYPESCRIPT_QUERIES).toContain('class_declaration');
       expect(TYPESCRIPT_QUERIES).toContain('@definition.class');
@@ -30,6 +53,18 @@ describe('tree-sitter queries', () => {
     it('captures function declarations', () => {
       expect(TYPESCRIPT_QUERIES).toContain('function_declaration');
       expect(TYPESCRIPT_QUERIES).toContain('@definition.function');
+    });
+
+    it('captures async generator function declarations as function definitions', () => {
+      const names = capturedDefinitionFunctionNames(`
+        export function userText() { return ''; }
+        export async function* runCoachLoop(): AsyncGenerator<string> {
+          yield 'ready';
+        }
+      `);
+
+      expect(names).toContain('userText');
+      expect(names).toContain('runCoachLoop');
     });
 
     it('captures method definitions', () => {


### PR DESCRIPTION
Problem
async function* declarations parse as generator_function_declaration, but the legacy definition query only captured function_declaration. That leaves exported async generators out of the Function graph, so context/impact can report Symbol not found for streaming or loop entry points. Fixes #2303.

Fix
- Capture generator_function_declaration as @definition.function for TypeScript and JavaScript.
- Add a query-level regression for exported async function*.
- Add a worker-backed integration regression that checks the Function node is emitted.

Test
- npm run build
- npm test -- --run test/unit/tree-sitter-queries.test.ts test/integration/typescript-async-generator-functions.test.ts
- npx tsc --noEmit
- git diff --check

Risk
Low. This only adds another named function-declaration node type to the existing Function definition path; anonymous generators remain unchanged.
