### PR TITLE
feat(cli): print AI-context writes + opt-out hint in analyze summary

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -1458,6 +1458,22 @@ const analyzeCommandImpl = async (
     );
     console.log(`  ${repoPath}`);
 
+    // Discoverability (#577/#1011/#1265/#1663): name the working-tree writes
+    // and the durable opt-out at the moment they happen, not only in the
+    // README. Mirrors the `!placement.branch` gate around
+    // generateAIContextFiles in runFullAnalysis (pinned --branch runs and
+    // skip-flags write nothing, so they print nothing).
+    const contextWrites = [
+      ...(skipAgentsMd ? [] : ['AGENTS.md', 'CLAUDE.md']),
+      ...(skipSkills ? [] : ['.claude/skills/gitnexus/']),
+    ];
+    if (result.isPrimaryBranch !== false && contextWrites.length > 0) {
+      console.log(
+        `  AI context updated: ${contextWrites.join(', ')} — opt out with --index-only ` +
+          `or a committed .gitnexusrc {"indexOnly": true}`,
+      );
+    }
+
     // Persistent (non-scrolling) warning when FTS indexing was skipped — the
     // progress-bar log() that fired mid-run has already scrolled away, so the
     // degraded-search state must also appear in the final summary (#1161).


### PR DESCRIPTION
## What

One summary line in `gitnexus analyze`: when the run (re)writes AI-context files, name them and the durable opt-out inline —

```
  AI context updated: AGENTS.md, CLAUDE.md, .claude/skills/gitnexus/ — opt out with --index-only or a committed .gitnexusrc {"indexOnly": true}
```

## Why

Every recent "analyze bloats my AGENTS.md" issue (#577, #1011, #1265, #1663) is the same story: the opt-outs already exist (`--index-only` / `--skip-agents-md` / `--skip-skills` since #1485, committed `.gitnexusrc` since #1996), but users learn about the writes from `git diff`, not from the tool — so they land on the issue tracker instead of the README. This closes the discoverability gap at the moment the writes happen.

## How

- Gated on `result.isPrimaryBranch !== false` — mirrors the `!placement.branch` gate around `generateAIContextFiles` in `runFullAnalysis`, so pinned `--branch` runs (which write nothing) print nothing.
- Gated on the resolved skip flags: each path segment only appears if that surface was actually written; fully opted-out runs print nothing.
- No behavior change beyond the one output line; the `alreadyUpToDate` fast path is untouched.

Refs #577, #1011, #1265, #1663 (those are being closed against the already-shipped opt-outs; this PR is the supplementary discoverability fix).

## Validation

- `tsc --noEmit` clean, `eslint` + `prettier` clean (pre-commit).
- `test/unit/analyze-gitnexusrc.test.ts` 10/10 pass.
- No existing test asserts on the summary text; the added logic is a conditional log line reusing the already-tested gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4Kq6gNrEAE8uoyS7PRnTo