### PR TITLE
chore: release v1.6.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.8",
+      "version": "1.6.9",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/gitnexus-claude-plugin/.claude-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "author": {
     "name": "GitNexus"
   },

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,64 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.9] - 2026-07-04
+
+### Added
+
+- **Flat workspace index follows the checked-out branch** — the default (non-multi-branch) index now tracks `git checkout` instead of staying pinned to the branch it was created on (#2364)
+- **Spring DI resolver for `@Autowired List<T>` injection** — collection-typed constructor/field injection resolves to all matching bean implementations (#2200)
+- **Opt-in CJK bigram segmentation for FTS search** — improves search relevance over Chinese/Japanese/Korean text (#2339)
+- **Compact, description-forward embedding text** — shorter, more targeted embedding input for symbol search (#2333, #2334)
+- **`Route` nodes get a `(method, url)` identity** — distinct HTTP verbs on the same URL are no longer merged into one node (#2289, #2302)
+- **Nuxt/Nitro auto-imports resolved in the TypeScript scope resolver** (#2026)
+- **Doc comments searchable across all languages** via FTS (#2286)
+- **Cross-file and inline HTTP handler resolution for `group`** — named handlers across files (#2275, #2277) and inline provider handlers via call-site line (#2276, #2282)
+- **Cross-repo call trace using PDG** for `group` (#2269)
+- **Java and Python conservative taint source/sink models** (#2267, #2253)
+- **Java and Kotlin HTTP consumer extraction expanded**, with Kotlin Spring provider parity (#2268, #2254, #1888)
+- **Django route extraction for multi-repo `group`** (#1836)
+- **Kilo Code + GitNexus MCP setup guide** (#2259)
+
+### Fixed
+
+- **Index metadata renamed to `gitnexus.json`** with dual-write compatibility for existing indexes (#2363)
+- **Java call graph** — cast-wrapped and `this.method()` receivers now resolve call edges (#2357)
+- **Icon imports consolidated** — fixes stale refs and a package-name collision (#2343)
+- **Embeddings** — CUDA 13 hosts now use a system-matched `onnxruntime-node` build for GPU acceleration (#2341)
+- **Ladybug single-writer transaction contention** now retries instead of failing (#2342)
+- **`--limit` CLI flag** — i18n-safe, guards 0/negative values, and truncates at the correct path (#2310)
+- **Ladybug pinned to 0.18.0**, validating the multi-writer deadlock fix (#2340)
+- **Full text file content stays searchable** in the FTS index (#2323)
+- **Vector distance threshold made configurable** (#2330)
+- **LadybugDB-incompatible multi-label Cypher replaced** in `group` queries (#2325, #2327)
+- **Windows `@group` reopen** — read-only bridge handle is cached to fix repeated reopen failures (#2274, #2313)
+- **FTS stemmer made configurable** (#2307)
+- **FastAPI `APIRouter` constructor prefixes applied** to nested routes (#2312)
+- **MCP `api_impact` response shape stabilized** for same-URL multi-verb routes (#2308, #2309)
+- **Generator function declarations indexed** (#2305)
+- **FTS indexes the `description` field** so doc comments are keyword-searchable (#2300)
+- **Spring interface-inherited routes resolved** (#2288, #2290)
+- **Spring method-level array-form route mappings recognized** (#2281)
+- **MCP `impact` callgraph mode tolerates adapter-materialized `line:0`** (#2279, #2283)
+- **Kotlin `fun interface` extraction** via a tree-sitter-kotlin re-vendor (#2271)
+- **`--pdg analyze` double-free fixed** — LadybugDB close-destructor crash avoided and connection serialization hardened (#2264)
+
+### Changed
+
+- **Root README restructured and all READMEs fact-checked** (#2360)
+- **Bundled skill reference drift fixed** in docs (#2362)
+
+### Performance
+
+- **`group`/HTTP route extraction skips source parsing** for files already covered by the graph (#2138 Part 2, #2265)
+
+### Chore / Dependencies
+
+- **gitnexus runtime** — bump `node-addon-api` 8.8.0 → 8.9.0 (#2366), `commander` 14.0.3 → 15.0.0 (#2322), `onnxruntime-node` (#2321), `onnxruntime-common` (#2320), `uuid` 14.0.0 → 14.0.1 (#2285)
+- **gitnexus dev** — bump `@types/node` (#2273)
+- **gitnexus-web** — bump `lucide-react` (#2349), `@langchain/langgraph` (#2344), `@playwright/test` (#2346), `@langchain/openai` (#2348, #2291), `@langchain/google-genai` (#2345), `langchain` 1.4.4 → 1.4.6 (#2294), `@vitest/coverage-v8` (#2297), `lru-cache` 11.3.6 → 11.5.1 (#2298), `@langchain/core` (#2293)
+- **CI** — bump `softprops/action-gh-release` 3.0.0 → 3.0.1 (#2352), `actions/cache` 5.0.5 → 6.1.0 (#2351), `actions/setup-python` 6.2.0 → 6.3.0 (#2350), `actions/checkout` 6.0.3 → 7.0.0 (#2292), `release-drafter/release-drafter` 7.3.1 → 7.4.0 (#2295)
+
 ## [1.6.8] - 2026-06-20
 
 ### Added

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.8",
+      "version": "1.6.9",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
## Summary
- Bump `gitnexus` to 1.6.9 (package.json + package-lock.json) and align the two Claude plugin manifests (`gitnexus-claude-plugin/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`)
- Add the `## [1.6.9]` CHANGELOG section covering the 65 commits merged since v1.6.8 (2026-06-20): workspace-index-follows-branch, Spring DI list injection, CJK FTS bigrams, PDG cross-repo trace, Java/Python taint models, Route (method,url) identity, and a long tail of fixes + dependency bumps

## Test plan
- [x] `npx prettier --check` passes on the 4 touched JSON manifests (root `.prettierignore` skips CHANGELOG.md)
- [x] All five version-bearing files verified in lockstep at 1.6.9 (`git grep '"1.6.9"'`)
- [x] Local pre-commit hook (lint-staged + typecheck) passed
- [ ] CI green on this PR
- [ ] After merge: push `v1.6.9` tag to trigger the stable npm publish (separate, deliberate step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)