### PR TITLE
feat: full Codex support — hooks, plugin marketplace, and setup (#2328, supersedes #1131)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "gitnexus-marketplace",
+  "interface": {
+    "displayName": "GitNexus"
+  },
+  "plugins": [
+    {
+      "name": "gitnexus",
+      "version": "1.6.9",
+      "source": {
+        "source": "local",
+        "path": "./gitnexus-claude-plugin"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,12 @@ gitnexus/vendor/**/node_modules/
 local_docs/
 
 # Local agent scratch / review prompts (never commit)
+# (.agents/plugins/marketplace.json is the checked-in Codex plugin
+# marketplace registry — the rest of .agents/ stays local scratch.)
 .tmp/
-.agents/
+.agents/*
+!.agents/plugins/
+.agents/plugins/*
+!.agents/plugins/marketplace.json
 .context/
 gitnexus/web/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,9 @@ routes between two modes based on the triggering event:
   not enforce branch reachability. No Docker build (RC-only). Before cutting a
   stable release, keep `gitnexus/package.json`,
   `gitnexus-claude-plugin/.claude-plugin/plugin.json`,
-  `.claude-plugin/marketplace.json`, and the matching `CHANGELOG.md` entry in
+  `.claude-plugin/marketplace.json`,
+  `gitnexus-claude-plugin/.codex-plugin/plugin.json`,
+  `.agents/plugins/marketplace.json`, and the matching `CHANGELOG.md` entry in
   lockstep — the always-on `gitnexus` unit suite now fails if those manifest
   versions drift.
 - **Release-candidate mode** — runs on every push to `main` (typically a

--- a/README.md
+++ b/README.md
@@ -199,13 +199,13 @@ flowchart TB
 | **Claude Code**          | Yes | Yes    | Yes (PreToolUse + PostToolUse)                                                           | **Full**     |
 | **Cursor**               | Yes | Yes    | Yes (postToolUse, [manual install](gitnexus-cursor-integration/README.md#hook-install))  | **Full**     |
 | **Antigravity** (Google) | Yes | Yes    | Yes (AfterTool, [Gemini CLI hooks schema](https://geminicli.com/docs/hooks/reference/))[¹](#fn-antigravity-hooks) | **Full**     |
-| **Codex**                | Yes | Yes    | —                                                                                        | MCP + Skills |
+| **Codex**                | Yes | Yes    | Yes (PreToolUse + PostToolUse, [Codex hooks](https://developers.openai.com/codex/hooks)) | **Full**     |
 | **OpenCode**             | Yes | Yes    | —                                                                                        | MCP + Skills |
 | **CodeBuddy** (Tencent)  | Yes | Yes    | —                                                                                        | MCP + Skills |
 | **Qoder** (Alibaba)      | Yes | Yes    | —                                                                                        | MCP + Skills |
 | **Windsurf**             | Yes | —      | —                                                                                        | MCP          |
 
-> **Claude Code** gets the deepest integration: MCP tools + agent skills + PreToolUse hooks that enrich searches with graph context + PostToolUse hooks that detect a stale index after commits and prompt the agent to reindex.
+> **Claude Code** and **Codex** get the deepest integration: MCP tools + agent skills + PreToolUse hooks that enrich searches with graph context + PostToolUse hooks that detect a stale index after commits and prompt the agent to reindex.
 
 <a id="fn-antigravity-hooks"></a>
 > ¹ **Antigravity hooks** follow the [Gemini CLI hooks reference](https://geminicli.com/docs/hooks/reference/) (Antigravity 2.0 is the documented successor to Gemini CLI). Augmentation runs in `AfterTool` because `BeforeTool` has no context-injection channel in the Gemini contract — the agent sees graph context appended to the tool result via `hookSpecificOutput.additionalContext`. Stale-index hints land in the same channel after a successful `git commit/merge/rebase/cherry-pick/pull`. The schema may evolve if Antigravity-specific hook docs diverge from Gemini CLI's; the implementation will track those changes.
@@ -223,7 +223,7 @@ claude mcp add gitnexus -- npx -y gitnexus@latest mcp
 claude mcp add gitnexus -- cmd /c npx -y gitnexus@latest mcp
 ```
 
-**Codex** (MCP + skills):
+**Codex** (full support — MCP + skills + hooks):
 
 ```bash
 codex mcp add gitnexus -- npx -y gitnexus@latest mcp
@@ -235,6 +235,15 @@ Or via `~/.codex/config.toml` (system scope) / `.codex/config.toml` (project sco
 [mcp_servers.gitnexus]
 command = "npx"
 args = ["-y", "gitnexus@latest", "mcp"]
+```
+
+Codex hooks (PreToolUse graph enrichment + PostToolUse stale-index detection in `~/.codex/hooks.json`, [same schema as Claude Code](https://developers.openai.com/codex/hooks)) need the bundled adapter script, so they are installed by `gitnexus setup -c codex` rather than manually.
+
+Alternatively, install everything as a [Codex plugin](https://developers.openai.com/codex/plugins/build) (MCP + skills + hooks in one step):
+
+```bash
+codex plugin marketplace add abhigyanpatwari/GitNexus
+# then inside Codex: /plugins → install "GitNexus"
 ```
 
 **Cursor** (`~/.cursor/mcp.json` — global, works for all projects):

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ codex plugin marketplace add abhigyanpatwari/GitNexus
 # then inside Codex: /plugins → install "GitNexus"
 ```
 
+> **Codex notes:** SessionStart is intentionally not registered — Codex reads [AGENTS.md natively](https://developers.openai.com/codex/guides/agents-md), which already carries the GitNexus context block. Newly installed hooks need a one-time approval in Codex via `/hooks` before they run. Pick **one** install route (`gitnexus setup -c codex` **or** the plugin): plugin hooks load alongside `~/.codex/hooks.json`, so installing both can fire duplicate hooks per tool call.
+
 **Cursor** (`~/.cursor/mcp.json` — global, works for all projects):
 
 ```json

--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "gitnexus",
+  "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
+  "version": "1.6.9",
+  "skills": "./skills",
+  "mcpServers": "./.mcp.json",
+  "hooks": "./hooks/hooks.json",
+  "interface": {
+    "displayName": "GitNexus",
+    "category": "Developer Tools",
+    "capabilities": [
+      "code-exploration",
+      "impact-analysis",
+      "debugging",
+      "refactoring",
+      "code-review"
+    ]
+  },
+  "author": {
+    "name": "GitNexus"
+  },
+  "homepage": "https://github.com/abhigyanpatwari/GitNexus",
+  "repository": "https://github.com/abhigyanpatwari/GitNexus",
+  "keywords": ["code-intelligence", "knowledge-graph", "mcp", "static-analysis"]
+}

--- a/gitnexus-claude-plugin/hooks/hooks.json
+++ b/gitnexus-claude-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/gitnexus-hook.js",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gitnexus-hook.js\"",
             "timeout": 10,
             "statusMessage": "Enriching with GitNexus graph context..."
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/gitnexus-hook.js",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gitnexus-hook.js\"",
             "timeout": 10,
             "statusMessage": "Checking GitNexus index freshness..."
           }

--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -79,6 +79,13 @@ codex mcp add gitnexus -- npx -y gitnexus@latest mcp
 
 Codex hooks (PreToolUse graph enrichment + PostToolUse stale-index detection in `~/.codex/hooks.json`, [same schema as Claude Code](https://developers.openai.com/codex/hooks)) need the bundled adapter script, so they are installed by `gitnexus setup -c codex` rather than manually.
 
+Alternatively, install everything as a [Codex plugin](https://developers.openai.com/codex/plugins/build) (MCP + skills + hooks in one step):
+
+```bash
+codex plugin marketplace add abhigyanpatwari/GitNexus
+# then inside Codex: /plugins → install "GitNexus"
+```
+
 ### Cursor / Windsurf
 
 Add to `~/.cursor/mcp.json` (global — works for all projects):

--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -43,13 +43,13 @@ To configure MCP for your editor, run `npx gitnexus setup` once — or set it up
 | **Claude Code**          | Yes | Yes    | Yes (PreToolUse + PostToolUse)                                                             | **Full**     |
 | **Cursor**               | Yes | Yes    | Yes (postToolUse, [manual install](../gitnexus-cursor-integration/README.md#hook-install)) | **Full**     |
 | **Antigravity** (Google) | Yes | Yes    | Yes (AfterTool, [Gemini CLI hooks schema](https://geminicli.com/docs/hooks/reference/))    | **Full**     |
-| **Codex**                | Yes | Yes    | —                                                                                          | MCP + Skills |
+| **Codex**                | Yes | Yes    | Yes (PreToolUse + PostToolUse, [Codex hooks](https://developers.openai.com/codex/hooks))   | **Full**     |
 | **OpenCode**             | Yes | Yes    | —                                                                                          | MCP + Skills |
 | **CodeBuddy** (Tencent)  | Yes | Yes    | —                                                                                          | MCP + Skills |
 | **Qoder** (Alibaba)      | Yes | Yes    | —                                                                                          | MCP + Skills |
 | **Windsurf**             | Yes | —      | —                                                                                          | MCP          |
 
-> **Claude Code** gets the deepest integration: MCP tools + agent skills + PreToolUse hooks that automatically enrich grep/glob/bash calls with knowledge graph context + PostToolUse hooks that detect a stale index after commits and prompt the agent to reindex.
+> **Claude Code** and **Codex** get the deepest integration: MCP tools + agent skills + PreToolUse hooks that automatically enrich grep/glob/bash calls with knowledge graph context + PostToolUse hooks that detect a stale index after commits and prompt the agent to reindex.
 
 ### Community Integrations
 
@@ -71,11 +71,13 @@ claude mcp add gitnexus -- npx -y gitnexus@latest mcp
 claude mcp add gitnexus -- cmd /c npx -y gitnexus@latest mcp
 ```
 
-### Codex (full support — MCP + skills)
+### Codex (full support — MCP + skills + hooks)
 
 ```bash
 codex mcp add gitnexus -- npx -y gitnexus@latest mcp
 ```
+
+Codex hooks (PreToolUse graph enrichment + PostToolUse stale-index detection in `~/.codex/hooks.json`, [same schema as Claude Code](https://developers.openai.com/codex/hooks)) need the bundled adapter script, so they are installed by `gitnexus setup -c codex` rather than manually.
 
 ### Cursor / Windsurf
 

--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -86,6 +86,8 @@ codex plugin marketplace add abhigyanpatwari/GitNexus
 # then inside Codex: /plugins → install "GitNexus"
 ```
 
+> **Codex notes:** SessionStart is intentionally not registered — Codex reads [AGENTS.md natively](https://developers.openai.com/codex/guides/agents-md), which already carries the GitNexus context block. Newly installed hooks need a one-time approval in Codex via `/hooks` before they run. Pick **one** install route (`gitnexus setup -c codex` **or** the plugin): plugin hooks load alongside `~/.codex/hooks.json`, so installing both can fire duplicate hooks per tool call.
+
 ### Cursor / Windsurf
 
 Add to `~/.cursor/mcp.json` (global — works for all projects):

--- a/gitnexus/src/cli/editor-targets.ts
+++ b/gitnexus/src/cli/editor-targets.ts
@@ -181,6 +181,17 @@ export function getEditorTargets(home: string = os.homedir()): EditorTargets {
       scriptDir: path.join(home, '.claude', 'hooks', 'gitnexus'),
     },
     {
+      id: 'codex',
+      label: 'Codex',
+      // Codex hooks use Claude Code's exact {hooks: {Event: [...]}} JSON shape
+      // and hookSpecificOutput response contract, in a dedicated hooks.json
+      // (https://developers.openai.com/codex/hooks).
+      settingsFile: path.join(home, '.codex', 'hooks.json'),
+      events: ['PreToolUse', 'PostToolUse'],
+      needle: 'gitnexus-hook',
+      scriptDir: path.join(home, '.codex', 'hooks', 'gitnexus'),
+    },
+    {
       id: 'antigravity',
       label: 'Antigravity',
       settingsFile: path.join(home, '.gemini', 'settings.json'),

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -487,21 +487,30 @@ export async function copyHookHelpers(
 }
 
 /**
- * Install GitNexus hooks to ~/.claude/settings.json for Claude Code.
- * Merges hook config without overwriting existing hooks, preserving
- * comments and formatting in the JSONC file.
+ * Install GitNexus hooks for editors that use Claude Code's hooks schema.
+ *
+ * Claude Code registers hooks in ~/.claude/settings.json; Codex uses a
+ * dedicated ~/.codex/hooks.json with the identical {hooks: {Event: [...]}}
+ * JSON shape, stdin payload, and hookSpecificOutput response contract
+ * (https://developers.openai.com/codex/hooks), so both runtimes share this
+ * installer and the same bundled adapter script. Merges hook config without
+ * overwriting existing hooks, preserving comments and formatting.
  */
-async function installClaudeCodeHooks(result: SetupResult): Promise<void> {
-  const claudeDir = path.join(os.homedir(), '.claude');
-  if (!(await dirExists(claudeDir))) return;
-
-  const claudeHook = hookTarget('claude');
+async function installClaudeSchemaHooks(
+  result: SetupResult,
+  id: 'claude' | 'codex',
+): Promise<void> {
+  const claudeHook = hookTarget(id);
   const settingsPath = claudeHook.settingsFile;
+  const label = `${claudeHook.label} hooks`;
+
+  // Gate on the editor's own config dir (~/.claude, ~/.codex) existing.
+  if (!(await dirExists(path.dirname(settingsPath)))) return;
 
   // Source hooks bundled within the gitnexus package (hooks/claude/)
   const pluginHooksPath = path.join(__dirname, '..', '..', 'hooks', 'claude');
 
-  // Copy unified hook script to ~/.claude/hooks/gitnexus/
+  // Copy unified hook script to the editor's hooks/gitnexus/ dir
   const destHooksDir = claudeHook.scriptDir;
 
   try {
@@ -516,7 +525,7 @@ async function installClaudeCodeHooks(result: SetupResult): Promise<void> {
       const jsonCli = JSON.stringify(normalizedCli);
       if (!content.includes(CLI_PATH_SOURCE_LITERAL)) {
         result.errors.push(
-          'Claude Code hooks: gitnexus-hook.cjs no longer contains the cliPath literal to patch — the installed hook may fail to resolve the CLI. Update CLI_PATH_SOURCE_LITERAL in setup.ts.',
+          `${label}: gitnexus-hook.cjs no longer contains the cliPath literal to patch — the installed hook may fail to resolve the CLI. Update CLI_PATH_SOURCE_LITERAL in setup.ts.`,
         );
       }
       content = content.replace(CLI_PATH_SOURCE_LITERAL, `let cliPath = ${jsonCli};`);
@@ -531,21 +540,14 @@ async function installClaudeCodeHooks(result: SetupResult): Promise<void> {
     try {
       await fs.access(dest);
     } catch {
-      result.errors.push(
-        'Claude Code hooks: adapter script was not installed — skipping hook registration',
-      );
+      result.errors.push(`${label}: adapter script was not installed — skipping hook registration`);
       return;
     }
 
-    const failedRequired = await copyHookHelpers(
-      pluginHooksPath,
-      destHooksDir,
-      'Claude Code hooks',
-      result,
-    );
+    const failedRequired = await copyHookHelpers(pluginHooksPath, destHooksDir, label, result);
     if (failedRequired.length > 0) {
       result.errors.push(
-        `Claude Code hooks: required helper(s) ${failedRequired.join(', ')} failed to copy — skipping hook registration`,
+        `${label}: required helper(s) ${failedRequired.join(', ')} failed to copy — skipping hook registration`,
       );
       return;
     }
@@ -565,8 +567,9 @@ async function installClaudeCodeHooks(result: SetupResult): Promise<void> {
 
     const hookEntries: Array<{ eventName: string; value: unknown }> = [];
 
-    // NOTE: SessionStart hooks are broken on Windows (Claude Code bug #23576).
-    // Session context is delivered via CLAUDE.md / skills instead.
+    // NOTE: SessionStart hooks are broken on Windows (Claude Code bug #23576),
+    // and Codex reads AGENTS.md natively. Session context is delivered via
+    // CLAUDE.md / AGENTS.md / skills instead.
 
     if (!hasGitnexusHook(parsed?.hooks, 'PreToolUse', claudeHook.needle)) {
       hookEntries.push({
@@ -602,20 +605,20 @@ async function installClaudeCodeHooks(result: SetupResult): Promise<void> {
     }
 
     if (hookEntries.length === 0) {
-      result.configured.push('Claude Code hooks (already configured)');
+      result.configured.push(`${label} (already configured)`);
       return;
     }
 
     const ok = await mergeHooksJsonc(settingsPath, hookEntries);
     if (ok) {
-      result.configured.push('Claude Code hooks (PreToolUse, PostToolUse)');
+      result.configured.push(`${label} (PreToolUse, PostToolUse)`);
     } else {
       result.errors.push(
-        'Claude Code hooks: settings.json is corrupt — skipping to preserve existing content',
+        `${label}: ${path.basename(settingsPath)} is corrupt — skipping to preserve existing content`,
       );
     }
   } catch (err: any) {
-    result.errors.push(`Claude Code hooks: ${err.message}`);
+    result.errors.push(`${label}: ${err.message}`);
   }
 }
 
@@ -1198,7 +1201,7 @@ export const setupCommand = async (options?: { codingAgent?: string[] | string }
   // Install global skills for platforms that support them
   if (selected.has('claude')) {
     await installClaudeCodeSkills(result);
-    await installClaudeCodeHooks(result);
+    await installClaudeSchemaHooks(result, 'claude');
   }
   if (selected.has('antigravity')) {
     await installAntigravitySkills(result);
@@ -1208,7 +1211,10 @@ export const setupCommand = async (options?: { codingAgent?: string[] | string }
   if (selected.has('opencode')) await installOpenCodeSkills(result);
   if (selected.has('codebuddy')) await installCodeBuddySkills(result);
   if (selected.has('qoder')) await installQoderSkills(result);
-  if (selected.has('codex')) await installCodexSkills(result);
+  if (selected.has('codex')) {
+    await installCodexSkills(result);
+    await installClaudeSchemaHooks(result, 'codex');
+  }
 
   // Print results
   if (result.configured.length > 0) {

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -500,9 +500,9 @@ async function installClaudeSchemaHooks(
   result: SetupResult,
   id: 'claude' | 'codex',
 ): Promise<void> {
-  const claudeHook = hookTarget(id);
-  const settingsPath = claudeHook.settingsFile;
-  const label = `${claudeHook.label} hooks`;
+  const hookCfg = hookTarget(id);
+  const settingsPath = hookCfg.settingsFile;
+  const label = `${hookCfg.label} hooks`;
 
   // Gate on the editor's own config dir (~/.claude, ~/.codex) existing.
   if (!(await dirExists(path.dirname(settingsPath)))) return;
@@ -511,7 +511,7 @@ async function installClaudeSchemaHooks(
   const pluginHooksPath = path.join(__dirname, '..', '..', 'hooks', 'claude');
 
   // Copy unified hook script to the editor's hooks/gitnexus/ dir
-  const destHooksDir = claudeHook.scriptDir;
+  const destHooksDir = hookCfg.scriptDir;
 
   try {
     await fs.mkdir(destHooksDir, { recursive: true });
@@ -571,7 +571,7 @@ async function installClaudeSchemaHooks(
     // and Codex reads AGENTS.md natively. Session context is delivered via
     // CLAUDE.md / AGENTS.md / skills instead.
 
-    if (!hasGitnexusHook(parsed?.hooks, 'PreToolUse', claudeHook.needle)) {
+    if (!hasGitnexusHook(parsed?.hooks, 'PreToolUse', hookCfg.needle)) {
       hookEntries.push({
         eventName: 'PreToolUse',
         value: {
@@ -587,7 +587,7 @@ async function installClaudeSchemaHooks(
         },
       });
     }
-    if (!hasGitnexusHook(parsed?.hooks, 'PostToolUse', claudeHook.needle)) {
+    if (!hasGitnexusHook(parsed?.hooks, 'PostToolUse', hookCfg.needle)) {
       hookEntries.push({
         eventName: 'PostToolUse',
         value: {

--- a/gitnexus/test/unit/cli-commands.test.ts
+++ b/gitnexus/test/unit/cli-commands.test.ts
@@ -49,6 +49,26 @@ describe('CLI commands', () => {
       expect(pluginManifest.version).toBe(pkg.default.version);
       expect(gitnexusEntries[0]?.version).toBe(pkg.default.version);
     });
+
+    it('keeps Codex plugin manifests aligned with the gitnexus release version', async () => {
+      const pkg = await import('../../package.json', { with: { type: 'json' } });
+      const pluginManifest = await readRepoJson<{ version: string }>(
+        'gitnexus-claude-plugin/.codex-plugin/plugin.json',
+      );
+      const marketplaceManifest = await readRepoJson<{
+        plugins?: Array<{ name: string; version: string }>;
+      }>('.agents/plugins/marketplace.json');
+
+      expect(Array.isArray(marketplaceManifest.plugins)).toBe(true);
+
+      const gitnexusEntries = (marketplaceManifest.plugins ?? []).filter(
+        (plugin) => plugin.name === 'gitnexus',
+      );
+
+      expect(gitnexusEntries).toHaveLength(1);
+      expect(pluginManifest.version).toBe(pkg.default.version);
+      expect(gitnexusEntries[0]?.version).toBe(pkg.default.version);
+    });
   });
 
   describe('package.json scripts', () => {

--- a/gitnexus/test/unit/setup.test.ts
+++ b/gitnexus/test/unit/setup.test.ts
@@ -10,6 +10,13 @@ const PKG_VERSION = (createRequire(import.meta.url)('../../package.json') as { v
   .version;
 const MCP_PINNED_REF = `gitnexus@${PKG_VERSION}`;
 
+/** Flatten the spied console.log calls into one searchable string. */
+const logLines = () =>
+  vi
+    .mocked(console.log)
+    .mock.calls.map((call) => call.join(' '))
+    .join('\n');
+
 const execFileMock = vi.fn((...args: any[]) => {
   const callback = args.at(-1);
   if (typeof callback === 'function') {
@@ -804,12 +811,8 @@ describe('Codex hooks (installClaudeSchemaHooks)', () => {
     const { setupCommand } = await import('../../src/cli/setup.js');
     await setupCommand();
 
-    const logged = vi
-      .mocked(console.log)
-      .mock.calls.map((call) => call.join(' '))
-      .join('\n');
     expect(await fs.readFile(hooksJsonPath(), 'utf-8')).toBe(corrupt);
-    expect(logged).toContain('Codex hooks: hooks.json is corrupt');
+    expect(logLines()).toContain('Codex hooks: hooks.json is corrupt');
   });
 });
 
@@ -820,12 +823,6 @@ describe('setup — non-ENOENT read/stat failures are surfaced, not masked', () 
 
   const errnoError = (code: string) =>
     Object.assign(new Error(`${code}: simulated failure`), { code });
-
-  const logLines = () =>
-    vi
-      .mocked(console.log)
-      .mock.calls.map((call) => call.join(' '))
-      .join('\n');
 
   beforeEach(async () => {
     vi.resetModules();

--- a/gitnexus/test/unit/setup.test.ts
+++ b/gitnexus/test/unit/setup.test.ts
@@ -708,6 +708,96 @@ describe('setupQoder', () => {
   });
 });
 
+describe('Codex hooks (installClaudeSchemaHooks)', () => {
+  let tempHome: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+
+  const hooksJsonPath = () => path.join(tempHome, '.codex', 'hooks.json');
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'gn-codex-hooks-'));
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+
+    // Only create ~/.codex — no other editor directories so their
+    // setup functions skip and don't pollute assertions.
+    await fs.mkdir(path.join(tempHome, '.codex'), { recursive: true });
+
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalUserProfile;
+    await fs.rm(tempHome, { recursive: true, force: true });
+  });
+
+  it('registers PreToolUse + PostToolUse in ~/.codex/hooks.json and installs the adapter', async () => {
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const hooks = JSON.parse(await fs.readFile(hooksJsonPath(), 'utf-8')).hooks;
+    expect(hooks).toMatchObject({
+      PreToolUse: [{ matcher: 'Grep|Glob|Bash' }],
+      PostToolUse: [{ matcher: 'Bash' }],
+    });
+    for (const event of ['PreToolUse', 'PostToolUse']) {
+      expect(hooks[event][0].hooks[0].command).toContain('gitnexus-hook');
+    }
+    await expect(
+      fs.access(path.join(tempHome, '.codex', 'hooks', 'gitnexus', 'gitnexus-hook.cjs')),
+    ).resolves.toBeUndefined();
+  });
+
+  it('is idempotent — a second setup run adds no duplicate entries', async () => {
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+    await setupCommand();
+
+    const hooks = JSON.parse(await fs.readFile(hooksJsonPath(), 'utf-8')).hooks;
+    expect(hooks.PreToolUse).toHaveLength(1);
+    expect(hooks.PostToolUse).toHaveLength(1);
+  });
+
+  it('preserves a user-owned hook already present in hooks.json', async () => {
+    await fs.writeFile(
+      hooksJsonPath(),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [{ matcher: 'Read', hooks: [{ type: 'command', command: 'my-own-hook' }] }],
+        },
+      }),
+      'utf-8',
+    );
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const hooks = JSON.parse(await fs.readFile(hooksJsonPath(), 'utf-8')).hooks;
+    const commands: string[] = hooks.PreToolUse.flatMap((e: { hooks: { command: string }[] }) =>
+      e.hooks.map((h) => h.command),
+    );
+    expect(commands).toContain('my-own-hook');
+    expect(commands.some((c: string) => c.includes('gitnexus-hook'))).toBe(true);
+  });
+
+  it('does not write hooks.json when ~/.codex is absent', async () => {
+    await fs.rm(path.join(tempHome, '.codex'), { recursive: true, force: true });
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    await expect(fs.access(hooksJsonPath())).rejects.toThrow();
+  });
+});
+
 describe('setup — non-ENOENT read/stat failures are surfaced, not masked', () => {
   let tempHome: string;
   let originalHome: string | undefined;

--- a/gitnexus/test/unit/setup.test.ts
+++ b/gitnexus/test/unit/setup.test.ts
@@ -796,6 +796,21 @@ describe('Codex hooks (installClaudeSchemaHooks)', () => {
 
     await expect(fs.access(hooksJsonPath())).rejects.toThrow();
   });
+
+  it('leaves a corrupt hooks.json untouched and reports it (fail closed)', async () => {
+    const corrupt = '{ this is not valid json !!!';
+    await fs.writeFile(hooksJsonPath(), corrupt, 'utf-8');
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    const logged = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => call.join(' '))
+      .join('\n');
+    expect(await fs.readFile(hooksJsonPath(), 'utf-8')).toBe(corrupt);
+    expect(logged).toContain('Codex hooks: hooks.json is corrupt');
+  });
 });
 
 describe('setup — non-ENOENT read/stat failures are surfaced, not masked', () => {
@@ -929,6 +944,30 @@ describe('setup — non-ENOENT read/stat failures are surfaced, not masked', () 
     vi.mocked(fs.readFile).mockRestore();
     expect(await fs.readFile(configPath, 'utf-8')).toBe(raw);
     expect(logLines()).toContain('Codex: EACCES');
+  });
+
+  it('does not rewrite an unreadable ~/.codex/hooks.json as hooks-only (fail closed)', async () => {
+    await fs.mkdir(path.join(tempHome, '.codex'), { recursive: true });
+    const hooksPath = path.join(tempHome, '.codex', 'hooks.json');
+    const raw = JSON.stringify({
+      hooks: { PreToolUse: [{ matcher: 'Read', hooks: [{ type: 'command', command: 'mine' }] }] },
+    });
+    await fs.writeFile(hooksPath, raw, 'utf-8');
+
+    const realReadFile = fs.readFile;
+    vi.spyOn(fs, 'readFile').mockImplementation(((file: any, ...rest: any[]) => {
+      if (String(file) === hooksPath) return Promise.reject(errnoError('EACCES'));
+      return (realReadFile as any)(file, ...rest);
+    }) as typeof fs.readFile);
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand();
+
+    vi.mocked(fs.readFile).mockRestore();
+    // The user's hooks survive; the installer reports instead of replacing
+    // the whole file with a gitnexus-only document.
+    expect(await fs.readFile(hooksPath, 'utf-8')).toBe(raw);
+    expect(logLines()).toContain('Codex hooks: EACCES');
   });
 });
 


### PR DESCRIPTION
## Summary

Completes Codex CLI support by merging the intent of three open workstreams into one verified implementation: **hooks** (#2328), **plugin/marketplace install** (#1131), and the already-shipped MCP + skills setup (#244). Every integration decision was verified against the official Codex docs (developers.openai.com/codex) rather than the assumptions in the original PRs.

> **Stacked on #2368** (CodeBuddy/Qoder) — it reuses that PR's shared `isEnoent` / editor-targets helpers. Merge #2368 first; this diff then reduces to the 3 commits listed below.

## What's included

### 1. Codex hooks — closes #2328, completes #244 (commit `87501a0c`)

Codex CLI's hooks use **Claude Code's exact schema**: the same `{hooks: {Event: [...]}}` JSON shape, the same stdin payload, and the same `hookSpecificOutput.additionalContext` response contract, registered in a dedicated `~/.codex/hooks.json` ([docs](https://developers.openai.com/codex/hooks)). So:

- `installClaudeCodeHooks` is parameterized into `installClaudeSchemaHooks('claude' | 'codex')` — both runtimes share one installer and the **same bundled `gitnexus-hook.cjs` adapter**, unchanged.
- A `codex` `HookTarget` in `editor-targets.ts` gives uninstall + the setup→uninstall round-trip tripwire full coverage with **zero uninstall.ts changes**.
- `gitnexus setup -c codex` now delivers PreToolUse graph enrichment + PostToolUse stale-index detection, matching Claude Code.
- **SessionStart deliberately not registered**: Codex reads `AGENTS.md` natively ([docs](https://developers.openai.com/codex/guides/agents-md)), which already carries the GitNexus context block — an echo hook would duplicate it.

### 2. Codex plugin install — supersedes #1131 (commit `d0df2bb3`, co-authored with @jublin)

#1131's approach was right, but its implementation duplicated 7 (now-stale) skills into a parallel `gitnexus-codex-plugin/` tree. Verified against the [plugin docs](https://developers.openai.com/codex/plugins/build): Codex sets `CLAUDE_PLUGIN_ROOT`/`CLAUDE_PLUGIN_DATA` for compatibility and loads the same SKILL.md skills, `hooks/hooks.json`, and `.mcp.json` — so the existing `gitnexus-claude-plugin/` is **already Codex-compatible as-is**. This PR adds only:

- `gitnexus-claude-plugin/.codex-plugin/plugin.json` (second manifest in the same folder, with `skills`/`mcpServers`/`hooks` pointers)
- `.agents/plugins/marketplace.json` (Codex marketplace registry, mirrors `.claude-plugin/marketplace.json`)
- a narrowed `.gitignore` rule (`.agents/` scratch stays ignored; only the registry file is tracked)

Install: `codex plugin marketplace add abhigyanpatwari/GitNexus` → `/plugins` → install GitNexus. Zero duplicated skills or hook scripts; the folder serves both runtimes.

### 3. Docs (commit `1f138ada`)

Codex promoted to **Full** in both editor tables; manual-config sections document `~/.codex/hooks.json` and the plugin marketplace path.

## Why #1878 is NOT merged (recommend closing)

#1878 claims Codex rejects `hookSpecificOutput` and wants a top-level `additionalContext`, detected via `CODEX_THREAD_ID`/`CODEX_CI`/`CODEX_MANAGED_PACKAGE_ROOT`. Verified against primary sources, both premises fail:

1. The [official hooks reference](https://developers.openai.com/codex/hooks) specifies the **same `hookSpecificOutput.hookEventName/additionalContext` wrapper Claude Code uses** — our existing hook output is already the documented Codex format.
2. None of those three env vars appear in the [official environment-variable docs](https://developers.openai.com/codex/environment-variables) (documented vars are `CODEX_HOME`, `CODEX_NON_INTERACTIVE`, etc.), so the detection would never fire in a real Codex runtime — and if forced, it would emit a shape the docs don't accept.

## Testing & verification

- `test/unit/setup.test.ts`: 4 new Codex-hook tests (registration + adapter install, idempotency, user-hook preservation, `~/.codex`-absent gate) — 48/48 passing
- `test/integration/setup-uninstall-roundtrip.test.ts`: the editor-targets-driven tripwire now exercises the Codex hook target automatically — passing
- `test/unit/uninstall.test.ts` (30/30), `test/unit/hooks.test.ts` — passing
- `tsc --noEmit` clean, eslint 0 errors, prettier clean
- Note: `detect_changes` MCP verification was unavailable locally (index storage-version mismatch v42/v41); change scope was verified manually — `setupCommand` is the only caller of the touched setup functions.

## Related

- Closes #2328, closes #244
- Supersedes #1131 (plugin, re-implemented without duplication — thanks @jublin)
- Recommends closing #1878 as not-planned (premise contradicted by official docs, evidence above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review follow-ups (tri-review 4629351888)

7-commit fix series `65b4fa94..f653d3b5` addressing all review findings, one commit per finding:

| Finding | Resolution |
|---|---|
| Version-lockstep guard gap (P2) | `65b4fa94` — guard test extended to both Codex manifests (verified red under deliberate mutation); CONTRIBUTING lockstep list updated |
| Plugin hooks not Windows-safe (P2) | `39f981b2` — commands quoted. No `commandWindows`: [codex source](https://github.com/openai/codex/blob/main/codex-rs/hooks/src/engine/discovery.rs) falls back to `command` on Windows with identical substitution. Verified: space-in-root smoke test, `claude plugin validate`, local `codex plugin marketplace add` |
| Missing EACCES/corrupt hooks.json tests (P2) | `982b14cb` — both fail-closed regression tests added |
| npm README missing plugin route (P2) | `778de5fd`; Codex notes (SessionStart exclusion, `/hooks` trust gate, choose-one install route) in `272e5f4d` |
| `claudeHook` naming (P3) | `9a2e9c0c` — renamed to `hookCfg` |
| `policy.authentication: "ON_INSTALL"` (P3) | **No change needed** — verified against [codex-rs marketplace.rs](https://github.com/openai/codex/blob/main/codex-rs/core-plugins/src/marketplace.rs): `authentication` is serde-optional and *defaults to* `ON_INSTALL`; the enum is `{ON_INSTALL, ON_USE}` (no "none"), and the field is inert without an auth flow. Removing it would be a behavioral no-op contradicting the docs' "always include" guidance |
| `logLines` duplication (post-fix review) | `f653d3b5` — hoisted to file scope |

**Post-deploy monitoring & validation:** the plugin surface has no telemetry — after merge, run `codex plugin marketplace add abhigyanpatwari/GitNexus` + `/plugins` install once as a smoke test (new installs pick plugin files up at merge, not at release), and watch issues for plugin-hook reports. Existing plugin installs receive the quoting fix at the next lockstep version bump (next stable release). No other runtime impact — remaining changes are tests and docs.
