### PR TITLE
fix: resolve imported/composed FastAPI route path constants (#2391)

### DIFF
--- a/gitnexus/src/core/group/extractors/http-patterns/python.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/python.ts
@@ -7,6 +7,13 @@ import {
   type LanguagePatterns,
 } from '../tree-sitter-scanner.js';
 import { normalizeExtractedRoutePath } from '../../../ingestion/route-extractors/route-path.js';
+import {
+  extractPythonModuleConstants,
+  parseConstOperands,
+  resolveOperands,
+  type ModuleConstants,
+  type Operand,
+} from '../../../ingestion/route-extractors/python-const-resolver.js';
 import type { HttpDetection, HttpLanguagePlugin, RepoContext } from './types.js';
 
 /**
@@ -75,6 +82,46 @@ const FASTAPI_ROUTER_PATTERNS = compilePatterns({
               object: (identifier) @obj (#eq? @obj "router")
               attribute: (identifier) @method (#match? @method "^(get|post|put|delete|patch)$"))
             arguments: (argument_list . (string) @path)))
+      `,
+    },
+  ],
+} satisfies LanguagePatterns<Record<string, never>>);
+
+// #2391: `@router.<verb>` / `@app.<verb>` whose first argument is a non-literal
+// path — a bare imported constant or a `+`-concatenation. The path is resolved
+// against the repo-wide constant map (parity with the ingestion side) and, on
+// failure, the route is skipped (no provider contract) exactly like ingestion.
+const FASTAPI_ROUTER_EXPR_PATTERNS = compilePatterns({
+  name: 'python-fastapi-router-expr',
+  language: Python,
+  patterns: [
+    {
+      meta: {},
+      query: `
+        (decorator
+          (call
+            function: (attribute
+              object: (identifier) @obj (#eq? @obj "router")
+              attribute: (identifier) @method (#match? @method "^(get|post|put|delete|patch)$"))
+            arguments: (argument_list . [(identifier) (binary_operator)] @path)))
+      `,
+    },
+  ],
+} satisfies LanguagePatterns<Record<string, never>>);
+
+const FASTAPI_APP_EXPR_PATTERNS = compilePatterns({
+  name: 'python-fastapi-app-expr',
+  language: Python,
+  patterns: [
+    {
+      meta: {},
+      query: `
+        (decorator
+          (call
+            function: (attribute
+              object: (identifier) @obj (#eq? @obj "app")
+              attribute: (identifier) @method (#match? @method "^(get|post|put|delete|patch)$"))
+            arguments: (argument_list . [(identifier) (binary_operator)] @path)))
       `,
     },
   ],
@@ -858,6 +905,13 @@ interface PythonRepoContext {
   prefixesByLongKey: Map<string, Set<string>>;
   /** stem only → set of prefixes (basename fallback, may collide) */
   prefixesByShortKey: Map<string, Set<string>>;
+  /**
+   * File-path-keyed module string constants (#2391), for resolving non-literal
+   * `@router`/`@app` decorator paths. Empty when the repo has no composed-constant
+   * route (cost gate). Keyed identically to the ingestion aggregate so provider
+   * contracts and graph Route nodes resolve the same paths (R4 parity).
+   */
+  constantsByFile: Map<string, ModuleConstants>;
 }
 
 /** Strip `.py` and return the bare basename (e.g. `api/users.py` → `users`). */
@@ -1022,11 +1076,48 @@ function buildPythonRepoContext(
     }
   }
 
+  // #2391: build the repo-wide constant map for resolving non-literal decorator
+  // paths. Cost gate (KTD6): only PARSE for constants when some file actually has
+  // a non-literal `@router`/`@app` decorator (cheap content pre-filter); a
+  // literal-only repo pays just one read pass. When active, parse EVERY `.py`
+  // file so the resolvable set matches the ingestion aggregate (R4 parity) — a
+  // narrower set would return null where ingestion resolves.
+  const constantsByFile = new Map<string, ModuleConstants>();
+  const pyContents = new Map<string, string>();
+  let hasComposedRoute = false;
+  for (const rel of files) {
+    if (!rel.endsWith('.py')) continue;
+    const src = readFile(rel);
+    if (!src) continue;
+    pyContents.set(rel, src);
+    if (!hasComposedRoute && NONLITERAL_ROUTE_DECORATOR_RE.test(src)) hasComposedRoute = true;
+  }
+  if (hasComposedRoute) {
+    for (const [rel, src] of pyContents) {
+      parser.setLanguage(Python);
+      const tree = parseSource(parser, src);
+      if (!tree) continue;
+      const mc = extractPythonModuleConstants(tree);
+      if (mc.literals.size > 0 || mc.exprs.size > 0 || mc.imports.size > 0) {
+        constantsByFile.set(rel, mc);
+      }
+    }
+  }
+
   return {
     prefixesByLongKey,
     prefixesByShortKey,
+    constantsByFile,
   };
 }
+
+// Cheap cost-gate pre-filter: a `@router`/`@app.<verb>(` call whose first
+// non-space argument character starts an identifier (not a quote or `)`), i.e. a
+// bare constant or the head of a `+`-concatenation. Deliberately loose — a false
+// positive only costs a parse pass; a false negative would silently drop the
+// feature, so it errs toward matching.
+const NONLITERAL_ROUTE_DECORATOR_RE =
+  /@\s*(?:app|router)\s*\.\s*(?:get|post|put|delete|patch)\s*\(\s*[A-Za-z_]/;
 
 function joinPrefix(prefix: string, route: string): string {
   // Delegate to the shared route-path normalizer so the group contract and the
@@ -1065,6 +1156,36 @@ export const PYTHON_HTTP_PLUGIN: HttpLanguagePlugin = {
     // is an imported (possibly aliased) symbol resolves to its real definition.
     const importMap = buildPythonImportMap(tree);
 
+    // #2391: fold a non-literal decorator argument (bare constant or
+    // `+`-concatenation) to its literal path against the repo constant map, or
+    // `null` → skip (the same floor the ingestion side applies, so provider
+    // contracts and graph Route nodes agree on both resolved and dropped routes).
+    const resolveExprArg = (argNode: Parser.SyntaxNode): string | null => {
+      const cbf = ctx?.constantsByFile;
+      if (!cbf || !fileRel) return null;
+      const operands: Operand[] | null =
+        argNode.type === 'identifier'
+          ? [{ kind: 'ref', name: argNode.text }]
+          : parseConstOperands(argNode);
+      return operands ? resolveOperands(fileRel, operands, cbf) : null;
+    };
+    const emitAppProvider = (httpMethod: string, pathVal: string, line: number): void => {
+      out.push({
+        role: 'provider',
+        framework: 'fastapi',
+        method: httpMethod,
+        path: pathVal,
+        name: null,
+        // The decorated handler has no captured name → resolve by line-span
+        // containment. Best-effort fallback: FastAPI routes are graph-backed
+        // (ingestion decorator routes) and the function span starts at `def`
+        // (decorators excluded), so this lands the single-decorator case and
+        // degrades to file-level for multi-decorator stacks.
+        line,
+        confidence: 0.8,
+      });
+    };
+
     // Providers: FastAPI @app.<verb>("/path") — already absolute path.
     for (const match of runCompiledPatterns(FASTAPI_APP_PATTERNS, tree)) {
       const methodNode = match.captures.method;
@@ -1074,20 +1195,18 @@ export const PYTHON_HTTP_PLUGIN: HttpLanguagePlugin = {
       if (!httpMethod) continue;
       const path = unquoteLiteral(pathNode.text);
       if (path === null) continue;
-      out.push({
-        role: 'provider',
-        framework: 'fastapi',
-        method: httpMethod,
-        path,
-        name: null,
-        // The decorated handler has no captured name → resolve by line-span
-        // containment. Best-effort fallback: FastAPI routes are graph-backed
-        // (ingestion decorator routes) and the function span starts at `def`
-        // (decorators excluded), so this lands the single-decorator case and
-        // degrades to file-level for multi-decorator stacks.
-        line: pathNode.startPosition.row + 1,
-        confidence: 0.8,
-      });
+      emitAppProvider(httpMethod, path, pathNode.startPosition.row + 1);
+    }
+    // Providers: FastAPI @app.<verb>(CONST | A + "/x") — resolved composed path.
+    for (const match of runCompiledPatterns(FASTAPI_APP_EXPR_PATTERNS, tree)) {
+      const methodNode = match.captures.method;
+      const pathNode = match.captures.path;
+      if (!methodNode || !pathNode) continue;
+      const httpMethod = FASTAPI_VERBS[methodNode.text];
+      if (!httpMethod) continue;
+      const resolved = resolveExprArg(pathNode);
+      if (resolved === null) continue; // skip floor
+      emitAppProvider(httpMethod, resolved, pathNode.startPosition.row + 1);
     }
 
     // Django providers come from the graph Route nodes (includes composed by
@@ -1112,15 +1231,11 @@ export const PYTHON_HTTP_PLUGIN: HttpLanguagePlugin = {
     // change is strictly additive vs. the prior @app-only behaviour;
     // when the same router is mounted under multiple prefixes we emit
     // one detection per prefix.
-    for (const match of runCompiledPatterns(FASTAPI_ROUTER_PATTERNS, tree)) {
-      const methodNode = match.captures.method;
-      const pathNode = match.captures.path;
-      if (!methodNode || !pathNode) continue;
-      const httpMethod = FASTAPI_VERBS[methodNode.text];
-      if (!httpMethod) continue;
-      const rawPath = unquoteLiteral(pathNode.text);
-      if (rawPath === null) continue;
-
+    // Join a `@router.<verb>` path with the include_router / APIRouter prefix(es)
+    // that apply to this file and emit one provider detection per prefix. Shared
+    // by the literal and the #2391 non-literal (resolved) router loops so both
+    // stack prefixes identically.
+    const emitRouterProvider = (httpMethod: string, rawPath: string, line: number): void => {
       // Long key first (precise, package-aware), short key as fallback.
       // Mirrors the ingestion-side resolution in parse-impl.ts so the
       // graph nodes and group contracts agree on which prefix applies.
@@ -1146,10 +1261,33 @@ export const PYTHON_HTTP_PLUGIN: HttpLanguagePlugin = {
           path: p,
           name: null,
           // Best-effort containment fallback — see the @app provider note above.
-          line: pathNode.startPosition.row + 1,
+          line,
           confidence: 0.8,
         });
       }
+    };
+
+    for (const match of runCompiledPatterns(FASTAPI_ROUTER_PATTERNS, tree)) {
+      const methodNode = match.captures.method;
+      const pathNode = match.captures.path;
+      if (!methodNode || !pathNode) continue;
+      const httpMethod = FASTAPI_VERBS[methodNode.text];
+      if (!httpMethod) continue;
+      const rawPath = unquoteLiteral(pathNode.text);
+      if (rawPath === null) continue;
+      emitRouterProvider(httpMethod, rawPath, pathNode.startPosition.row + 1);
+    }
+    // Providers: FastAPI @router.<verb>(CONST | A + "/x") — resolved composed path
+    // (#2391). Null resolution → skip, so provider/graph parity holds.
+    for (const match of runCompiledPatterns(FASTAPI_ROUTER_EXPR_PATTERNS, tree)) {
+      const methodNode = match.captures.method;
+      const pathNode = match.captures.path;
+      if (!methodNode || !pathNode) continue;
+      const httpMethod = FASTAPI_VERBS[methodNode.text];
+      if (!httpMethod) continue;
+      const resolved = resolveExprArg(pathNode);
+      if (resolved === null) continue;
+      emitRouterProvider(httpMethod, resolved, pathNode.startPosition.row + 1);
     }
 
     // Providers: Flask `app.add_url_rule('/path', view_func=handler, methods=[…])`.

--- a/gitnexus/src/core/group/extractors/http-patterns/python.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/python.ts
@@ -10,9 +10,9 @@ import { normalizeExtractedRoutePath } from '../../../ingestion/route-extractors
 import {
   extractPythonModuleConstants,
   parseConstOperands,
+  resolveConstant,
   resolveOperands,
   type ModuleConstants,
-  type Operand,
 } from '../../../ingestion/route-extractors/python-const-resolver.js';
 import type { HttpDetection, HttpLanguagePlugin, RepoContext } from './types.js';
 
@@ -1170,10 +1170,10 @@ export const PYTHON_HTTP_PLUGIN: HttpLanguagePlugin = {
     const resolveExprArg = (argNode: Parser.SyntaxNode): string | null => {
       const cbf = ctx?.constantsByFile;
       if (!cbf || !fileRel) return null;
-      const operands: Operand[] | null =
-        argNode.type === 'identifier'
-          ? [{ kind: 'ref', name: argNode.text }]
-          : parseConstOperands(argNode);
+      // A bare constant name resolves through the by-name entry point; a
+      // `+`-concatenation parses to an operand list first.
+      if (argNode.type === 'identifier') return resolveConstant(fileRel, argNode.text, cbf);
+      const operands = parseConstOperands(argNode);
       return operands ? resolveOperands(fileRel, operands, cbf) : null;
     };
     const emitAppProvider = (httpMethod: string, pathVal: string, line: number): void => {

--- a/gitnexus/src/core/group/extractors/http-patterns/python.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/python.ts
@@ -974,13 +974,15 @@ function recordPrefix(target: Map<string, Set<string>>, key: string, prefix: str
 // Cheap cost-gate pre-filter: a `@router`/`@app.<verb>(` call whose first
 // argument is non-literal — either it STARTS with an identifier (a bare constant
 // or the head of `CONST + "/x"`), or it is a string-literal-LEADING concat
-// (`"/api" + SUFFIX`) detected by a `+` before the closing paren on the decorator
-// line (#2393). Gating the literal-leading case on the `+` (not merely a leading
-// quote) keeps a plain string route `@router.get("/x")` OFF the gate, so a
-// literal-only repo pays no parse pass. Deliberately loose — a false positive
-// only costs a parse; a false negative would silently drop the feature.
+// (`"/api" + SUFFIX`) detected by a `+` before the decorator's closing paren
+// (#2393). `[^)]*` spans the whole argument, including a Black-formatted concat
+// that wraps across lines, but stays bounded by the decorator's own `)`. Gating
+// the literal-leading case on the `+` (not merely a leading quote) keeps a plain
+// string route `@router.get("/x")` OFF the gate, so a literal-only repo pays no
+// parse pass. Deliberately loose — a false positive only costs a parse; a false
+// negative would silently drop the feature.
 const NONLITERAL_ROUTE_DECORATOR_RE =
-  /@\s*(?:app|router)\s*\.\s*(?:get|post|put|delete|patch)\s*\(\s*(?:[A-Za-z_]|["'][^)\n]*\+)/;
+  /@\s*(?:app|router)\s*\.\s*(?:get|post|put|delete|patch)\s*\(\s*(?:[A-Za-z_]|["'][^)]*\+)/;
 
 function buildPythonRepoContext(
   files: string[],

--- a/gitnexus/src/core/group/extractors/http-patterns/python.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/python.ts
@@ -971,6 +971,17 @@ function recordPrefix(target: Map<string, Set<string>>, key: string, prefix: str
   target.set(key, set);
 }
 
+// Cheap cost-gate pre-filter: a `@router`/`@app.<verb>(` call whose first
+// argument is non-literal — either it STARTS with an identifier (a bare constant
+// or the head of `CONST + "/x"`), or it is a string-literal-LEADING concat
+// (`"/api" + SUFFIX`) detected by a `+` before the closing paren on the decorator
+// line (#2393). Gating the literal-leading case on the `+` (not merely a leading
+// quote) keeps a plain string route `@router.get("/x")` OFF the gate, so a
+// literal-only repo pays no parse pass. Deliberately loose — a false positive
+// only costs a parse; a false negative would silently drop the feature.
+const NONLITERAL_ROUTE_DECORATOR_RE =
+  /@\s*(?:app|router)\s*\.\s*(?:get|post|put|delete|patch)\s*\(\s*(?:[A-Za-z_]|["'][^)\n]*\+)/;
+
 function buildPythonRepoContext(
   files: string[],
   parser: Parser,
@@ -1114,17 +1125,6 @@ function buildPythonRepoContext(
     constantsByFile,
   };
 }
-
-// Cheap cost-gate pre-filter: a `@router`/`@app.<verb>(` call whose first
-// argument is non-literal — either it STARTS with an identifier (a bare constant
-// or the head of `CONST + "/x"`), or it is a string-literal-LEADING concat
-// (`"/api" + SUFFIX`) detected by a `+` before the closing paren on the decorator
-// line (#2393). Gating the literal-leading case on the `+` (not merely a leading
-// quote) keeps a plain string route `@router.get("/x")` OFF the gate, so a
-// literal-only repo pays no parse pass. Deliberately loose — a false positive
-// only costs a parse; a false negative would silently drop the feature.
-const NONLITERAL_ROUTE_DECORATOR_RE =
-  /@\s*(?:app|router)\s*\.\s*(?:get|post|put|delete|patch)\s*\(\s*(?:[A-Za-z_]|["'][^)\n]*\+)/;
 
 function joinPrefix(prefix: string, route: string): string {
   // Delegate to the shared route-path normalizer so the group contract and the

--- a/gitnexus/src/core/group/extractors/http-patterns/python.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/python.ts
@@ -1112,12 +1112,15 @@ function buildPythonRepoContext(
 }
 
 // Cheap cost-gate pre-filter: a `@router`/`@app.<verb>(` call whose first
-// non-space argument character starts an identifier (not a quote or `)`), i.e. a
-// bare constant or the head of a `+`-concatenation. Deliberately loose — a false
-// positive only costs a parse pass; a false negative would silently drop the
-// feature, so it errs toward matching.
+// argument is non-literal — either it STARTS with an identifier (a bare constant
+// or the head of `CONST + "/x"`), or it is a string-literal-LEADING concat
+// (`"/api" + SUFFIX`) detected by a `+` before the closing paren on the decorator
+// line (#2393). Gating the literal-leading case on the `+` (not merely a leading
+// quote) keeps a plain string route `@router.get("/x")` OFF the gate, so a
+// literal-only repo pays no parse pass. Deliberately loose — a false positive
+// only costs a parse; a false negative would silently drop the feature.
 const NONLITERAL_ROUTE_DECORATOR_RE =
-  /@\s*(?:app|router)\s*\.\s*(?:get|post|put|delete|patch)\s*\(\s*[A-Za-z_]/;
+  /@\s*(?:app|router)\s*\.\s*(?:get|post|put|delete|patch)\s*\(\s*(?:[A-Za-z_]|["'][^)\n]*\+)/;
 
 function joinPrefix(prefix: string, route: string): string {
   // Delegate to the shared route-path normalizer so the group contract and the

--- a/gitnexus/src/core/group/extractors/http-patterns/python.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/python.ts
@@ -1006,112 +1006,111 @@ function buildPythonRepoContext(
     if (!hasComposedRoute && NONLITERAL_ROUTE_DECORATOR_RE.test(src)) hasComposedRoute = true;
   }
 
-  // Cross-file pre-pass: only `include_router` sites need it — they bind a
-  // prefix declared in one file to a router defined in another. Same-file
-  // `APIRouter(prefix=...)` is resolved in scan() from the file's own tree, so
-  // APIRouter-only files are left out here and never parsed twice.
-  for (const src of pyContents.values()) {
-    if (!src.includes('include_router')) continue;
+  // Single PARSE pass (#2391): parse each `.py` at most once and feed BOTH the
+  // include_router prefix pre-pass and the composed-constant map below. This used
+  // to be two loops, so an include_router file in a composed repo was parsed
+  // twice. A file that needs neither pass is not parsed at all (cost gates intact).
+  //
+  // Cross-file pre-pass: only `include_router` sites need it — they bind a prefix
+  // declared in one file to a router defined in another. Same-file
+  // `APIRouter(prefix=...)` is resolved in scan() from the file's own tree.
+  const constantsByFile = new Map<string, ModuleConstants>();
+  for (const [rel, src] of pyContents) {
+    const needsRouter = src.includes('include_router');
+    if (!needsRouter && !hasComposedRoute) continue;
     parser.setLanguage(Python);
     const tree = parseSource(parser, src);
     if (!tree) continue;
 
-    // Local name → (short, long) map for the current file, populated
-    // from `from <module> import router [as <alias>]` statements. The
-    // alias (or 'router' when there is no alias) is the local name
-    // we'll later see passed to `<host>.include_router`.
-    interface LocalImport {
-      moduleShort: string;
-      moduleLong: string;
-    }
-    const localNameToModule = new Map<string, LocalImport>();
-    for (const m of runCompiledPatterns(FROM_IMPORT_ROUTER_PATTERNS, tree)) {
-      const moduleNode = m.captures.module;
-      const aliasNode = m.captures.alias;
-      const importedNode = m.captures.imported;
-      if (!moduleNode || !importedNode) continue;
-      const localName = aliasNode?.text ?? importedNode.text;
-      const moduleShort = lastSegmentOfDotted(moduleNode.text);
-      if (!moduleShort) continue;
-      const moduleLong = lastTwoSegmentsAsLongKey(moduleNode.text);
-      localNameToModule.set(localName, { moduleShort, moduleLong });
-    }
+    if (needsRouter) {
+      // Local name → (short, long) map for the current file, populated
+      // from `from <module> import router [as <alias>]` statements. The
+      // alias (or 'router' when there is no alias) is the local name
+      // we'll later see passed to `<host>.include_router`.
+      interface LocalImport {
+        moduleShort: string;
+        moduleLong: string;
+      }
+      const localNameToModule = new Map<string, LocalImport>();
+      for (const m of runCompiledPatterns(FROM_IMPORT_ROUTER_PATTERNS, tree)) {
+        const moduleNode = m.captures.module;
+        const aliasNode = m.captures.alias;
+        const importedNode = m.captures.imported;
+        if (!moduleNode || !importedNode) continue;
+        const localName = aliasNode?.text ?? importedNode.text;
+        const moduleShort = lastSegmentOfDotted(moduleNode.text);
+        if (!moduleShort) continue;
+        const moduleLong = lastTwoSegmentsAsLongKey(moduleNode.text);
+        localNameToModule.set(localName, { moduleShort, moduleLong });
+      }
 
-    // Module-alias map: name imported from a multi-segment package →
-    // long key. Lets Shape A look up the precise file for `<name>.router`
-    // even when `<name>` collides with another package's basename.
-    const localNameToModuleAlias = new Map<string, string>();
-    for (const m of runCompiledPatterns(FROM_IMPORT_MODULE_PATTERNS, tree)) {
-      const moduleNode = m.captures.module;
-      const importedNode = m.captures.imported;
-      const aliasNode = m.captures.alias;
-      if (!moduleNode || !importedNode) continue;
-      // Skip the `router` shape — already handled by FROM_IMPORT_ROUTER_PATTERNS
-      // above and stored under its router-aware semantics.
-      if (importedNode.text === 'router') continue;
-      const moduleLong = lastTwoSegmentsAsLongKey(`${moduleNode.text}.${importedNode.text}`);
-      if (!moduleLong) continue;
-      const localName = aliasNode?.text ?? importedNode.text;
-      localNameToModuleAlias.set(localName, moduleLong);
-    }
+      // Module-alias map: name imported from a multi-segment package →
+      // long key. Lets Shape A look up the precise file for `<name>.router`
+      // even when `<name>` collides with another package's basename.
+      const localNameToModuleAlias = new Map<string, string>();
+      for (const m of runCompiledPatterns(FROM_IMPORT_MODULE_PATTERNS, tree)) {
+        const moduleNode = m.captures.module;
+        const importedNode = m.captures.imported;
+        const aliasNode = m.captures.alias;
+        if (!moduleNode || !importedNode) continue;
+        // Skip the `router` shape — already handled by FROM_IMPORT_ROUTER_PATTERNS
+        // above and stored under its router-aware semantics.
+        if (importedNode.text === 'router') continue;
+        const moduleLong = lastTwoSegmentsAsLongKey(`${moduleNode.text}.${importedNode.text}`);
+        if (!moduleLong) continue;
+        const localName = aliasNode?.text ?? importedNode.text;
+        localNameToModuleAlias.set(localName, moduleLong);
+      }
 
-    // Shape A: `<host>.include_router(<module>.router, prefix='/x')`.
-    // The call site gives us only a short module name. We promote to a
-    // long key when the same file imports `<module>` via either
-    // `from <pkg> import <module>` (recorded in `localNameToModuleAlias`
-    // — the typical pattern) or, less commonly, a router-aware import
-    // statement. Only fall back to the basename short key when neither
-    // alias is available.
-    for (const m of runCompiledPatterns(INCLUDE_ROUTER_ATTR_PATTERNS, tree)) {
-      const modNode = m.captures.router_module;
-      const prefixNode = m.captures.prefix;
-      if (!modNode || !prefixNode) continue;
-      const prefix = unquoteLiteral(prefixNode.text);
-      if (prefix === null) continue;
-      const moduleShort = modNode.text;
-      const aliasLong = localNameToModuleAlias.get(moduleShort);
-      const sameFileImport = localNameToModule.get(moduleShort);
-      const longKey = aliasLong ?? sameFileImport?.moduleLong;
-      if (longKey) {
-        recordPrefix(prefixesByLongKey, longKey, prefix);
-      } else {
-        recordPrefix(prefixesByShortKey, moduleShort, prefix);
+      // Shape A: `<host>.include_router(<module>.router, prefix='/x')`.
+      // The call site gives us only a short module name. We promote to a
+      // long key when the same file imports `<module>` via either
+      // `from <pkg> import <module>` (recorded in `localNameToModuleAlias`
+      // — the typical pattern) or, less commonly, a router-aware import
+      // statement. Only fall back to the basename short key when neither
+      // alias is available.
+      for (const m of runCompiledPatterns(INCLUDE_ROUTER_ATTR_PATTERNS, tree)) {
+        const modNode = m.captures.router_module;
+        const prefixNode = m.captures.prefix;
+        if (!modNode || !prefixNode) continue;
+        const prefix = unquoteLiteral(prefixNode.text);
+        if (prefix === null) continue;
+        const moduleShort = modNode.text;
+        const aliasLong = localNameToModuleAlias.get(moduleShort);
+        const sameFileImport = localNameToModule.get(moduleShort);
+        const longKey = aliasLong ?? sameFileImport?.moduleLong;
+        if (longKey) {
+          recordPrefix(prefixesByLongKey, longKey, prefix);
+        } else {
+          recordPrefix(prefixesByShortKey, moduleShort, prefix);
+        }
+      }
+
+      // Shape B: `<host>.include_router(my_router, prefix='/x')` — resolve
+      // `my_router` via the import map built above. Whenever the import
+      // statement supplied a multi-segment module path the long key is
+      // recorded, eliminating cross-package collisions.
+      for (const m of runCompiledPatterns(INCLUDE_ROUTER_NAME_PATTERNS, tree)) {
+        const nameNode = m.captures.router_name;
+        const prefixNode = m.captures.prefix;
+        if (!nameNode || !prefixNode) continue;
+        const localImp = localNameToModule.get(nameNode.text);
+        if (!localImp) continue;
+        const prefix = unquoteLiteral(prefixNode.text);
+        if (prefix === null) continue;
+        if (localImp.moduleLong) {
+          recordPrefix(prefixesByLongKey, localImp.moduleLong, prefix);
+        } else {
+          recordPrefix(prefixesByShortKey, localImp.moduleShort, prefix);
+        }
       }
     }
 
-    // Shape B: `<host>.include_router(my_router, prefix='/x')` — resolve
-    // `my_router` via the import map built above. Whenever the import
-    // statement supplied a multi-segment module path the long key is
-    // recorded, eliminating cross-package collisions.
-    for (const m of runCompiledPatterns(INCLUDE_ROUTER_NAME_PATTERNS, tree)) {
-      const nameNode = m.captures.router_name;
-      const prefixNode = m.captures.prefix;
-      if (!nameNode || !prefixNode) continue;
-      const localImp = localNameToModule.get(nameNode.text);
-      if (!localImp) continue;
-      const prefix = unquoteLiteral(prefixNode.text);
-      if (prefix === null) continue;
-      if (localImp.moduleLong) {
-        recordPrefix(prefixesByLongKey, localImp.moduleLong, prefix);
-      } else {
-        recordPrefix(prefixesByShortKey, localImp.moduleShort, prefix);
-      }
-    }
-  }
-
-  // #2391: build the repo-wide constant map for resolving non-literal decorator
-  // paths. Cost gate (KTD6): only PARSE for constants when some file actually has
-  // a non-literal `@router`/`@app` decorator (the `hasComposedRoute` pre-filter
-  // computed in the single read pass above); a literal-only repo does no parsing
-  // here. When active, parse EVERY `.py` file so the resolvable set matches the
-  // ingestion aggregate (R4 parity) — a narrower set would return null where
-  // ingestion resolves.
-  const constantsByFile = new Map<string, ModuleConstants>();
-  if (hasComposedRoute) {
-    for (const [rel, src] of pyContents) {
-      parser.setLanguage(Python);
-      const tree = parseSource(parser, src);
-      if (!tree) continue;
+    // #2391: build the repo-wide constant map for resolving non-literal decorator
+    // paths (KTD6 cost gate: only when `hasComposedRoute`). Parse EVERY `.py` so
+    // the resolvable set matches the ingestion aggregate (R4 parity) — a narrower
+    // set would return null where ingestion resolves.
+    if (hasComposedRoute) {
       const mc = extractPythonModuleConstants(tree);
       if (mc.literals.size > 0 || mc.exprs.size > 0 || mc.imports.size > 0) {
         constantsByFile.set(rel, mc);

--- a/gitnexus/src/core/group/extractors/http-patterns/python.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/python.ts
@@ -980,14 +980,26 @@ function buildPythonRepoContext(
   const prefixesByLongKey = new Map<string, Set<string>>();
   const prefixesByShortKey = new Map<string, Set<string>>();
 
-  // Cross-file pre-pass: only `include_router` sites need it — they bind a
-  // prefix declared in one file to a router defined in another. Same-file
-  // `APIRouter(prefix=...)` is resolved in scan() from the file's own tree, so
-  // APIRouter-only files are left out here and never parsed twice.
+  // Single read pass (#2393): slurp every `.py` file's content ONCE. This used to
+  // be two passes — the include_router pre-pass below and the #2391 constant cost
+  // gate each re-read every `.py` file. The composed-route cost gate is computed
+  // in the same pass so a literal-only repo still does exactly one read and zero
+  // parses.
+  const pyContents = new Map<string, string>();
+  let hasComposedRoute = false;
   for (const rel of files) {
     if (!rel.endsWith('.py')) continue;
     const src = readFile(rel);
     if (!src) continue;
+    pyContents.set(rel, src);
+    if (!hasComposedRoute && NONLITERAL_ROUTE_DECORATOR_RE.test(src)) hasComposedRoute = true;
+  }
+
+  // Cross-file pre-pass: only `include_router` sites need it — they bind a
+  // prefix declared in one file to a router defined in another. Same-file
+  // `APIRouter(prefix=...)` is resolved in scan() from the file's own tree, so
+  // APIRouter-only files are left out here and never parsed twice.
+  for (const src of pyContents.values()) {
     if (!src.includes('include_router')) continue;
     parser.setLanguage(Python);
     const tree = parseSource(parser, src);
@@ -1078,20 +1090,12 @@ function buildPythonRepoContext(
 
   // #2391: build the repo-wide constant map for resolving non-literal decorator
   // paths. Cost gate (KTD6): only PARSE for constants when some file actually has
-  // a non-literal `@router`/`@app` decorator (cheap content pre-filter); a
-  // literal-only repo pays just one read pass. When active, parse EVERY `.py`
-  // file so the resolvable set matches the ingestion aggregate (R4 parity) — a
-  // narrower set would return null where ingestion resolves.
+  // a non-literal `@router`/`@app` decorator (the `hasComposedRoute` pre-filter
+  // computed in the single read pass above); a literal-only repo does no parsing
+  // here. When active, parse EVERY `.py` file so the resolvable set matches the
+  // ingestion aggregate (R4 parity) — a narrower set would return null where
+  // ingestion resolves.
   const constantsByFile = new Map<string, ModuleConstants>();
-  const pyContents = new Map<string, string>();
-  let hasComposedRoute = false;
-  for (const rel of files) {
-    if (!rel.endsWith('.py')) continue;
-    const src = readFile(rel);
-    if (!src) continue;
-    pyContents.set(rel, src);
-    if (!hasComposedRoute && NONLITERAL_ROUTE_DECORATOR_RE.test(src)) hasComposedRoute = true;
-  }
   if (hasComposedRoute) {
     for (const [rel, src] of pyContents) {
       parser.setLanguage(Python);

--- a/gitnexus/src/core/group/extractors/http-patterns/python.ts
+++ b/gitnexus/src/core/group/extractors/http-patterns/python.ts
@@ -10,9 +10,9 @@ import { normalizeExtractedRoutePath } from '../../../ingestion/route-extractors
 import {
   extractPythonModuleConstants,
   parseConstOperands,
-  resolveConstant,
   resolveOperands,
   type ModuleConstants,
+  type Operand,
 } from '../../../ingestion/route-extractors/python-const-resolver.js';
 import type { HttpDetection, HttpLanguagePlugin, RepoContext } from './types.js';
 
@@ -1169,10 +1169,15 @@ export const PYTHON_HTTP_PLUGIN: HttpLanguagePlugin = {
     const resolveExprArg = (argNode: Parser.SyntaxNode): string | null => {
       const cbf = ctx?.constantsByFile;
       if (!cbf || !fileRel) return null;
-      // A bare constant name resolves through the by-name entry point; a
-      // `+`-concatenation parses to an operand list first.
-      if (argNode.type === 'identifier') return resolveConstant(fileRel, argNode.text, cbf);
-      const operands = parseConstOperands(argNode);
+      // Build an operand list and fold via `resolveOperands` — the SAME entry the
+      // ingestion side uses (parse-impl folds `routePathOperands`). Using the
+      // by-name `resolveConstant` here would enter `foldName` one depth shallower,
+      // so at the MAX_RESOLVE_DEPTH boundary the group would resolve a chain
+      // ingestion drops, breaking R4 parity (#2393).
+      const operands: Operand[] | null =
+        argNode.type === 'identifier'
+          ? [{ kind: 'ref', name: argNode.text }]
+          : parseConstOperands(argNode);
       return operands ? resolveOperands(fileRel, operands, cbf) : null;
     };
     const emitAppProvider = (httpMethod: string, pathVal: string, line: number): void => {

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -16,6 +16,7 @@ import type {
   ExtractedRoute,
   ExtractedFetchCall,
   ExtractedDecoratorRoute,
+  ExtractedModuleConstants,
   ExtractedToolDef,
   FileScopeBindings,
   ExtractedORMQuery,
@@ -40,6 +41,8 @@ export interface WorkerExtractedData {
   routerImports: ExtractedRouterImport[];
   routerConstructorPrefixes: ExtractedRouterConstructorPrefix[];
   routerModuleAliases: ExtractedRouterModuleAlias[];
+  /** Per-file Python module constants for cross-file route-path resolution (#2391). */
+  moduleConstants: ExtractedModuleConstants[];
   toolDefs: ExtractedToolDef[];
   ormQueries: ExtractedORMQuery[];
   /** Project-wide Spring class/interface views for the #2288 inheritance pass. */
@@ -84,6 +87,7 @@ export const mergeChunkResults = (
   const allRouterImports: ExtractedRouterImport[] = [];
   const allRouterConstructorPrefixes: ExtractedRouterConstructorPrefix[] = [];
   const allRouterModuleAliases: ExtractedRouterModuleAlias[] = [];
+  const allModuleConstants: ExtractedModuleConstants[] = [];
   const allSpringTypes: SharedSpringType[] = [];
   const allToolDefs: ExtractedToolDef[] = [];
   const allORMQueries: ExtractedORMQuery[] = [];
@@ -130,6 +134,7 @@ export const mergeChunkResults = (
       allRouterConstructorPrefixes.push(item);
     }
     for (const item of result.routerModuleAliases ?? []) allRouterModuleAliases.push(item);
+    for (const item of result.moduleConstants ?? []) allModuleConstants.push(item);
     for (const item of result.springTypes ?? []) allSpringTypes.push(item);
     for (const item of result.toolDefs) allToolDefs.push(item);
     if (result.ormQueries) for (const item of result.ormQueries) allORMQueries.push(item);
@@ -147,6 +152,7 @@ export const mergeChunkResults = (
     routerImports: allRouterImports,
     routerConstructorPrefixes: allRouterConstructorPrefixes,
     routerModuleAliases: allRouterModuleAliases,
+    moduleConstants: allModuleConstants,
     toolDefs: allToolDefs,
     ormQueries: allORMQueries,
     springTypes: allSpringTypes,

--- a/gitnexus/src/core/ingestion/pipeline-phases/parse-impl.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/parse-impl.ts
@@ -84,6 +84,10 @@ import type {
 } from '../route-extractors/fastapi-router-bindings.js';
 import { normalizeExtractedRoutePath } from '../route-extractors/route-path.js';
 import {
+  resolveOperands,
+  type ModuleConstants,
+} from '../route-extractors/python-const-resolver.js';
+import {
   resolveInheritedSpringRoutes,
   type SharedSpringType,
 } from '../route-extractors/spring-shared.js';
@@ -1157,6 +1161,40 @@ export async function runChunkedParseAndResolve(
 
   // FastAPI router-prefix resolution (cross-file).
   //
+  // #2391: resolve non-literal FastAPI decorator route paths (imported/composed
+  // string constants) BEFORE the include_router/APIRouter prefix pass below, so a
+  // resolved path is then prefix-joined like any literal path. Each such route
+  // carries `routePathExpr`/`routePathOperands` and an empty `routePath`; we fold
+  // the operands against the repo-wide, file-path-keyed constant map. On failure
+  // we DROP the route (KTD5 skip floor) rather than emit a phantom `POST /`.
+  if (allDecoratorRoutes.some((dr) => dr.routePathExpr !== undefined)) {
+    const repoConstants = new Map<string, ModuleConstants>();
+    for (const { filePath, constants } of allModuleConstants) {
+      repoConstants.set(filePath, constants);
+    }
+    const resolvedRoutes: ExtractedDecoratorRoute[] = [];
+    let skipped = 0;
+    for (const dr of allDecoratorRoutes) {
+      if (dr.routePathExpr === undefined) {
+        resolvedRoutes.push(dr);
+        continue;
+      }
+      const value = dr.routePathOperands
+        ? resolveOperands(dr.filePath, dr.routePathOperands, repoConstants)
+        : null;
+      if (value === null) {
+        skipped++;
+        continue;
+      }
+      resolvedRoutes.push({ ...dr, routePath: value });
+    }
+    allDecoratorRoutes.length = 0;
+    for (const dr of resolvedRoutes) allDecoratorRoutes.push(dr);
+    if (isDev && skipped > 0) {
+      logger.info(`  🧩 Resolved composed route constants; ${skipped} unresolved route(s) skipped`);
+    }
+  }
+
   // Workers emit two kinds of records per Python file:
   //   • `routerIncludes` — every `app.include_router(<routerExpr>, prefix='/x')`
   //     site, where `routerExpr` is either `<module>.router` (Shape A) or a

--- a/gitnexus/src/core/ingestion/pipeline-phases/parse-impl.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/parse-impl.ts
@@ -70,6 +70,7 @@ import type { WorkerPool } from '../workers/worker-pool.js';
 import type {
   ExtractedDecoratorRoute,
   ExtractedFetchCall,
+  ExtractedModuleConstants,
   ExtractedORMQuery,
   ExtractedRoute,
   ExtractedToolDef,
@@ -627,6 +628,9 @@ export async function runChunkedParseAndResolve(
   const allRouterImports: ExtractedRouterImport[] = [];
   const allRouterConstructorPrefixes: ExtractedRouterConstructorPrefix[] = [];
   const allRouterModuleAliases: ExtractedRouterModuleAlias[] = [];
+  // Per-file Python module constants (#2391); resolved into decorator route paths
+  // below, after cross-file aggregation, alongside the include_router prefix pass.
+  const allModuleConstants: ExtractedModuleConstants[] = [];
   const allSpringTypes: SharedSpringType[] = [];
   const allToolDefs: ExtractedToolDef[] = [];
   const allORMQueries: ExtractedORMQuery[] = [];
@@ -789,6 +793,9 @@ export async function runChunkedParseAndResolve(
         }
         if (chunkWorkerData.routerModuleAliases?.length) {
           for (const item of chunkWorkerData.routerModuleAliases) allRouterModuleAliases.push(item);
+        }
+        if (chunkWorkerData.moduleConstants?.length) {
+          for (const item of chunkWorkerData.moduleConstants) allModuleConstants.push(item);
         }
         if (chunkWorkerData.springTypes?.length) {
           for (const item of chunkWorkerData.springTypes) allSpringTypes.push(item);

--- a/gitnexus/src/core/ingestion/route-extractors/constant-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/constant-resolver.ts
@@ -1,0 +1,173 @@
+/**
+ * Language-agnostic string-constant folding for route-path resolution (#2391).
+ *
+ * Route decorators/annotations frequently build their path from a constant rather
+ * than a string literal — `@router.post(API_V1_WIDGETS_GET)` (Python),
+ * `@GetMapping(PathConstants.WIDGETS)` (Spring), and the Kotlin/C# equivalents are
+ * the same shape. This module folds such a constant — or an inline
+ * `+`-concatenation — to its literal value, following `+` operands and import
+ * chains across a repo-wide, file-keyed constant map.
+ *
+ * The FOLD is language-neutral: it walks {@link Operand} lists and
+ * {@link ModuleConstants} that ANY language's extractor can produce, and defers
+ * the one language-specific decision — mapping an import specifier to the file it
+ * refers to — to a caller-supplied {@link ImportResolver}. A language binding
+ * (e.g. `python-const-resolver.ts`) provides that resolver plus a tree →
+ * {@link ModuleConstants} extractor and, if wanted, thin pre-bound wrappers.
+ *
+ * This mirrors how `route-path.ts` (URL normalization) and `spring-shared.ts`
+ * (annotation primitives) are shared across the ingestion and group layers and
+ * across languages: the reusable core lives in one place; per-language semantics
+ * plug in. It deliberately does NOT reuse `ScopeResolver` (which resolves symbol
+ * IDENTITIES, not literal string VALUES) or the `--pdg` `REACHING_DEF` layer
+ * (intra-procedural, function-local, def→use reachability — not module-level
+ * cross-file value folding).
+ */
+
+/** Depth ceiling for the import/constant chase. A heuristic bound, not a proven
+ * one; overrun floors to `null` (skip), never a wrong value. */
+const MAX_RESOLVE_DEPTH = 8;
+
+/**
+ * One term of a constant's right-hand side. A `+`-concatenation
+ * (`A + "/b" + C`) becomes an ordered `Operand[]`; a bare literal is a
+ * single-element list.
+ */
+export type Operand =
+  | { readonly kind: 'literal'; readonly value: string }
+  | { readonly kind: 'ref'; readonly name: string };
+
+/**
+ * A `from <module> import <name> [as <local>]` (or the language's equivalent)
+ * binding. `module` is the import specifier as written (e.g. `.constants`,
+ * `..pkg.constants`, `api.constants`) so the {@link ImportResolver} can apply
+ * language-specific rules; `originalName` is the exported name in the target
+ * module (pre-alias). The map key is the local (in-file) name.
+ */
+export interface ImportBinding {
+  readonly module: string;
+  readonly originalName: string;
+}
+
+/**
+ * String-valued module-level constants of one source file. `literals` are
+ * fully-resolved (`X = "/a"`); `exprs` are unresolved operand lists
+ * (`X = A + "/b"`); `imports` maps a local name to the module it was imported
+ * from. All string keys are the in-file (local) names.
+ */
+export interface ModuleConstants {
+  readonly literals: Map<string, string>;
+  readonly exprs: Map<string, readonly Operand[]>;
+  readonly imports: Map<string, ImportBinding>;
+}
+
+/** Repo-wide map: unique file key (e.g. `app/constants.py`) → that file's
+ * {@link ModuleConstants}. */
+export type RepoConstants = ReadonlyMap<string, ModuleConstants>;
+
+/**
+ * Resolve an import specifier (as written) from `importingFileKey` to the unique
+ * repo file key it refers to, or `null` when it cannot be pinned to exactly one
+ * file. This is the sole language-specific dependency of the fold: Python uses
+ * leading-dot relative imports + `.py`-suffix rules; a JVM binding would use
+ * package/classpath rules. Returning `null` on ambiguity keeps the fold honest —
+ * an unresolvable or ambiguous import floors to skip, never a wrong path.
+ */
+export type ImportResolver = (
+  importingFileKey: string,
+  moduleSpec: string,
+  repoKeys: ReadonlySet<string>,
+) => string | null;
+
+interface ResolveState {
+  readonly repo: RepoConstants;
+  readonly repoKeys: ReadonlySet<string>;
+  readonly resolveImport: ImportResolver;
+  readonly visited: Set<string>;
+}
+
+/**
+ * Fold an operand list to its concatenated literal, or `null` if any operand is
+ * unresolvable (an unknown name, a non-string term, a cycle, or a depth overrun).
+ */
+function foldExpr(
+  fileKey: string,
+  operands: readonly Operand[],
+  state: ResolveState,
+  depth: number,
+): string | null {
+  if (depth > MAX_RESOLVE_DEPTH) return null;
+  let out = '';
+  for (const op of operands) {
+    if (op.kind === 'literal') {
+      out += op.value;
+      continue;
+    }
+    const resolved = foldName(fileKey, op.name, state, depth + 1);
+    if (resolved === null) return null;
+    out += resolved;
+  }
+  return out;
+}
+
+function foldName(
+  fileKey: string,
+  name: string,
+  state: ResolveState,
+  depth: number,
+): string | null {
+  if (depth > MAX_RESOLVE_DEPTH) return null;
+  const guard = `${fileKey}::${name}`;
+  if (state.visited.has(guard)) return null; // cycle
+  state.visited.add(guard);
+
+  const mc = state.repo.get(fileKey);
+  if (!mc) return null;
+
+  const literal = mc.literals.get(name);
+  if (literal !== undefined) return literal;
+
+  const expr = mc.exprs.get(name);
+  if (expr !== undefined) return foldExpr(fileKey, expr, state, depth + 1);
+
+  const imp = mc.imports.get(name);
+  if (imp !== undefined) {
+    const targetKey = state.resolveImport(fileKey, imp.module, state.repoKeys);
+    if (targetKey === null) return null;
+    return foldName(targetKey, imp.originalName, state, depth + 1);
+  }
+
+  return null;
+}
+
+function newState(repo: RepoConstants, resolveImport: ImportResolver): ResolveState {
+  return { repo, repoKeys: new Set(repo.keys()), resolveImport, visited: new Set() };
+}
+
+/**
+ * Resolve a single named constant referenced in `fileKey` to its literal string
+ * value, folding `+` concatenation and following import chains via
+ * `resolveImport`, or `null` when it cannot be fully folded.
+ */
+export function resolveConstant(
+  fileKey: string,
+  name: string,
+  repo: RepoConstants,
+  resolveImport: ImportResolver,
+): string | null {
+  return foldName(fileKey, name, newState(repo, resolveImport), 0);
+}
+
+/**
+ * Resolve an inline operand list (an unnamed `+`-expression captured directly at
+ * a decorator/annotation argument, e.g. `@router.get(API_V1 + "/widgets")`)
+ * against `fileKey`.
+ */
+export function resolveOperands(
+  fileKey: string,
+  operands: readonly Operand[],
+  repo: RepoConstants,
+  resolveImport: ImportResolver,
+): string | null {
+  return foldExpr(fileKey, operands, newState(repo, resolveImport), 0);
+}

--- a/gitnexus/src/core/ingestion/route-extractors/constant-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/constant-resolver.ts
@@ -28,6 +28,13 @@
  * one; overrun floors to `null` (skip), never a wrong value. */
 const MAX_RESOLVE_DEPTH = 8;
 
+/** Max length of a folded path. Real route paths are well under this; a fold that
+ * exceeds it is a pathological self-multiplying concat (`X = A + A; A = B + B; …`)
+ * whose true value is genuinely huge — building it risks a `RangeError`/heap OOM,
+ * so we floor to `null` (skip) instead (#2393). The depth cap bounds recursion but
+ * NOT output size, which grows multiplicatively; this bounds the output. */
+const MAX_FOLD_LENGTH = 8192;
+
 /**
  * One term of a constant's right-hand side. A `+`-concatenation
  * (`A + "/b" + C`) becomes an ordered `Operand[]`; a bare literal is a
@@ -84,6 +91,7 @@ interface ResolveState {
   readonly repoKeys: ReadonlySet<string>;
   readonly resolveImport: ImportResolver;
   readonly visited: Set<string>;
+  readonly memo: Map<string, string>;
 }
 
 /**
@@ -101,11 +109,12 @@ function foldExpr(
   for (const op of operands) {
     if (op.kind === 'literal') {
       out += op.value;
-      continue;
+    } else {
+      const resolved = foldName(fileKey, op.name, state, depth + 1);
+      if (resolved === null) return null;
+      out += resolved;
     }
-    const resolved = foldName(fileKey, op.name, state, depth + 1);
-    if (resolved === null) return null;
-    out += resolved;
+    if (out.length > MAX_FOLD_LENGTH) return null; // pathological self-multiplying concat → drop
   }
   return out;
 }
@@ -118,39 +127,62 @@ function foldName(
 ): string | null {
   if (depth > MAX_RESOLVE_DEPTH) return null;
   const guard = `${fileKey}::${name}`;
-  // `visited` is the ACTIVE resolution stack, not a seen-ever set: a name is a
-  // cycle only while it is still being resolved on the current stack (#2393). We
-  // pop it in `finally` so a name reached twice in one fold (`A + A`, or a
-  // diamond `X = P + Q` where P and Q share a base) folds instead of being
-  // mis-flagged as a cycle and dropped. Re-computation is bounded by
-  // MAX_RESOLVE_DEPTH (≤ 2^8 folds), so no blowup is reintroduced.
-  if (state.visited.has(guard)) return null; // cycle
+  // Memoize successful folds. `visited` (below) is the ACTIVE resolution stack
+  // for cycle detection — popped on unwind so `A + A` / diamonds fold instead of
+  // false-cycling (#2393) — but popping it alone reintroduces recomputation: a
+  // wide shared-descendant DAG re-folds each child once per reference, O(fanout^depth),
+  // which can exhaust the heap. The never-popped `memo` caps that at O(nodes): a
+  // name resolved on one branch is returned directly on the next. Only SUCCESSES
+  // are cached — a `null` may be transient (a name that is a cycle on the current
+  // branch can resolve on another), so caching it would be unsound.
+  const memoized = state.memo.get(guard);
+  if (memoized !== undefined) return memoized;
+  if (state.visited.has(guard)) return null; // cycle: `name` is on the active stack
   state.visited.add(guard);
   try {
-    const mc = state.repo.get(fileKey);
-    if (!mc) return null;
-
-    const literal = mc.literals.get(name);
-    if (literal !== undefined) return literal;
-
-    const expr = mc.exprs.get(name);
-    if (expr !== undefined) return foldExpr(fileKey, expr, state, depth + 1);
-
-    const imp = mc.imports.get(name);
-    if (imp !== undefined) {
-      const targetKey = state.resolveImport(fileKey, imp.module, state.repoKeys);
-      if (targetKey === null) return null;
-      return foldName(targetKey, imp.originalName, state, depth + 1);
-    }
-
-    return null;
+    const result = computeFold(fileKey, name, state, depth);
+    if (result !== null) state.memo.set(guard, result);
+    return result;
   } finally {
     state.visited.delete(guard);
   }
 }
 
+/** The literal/expr/import resolution for one name. Cycle guard + memo live in
+ * {@link foldName}; this is the pure lookup body. */
+function computeFold(
+  fileKey: string,
+  name: string,
+  state: ResolveState,
+  depth: number,
+): string | null {
+  const mc = state.repo.get(fileKey);
+  if (!mc) return null;
+
+  const literal = mc.literals.get(name);
+  if (literal !== undefined) return literal;
+
+  const expr = mc.exprs.get(name);
+  if (expr !== undefined) return foldExpr(fileKey, expr, state, depth + 1);
+
+  const imp = mc.imports.get(name);
+  if (imp !== undefined) {
+    const targetKey = state.resolveImport(fileKey, imp.module, state.repoKeys);
+    if (targetKey === null) return null;
+    return foldName(targetKey, imp.originalName, state, depth + 1);
+  }
+
+  return null;
+}
+
 function newState(repo: RepoConstants, resolveImport: ImportResolver): ResolveState {
-  return { repo, repoKeys: new Set(repo.keys()), resolveImport, visited: new Set() };
+  return {
+    repo,
+    repoKeys: new Set(repo.keys()),
+    resolveImport,
+    visited: new Set(),
+    memo: new Map(),
+  };
 }
 
 /**

--- a/gitnexus/src/core/ingestion/route-extractors/constant-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/constant-resolver.ts
@@ -118,26 +118,35 @@ function foldName(
 ): string | null {
   if (depth > MAX_RESOLVE_DEPTH) return null;
   const guard = `${fileKey}::${name}`;
+  // `visited` is the ACTIVE resolution stack, not a seen-ever set: a name is a
+  // cycle only while it is still being resolved on the current stack (#2393). We
+  // pop it in `finally` so a name reached twice in one fold (`A + A`, or a
+  // diamond `X = P + Q` where P and Q share a base) folds instead of being
+  // mis-flagged as a cycle and dropped. Re-computation is bounded by
+  // MAX_RESOLVE_DEPTH (≤ 2^8 folds), so no blowup is reintroduced.
   if (state.visited.has(guard)) return null; // cycle
   state.visited.add(guard);
+  try {
+    const mc = state.repo.get(fileKey);
+    if (!mc) return null;
 
-  const mc = state.repo.get(fileKey);
-  if (!mc) return null;
+    const literal = mc.literals.get(name);
+    if (literal !== undefined) return literal;
 
-  const literal = mc.literals.get(name);
-  if (literal !== undefined) return literal;
+    const expr = mc.exprs.get(name);
+    if (expr !== undefined) return foldExpr(fileKey, expr, state, depth + 1);
 
-  const expr = mc.exprs.get(name);
-  if (expr !== undefined) return foldExpr(fileKey, expr, state, depth + 1);
+    const imp = mc.imports.get(name);
+    if (imp !== undefined) {
+      const targetKey = state.resolveImport(fileKey, imp.module, state.repoKeys);
+      if (targetKey === null) return null;
+      return foldName(targetKey, imp.originalName, state, depth + 1);
+    }
 
-  const imp = mc.imports.get(name);
-  if (imp !== undefined) {
-    const targetKey = state.resolveImport(fileKey, imp.module, state.repoKeys);
-    if (targetKey === null) return null;
-    return foldName(targetKey, imp.originalName, state, depth + 1);
+    return null;
+  } finally {
+    state.visited.delete(guard);
   }
-
-  return null;
 }
 
 function newState(repo: RepoConstants, resolveImport: ImportResolver): ResolveState {

--- a/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
@@ -1,0 +1,230 @@
+/**
+ * Python module-level string-constant resolver (#2391).
+ *
+ * FastAPI route decorators frequently build their path from a constant rather
+ * than a string literal:
+ *
+ *   # constants.py
+ *   API_V1 = "/api/v1"
+ *   API_V1_WIDGETS = API_V1 + "/widgets"
+ *   API_V1_WIDGETS_GET = API_V1_WIDGETS + "/get"
+ *
+ *   # routes.py
+ *   from .constants import API_V1_WIDGETS_GET
+ *   @router.post(API_V1_WIDGETS_GET)          # -> POST /api/v1/widgets/get
+ *
+ * Without folding these constants the route path is empty and the route is
+ * indexed as `POST /` (or dropped entirely on the group-contract side). This
+ * module folds such constants to their literal value, following `+`
+ * concatenation and import chains across module files.
+ *
+ * Two halves live here:
+ *   • the PURE resolver ({@link resolveConstant} / {@link resolveExpr}) that
+ *     folds an already-extracted repo map — no tree-sitter dependency, unit
+ *     testable directly; and
+ *   • {@link extractPythonModuleConstants}, which walks a parsed tree into the
+ *     {@link ModuleConstants} shape the resolver consumes (added in U2).
+ *
+ * Why a new module and not `core/scope-resolution` (`ScopeResolver`) or the
+ * group's `buildLocalStringMap`: the scope-resolution machinery resolves symbol
+ * IDENTITIES (call / inheritance edges), not literal string VALUES;
+ * `buildLocalStringMap` folds a single same-file string literal into one local
+ * variable (no `+`, no imports). Neither can produce a transitive cross-module
+ * string value, so this is a genuinely new concern, not a re-implementation.
+ *
+ * Keying (KTD4): the repo map is keyed by unique POSIX file path, NOT the
+ * dot-stripped module basename. `from .constants import X`,
+ * `from ..pkg.constants import X`, and `from constants import X` all collapse to
+ * the basename `constants` — a ubiquitous filename — so basename keying would
+ * resolve one package's routes to another's literal (a confidently WRONG path,
+ * worse than an unresolved one). A relative import is therefore resolved against
+ * the importing file's package directory (walk up one level per leading dot); an
+ * absolute import is matched by unique path suffix and returns `null` (skip
+ * floor) when ambiguous.
+ */
+
+/** Depth ceiling for the import/constant chase. Mirrors `django.ts`'s
+ * `MAX_INCLUDE_DEPTH` — a heuristic bound, not a proven one; overrun floors to
+ * `null` (skip), never a wrong path. */
+const MAX_RESOLVE_DEPTH = 8;
+
+/**
+ * One term of a constant's right-hand side. A `+`-concatenation
+ * (`A + "/b" + C`) becomes an ordered `Operand[]`; a bare literal is a
+ * single-element list.
+ */
+export type Operand =
+  | { readonly kind: 'literal'; readonly value: string }
+  | { readonly kind: 'ref'; readonly name: string };
+
+/**
+ * A `from <module> import <name> [as <local>]` binding. `module` keeps its
+ * leading dots verbatim (`.constants`, `..pkg.constants`, `api.constants`) so
+ * the resolver can distinguish relative from absolute imports; `originalName`
+ * is the exported name in the target module (pre-alias).
+ */
+export interface ImportBinding {
+  readonly module: string;
+  readonly originalName: string;
+}
+
+/**
+ * String-valued module-level constants of one Python file. `literals` are
+ * fully-resolved (`X = "/a"`); `exprs` are unresolved operand lists
+ * (`X = A + "/b"`); `imports` maps a local name to the module it was imported
+ * from. All string keys are the in-file (local) names.
+ */
+export interface ModuleConstants {
+  readonly literals: Map<string, string>;
+  readonly exprs: Map<string, readonly Operand[]>;
+  readonly imports: Map<string, ImportBinding>;
+}
+
+/** Repo-wide map: unique POSIX file path (e.g. `app/constants.py`) →
+ * that file's {@link ModuleConstants}. */
+export type RepoConstants = ReadonlyMap<string, ModuleConstants>;
+
+function dirOf(fileKey: string): string {
+  const slash = fileKey.lastIndexOf('/');
+  return slash >= 0 ? fileKey.slice(0, slash) : '';
+}
+
+/** Collapse `a/b/../c` and `./` segments in a POSIX-ish path. */
+function normalizePosix(path: string): string {
+  const out: string[] = [];
+  for (const seg of path.split('/')) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') {
+      if (out.length > 0 && out[out.length - 1] !== '..') out.pop();
+      else out.push('..');
+    } else {
+      out.push(seg);
+    }
+  }
+  return out.join('/');
+}
+
+/**
+ * Resolve an import's module specifier to the unique file key it refers to, or
+ * `null` when it cannot be pinned to exactly one file (KTD4).
+ *
+ * Relative imports (`.constants`, `..pkg.mod`) resolve against the importing
+ * file's directory — one level up per leading dot beyond the first — and must
+ * hit an existing file key exactly. Absolute imports (`api.constants`) are
+ * matched by unique path suffix; a suffix shared by 2+ files is ambiguous and
+ * returns `null` rather than an arbitrary winner.
+ */
+export function resolveImportToFileKey(
+  importingFileKey: string,
+  moduleSpec: string,
+  repoKeys: ReadonlySet<string>,
+): string | null {
+  const dots = moduleSpec.length - moduleSpec.replace(/^\.+/, '').length;
+  const bare = moduleSpec.slice(dots);
+  const modPath = bare.replace(/\./g, '/');
+
+  if (dots > 0) {
+    // 1 dot = current package (the importing file's dir); each extra dot walks
+    // up one more level.
+    let base = dirOf(importingFileKey);
+    for (let i = 1; i < dots; i++) base = dirOf(base);
+    const candidate = normalizePosix(`${base}/${modPath}`) + '.py';
+    return repoKeys.has(candidate) ? candidate : null;
+  }
+
+  // Absolute: match by unique path suffix. `api.constants` -> `api/constants.py`.
+  const suffix = `${modPath}.py`;
+  let hit: string | null = null;
+  for (const key of repoKeys) {
+    if (key === suffix || key.endsWith(`/${suffix}`)) {
+      if (hit !== null) return null; // ambiguous — refuse to guess
+      hit = key;
+    }
+  }
+  return hit;
+}
+
+interface ResolveState {
+  readonly repo: RepoConstants;
+  readonly repoKeys: ReadonlySet<string>;
+  readonly visited: Set<string>;
+}
+
+/**
+ * Fold an operand list to its concatenated literal, or `null` if any operand is
+ * unresolvable (an unknown name, a non-string term, a cycle, or a depth
+ * overrun). Shared by {@link resolveConstant} and by an inline `binary_operator`
+ * decorator argument (U3 hands its operands straight here).
+ */
+export function resolveExpr(
+  fileKey: string,
+  operands: readonly Operand[],
+  state: ResolveState,
+  depth: number,
+): string | null {
+  if (depth > MAX_RESOLVE_DEPTH) return null;
+  let out = '';
+  for (const op of operands) {
+    if (op.kind === 'literal') {
+      out += op.value;
+      continue;
+    }
+    const resolved = resolveName(fileKey, op.name, state, depth + 1);
+    if (resolved === null) return null;
+    out += resolved;
+  }
+  return out;
+}
+
+function resolveName(
+  fileKey: string,
+  name: string,
+  state: ResolveState,
+  depth: number,
+): string | null {
+  if (depth > MAX_RESOLVE_DEPTH) return null;
+  const guard = `${fileKey}::${name}`;
+  if (state.visited.has(guard)) return null; // cycle
+  state.visited.add(guard);
+
+  const mc = state.repo.get(fileKey);
+  if (!mc) return null;
+
+  const literal = mc.literals.get(name);
+  if (literal !== undefined) return literal;
+
+  const expr = mc.exprs.get(name);
+  if (expr !== undefined) return resolveExpr(fileKey, expr, state, depth + 1);
+
+  const imp = mc.imports.get(name);
+  if (imp !== undefined) {
+    const targetKey = resolveImportToFileKey(fileKey, imp.module, state.repoKeys);
+    if (targetKey === null) return null;
+    return resolveName(targetKey, imp.originalName, state, depth + 1);
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a single named constant referenced in `fileKey` to its literal string
+ * value, folding `+` concatenation and following import chains, or `null` when
+ * it cannot be fully folded. Each call uses a fresh cycle-guard.
+ */
+export function resolveConstant(fileKey: string, name: string, repo: RepoConstants): string | null {
+  const state: ResolveState = { repo, repoKeys: new Set(repo.keys()), visited: new Set() };
+  return resolveName(fileKey, name, state, 0);
+}
+
+/**
+ * Resolve an inline operand list (an unnamed `+`-expression captured directly at
+ * a decorator arg, e.g. `@router.get(API_V1 + "/widgets")`) against `fileKey`.
+ */
+export function resolveOperands(
+  fileKey: string,
+  operands: readonly Operand[],
+  repo: RepoConstants,
+): string | null {
+  const state: ResolveState = { repo, repoKeys: new Set(repo.keys()), visited: new Set() };
+  return resolveExpr(fileKey, operands, state, 0);
+}

--- a/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
@@ -142,8 +142,17 @@ export function resolveOperands(
  * `concatenated_string` adjacency, and non-`+` operators — returns `null`, which
  * makes the constant unresolvable (→ skip floor), never a wrong value.
  */
-export function parseConstOperands(node: SyntaxNode | null | undefined): Operand[] | null {
+export function parseConstOperands(
+  node: SyntaxNode | null | undefined,
+  depth = 0,
+): Operand[] | null {
   if (!node) return null;
+  // Defense-in-depth: bound the recursion so an adversarial deep `+`-chain floors
+  // to null (skip) rather than risking a stack overflow. 64 is far beyond any real
+  // route-path constant chain; tree-sitter caps expression nesting well below the
+  // JS stack limit today, so this is a belt-and-suspenders guard, not a reachable
+  // crash. Mirrors the fold engine's MAX_RESOLVE_DEPTH.
+  if (depth > 64) return null;
   if (node.type === 'string') {
     const value = extractStringContent(node);
     return value === null ? null : [{ kind: 'literal', value }];
@@ -154,8 +163,8 @@ export function parseConstOperands(node: SyntaxNode | null | undefined): Operand
   if (node.type === 'binary_operator') {
     const isPlus = (node.children ?? []).some((c) => c.type === '+');
     if (!isPlus) return null;
-    const left = parseConstOperands(node.childForFieldName('left'));
-    const right = parseConstOperands(node.childForFieldName('right'));
+    const left = parseConstOperands(node.childForFieldName('left'), depth + 1);
+    const right = parseConstOperands(node.childForFieldName('right'), depth + 1);
     if (left === null || right === null) return null;
     return [...left, ...right];
   }

--- a/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
@@ -78,10 +78,26 @@ export const resolvePythonImport: ImportResolver = (importingFileKey, moduleSpec
 
   if (dots > 0) {
     // 1 dot = current package (the importing file's dir); each extra dot walks
-    // up one more level.
-    let base = dirOf(importingFileKey);
-    for (let i = 1; i < dots; i++) base = dirOf(base);
-    const candidate = normalizePosix(`${base}/${modPath}`) + '.py';
+    // up one more level. If the walk would climb ABOVE the repo root (more extra
+    // dots than the importing file has directory levels), the import escapes the
+    // tree → null, rather than clamping to an unrelated root-level `<name>.py`.
+    const dir = dirOf(importingFileKey);
+    const depth = dir === '' ? 0 : dir.split('/').length;
+    const walk = dots - 1;
+    if (walk > depth) return null;
+
+    let base = dir;
+    for (let i = 0; i < walk; i++) base = dirOf(base);
+
+    // `from . import X` / `from .. import X` (no module after the dots): the
+    // module IS the package, whose file is `<base>/__init__.py`, not a sibling
+    // `<base>.py`.
+    const candidate =
+      modPath === ''
+        ? base === ''
+          ? '__init__.py'
+          : `${base}/__init__.py`
+        : normalizePosix(`${base}/${modPath}`) + '.py';
     return repoKeys.has(candidate) ? candidate : null;
   }
 

--- a/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
@@ -43,6 +43,9 @@
  * floor) when ambiguous.
  */
 
+import { extractStringContent, type SyntaxNode } from '../utils/ast-helpers.js';
+import type Parser from 'tree-sitter';
+
 /** Depth ceiling for the import/constant chase. Mirrors `django.ts`'s
  * `MAX_INCLUDE_DEPTH` — a heuristic bound, not a proven one; overrun floors to
  * `null` (skip), never a wrong path. */
@@ -227,4 +230,113 @@ export function resolveOperands(
 ): string | null {
   const state: ResolveState = { repo, repoKeys: new Set(repo.keys()), visited: new Set() };
   return resolveExpr(fileKey, operands, state, 0);
+}
+
+// ─── Tree → ModuleConstants extraction (U2) ──────────────────────────────────
+
+/**
+ * Parse a right-hand side into an operand list, or `null` when it is not a
+ * foldable string expression. Handles a bare string literal, a bare identifier
+ * (`X = Y`), and left-associative `+` chains of the two (`A + "/b" + C`).
+ * Everything else — numbers, calls, attribute access (`settings.X`), f-strings,
+ * `concatenated_string` adjacency, and non-`+` operators — returns `null`, which
+ * makes the constant unresolvable (→ skip floor), never a wrong value.
+ */
+export function parseConstOperands(node: SyntaxNode | null | undefined): Operand[] | null {
+  if (!node) return null;
+  if (node.type === 'string') {
+    const value = extractStringContent(node);
+    return value === null ? null : [{ kind: 'literal', value }];
+  }
+  if (node.type === 'identifier') {
+    return [{ kind: 'ref', name: node.text }];
+  }
+  if (node.type === 'binary_operator') {
+    const isPlus = (node.children ?? []).some((c) => c.type === '+');
+    if (!isPlus) return null;
+    const left = parseConstOperands(node.childForFieldName('left'));
+    const right = parseConstOperands(node.childForFieldName('right'));
+    if (left === null || right === null) return null;
+    return [...left, ...right];
+  }
+  return null;
+}
+
+/**
+ * Extract the module-level string constants and `from … import …` bindings of
+ * one parsed Python file into the {@link ModuleConstants} shape the resolver
+ * consumes. Only top-level (`module`-direct) statements are walked — function-
+ * and class-local names never become route path constants and must not leak in.
+ *
+ * Assignment semantics are last-wins in source order (matches Python): a rebind
+ * to a non-string (`X = "/a"; X = build()`) drops `X` to unresolvable rather than
+ * keeping the stale literal; `X += "/b"` folds onto the prior representation.
+ */
+export function extractPythonModuleConstants(tree: Parser.Tree): ModuleConstants {
+  const literals = new Map<string, string>();
+  const exprs = new Map<string, readonly Operand[]>();
+  const imports = new Map<string, ImportBinding>();
+
+  // Apply an assignment result, honoring last-wins: clear any prior binding for
+  // `name`, then set the new one (a `null` rep leaves it cleared = unresolvable).
+  const setName = (name: string, ops: Operand[] | null): void => {
+    literals.delete(name);
+    exprs.delete(name);
+    if (ops === null) return;
+    if (ops.length === 1 && ops[0].kind === 'literal') literals.set(name, ops[0].value);
+    else exprs.set(name, ops);
+  };
+
+  const currentOps = (name: string): Operand[] | null => {
+    const lit = literals.get(name);
+    if (lit !== undefined) return [{ kind: 'literal', value: lit }];
+    const ex = exprs.get(name);
+    return ex !== undefined ? [...ex] : null;
+  };
+
+  const handleImport = (node: SyntaxNode): void => {
+    const moduleNode = node.childForFieldName('module_name');
+    const moduleSpec = moduleNode?.text;
+    if (!moduleSpec) return;
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (!child || child.id === moduleNode?.id) continue;
+      if (child.type === 'dotted_name') {
+        imports.set(child.text, { module: moduleSpec, originalName: child.text });
+      } else if (child.type === 'aliased_import') {
+        const nameNode = child.childForFieldName('name');
+        const aliasNode = child.childForFieldName('alias');
+        if (nameNode && aliasNode) {
+          imports.set(aliasNode.text, { module: moduleSpec, originalName: nameNode.text });
+        }
+      }
+    }
+  };
+
+  for (let i = 0; i < tree.rootNode.namedChildCount; i++) {
+    const stmt = tree.rootNode.namedChild(i);
+    if (!stmt) continue;
+    if (stmt.type === 'import_from_statement') {
+      handleImport(stmt);
+      continue;
+    }
+    if (stmt.type !== 'expression_statement') continue;
+    const inner = stmt.namedChild(0);
+    if (!inner) continue;
+
+    if (inner.type === 'assignment') {
+      const left = inner.childForFieldName('left');
+      if (left?.type !== 'identifier') continue; // only bare-name module constants
+      setName(left.text, parseConstOperands(inner.childForFieldName('right')));
+    } else if (inner.type === 'augmented_assignment') {
+      const left = inner.childForFieldName('left');
+      if (left?.type !== 'identifier') continue;
+      const isPlusEq = inner.childForFieldName('operator')?.text === '+=';
+      const prior = currentOps(left.text);
+      const rhs = parseConstOperands(inner.childForFieldName('right'));
+      setName(left.text, isPlusEq && prior && rhs ? [...prior, ...rhs] : null);
+    }
+  }
+
+  return { literals, exprs, imports };
 }

--- a/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
@@ -161,14 +161,33 @@ export function extractPythonModuleConstants(tree: Parser.Tree): ModuleConstants
   const exprs = new Map<string, readonly Operand[]>();
   const imports = new Map<string, { module: string; originalName: string }>();
 
+  // The three maps are ONE logical namespace keyed by local name: a write to any
+  // one clears the other two, so last-binding-in-source-order wins (matches
+  // Python) and a name never carries a stale binding from a different map (#2391,
+  // #2393). Without this, `from .c import X; X = <dynamic>` would keep the stale
+  // import and resolve a confidently WRONG path instead of dropping.
+
   // Apply an assignment result, honoring last-wins: clear any prior binding for
-  // `name`, then set the new one (a `null` rep leaves it cleared = unresolvable).
+  // `name` (including a shadowed import), then set the new one (a `null` rep
+  // leaves it cleared = unresolvable).
   const setName = (name: string, ops: Operand[] | null): void => {
     literals.delete(name);
     exprs.delete(name);
+    imports.delete(name);
     if (ops === null) return;
     if (ops.length === 1 && ops[0].kind === 'literal') literals.set(name, ops[0].value);
     else exprs.set(name, ops);
+  };
+
+  // Bind an import for `localName`, clearing any prior local literal/expr of the
+  // same name (an import shadows an earlier assignment, and vice versa).
+  const bindImport = (
+    localName: string,
+    binding: { module: string; originalName: string },
+  ): void => {
+    literals.delete(localName);
+    exprs.delete(localName);
+    imports.set(localName, binding);
   };
 
   const currentOps = (name: string): Operand[] | null => {
@@ -186,12 +205,12 @@ export function extractPythonModuleConstants(tree: Parser.Tree): ModuleConstants
       const child = node.namedChild(i);
       if (!child || child.id === moduleNode?.id) continue;
       if (child.type === 'dotted_name') {
-        imports.set(child.text, { module: moduleSpec, originalName: child.text });
+        bindImport(child.text, { module: moduleSpec, originalName: child.text });
       } else if (child.type === 'aliased_import') {
         const nameNode = child.childForFieldName('name');
         const aliasNode = child.childForFieldName('alias');
         if (nameNode && aliasNode) {
-          imports.set(aliasNode.text, { module: moduleSpec, originalName: nameNode.text });
+          bindImport(aliasNode.text, { module: moduleSpec, originalName: nameNode.text });
         }
       }
     }

--- a/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
@@ -139,8 +139,9 @@ export function resolveOperands(
  * foldable string expression. Handles a bare string literal, a bare identifier
  * (`X = Y`), and left-associative `+` chains of the two (`A + "/b" + C`).
  * Everything else — numbers, calls, attribute access (`settings.X`), f-strings,
- * `concatenated_string` adjacency, and non-`+` operators — returns `null`, which
- * makes the constant unresolvable (→ skip floor), never a wrong value.
+ * conditional expressions (`x if c else y`), `concatenated_string` adjacency, and
+ * non-`+` operators — returns `null`, which makes the constant unresolvable
+ * (→ skip floor), never a wrong value.
  */
 export function parseConstOperands(
   node: SyntaxNode | null | undefined,

--- a/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
@@ -181,6 +181,12 @@ export function parseConstOperands(
  * Assignment semantics are last-wins in source order (matches Python): a rebind
  * to a non-string (`X = "/a"; X = build()`) drops `X` to unresolvable rather than
  * keeping the stale literal; `X += "/b"` folds onto the prior representation.
+ *
+ * Assignment RHS references are SNAPSHOTTED at the assignment line (`snapshot`),
+ * not resolved lazily against a name's final binding — so `ROUTE = BASE; BASE +=
+ * "/v1"` leaves `ROUTE` at BASE's value AT the `ROUTE =` line, never the mutated
+ * one. Without this, an aliased-then-rebound constant resolved to a confidently
+ * wrong path (#2393).
  */
 export function extractPythonModuleConstants(tree: Parser.Tree): ModuleConstants {
   const literals = new Map<string, string>();
@@ -220,11 +226,46 @@ export function extractPythonModuleConstants(tree: Parser.Tree): ModuleConstants
     imports.set(localName, binding);
   };
 
-  const currentOps = (name: string): Operand[] | null => {
+  // Freeze a name's CURRENT binding into a stable operand list that is immune to
+  // any LATER rebind of `name`: a literal value, a copy of the current expr (whose
+  // refs are themselves already frozen, see `snapshot`), or an import preserved
+  // under a synthetic `$imp$N` key (`$` can never appear in a Python identifier, so
+  // it cannot collide with a real name). Returns null when `name` is not yet bound
+  // (a forward reference — left lazy).
+  const freeze = (name: string): Operand[] | null => {
     const lit = literals.get(name);
     if (lit !== undefined) return [{ kind: 'literal', value: lit }];
     const ex = exprs.get(name);
-    return ex !== undefined ? [...ex] : null;
+    if (ex !== undefined) return [...ex];
+    const imp = imports.get(name);
+    if (imp !== undefined) {
+      const aliasKey = `$imp$${importAliasSeq++}`;
+      imports.set(aliasKey, imp);
+      return [{ kind: 'ref', name: aliasKey }];
+    }
+    return null;
+  };
+
+  // Snapshot an assignment RHS: replace each ref to an ALREADY-BOUND name with that
+  // name's frozen value, so a later rebind of that name does not retroactively
+  // change this binding — Python assigns by value at this source line, so
+  // `ROUTE = BASE; BASE += "/v1"` must leave ROUTE at BASE's value AT the `ROUTE =`
+  // line, never the mutated one (#2393). Unbound refs (forward references) stay
+  // lazy. Because every assignment snapshots, stored exprs only ever contain
+  // literals, frozen `$imp$N` refs, or lazy forward refs — never a live mutable ref.
+  const snapshot = (ops: Operand[] | null): Operand[] | null => {
+    if (ops === null) return null;
+    const out: Operand[] = [];
+    for (const op of ops) {
+      if (op.kind === 'literal') {
+        out.push(op);
+        continue;
+      }
+      const frozen = freeze(op.name);
+      if (frozen === null) out.push(op);
+      else out.push(...frozen);
+    }
+    return out;
   };
 
   const handleImport = (node: SyntaxNode): void => {
@@ -260,28 +301,17 @@ export function extractPythonModuleConstants(tree: Parser.Tree): ModuleConstants
     if (inner.type === 'assignment') {
       const left = inner.childForFieldName('left');
       if (left?.type !== 'identifier') continue; // only bare-name module constants
-      setName(left.text, parseConstOperands(inner.childForFieldName('right')));
+      setName(left.text, snapshot(parseConstOperands(inner.childForFieldName('right'))));
     } else if (inner.type === 'augmented_assignment') {
       const left = inner.childForFieldName('left');
       if (left?.type !== 'identifier') continue;
       const name = left.text;
       const isPlusEq = inner.childForFieldName('operator')?.text === '+=';
-      const rhs = parseConstOperands(inner.childForFieldName('right'));
-      // `X += rhs` folds onto X's prior value. When X is a local literal/expr,
-      // currentOps returns it. When X is an IMPORT, preserve the imported value
-      // under a synthetic `$imp$N` key ($ can never appear in a Python
-      // identifier, so it cannot collide with a real name) and reference it — so
-      // `from .c import BASE; BASE += "/v1"` folds to `<imported BASE>/v1` instead
-      // of dropping (#2393). setName below then clears X's own import binding.
-      let prior = currentOps(name);
-      if (prior === null && isPlusEq) {
-        const imp = imports.get(name);
-        if (imp !== undefined) {
-          const aliasKey = `$imp$${importAliasSeq++}`;
-          imports.set(aliasKey, imp);
-          prior = [{ kind: 'ref', name: aliasKey }];
-        }
-      }
+      // `X += rhs` folds onto X's CURRENT frozen value (`freeze` handles a local
+      // literal/expr and an imported base via the `$imp$N` alias). Both sides are
+      // snapshotted so a later rebind cannot retroactively change this binding.
+      const prior = freeze(name);
+      const rhs = snapshot(parseConstOperands(inner.childForFieldName('right')));
       setName(name, isPlusEq && prior && rhs ? [...prior, ...rhs] : null);
     }
   }

--- a/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
@@ -107,6 +107,17 @@ function normalizePosix(path: string): string {
   return out.join('/');
 }
 
+// ponytail: the fold core ({@link resolveExpr}/{@link resolveConstant}) is
+// language-agnostic — it walks an Operand[] + a file→ModuleConstants map. Only
+// this function and {@link extractPythonModuleConstants} encode PYTHON import
+// semantics (leading-dot relative imports, `.py` module files). Java/Kotlin/C#
+// route path constants (`@GetMapping(PathConstants.X)`, `@RequestMapping(PREFIX)`)
+// are the SAME problem and are currently literal-only (see http-patterns/java.ts,
+// kotlin.ts). When a second language needs this, generalize by parameterizing the
+// fold with a pluggable `(importingFileKey, moduleSpec) → fileKey` resolver plus a
+// per-language `extractModuleConstants` — the language-agnostic-primitive shape
+// used by route-path.ts / spring-shared.ts. Not done now (YAGNI: Python is the only
+// consumer, #2391), but this is the seam.
 /**
  * Resolve an import's module specifier to the unique file key it refers to, or
  * `null` when it cannot be pinned to exactly one file (KTD4).

--- a/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
@@ -1,36 +1,14 @@
 /**
- * Python module-level string-constant resolver (#2391).
+ * Python binding for the language-agnostic constant resolver (#2391).
  *
- * FastAPI route decorators frequently build their path from a constant rather
- * than a string literal:
- *
- *   # constants.py
- *   API_V1 = "/api/v1"
- *   API_V1_WIDGETS = API_V1 + "/widgets"
- *   API_V1_WIDGETS_GET = API_V1_WIDGETS + "/get"
- *
- *   # routes.py
- *   from .constants import API_V1_WIDGETS_GET
- *   @router.post(API_V1_WIDGETS_GET)          # -> POST /api/v1/widgets/get
- *
- * Without folding these constants the route path is empty and the route is
- * indexed as `POST /` (or dropped entirely on the group-contract side). This
- * module folds such constants to their literal value, following `+`
- * concatenation and import chains across module files.
- *
- * Two halves live here:
- *   • the PURE resolver ({@link resolveConstant} / {@link resolveExpr}) that
- *     folds an already-extracted repo map — no tree-sitter dependency, unit
- *     testable directly; and
- *   • {@link extractPythonModuleConstants}, which walks a parsed tree into the
- *     {@link ModuleConstants} shape the resolver consumes (added in U2).
- *
- * Why a new module and not `core/scope-resolution` (`ScopeResolver`) or the
- * group's `buildLocalStringMap`: the scope-resolution machinery resolves symbol
- * IDENTITIES (call / inheritance edges), not literal string VALUES;
- * `buildLocalStringMap` folds a single same-file string literal into one local
- * variable (no `+`, no imports). Neither can produce a transitive cross-module
- * string value, so this is a genuinely new concern, not a re-implementation.
+ * Supplies the two Python-specific pieces the shared fold in
+ * `constant-resolver.ts` needs — {@link resolvePythonImport} (import-specifier →
+ * file, honoring leading-dot relative imports and `.py` module files) and
+ * {@link extractPythonModuleConstants} (tree → {@link ModuleConstants}) — plus
+ * pre-bound {@link resolveConstant}/{@link resolveOperands} wrappers so Python
+ * callers stay language-oblivious. The reusable fold, the cycle guard, and the
+ * depth cap all live in the agnostic core; a JVM/other language binding reuses
+ * that core with its own `ImportResolver` + extractor.
  *
  * Keying (KTD4): the repo map is keyed by unique POSIX file path, NOT the
  * dot-stripped module basename. `from .constants import X`,
@@ -45,47 +23,23 @@
 
 import { extractStringContent, type SyntaxNode } from '../utils/ast-helpers.js';
 import type Parser from 'tree-sitter';
+import {
+  resolveConstant as foldConstant,
+  resolveOperands as foldOperands,
+  type ImportResolver,
+  type ModuleConstants,
+  type Operand,
+  type RepoConstants,
+} from './constant-resolver.js';
 
-/** Depth ceiling for the import/constant chase. Mirrors `django.ts`'s
- * `MAX_INCLUDE_DEPTH` — a heuristic bound, not a proven one; overrun floors to
- * `null` (skip), never a wrong path. */
-const MAX_RESOLVE_DEPTH = 8;
-
-/**
- * One term of a constant's right-hand side. A `+`-concatenation
- * (`A + "/b" + C`) becomes an ordered `Operand[]`; a bare literal is a
- * single-element list.
- */
-export type Operand =
-  | { readonly kind: 'literal'; readonly value: string }
-  | { readonly kind: 'ref'; readonly name: string };
-
-/**
- * A `from <module> import <name> [as <local>]` binding. `module` keeps its
- * leading dots verbatim (`.constants`, `..pkg.constants`, `api.constants`) so
- * the resolver can distinguish relative from absolute imports; `originalName`
- * is the exported name in the target module (pre-alias).
- */
-export interface ImportBinding {
-  readonly module: string;
-  readonly originalName: string;
-}
-
-/**
- * String-valued module-level constants of one Python file. `literals` are
- * fully-resolved (`X = "/a"`); `exprs` are unresolved operand lists
- * (`X = A + "/b"`); `imports` maps a local name to the module it was imported
- * from. All string keys are the in-file (local) names.
- */
-export interface ModuleConstants {
-  readonly literals: Map<string, string>;
-  readonly exprs: Map<string, readonly Operand[]>;
-  readonly imports: Map<string, ImportBinding>;
-}
-
-/** Repo-wide map: unique POSIX file path (e.g. `app/constants.py`) →
- * that file's {@link ModuleConstants}. */
-export type RepoConstants = ReadonlyMap<string, ModuleConstants>;
+// Re-export the agnostic types so existing Python callers keep a single import
+// site (`import { …, type ModuleConstants } from './python-const-resolver.js'`).
+export type {
+  ImportBinding,
+  ModuleConstants,
+  Operand,
+  RepoConstants,
+} from './constant-resolver.js';
 
 function dirOf(fileKey: string): string {
   const slash = fileKey.lastIndexOf('/');
@@ -107,20 +61,9 @@ function normalizePosix(path: string): string {
   return out.join('/');
 }
 
-// ponytail: the fold core ({@link resolveExpr}/{@link resolveConstant}) is
-// language-agnostic — it walks an Operand[] + a file→ModuleConstants map. Only
-// this function and {@link extractPythonModuleConstants} encode PYTHON import
-// semantics (leading-dot relative imports, `.py` module files). Java/Kotlin/C#
-// route path constants (`@GetMapping(PathConstants.X)`, `@RequestMapping(PREFIX)`)
-// are the SAME problem and are currently literal-only (see http-patterns/java.ts,
-// kotlin.ts). When a second language needs this, generalize by parameterizing the
-// fold with a pluggable `(importingFileKey, moduleSpec) → fileKey` resolver plus a
-// per-language `extractModuleConstants` — the language-agnostic-primitive shape
-// used by route-path.ts / spring-shared.ts. Not done now (YAGNI: Python is the only
-// consumer, #2391), but this is the seam.
 /**
- * Resolve an import's module specifier to the unique file key it refers to, or
- * `null` when it cannot be pinned to exactly one file (KTD4).
+ * The Python {@link ImportResolver}: map an import specifier to the unique file
+ * key it refers to, or `null` when it cannot be pinned to exactly one file (KTD4).
  *
  * Relative imports (`.constants`, `..pkg.mod`) resolve against the importing
  * file's directory — one level up per leading dot beyond the first — and must
@@ -128,11 +71,7 @@ function normalizePosix(path: string): string {
  * matched by unique path suffix; a suffix shared by 2+ files is ambiguous and
  * returns `null` rather than an arbitrary winner.
  */
-export function resolveImportToFileKey(
-  importingFileKey: string,
-  moduleSpec: string,
-  repoKeys: ReadonlySet<string>,
-): string | null {
+export const resolvePythonImport: ImportResolver = (importingFileKey, moduleSpec, repoKeys) => {
   const dots = moduleSpec.length - moduleSpec.replace(/^\.+/, '').length;
   const bare = moduleSpec.slice(dots);
   const modPath = bare.replace(/\./g, '/');
@@ -156,97 +95,31 @@ export function resolveImportToFileKey(
     }
   }
   return hit;
-}
-
-interface ResolveState {
-  readonly repo: RepoConstants;
-  readonly repoKeys: ReadonlySet<string>;
-  readonly visited: Set<string>;
-}
+};
 
 /**
- * Fold an operand list to its concatenated literal, or `null` if any operand is
- * unresolvable (an unknown name, a non-string term, a cycle, or a depth
- * overrun). Shared by {@link resolveConstant} and by an inline `binary_operator`
- * decorator argument (U3 hands its operands straight here).
- */
-export function resolveExpr(
-  fileKey: string,
-  operands: readonly Operand[],
-  state: ResolveState,
-  depth: number,
-): string | null {
-  if (depth > MAX_RESOLVE_DEPTH) return null;
-  let out = '';
-  for (const op of operands) {
-    if (op.kind === 'literal') {
-      out += op.value;
-      continue;
-    }
-    const resolved = resolveName(fileKey, op.name, state, depth + 1);
-    if (resolved === null) return null;
-    out += resolved;
-  }
-  return out;
-}
-
-function resolveName(
-  fileKey: string,
-  name: string,
-  state: ResolveState,
-  depth: number,
-): string | null {
-  if (depth > MAX_RESOLVE_DEPTH) return null;
-  const guard = `${fileKey}::${name}`;
-  if (state.visited.has(guard)) return null; // cycle
-  state.visited.add(guard);
-
-  const mc = state.repo.get(fileKey);
-  if (!mc) return null;
-
-  const literal = mc.literals.get(name);
-  if (literal !== undefined) return literal;
-
-  const expr = mc.exprs.get(name);
-  if (expr !== undefined) return resolveExpr(fileKey, expr, state, depth + 1);
-
-  const imp = mc.imports.get(name);
-  if (imp !== undefined) {
-    const targetKey = resolveImportToFileKey(fileKey, imp.module, state.repoKeys);
-    if (targetKey === null) return null;
-    return resolveName(targetKey, imp.originalName, state, depth + 1);
-  }
-
-  return null;
-}
-
-/**
- * Resolve a single named constant referenced in `fileKey` to its literal string
- * value, folding `+` concatenation and following import chains, or `null` when
- * it cannot be fully folded. Each call uses a fresh cycle-guard.
+ * Resolve a single named Python constant referenced in `fileKey` to its literal
+ * value, or `null`. Python-bound wrapper over the agnostic fold.
  */
 export function resolveConstant(fileKey: string, name: string, repo: RepoConstants): string | null {
-  const state: ResolveState = { repo, repoKeys: new Set(repo.keys()), visited: new Set() };
-  return resolveName(fileKey, name, state, 0);
+  return foldConstant(fileKey, name, repo, resolvePythonImport);
 }
 
 /**
- * Resolve an inline operand list (an unnamed `+`-expression captured directly at
- * a decorator arg, e.g. `@router.get(API_V1 + "/widgets")`) against `fileKey`.
+ * Resolve an inline Python operand list (an unnamed `+`-expression at a decorator
+ * argument, e.g. `@router.get(API_V1 + "/widgets")`) against `fileKey`.
+ * Python-bound wrapper over the agnostic fold.
  */
 export function resolveOperands(
   fileKey: string,
   operands: readonly Operand[],
   repo: RepoConstants,
 ): string | null {
-  const state: ResolveState = { repo, repoKeys: new Set(repo.keys()), visited: new Set() };
-  return resolveExpr(fileKey, operands, state, 0);
+  return foldOperands(fileKey, operands, repo, resolvePythonImport);
 }
 
-// ─── Tree → ModuleConstants extraction (U2) ──────────────────────────────────
-
 /**
- * Parse a right-hand side into an operand list, or `null` when it is not a
+ * Parse a Python right-hand side into an operand list, or `null` when it is not a
  * foldable string expression. Handles a bare string literal, a bare identifier
  * (`X = Y`), and left-associative `+` chains of the two (`A + "/b" + C`).
  * Everything else — numbers, calls, attribute access (`settings.X`), f-strings,
@@ -286,7 +159,7 @@ export function parseConstOperands(node: SyntaxNode | null | undefined): Operand
 export function extractPythonModuleConstants(tree: Parser.Tree): ModuleConstants {
   const literals = new Map<string, string>();
   const exprs = new Map<string, readonly Operand[]>();
-  const imports = new Map<string, ImportBinding>();
+  const imports = new Map<string, { module: string; originalName: string }>();
 
   // Apply an assignment result, honoring last-wins: clear any prior binding for
   // `name`, then set the new one (a `null` rep leaves it cleared = unresolvable).

--- a/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/python-const-resolver.ts
@@ -186,6 +186,10 @@ export function extractPythonModuleConstants(tree: Parser.Tree): ModuleConstants
   const literals = new Map<string, string>();
   const exprs = new Map<string, readonly Operand[]>();
   const imports = new Map<string, { module: string; originalName: string }>();
+  // Monotonic counter for synthetic import-alias keys (see the `+=`-on-import
+  // case in the augmented-assignment branch below). Per-file, so keys are unique
+  // within this file's ModuleConstants.
+  let importAliasSeq = 0;
 
   // The three maps are ONE logical namespace keyed by local name: a write to any
   // one clears the other two, so last-binding-in-source-order wins (matches
@@ -260,10 +264,25 @@ export function extractPythonModuleConstants(tree: Parser.Tree): ModuleConstants
     } else if (inner.type === 'augmented_assignment') {
       const left = inner.childForFieldName('left');
       if (left?.type !== 'identifier') continue;
+      const name = left.text;
       const isPlusEq = inner.childForFieldName('operator')?.text === '+=';
-      const prior = currentOps(left.text);
       const rhs = parseConstOperands(inner.childForFieldName('right'));
-      setName(left.text, isPlusEq && prior && rhs ? [...prior, ...rhs] : null);
+      // `X += rhs` folds onto X's prior value. When X is a local literal/expr,
+      // currentOps returns it. When X is an IMPORT, preserve the imported value
+      // under a synthetic `$imp$N` key ($ can never appear in a Python
+      // identifier, so it cannot collide with a real name) and reference it — so
+      // `from .c import BASE; BASE += "/v1"` folds to `<imported BASE>/v1` instead
+      // of dropping (#2393). setName below then clears X's own import binding.
+      let prior = currentOps(name);
+      if (prior === null && isPlusEq) {
+        const imp = imports.get(name);
+        if (imp !== undefined) {
+          const aliasKey = `$imp$${importAliasSeq++}`;
+          imports.set(aliasKey, imp);
+          prior = [{ kind: 'ref', name: aliasKey }];
+        }
+      }
+      setName(name, isPlusEq && prior && rhs ? [...prior, ...rhs] : null);
     }
   }
 

--- a/gitnexus/src/core/ingestion/tree-sitter-queries.ts
+++ b/gitnexus/src/core/ingestion/tree-sitter-queries.ts
@@ -721,13 +721,24 @@ export const PYTHON_QUERIES = `
     (string (string_content) @http_client.url))) @http_client
 
 ; Python decorators: @app.route, @router.get, etc.
+; The first positional argument is captured three ways (#2391): a string literal
+; path via @decorator.arg (quote-free, the fast path); a bare constant name or a
+; plus-concatenation via @decorator.arg_expr (resolved cross-file by the constant
+; resolver). The anchored optional alternation pins to the FIRST arg and stays
+; optional, so no-arg decorators (@app.tool(), etc.) and non-path first args still
+; match.
 (decorator
   (call
     function: (attribute
       object: (identifier) @decorator.receiver
       attribute: (identifier) @decorator.name)
     arguments: (argument_list
-      (string (string_content) @decorator.arg)?))) @decorator
+      .
+      [
+        (string (string_content)? @decorator.arg) @decorator.arg_str
+        (identifier) @decorator.arg_expr
+        (binary_operator) @decorator.arg_expr
+      ]?))) @decorator
 `;
 
 // Java queries - works with tree-sitter-java

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -313,6 +313,21 @@ export interface ExtractedDecoratorRoute {
    */
   decoratorReceiver?: string;
   /**
+   * Raw text of a non-literal decorator path argument (`#2391`), e.g.
+   * `API_V1_WIDGETS_GET` or `API_V1 + "/widgets"`. Present only when the
+   * decorator's first argument was NOT a string literal, in which case
+   * `routePath` is empty and parse-impl resolves the constant cross-file (or
+   * drops the route on failure). Absent for ordinary string-literal routes.
+   */
+  routePathExpr?: string;
+  /**
+   * Parsed operand list for {@link routePathExpr} — an identifier reference or a
+   * `+`-concatenation, in the {@link Operand} shape the constant resolver folds.
+   * `undefined` when the expression was not a foldable string form (e.g. an
+   * attribute access), in which case the route is dropped at resolution.
+   */
+  routePathOperands?: Operand[];
+  /**
    * FastAPI `app.include_router(prefix='/x')` prefix that applies to
    * this route. Filled by parse-impl after cross-file aggregation; the
    * routes phase joins it via `normalizeExtractedRoutePath`. `null` /
@@ -329,6 +344,18 @@ export interface ExtractedDecoratorRoute {
    * resolution then falls back (the Route node simply carries no handlerSymbolId).
    */
   handlerName?: string;
+}
+
+/**
+ * One Python file's module-level string constants (#2391), used by parse-impl to
+ * resolve non-literal decorator route paths cross-file. `constants` is the
+ * `Map`-based {@link ModuleConstants} shape — it survives the worker
+ * `postMessage` boundary (structured clone) and the parse cache
+ * (`mapReplacer`/`mapReviver`) without conversion.
+ */
+export interface ExtractedModuleConstants {
+  filePath: string;
+  constants: ModuleConstants;
 }
 
 export interface ExtractedToolDef {
@@ -415,6 +442,13 @@ export interface ParseWorkerResult {
    * predate the field; consumers must guard with `if (… ?? [])`).
    */
   routerModuleAliases?: ExtractedRouterModuleAlias[];
+  /**
+   * Per-file Python module-level string constants (#2391). parse-impl aggregates
+   * these into a repo-wide, file-path-keyed map and resolves each decorator
+   * route's non-literal path expression against it. Optional for cache backward
+   * compatibility (older entries predate the field; consumers guard with `?? []`).
+   */
+  moduleConstants?: ExtractedModuleConstants[];
   toolDefs: ExtractedToolDef[];
   ormQueries: ExtractedORMQuery[];
   constructorBindings: FileConstructorBindings[];
@@ -1173,6 +1207,12 @@ export function extractORMQueries(
 // import the function and its types directly from `route-extractors/`.
 
 import { extractFastAPIRouterBindings } from '../route-extractors/fastapi-router-bindings.js';
+import {
+  extractPythonModuleConstants,
+  parseConstOperands,
+  type ModuleConstants,
+  type Operand,
+} from '../route-extractors/python-const-resolver.js';
 
 /**
  * Report a non-fatal worker issue to the pool over IPC so a caught error is not
@@ -1452,6 +1492,12 @@ const processFileGroup = (
       if (captureMap['decorator'] && captureMap['decorator.name']) {
         const decoratorName = captureMap['decorator.name'].text;
         const decoratorArg = captureMap['decorator.arg']?.text;
+        // #2391: the first positional arg captured as either a string node
+        // (`arg_str`, present even for the empty-string literal `""` which has no
+        // `string_content`) or a non-literal expression (`arg_expr`: an
+        // identifier or a `+`-concatenation).
+        const decoratorArgStr = captureMap['decorator.arg_str'];
+        const decoratorArgExpr = captureMap['decorator.arg_expr'];
         const decoratorReceiver = captureMap['decorator.receiver']?.text;
         const decoratorNode = captureMap['decorator'];
         // Store by the decorator's end line — the definition follows immediately after
@@ -1461,19 +1507,39 @@ const processFileGroup = (
         });
 
         if (ROUTE_DECORATOR_NAMES.has(decoratorName)) {
-          const routePath = decoratorArg || '';
           const method = decoratorName.replace('Mapping', '').toUpperCase();
           const httpMethod = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].includes(method)
             ? method
             : 'GET';
-          result.decoratorRoutes.push({
+          const base = {
             filePath: file.path,
-            routePath,
             httpMethod,
             decoratorName,
             lineNumber: decoratorNode.startPosition.row + lineOffset,
             ...(decoratorReceiver ? { decoratorReceiver } : {}),
-          });
+          };
+          if (decoratorArgStr) {
+            // String-literal path (the fast path, unchanged). Empty-string
+            // literal `""` has no `string_content` → `decoratorArg` undefined →
+            // routePath '' (a valid path under an APIRouter prefix).
+            result.decoratorRoutes.push({ ...base, routePath: decoratorArg ?? '' });
+          } else if (decoratorArgExpr) {
+            // #2391 non-literal path (imported/composed constant). Emit the raw
+            // expression + its operands for cross-file resolution in parse-impl;
+            // `routePath` stays empty until resolved (or the route is dropped).
+            const operands: Operand[] | null =
+              decoratorArgExpr.type === 'identifier'
+                ? [{ kind: 'ref', name: decoratorArgExpr.text }]
+                : parseConstOperands(decoratorArgExpr);
+            result.decoratorRoutes.push({
+              ...base,
+              routePath: '',
+              routePathExpr: decoratorArgExpr.text,
+              ...(operands ? { routePathOperands: operands } : {}),
+            });
+          }
+          // Otherwise the first arg is absent or an unsupported shape
+          // (attribute access, call, …) → skip; never a phantom `POST /`.
         }
         // MCP/RPC tool detection: @mcp.tool(), @app.tool(), @server.tool()
         if (decoratorName === 'tool') {
@@ -2444,6 +2510,14 @@ const processFileGroup = (
         (result.routerModuleAliases ??= []),
         (result.routerConstructorPrefixes ??= []),
       );
+      // #2391: harvest module-level string constants + from-imports so parse-impl
+      // can resolve non-literal decorator route paths cross-file. Only emit for
+      // files that carry something resolvable (a constant definition or an import
+      // binding) to keep the aggregate bounded on large repos.
+      const constants = extractPythonModuleConstants(tree);
+      if (constants.literals.size > 0 || constants.exprs.size > 0 || constants.imports.size > 0) {
+        (result.moduleConstants ??= []).push({ filePath: file.path, constants });
+      }
     }
 
     // Language-specific decorator route extraction via provider hook.

--- a/gitnexus/src/core/ingestion/workers/result-merge.ts
+++ b/gitnexus/src/core/ingestion/workers/result-merge.ts
@@ -45,6 +45,10 @@ export const mergeResult = (target: ParseWorkerResult, src: ParseWorkerResult): 
     target.routerModuleAliases ??= [];
     appendAll(target.routerModuleAliases, src.routerModuleAliases);
   }
+  if (src.moduleConstants) {
+    target.moduleConstants ??= [];
+    appendAll(target.moduleConstants, src.moduleConstants);
+  }
   if (src.springTypes) {
     target.springTypes ??= [];
     appendAll(target.springTypes, src.springTypes);

--- a/gitnexus/src/storage/parse-cache.ts
+++ b/gitnexus/src/storage/parse-cache.ts
@@ -55,7 +55,7 @@ import type { ParseWorkerResult } from '../core/ingestion/workers/parse-worker.j
 // the main thread (the #1983 OOM). Because the two stores share this version,
 // any future change to the `ParsedFile` serialization shape MUST bump
 // SCHEMA_BUMP so both invalidate in lockstep.
-const SCHEMA_BUMP = 11; // #2391: ExtractedDecoratorRoute gained `routePathExpr`/`routePathOperands` and ParseWorkerResult gained per-file `moduleConstants`; warm caches must invalidate or composed FastAPI routes silently stay `POST /` on replayed pre-upgrade shards. (10 = PR #2200: Property nodes gained `rawDeclaredType` + `annotations` for Spring DI)
+const SCHEMA_BUMP = 12; // #2391 follow-up: extractPythonModuleConstants changed what it EMITS for the same source (binding mutual-exclusivity clears stale imports; RHS refs are snapshotted; `$imp$N` aliases). `moduleConstants` is cached verbatim, so a warm shard built pre-fix would replay stale/WRONG folds and the correctness fixes would silently no-op on upgrade — bump to force re-extraction. (11 = #2391: ExtractedDecoratorRoute gained `routePathExpr`/`routePathOperands` + ParseWorkerResult gained per-file `moduleConstants`. 10 = PR #2200: Property nodes gained `rawDeclaredType` + `annotations` for Spring DI)
 const GITNEXUS_PKG_VERSION = (() => {
   try {
     // package.json sits at gitnexus/package.json — two levels up from

--- a/gitnexus/src/storage/parse-cache.ts
+++ b/gitnexus/src/storage/parse-cache.ts
@@ -55,7 +55,7 @@ import type { ParseWorkerResult } from '../core/ingestion/workers/parse-worker.j
 // the main thread (the #1983 OOM). Because the two stores share this version,
 // any future change to the `ParsedFile` serialization shape MUST bump
 // SCHEMA_BUMP so both invalidate in lockstep.
-const SCHEMA_BUMP = 10; // PR #2200: Property nodes gained `rawDeclaredType` + `annotations` (Spring DI); warm caches must invalidate or the DI phase silently no-ops on replayed pre-upgrade nodes
+const SCHEMA_BUMP = 11; // #2391: ExtractedDecoratorRoute gained `routePathExpr`/`routePathOperands` and ParseWorkerResult gained per-file `moduleConstants`; warm caches must invalidate or composed FastAPI routes silently stay `POST /` on replayed pre-upgrade shards. (10 = PR #2200: Property nodes gained `rawDeclaredType` + `annotations` for Spring DI)
 const GITNEXUS_PKG_VERSION = (() => {
   try {
     // package.json sits at gitnexus/package.json — two levels up from

--- a/gitnexus/test/fixtures/fastapi-composed-app/app/constants.py
+++ b/gitnexus/test/fixtures/fastapi-composed-app/app/constants.py
@@ -1,0 +1,3 @@
+API_V1 = "/api/v1"
+API_V1_WIDGETS = API_V1 + "/widgets"
+API_V1_WIDGETS_GET = API_V1_WIDGETS + "/get"

--- a/gitnexus/test/fixtures/fastapi-composed-app/app/prefixed.py
+++ b/gitnexus/test/fixtures/fastapi-composed-app/app/prefixed.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from .constants import API_V1_WIDGETS_GET
+
+router = APIRouter(prefix="/v2")
+
+
+@router.post(API_V1_WIDGETS_GET)
+async def create_widget_v2():
+    return {"success": True}

--- a/gitnexus/test/fixtures/fastapi-composed-app/app/routes.py
+++ b/gitnexus/test/fixtures/fastapi-composed-app/app/routes.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter
+
+from .constants import API_V1_WIDGETS_GET
+
+router = APIRouter()
+
+
+@router.post(API_V1_WIDGETS_GET)
+async def create_widget():
+    return {"success": True}
+
+
+@router.get("/literal/health")
+async def health():
+    return {"ok": True}
+
+
+@router.delete(UNKNOWN_ROUTE_CONST)
+async def remove_widget():
+    return {"deleted": True}

--- a/gitnexus/test/fixtures/fastapi-composed-app/app/snapshot.py
+++ b/gitnexus/test/fixtures/fastapi-composed-app/app/snapshot.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+
+from .constants import API_V1
+
+app = FastAPI()
+
+# #2393 source-order snapshot: SNAP captures API_V1's value at THIS line ("/api/v1").
+# The later `API_V1 += "/mutated"` must not retroactively change SNAP's route.
+SNAP = API_V1
+API_V1 += "/mutated"
+
+
+@app.get(SNAP)
+async def snap_route():
+    return {}

--- a/gitnexus/test/fixtures/fastapi-composed-app/deep/base.py
+++ b/gitnexus/test/fixtures/fastapi-composed-app/deep/base.py
@@ -1,0 +1,1 @@
+ROOT = "/root"

--- a/gitnexus/test/fixtures/fastapi-composed-app/deep/leaf.py
+++ b/gitnexus/test/fixtures/fastapi-composed-app/deep/leaf.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from .mid import MID
+
+router = APIRouter()
+
+
+@router.get(MID + "/leaf")
+async def leaf():
+    return {}

--- a/gitnexus/test/fixtures/fastapi-composed-app/deep/mid.py
+++ b/gitnexus/test/fixtures/fastapi-composed-app/deep/mid.py
@@ -1,0 +1,3 @@
+from .base import ROOT
+
+MID = ROOT + "/mid"

--- a/gitnexus/test/fixtures/fastapi-composed-app/pkg_a/constants.py
+++ b/gitnexus/test/fixtures/fastapi-composed-app/pkg_a/constants.py
@@ -1,0 +1,1 @@
+SHARED = "/a-shared"

--- a/gitnexus/test/fixtures/fastapi-composed-app/pkg_a/routes.py
+++ b/gitnexus/test/fixtures/fastapi-composed-app/pkg_a/routes.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from .constants import SHARED
+
+router = APIRouter()
+
+
+@router.get(SHARED)
+async def handler_a():
+    return {}

--- a/gitnexus/test/fixtures/fastapi-composed-app/pkg_b/constants.py
+++ b/gitnexus/test/fixtures/fastapi-composed-app/pkg_b/constants.py
@@ -1,0 +1,1 @@
+SHARED = "/b-shared"

--- a/gitnexus/test/fixtures/fastapi-composed-app/pkg_b/routes.py
+++ b/gitnexus/test/fixtures/fastapi-composed-app/pkg_b/routes.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from .constants import SHARED
+
+router = APIRouter()
+
+
+@router.get(SHARED)
+async def handler_b():
+    return {}

--- a/gitnexus/test/integration/fastapi-composed-route-constants.test.ts
+++ b/gitnexus/test/integration/fastapi-composed-route-constants.test.ts
@@ -142,9 +142,9 @@ describe('FastAPI composed route constants — ingestion↔group parity (#2391 R
 
     // Every composed route the ingestion side resolved is also a group provider
     // path, and vice versa — the two subsystems agree (R4), including the
-    // multi-hop and per-package-collision cases. (The `/v2` constructor-prefix
-    // route is ingestion-only garnish via APIRouter(prefix); the shared composed
-    // paths are what must match.)
+    // multi-hop and per-package-collision cases. (The `/v2` APIRouter(prefix)
+    // route is emitted by BOTH sides as well — asserted separately above; the
+    // four paths below are this block's shared-parity set.)
     for (const composed of ['/api/v1/widgets/get', '/root/mid/leaf', '/a-shared', '/b-shared']) {
       expect(ingestionUrls.has(composed)).toBe(true);
       expect(groupPaths.has(composed)).toBe(true);

--- a/gitnexus/test/integration/fastapi-composed-route-constants.test.ts
+++ b/gitnexus/test/integration/fastapi-composed-route-constants.test.ts
@@ -1,0 +1,78 @@
+/**
+ * End-to-end coverage of imported/composed FastAPI route path constants (#2391).
+ *
+ * `@router.post(API_V1_WIDGETS_GET)` — where the path is an imported constant
+ * built by `+`-concatenation in another module — must index as
+ * `POST /api/v1/widgets/get` in the ingestion `Route` graph nodes (which drive
+ * `route_map` / `api_impact`), NOT as `POST /`. An argument that cannot be folded
+ * to a literal is skipped entirely (KTD5 floor), never recorded as `/`.
+ *
+ * The group HTTP-contract parity, multi-hop chains, the module-collision floor,
+ * and the warm-cache guard are added by U5/U6 (see the sibling describe blocks
+ * and `http-route-extractor.test.ts`).
+ *
+ * Fixture: `test/fixtures/fastapi-composed-app/`.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'node:path';
+import { runPipelineFromRepo } from '../../src/core/ingestion/pipeline.js';
+import type { PipelineResult } from '../../types/pipeline.js';
+
+const FIXTURE = path.resolve(__dirname, '..', 'fixtures', 'fastapi-composed-app');
+
+describe('FastAPI composed route constants — ingestion pipeline (#2391)', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(FIXTURE, () => {}, {});
+  }, 60_000);
+
+  function routes(): { method: string | undefined; url: string }[] {
+    const out: { method: string | undefined; url: string }[] = [];
+    result.graph.forEachNode((n) => {
+      if (n.label !== 'Route') return;
+      const method = n.properties.method;
+      out.push({
+        method: method === undefined ? undefined : String(method),
+        url: String(n.properties.name),
+      });
+    });
+    return out;
+  }
+  const urls = (): string[] =>
+    routes()
+      .map((r) => r.url)
+      .sort();
+
+  it('resolves the imported composed constant to its full path', () => {
+    expect(routes()).toContainEqual({ method: 'POST', url: '/api/v1/widgets/get' });
+  });
+
+  it('never records a phantom `/` for a non-literal path', () => {
+    expect(urls()).not.toContain('/');
+  });
+
+  it('leaves an ordinary string-literal sibling route unchanged', () => {
+    expect(routes()).toContainEqual({ method: 'GET', url: '/literal/health' });
+  });
+
+  it('skips an unresolvable constant argument (no Route node, not `/`)', () => {
+    // `@router.delete(UNKNOWN_ROUTE_CONST)` — the constant is defined nowhere, so
+    // it folds to null and the route is dropped rather than indexed as `DELETE /`.
+    expect(routes().some((r) => r.method === 'DELETE')).toBe(false);
+  });
+
+  it('joins an APIRouter(prefix=…) with a resolved composed path', () => {
+    // prefixed.py: `router = APIRouter(prefix="/v2")` + `@router.post(COMPOSED)`.
+    expect(routes()).toContainEqual({ method: 'POST', url: '/v2/api/v1/widgets/get' });
+  });
+
+  it('keeps two composed routes at distinct paths as distinct nodes', () => {
+    const composed = routes().filter((r) => r.url.endsWith('/api/v1/widgets/get'));
+    expect(composed.map((r) => r.url).sort()).toEqual([
+      '/api/v1/widgets/get',
+      '/v2/api/v1/widgets/get',
+    ]);
+  });
+});

--- a/gitnexus/test/integration/fastapi-composed-route-constants.test.ts
+++ b/gitnexus/test/integration/fastapi-composed-route-constants.test.ts
@@ -16,8 +16,18 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import path from 'node:path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import Parser from 'tree-sitter';
+import Python from 'tree-sitter-python';
 import { runPipelineFromRepo } from '../../src/core/ingestion/pipeline.js';
 import type { PipelineResult } from '../../types/pipeline.js';
+import { PYTHON_HTTP_PLUGIN } from '../../src/core/group/extractors/http-patterns/python.js';
+import {
+  loadParseCache,
+  saveParseCache,
+  PARSE_CACHE_VERSION,
+} from '../../src/storage/parse-cache.js';
 
 const FIXTURE = path.resolve(__dirname, '..', 'fixtures', 'fastapi-composed-app');
 
@@ -75,4 +85,109 @@ describe('FastAPI composed route constants — ingestion pipeline (#2391)', () =
       '/v2/api/v1/widgets/get',
     ]);
   });
+
+  it('resolves a multi-hop import chain (leaf → mid → base) with an inline concat', () => {
+    // deep/base.py ROOT=/root → deep/mid.py MID=ROOT+"/mid" → deep/leaf.py
+    // @router.get(MID + "/leaf").
+    expect(routes()).toContainEqual({ method: 'GET', url: '/root/mid/leaf' });
+  });
+
+  it('resolves same-named constants in different packages against their OWN package', () => {
+    // pkg_a/constants.py SHARED="/a-shared" and pkg_b/constants.py SHARED="/b-shared",
+    // each imported via `from .constants import SHARED`. Never crossed (KTD4).
+    expect(routes()).toContainEqual({ method: 'GET', url: '/a-shared' });
+    expect(routes()).toContainEqual({ method: 'GET', url: '/b-shared' });
+    expect(urls().filter((u) => u.endsWith('-shared'))).toEqual(['/a-shared', '/b-shared']);
+  });
+});
+
+// ─── R4 parity: the group HTTP-contract layer resolves the same paths ─────────
+
+describe('FastAPI composed route constants — ingestion↔group parity (#2391 R4)', () => {
+  it('group provider paths match the ingestion Route-node paths for composed routes', async () => {
+    const ingestion = await runPipelineFromRepo(FIXTURE, () => {}, {});
+    const ingestionUrls = new Set<string>();
+    ingestion.graph.forEachNode((n) => {
+      if (n.label === 'Route') ingestionUrls.add(String(n.properties.name));
+    });
+
+    // Run the group plugin over the same fixture files.
+    const files: Record<string, string> = {};
+    const walk = (dir: string, rel: string): void => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const abs = path.join(dir, entry.name);
+        const r = rel ? `${rel}/${entry.name}` : entry.name;
+        if (entry.isDirectory()) walk(abs, r);
+        else if (entry.name.endsWith('.py')) files[r] = fs.readFileSync(abs, 'utf8');
+      }
+    };
+    walk(FIXTURE, '');
+    const parser = new Parser();
+    const parseSource = (p: Parser, src: string): Parser.Tree => {
+      p.setLanguage(Python);
+      return p.parse(src);
+    };
+    const ctx = PYTHON_HTTP_PLUGIN.prepareRepo?.({
+      files: Object.keys(files),
+      parser,
+      readFile: (r) => files[r] ?? null,
+      parseSource,
+    });
+    const groupPaths = new Set<string>();
+    for (const [rel, src] of Object.entries(files)) {
+      for (const d of PYTHON_HTTP_PLUGIN.scan(parseSource(parser, src), ctx, rel)) {
+        if (d.role === 'provider') groupPaths.add(d.path);
+      }
+    }
+
+    // Every composed route the ingestion side resolved is also a group provider
+    // path, and vice versa — the two subsystems agree (R4), including the
+    // multi-hop and per-package-collision cases. (The `/v2` constructor-prefix
+    // route is ingestion-only garnish via APIRouter(prefix); the shared composed
+    // paths are what must match.)
+    for (const composed of ['/api/v1/widgets/get', '/root/mid/leaf', '/a-shared', '/b-shared']) {
+      expect(ingestionUrls.has(composed)).toBe(true);
+      expect(groupPaths.has(composed)).toBe(true);
+    }
+    // Neither side invents a phantom `/` for the unresolvable DELETE route.
+    expect(ingestionUrls.has('/')).toBe(false);
+    expect(groupPaths.has('/')).toBe(false);
+  }, 60_000);
+});
+
+// ─── Warm parse-cache: composed routes survive the cache serialization ────────
+
+describe('FastAPI composed route constants — warm parse-cache (#2391 SCHEMA_BUMP)', () => {
+  it('re-resolves the composed route on an all-hit warm run after a save/load round-trip', async () => {
+    const storageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-composed-warm-'));
+    try {
+      // Run #1 populates the parse cache.
+      const cold = {
+        version: PARSE_CACHE_VERSION,
+        entries: new Map(),
+        usedKeys: new Set<string>(),
+      };
+      await runPipelineFromRepo(FIXTURE, () => {}, { parseCache: cold });
+
+      // Force the JSON round-trip (mapReplacer/mapReviver) the real warm path uses
+      // — this is where the new `moduleConstants` Maps and `routePathExpr` fields
+      // must survive, or a warm re-analyze silently drops the composed route.
+      await saveParseCache(storageDir, cold);
+      const warm = await loadParseCache(storageDir);
+      expect(warm).not.toBeNull();
+
+      const result = await runPipelineFromRepo(FIXTURE, () => {}, {
+        parseCache: warm ?? undefined,
+      });
+      const urls = new Set<string>();
+      result.graph.forEachNode((n) => {
+        if (n.label === 'Route') urls.add(String(n.properties.name));
+      });
+      expect(urls.has('/api/v1/widgets/get')).toBe(true);
+      expect(urls.has('/root/mid/leaf')).toBe(true);
+      expect(urls.has('/')).toBe(false);
+    } finally {
+      fs.rmSync(storageDir, { recursive: true, force: true });
+    }
+  }, 120_000);
 });

--- a/gitnexus/test/integration/fastapi-composed-route-constants.test.ts
+++ b/gitnexus/test/integration/fastapi-composed-route-constants.test.ts
@@ -99,6 +99,13 @@ describe('FastAPI composed route constants — ingestion pipeline (#2391)', () =
     expect(routes()).toContainEqual({ method: 'GET', url: '/b-shared' });
     expect(urls().filter((u) => u.endsWith('-shared'))).toEqual(['/a-shared', '/b-shared']);
   });
+
+  it('snapshots an aliased constant before a later mutation, end-to-end (#2393)', () => {
+    // app/snapshot.py: `SNAP = API_V1` (captures "/api/v1") then `API_V1 += "/mutated"`.
+    // SNAP's route must be the pre-mutation value, never the mutated one.
+    expect(routes()).toContainEqual({ method: 'GET', url: '/api/v1' });
+    expect(urls()).not.toContain('/api/v1/mutated');
+  });
 });
 
 // ─── R4 parity: the group HTTP-contract layer resolves the same paths ─────────

--- a/gitnexus/test/unit/constant-resolver.test.ts
+++ b/gitnexus/test/unit/constant-resolver.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The language-agnostic constant-fold core (#2391). The exhaustive Python fold
+ * behavior is pinned in `python-const-resolver.test.ts`; this file proves the
+ * core is genuinely language-neutral by driving it with a NON-Python (Java-style)
+ * {@link ImportResolver}, so a future Spring/Kotlin/C# binding can reuse the fold,
+ * cycle guard, and depth cap by supplying only its own import resolver + extractor.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveConstant,
+  resolveOperands,
+  type ImportResolver,
+  type ModuleConstants,
+  type Operand,
+  type RepoConstants,
+} from '../../src/core/ingestion/route-extractors/constant-resolver.js';
+
+const lit = (value: string): Operand => ({ kind: 'literal', value });
+const ref = (name: string): Operand => ({ kind: 'ref', name });
+const mc = (parts: {
+  literals?: Record<string, string>;
+  exprs?: Record<string, Operand[]>;
+  imports?: Record<string, { module: string; originalName: string }>;
+}): ModuleConstants => ({
+  literals: new Map(Object.entries(parts.literals ?? {})),
+  exprs: new Map(Object.entries(parts.exprs ?? {})),
+  imports: new Map(Object.entries(parts.imports ?? {})),
+});
+
+// A deliberately non-Python resolver: JVM-style `com.app.Paths` → `com/app/Paths.java`.
+const javaImport: ImportResolver = (_importingFileKey, moduleSpec, repoKeys) => {
+  const candidate = moduleSpec.replace(/\./g, '/') + '.java';
+  return repoKeys.has(candidate) ? candidate : null;
+};
+
+describe('constant-resolver — language-agnostic core', () => {
+  it('folds a named constant across a Java-style import chain', () => {
+    const repo: RepoConstants = new Map([
+      [
+        'com/app/Paths.java',
+        mc({ literals: { API: '/api' }, exprs: { WIDGETS: [ref('API'), lit('/widgets')] } }),
+      ],
+      [
+        'com/app/Routes.java',
+        mc({ imports: { WIDGETS: { module: 'com.app.Paths', originalName: 'WIDGETS' } } }),
+      ],
+    ]);
+    expect(resolveConstant('com/app/Routes.java', 'WIDGETS', repo, javaImport)).toBe(
+      '/api/widgets',
+    );
+  });
+
+  it('folds an inline operand list through the injected resolver', () => {
+    const repo: RepoConstants = new Map([
+      ['com/app/Paths.java', mc({ literals: { API: '/api' } })],
+      [
+        'com/app/Routes.java',
+        mc({ imports: { API: { module: 'com.app.Paths', originalName: 'API' } } }),
+      ],
+    ]);
+    expect(
+      resolveOperands('com/app/Routes.java', [ref('API'), lit('/widgets')], repo, javaImport),
+    ).toBe('/api/widgets');
+  });
+
+  it('floors to null when the resolver cannot pin the import', () => {
+    const repo: RepoConstants = new Map([
+      [
+        'com/app/Routes.java',
+        mc({ imports: { X: { module: 'com.missing.Paths', originalName: 'X' } } }),
+      ],
+    ]);
+    expect(resolveConstant('com/app/Routes.java', 'X', repo, javaImport)).toBeNull();
+  });
+
+  it('applies the cycle guard and depth cap independent of the resolver', () => {
+    const cyclic: RepoConstants = new Map([['m', mc({ exprs: { A: [ref('B')], B: [ref('A')] } })]]);
+    expect(resolveConstant('m', 'A', cyclic, javaImport)).toBeNull();
+
+    const exprs: Record<string, Operand[]> = {};
+    for (let i = 0; i < 20; i++) exprs[`A${i}`] = [ref(`A${i + 1}`)];
+    const deep: RepoConstants = new Map([['m', mc({ exprs, literals: { A20: '/end' } })]]);
+    expect(resolveConstant('m', 'A0', deep, javaImport)).toBeNull();
+  });
+});

--- a/gitnexus/test/unit/constant-resolver.test.ts
+++ b/gitnexus/test/unit/constant-resolver.test.ts
@@ -97,6 +97,19 @@ describe('constant-resolver — language-agnostic core', () => {
     );
   });
 
+  it('by-name and operand-list entry differ at the depth boundary (#2393 parity)', () => {
+    // A hop chain that lands exactly at MAX_RESOLVE_DEPTH for the operand-list
+    // entry (one depth deeper than the by-name entry). This is why the group side
+    // must fold identifier args via resolveOperands([ref]) — the SAME entry the
+    // ingestion side uses — not resolveConstant, which would resolve here and
+    // break ingestion↔group parity at the boundary.
+    const exprs: Record<string, Operand[]> = {};
+    for (let i = 0; i < 4; i++) exprs[`A${i}`] = [ref(`A${i + 1}`)];
+    const repo: RepoConstants = new Map([['m', mc({ exprs, literals: { A4: '/end' } })]]);
+    expect(resolveOperands('m', [ref('A0')], repo, javaImport)).toBeNull();
+    expect(resolveConstant('m', 'A0', repo, javaImport)).toBe('/end');
+  });
+
   it('drops a pathological self-multiplying concat instead of exhausting memory (#2393)', () => {
     // Each level references the next 64×, so the true value is 64^4 chars — folding
     // it naively blows the heap (RangeError/OOM). The fold-length cap must floor it

--- a/gitnexus/test/unit/constant-resolver.test.ts
+++ b/gitnexus/test/unit/constant-resolver.test.ts
@@ -97,6 +97,17 @@ describe('constant-resolver — language-agnostic core', () => {
     );
   });
 
+  it('drops a pathological self-multiplying concat instead of exhausting memory (#2393)', () => {
+    // Each level references the next 64×, so the true value is 64^4 chars — folding
+    // it naively blows the heap (RangeError/OOM). The fold-length cap must floor it
+    // to null (drop). This resolves ~instantly; without the cap it OOMs.
+    const W = 64;
+    const exprs: Record<string, Operand[]> = {};
+    for (let i = 0; i < 4; i++) exprs[`L${i}`] = Array.from({ length: W }, () => ref(`L${i + 1}`));
+    const repo: RepoConstants = new Map([['m', mc({ exprs, literals: { L4: '/leaf' } })]]);
+    expect(resolveConstant('m', 'L0', repo, javaImport)).toBeNull();
+  });
+
   it('folds a diamond where two operands share a common base (#2393)', () => {
     const repo: RepoConstants = new Map([
       [

--- a/gitnexus/test/unit/constant-resolver.test.ts
+++ b/gitnexus/test/unit/constant-resolver.test.ts
@@ -83,4 +83,35 @@ describe('constant-resolver — language-agnostic core', () => {
     const deep: RepoConstants = new Map([['m', mc({ exprs, literals: { A20: '/end' } })]]);
     expect(resolveConstant('m', 'A0', deep, javaImport)).toBeNull();
   });
+
+  it('folds a constant referenced twice in one expression (not a false cycle) (#2393)', () => {
+    const repo: RepoConstants = new Map([['m', mc({ literals: { A: '/a' } })]]);
+    // `A + A` — the second reference must NOT be mistaken for a cycle.
+    expect(resolveOperands('m', [ref('A'), ref('A')], repo, javaImport)).toBe('/a/a');
+  });
+
+  it('folds a reused separator constant (#2393)', () => {
+    const repo: RepoConstants = new Map([['m', mc({ literals: { SLASH: '/', PATH: 'p' } })]]);
+    expect(resolveOperands('m', [ref('SLASH'), ref('PATH'), ref('SLASH')], repo, javaImport)).toBe(
+      '/p/',
+    );
+  });
+
+  it('folds a diamond where two operands share a common base (#2393)', () => {
+    const repo: RepoConstants = new Map([
+      [
+        'm',
+        mc({
+          literals: { BASE: '/base' },
+          exprs: {
+            P: [ref('BASE'), lit('/p')],
+            Q: [ref('BASE'), lit('/q')],
+            X: [ref('P'), ref('Q')],
+          },
+        }),
+      ],
+    ]);
+    // BASE is reached transitively via both P and Q within X's single fold.
+    expect(resolveConstant('m', 'X', repo, javaImport)).toBe('/base/p/base/q');
+  });
 });

--- a/gitnexus/test/unit/group/fastapi-composed-provider.test.ts
+++ b/gitnexus/test/unit/group/fastapi-composed-provider.test.ts
@@ -160,6 +160,24 @@ describe('group FastAPI composed-constant providers (#2391)', () => {
     expect(parseCalls).toBe(1);
   });
 
+  it('resolves a multiline (Black-formatted) literal-leading concat (#2393)', () => {
+    const { providers, parseCalls } = run({
+      'app/constants.py': 'SUFFIX = "/users"',
+      'app/routes.py': [
+        'from fastapi import APIRouter',
+        'from .constants import SUFFIX',
+        'router = APIRouter()',
+        '@router.get(',
+        '    "/api"',
+        '    + SUFFIX',
+        ')',
+        'async def list_users(): return {}',
+      ].join('\n'),
+    });
+    expect(parseCalls).toBeGreaterThan(0); // gate must fire across the line break
+    expect(providers).toContainEqual({ method: 'GET', path: '/api/users' });
+  });
+
   it('resolves a composed @app.<verb>(CONST) provider (#2393 EXPR-branch coverage)', () => {
     const { providers } = run({
       'app/constants.py': 'API_CONST = "/health"',

--- a/gitnexus/test/unit/group/fastapi-composed-provider.test.ts
+++ b/gitnexus/test/unit/group/fastapi-composed-provider.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Group HTTP-contract layer: FastAPI provider detections for non-literal decorator
+ * paths (#2391 U5). Exercises `PYTHON_HTTP_PLUGIN.prepareRepo` + `scan` directly
+ * with a real tree-sitter parser (no DB / extractor machinery), asserting:
+ *   • an imported/composed constant resolves to the same path the ingestion side
+ *     produces (R4 parity), including APIRouter(prefix=…) stacking;
+ *   • string-literal routes are unchanged;
+ *   • an unresolvable argument emits NO provider (skip parity with ingestion);
+ *   • the cost gate: a literal-only repo builds no constant map (no extra parse).
+ */
+
+import { describe, it, expect } from 'vitest';
+import Parser from 'tree-sitter';
+import Python from 'tree-sitter-python';
+import { PYTHON_HTTP_PLUGIN } from '../../../src/core/group/extractors/http-patterns/python.js';
+import type { HttpDetection } from '../../../src/core/group/extractors/http-patterns/types.js';
+
+const parser = new Parser();
+const parseSource = (p: Parser, src: string): Parser.Tree => {
+  p.setLanguage(Python);
+  return p.parse(src);
+};
+
+interface RunResult {
+  providers: { method: string; path: string }[];
+  parseCalls: number;
+}
+
+function run(files: Record<string, string>): RunResult {
+  let parseCalls = 0;
+  const countingParse = (p: Parser, src: string): Parser.Tree => {
+    parseCalls++;
+    return parseSource(p, src);
+  };
+  const readFile = (rel: string): string | null => files[rel] ?? null;
+  const ctx = PYTHON_HTTP_PLUGIN.prepareRepo?.({
+    files: Object.keys(files),
+    parser,
+    readFile,
+    parseSource: countingParse,
+  });
+  const providers: { method: string; path: string }[] = [];
+  for (const rel of Object.keys(files)) {
+    if (!rel.endsWith('.py')) continue;
+    const detections: HttpDetection[] = PYTHON_HTTP_PLUGIN.scan(
+      parseSource(parser, files[rel]),
+      ctx,
+      rel,
+    );
+    for (const d of detections) {
+      if (d.role === 'provider') providers.push({ method: d.method, path: d.path });
+    }
+  }
+  return { providers, parseCalls };
+}
+
+const CONSTANTS = [
+  'API_V1 = "/api/v1"',
+  'API_V1_WIDGETS = API_V1 + "/widgets"',
+  'API_V1_WIDGETS_GET = API_V1_WIDGETS + "/get"',
+].join('\n');
+
+describe('group FastAPI composed-constant providers (#2391)', () => {
+  it('resolves an imported composed constant to its full path', () => {
+    const { providers } = run({
+      'app/constants.py': CONSTANTS,
+      'app/routes.py': [
+        'from fastapi import APIRouter',
+        'from .constants import API_V1_WIDGETS_GET',
+        'router = APIRouter()',
+        '@router.post(API_V1_WIDGETS_GET)',
+        'async def create(): return {}',
+      ].join('\n'),
+    });
+    expect(providers).toContainEqual({ method: 'POST', path: '/api/v1/widgets/get' });
+  });
+
+  it('stacks an APIRouter(prefix=…) onto a resolved composed path', () => {
+    const { providers } = run({
+      'app/constants.py': CONSTANTS,
+      'app/routes.py': [
+        'from fastapi import APIRouter',
+        'from .constants import API_V1_WIDGETS_GET',
+        'router = APIRouter(prefix="/v2")',
+        '@router.post(API_V1_WIDGETS_GET)',
+        'async def create(): return {}',
+      ].join('\n'),
+    });
+    expect(providers).toContainEqual({ method: 'POST', path: '/v2/api/v1/widgets/get' });
+  });
+
+  it('leaves a string-literal route unchanged and emits no provider for an unresolvable arg', () => {
+    const { providers } = run({
+      'app/routes.py': [
+        'from fastapi import APIRouter',
+        'router = APIRouter()',
+        '@router.get("/literal/health")',
+        'async def health(): return {}',
+        '@router.delete(UNKNOWN_CONST)',
+        'async def remove(): return {}',
+      ].join('\n'),
+    });
+    expect(providers).toContainEqual({ method: 'GET', path: '/literal/health' });
+    expect(providers.some((p) => p.method === 'DELETE')).toBe(false);
+  });
+
+  it('cost gate: a literal-only repo parses no files for constants', () => {
+    // No non-literal decorator and no include_router ⇒ prepareRepo does zero
+    // parsing (the constant map is never built).
+    const { parseCalls } = run({
+      'app/routes.py': [
+        'from fastapi import APIRouter',
+        'router = APIRouter()',
+        '@router.get("/only/literal")',
+        'async def f(): return {}',
+      ].join('\n'),
+    });
+    expect(parseCalls).toBe(0);
+  });
+
+  it('cost gate: a composed repo does parse for constants', () => {
+    const { parseCalls } = run({
+      'app/constants.py': CONSTANTS,
+      'app/routes.py': '@router.post(API_V1_WIDGETS_GET)\nasync def f(): return {}\n',
+    });
+    expect(parseCalls).toBeGreaterThan(0);
+  });
+});

--- a/gitnexus/test/unit/group/fastapi-composed-provider.test.ts
+++ b/gitnexus/test/unit/group/fastapi-composed-provider.test.ts
@@ -143,6 +143,23 @@ describe('group FastAPI composed-constant providers (#2391)', () => {
     expect(providers).toContainEqual({ method: 'GET', path: '/api/users' });
   });
 
+  it('parses a file that needs both the router pre-pass and the constant map once (#2393)', () => {
+    // The file has BOTH include_router and a composed route; before the single
+    // parse-pass merge it was parsed twice in prepareRepo, now once.
+    const { parseCalls } = run({
+      'app/main.py': [
+        'from fastapi import APIRouter',
+        'from .sub import sub_router',
+        'router = APIRouter()',
+        'API_CONST = "/y"',
+        'app.include_router(sub_router, prefix="/x")',
+        '@router.get(API_CONST)',
+        'async def f(): return {}',
+      ].join('\n'),
+    });
+    expect(parseCalls).toBe(1);
+  });
+
   it('resolves a composed @app.<verb>(CONST) provider (#2393 EXPR-branch coverage)', () => {
     const { providers } = run({
       'app/constants.py': 'API_CONST = "/health"',

--- a/gitnexus/test/unit/group/fastapi-composed-provider.test.ts
+++ b/gitnexus/test/unit/group/fastapi-composed-provider.test.ts
@@ -125,4 +125,35 @@ describe('group FastAPI composed-constant providers (#2391)', () => {
     });
     expect(parseCalls).toBeGreaterThan(0);
   });
+
+  it('resolves a string-literal-LEADING concat as the sole composed route (#2393 parity)', () => {
+    // `@router.get("/api" + SUFFIX)` starts with a quote, so the pre-widen cost
+    // gate missed it and the group dropped a route ingestion resolved.
+    const { providers, parseCalls } = run({
+      'app/constants.py': 'SUFFIX = "/users"',
+      'app/routes.py': [
+        'from fastapi import APIRouter',
+        'from .constants import SUFFIX',
+        'router = APIRouter()',
+        '@router.get("/api" + SUFFIX)',
+        'async def list_users(): return {}',
+      ].join('\n'),
+    });
+    expect(parseCalls).toBeGreaterThan(0); // gate now fires on the literal-leading concat
+    expect(providers).toContainEqual({ method: 'GET', path: '/api/users' });
+  });
+
+  it('resolves a composed @app.<verb>(CONST) provider (#2393 EXPR-branch coverage)', () => {
+    const { providers } = run({
+      'app/constants.py': 'API_CONST = "/health"',
+      'app/main.py': [
+        'from fastapi import FastAPI',
+        'from .constants import API_CONST',
+        'app = FastAPI()',
+        '@app.get(API_CONST)',
+        'async def health(): return {}',
+      ].join('\n'),
+    });
+    expect(providers).toContainEqual({ method: 'GET', path: '/health' });
+  });
 });

--- a/gitnexus/test/unit/python-const-resolver.test.ts
+++ b/gitnexus/test/unit/python-const-resolver.test.ts
@@ -11,10 +11,13 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import Parser from 'tree-sitter';
+import Python from 'tree-sitter-python';
 import {
   resolveConstant,
   resolveOperands,
   resolveImportToFileKey,
+  extractPythonModuleConstants,
   type ModuleConstants,
   type Operand,
   type ImportBinding,
@@ -195,5 +198,72 @@ describe('resolveImportToFileKey', () => {
 
   it('returns null when the target file does not exist', () => {
     expect(resolveImportToFileKey('a/routes.py', '.missing', keys)).toBeNull();
+  });
+});
+
+// ─── U2: tree → ModuleConstants extraction (real parse) ──────────────────────
+
+const parser = new Parser();
+parser.setLanguage(Python);
+const extract = (src: string): ModuleConstants => extractPythonModuleConstants(parser.parse(src));
+const repoFrom = (files: Record<string, string>): RepoConstants =>
+  new Map(Object.entries(files).map(([k, src]) => [k, extract(src)]));
+
+describe('extractPythonModuleConstants', () => {
+  it('extracts a bare string literal', () => {
+    const mcs = extract('X = "/a"\n');
+    expect(mcs.literals.get('X')).toBe('/a');
+  });
+
+  it('extracts a + concat as an ordered operand list', () => {
+    const mcs = extract('X = A + "/b"\n');
+    expect(mcs.exprs.get('X')).toEqual([
+      { kind: 'ref', name: 'A' },
+      { kind: 'literal', value: '/b' },
+    ]);
+  });
+
+  it('folds an augmented assignment (X += "/b")', () => {
+    const r = new Map([['m.py', extract('X = "/a"\nX += "/b"\n')]]);
+    expect(resolveConstant('m.py', 'X', r)).toBe('/a/b');
+  });
+
+  it('applies last-wins rebind and drops a non-string rebind', () => {
+    const r1 = new Map([['m.py', extract('X = "/a"\nX = "/b"\n')]]);
+    expect(resolveConstant('m.py', 'X', r1)).toBe('/b');
+    const r2 = new Map([['m.py', extract('X = "/a"\nX = build()\n')]]);
+    expect(resolveConstant('m.py', 'X', r2)).toBeNull();
+  });
+
+  it('extracts from-import bindings, including aliases and relative paths', () => {
+    const mcs = extract('from .constants import X\nfrom pkg.mod import Y as Z\n');
+    expect(mcs.imports.get('X')).toEqual({ module: '.constants', originalName: 'X' });
+    expect(mcs.imports.get('Z')).toEqual({ module: 'pkg.mod', originalName: 'Y' });
+  });
+
+  it('ignores non-string assignments', () => {
+    const mcs = extract('N = 5\ncfg = Settings()\nP = "/p"\n');
+    expect(mcs.literals.has('N')).toBe(false);
+    expect(mcs.exprs.has('cfg')).toBe(false);
+    expect(mcs.literals.get('P')).toBe('/p');
+  });
+
+  it('resolves the full issue repro end-to-end (extractor → resolver)', () => {
+    const r = repoFrom({
+      'app/constants.py': [
+        'API_V1 = "/api/v1"',
+        'API_V1_WIDGETS = API_V1 + "/widgets"',
+        'API_V1_WIDGETS_GET = API_V1_WIDGETS + "/get"',
+      ].join('\n'),
+      'app/routes.py': 'from .constants import API_V1_WIDGETS_GET\n',
+    });
+    expect(resolveConstant('app/routes.py', 'API_V1_WIDGETS_GET', r)).toBe('/api/v1/widgets/get');
+  });
+
+  it('survives a structured-clone round-trip (worker/cache boundary)', () => {
+    const cloned = structuredClone(extract('X = "/a"\nfrom .c import Y\n'));
+    const r = new Map([['m.py', cloned]]);
+    expect(resolveConstant('m.py', 'X', r)).toBe('/a');
+    expect(cloned.imports.get('Y')).toEqual({ module: '.c', originalName: 'Y' });
   });
 });

--- a/gitnexus/test/unit/python-const-resolver.test.ts
+++ b/gitnexus/test/unit/python-const-resolver.test.ts
@@ -199,6 +199,22 @@ describe('resolvePythonImport', () => {
   it('returns null when the target file does not exist', () => {
     expect(resolvePythonImport('a/routes.py', '.missing', keys)).toBeNull();
   });
+
+  it('resolves `from . import` to the package __init__.py, not a sibling <dir>.py (#2393)', () => {
+    const k = new Set(['pkg/__init__.py', 'pkg/routes.py']);
+    expect(resolvePythonImport('pkg/routes.py', '.', k)).toBe('pkg/__init__.py');
+  });
+
+  it('returns null for `from . import` when the package __init__.py is absent (#2393)', () => {
+    expect(resolvePythonImport('pkg/routes.py', '.', new Set(['pkg/routes.py']))).toBeNull();
+  });
+
+  it('returns null for an over-deep relative import even if the clamped target exists (#2393)', () => {
+    // `from ...constants` from a repo-root file climbs two levels above the root.
+    // Without the guard it would clamp to a bare `constants.py`; it must return null.
+    const k = new Set(['constants.py', 'routes.py']);
+    expect(resolvePythonImport('routes.py', '...constants', k)).toBeNull();
+  });
 });
 
 // ─── U2: tree → ModuleConstants extraction (real parse) ──────────────────────

--- a/gitnexus/test/unit/python-const-resolver.test.ts
+++ b/gitnexus/test/unit/python-const-resolver.test.ts
@@ -322,12 +322,27 @@ describe('extractPythonModuleConstants — binding mutual-exclusivity (#2393)', 
     expect(resolveConstant('app/routes.py', 'ROUTE', r)).toBe('/imported');
   });
 
-  it('drops (never stale-import) an augmented assignment onto an imported base', () => {
-    // Deferred: folding `imported_base + "/v1"` would need currentOps to follow
-    // the import binding. Until then the skip floor drops it — never the stale "/api".
+  it('folds an augmented assignment onto an imported base (#2393)', () => {
     const r = repoFrom({
       'app/constants.py': 'BASE = "/api"\n',
       'app/routes.py': 'from .constants import BASE\nBASE += "/v1"\n',
+    });
+    expect(resolveConstant('app/routes.py', 'BASE', r)).toBe('/api/v1');
+  });
+
+  it('folds a chain of += onto an imported base (#2393)', () => {
+    const r = repoFrom({
+      'app/constants.py': 'BASE = "/api"\n',
+      'app/routes.py': 'from .constants import BASE\nBASE += "/a"\nBASE += "/b"\n',
+    });
+    expect(resolveConstant('app/routes.py', 'BASE', r)).toBe('/api/a/b');
+  });
+
+  it('drops a += onto an imported base that itself cannot be resolved (skip floor holds)', () => {
+    const r = repoFrom({
+      // `.missing` does not exist → the imported base is unresolvable → drop, never
+      // a wrong path.
+      'app/routes.py': 'from .missing import BASE\nBASE += "/v1"\n',
     });
     expect(resolveConstant('app/routes.py', 'BASE', r)).toBeNull();
   });

--- a/gitnexus/test/unit/python-const-resolver.test.ts
+++ b/gitnexus/test/unit/python-const-resolver.test.ts
@@ -239,6 +239,13 @@ describe('extractPythonModuleConstants', () => {
     ]);
   });
 
+  it('caps recursion on a pathological deep + chain — null, not a throw (#2393)', () => {
+    const chain = Array.from({ length: 100 }, (_, i) => `A${i}`).join(' + ');
+    const mcs = extract(`X = ${chain}\n`); // depth > 64 → parseConstOperands floors to null
+    expect(mcs.exprs.has('X')).toBe(false);
+    expect(mcs.literals.has('X')).toBe(false);
+  });
+
   it('folds an augmented assignment (X += "/b")', () => {
     const r = new Map([['m.py', extract('X = "/a"\nX += "/b"\n')]]);
     expect(resolveConstant('m.py', 'X', r)).toBe('/a/b');

--- a/gitnexus/test/unit/python-const-resolver.test.ts
+++ b/gitnexus/test/unit/python-const-resolver.test.ts
@@ -347,3 +347,33 @@ describe('extractPythonModuleConstants — binding mutual-exclusivity (#2393)', 
     expect(resolveConstant('app/routes.py', 'BASE', r)).toBeNull();
   });
 });
+
+describe('extractPythonModuleConstants — source-order snapshot (#2393)', () => {
+  it('snapshots an aliased imported base before a later += (no wrong path)', () => {
+    // Python: ROUTE captures BASE's value at the `ROUTE =` line ("/api"); the later
+    // `BASE += "/v1"` must NOT retroactively change ROUTE.
+    const r = repoFrom({
+      'app/constants.py': 'BASE = "/api"\n',
+      'app/routes.py': 'from .constants import BASE\nROUTE = BASE\nBASE += "/v1"\n',
+    });
+    expect(resolveConstant('app/routes.py', 'ROUTE', r)).toBe('/api');
+    expect(resolveConstant('app/routes.py', 'BASE', r)).toBe('/api/v1');
+  });
+
+  it('snapshots an aliased local constant before a later += (no wrong path)', () => {
+    const r = repoFrom({ 'm.py': 'API = "/api"\nROUTE = API\nAPI += "/x"\n' });
+    expect(resolveConstant('m.py', 'ROUTE', r)).toBe('/api');
+    expect(resolveConstant('m.py', 'API', r)).toBe('/api/x');
+  });
+
+  it('snapshots an aliased local constant before a later plain rebind (no wrong path)', () => {
+    const r = repoFrom({ 'm.py': 'API = "/api"\nROUTE = API\nAPI = "/other"\n' });
+    expect(resolveConstant('m.py', 'ROUTE', r)).toBe('/api');
+    expect(resolveConstant('m.py', 'API', r)).toBe('/other');
+  });
+
+  it('still folds a normal same-file reference chain (snapshot inlines bound refs)', () => {
+    const r = repoFrom({ 'm.py': 'A = "/a"\nB = A + "/b"\nC = B + "/c"\n' });
+    expect(resolveConstant('m.py', 'C', r)).toBe('/a/b/c');
+  });
+});

--- a/gitnexus/test/unit/python-const-resolver.test.ts
+++ b/gitnexus/test/unit/python-const-resolver.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Unit tests for the PURE half of the Python constant resolver (#2391):
+ * {@link resolveConstant} / {@link resolveOperands} / {@link resolveImportToFileKey}.
+ *
+ * These operate on a hand-built {@link RepoConstants} map, so no tree-sitter is
+ * involved — the tree → ModuleConstants extraction is covered separately in the
+ * U2 section of this file. The scenarios mirror the plan's U1 test list: same-file
+ * literals/concat, single- and multi-hop imports, the issue's chained repro,
+ * aliasing, inline operands, the relative-import collision (KTD4), cycles, the
+ * depth cap, and non-foldable / unknown / package-`__init__` cases → null.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveConstant,
+  resolveOperands,
+  resolveImportToFileKey,
+  type ModuleConstants,
+  type Operand,
+  type ImportBinding,
+  type RepoConstants,
+} from '../../src/core/ingestion/route-extractors/python-const-resolver.js';
+
+const lit = (value: string): Operand => ({ kind: 'literal', value });
+const ref = (name: string): Operand => ({ kind: 'ref', name });
+
+function mc(parts: {
+  literals?: Record<string, string>;
+  exprs?: Record<string, Operand[]>;
+  imports?: Record<string, ImportBinding>;
+}): ModuleConstants {
+  return {
+    literals: new Map(Object.entries(parts.literals ?? {})),
+    exprs: new Map(Object.entries(parts.exprs ?? {})),
+    imports: new Map(Object.entries(parts.imports ?? {})),
+  };
+}
+
+const repo = (entries: Record<string, ModuleConstants>): RepoConstants =>
+  new Map(Object.entries(entries));
+
+describe('resolveConstant — same file', () => {
+  it('resolves a bare literal', () => {
+    const r = repo({ 'm.py': mc({ literals: { X: '/a' } }) });
+    expect(resolveConstant('m.py', 'X', r)).toBe('/a');
+  });
+
+  it('folds a concat of two literals', () => {
+    const r = repo({ 'm.py': mc({ exprs: { X: [lit('/a'), lit('/b')] } }) });
+    expect(resolveConstant('m.py', 'X', r)).toBe('/a/b');
+  });
+
+  it('folds a concat referencing another same-file const', () => {
+    const r = repo({ 'm.py': mc({ literals: { A: '/a' }, exprs: { X: [ref('A'), lit('/b')] } }) });
+    expect(resolveConstant('m.py', 'X', r)).toBe('/a/b');
+  });
+});
+
+describe('resolveConstant — across imports', () => {
+  it('resolves a single import hop', () => {
+    const r = repo({
+      'app/constants.py': mc({ literals: { X: '/a' } }),
+      'app/routes.py': mc({ imports: { X: { module: '.constants', originalName: 'X' } } }),
+    });
+    expect(resolveConstant('app/routes.py', 'X', r)).toBe('/a');
+  });
+
+  it('resolves the issue repro: chained in-module concat behind an import', () => {
+    const r = repo({
+      'app/constants.py': mc({
+        literals: { API_V1: '/api/v1' },
+        exprs: {
+          API_V1_WIDGETS: [ref('API_V1'), lit('/widgets')],
+          API_V1_WIDGETS_GET: [ref('API_V1_WIDGETS'), lit('/get')],
+        },
+      }),
+      'app/routes.py': mc({
+        imports: {
+          API_V1_WIDGETS_GET: { module: '.constants', originalName: 'API_V1_WIDGETS_GET' },
+        },
+      }),
+    });
+    expect(resolveConstant('app/routes.py', 'API_V1_WIDGETS_GET', r)).toBe('/api/v1/widgets/get');
+  });
+
+  it('resolves a multi-module chain (base -> constants -> routes)', () => {
+    const r = repo({
+      'app/base.py': mc({ literals: { API_V1: '/api/v1' } }),
+      'app/constants.py': mc({
+        imports: { API_V1: { module: '.base', originalName: 'API_V1' } },
+        exprs: { WIDGETS: [ref('API_V1'), lit('/widgets')] },
+      }),
+      'app/routes.py': mc({
+        imports: { WIDGETS: { module: '.constants', originalName: 'WIDGETS' } },
+      }),
+    });
+    expect(resolveConstant('app/routes.py', 'WIDGETS', r)).toBe('/api/v1/widgets');
+  });
+
+  it('resolves an aliased import via the original name', () => {
+    const r = repo({
+      'app/constants.py': mc({ literals: { X: '/a' } }),
+      'app/routes.py': mc({ imports: { Y: { module: '.constants', originalName: 'X' } } }),
+    });
+    expect(resolveConstant('app/routes.py', 'Y', r)).toBe('/a');
+  });
+});
+
+describe('resolveOperands — inline decorator expression', () => {
+  it('folds an inline operand list with a const ref', () => {
+    const r = repo({ 'app/routes.py': mc({ literals: { API_V1: '/api/v1' } }) });
+    expect(resolveOperands('app/routes.py', [ref('API_V1'), lit('/widgets')], r)).toBe(
+      '/api/v1/widgets',
+    );
+  });
+});
+
+describe('resolveConstant — relative-import collision (KTD4)', () => {
+  const r = repo({
+    'a/constants.py': mc({ literals: { API_PREFIX: '/a' } }),
+    'b/constants.py': mc({ literals: { API_PREFIX: '/b' } }),
+    'a/routes.py': mc({
+      imports: { API_PREFIX: { module: '.constants', originalName: 'API_PREFIX' } },
+    }),
+    'b/routes.py': mc({
+      imports: { API_PREFIX: { module: '.constants', originalName: 'API_PREFIX' } },
+    }),
+    'c/routes.py': mc({
+      imports: { API_PREFIX: { module: 'constants', originalName: 'API_PREFIX' } },
+    }),
+  });
+
+  it('resolves each package against its own constants.py', () => {
+    expect(resolveConstant('a/routes.py', 'API_PREFIX', r)).toBe('/a');
+    expect(resolveConstant('b/routes.py', 'API_PREFIX', r)).toBe('/b');
+  });
+
+  it('returns null for an ambiguous absolute import (two matching files)', () => {
+    expect(resolveConstant('c/routes.py', 'API_PREFIX', r)).toBeNull();
+  });
+});
+
+describe('resolveConstant — unresolvable → null', () => {
+  it('breaks a cycle', () => {
+    const r = repo({ 'm.py': mc({ exprs: { A: [ref('B')], B: [ref('A')] } }) });
+    expect(resolveConstant('m.py', 'A', r)).toBeNull();
+  });
+
+  it('returns null past the depth cap', () => {
+    const exprs: Record<string, Operand[]> = {};
+    for (let i = 0; i < 20; i++) exprs[`A${i}`] = [ref(`A${i + 1}`)];
+    const r = repo({ 'm.py': mc({ exprs, literals: { A20: '/end' } }) });
+    expect(resolveConstant('m.py', 'A0', r)).toBeNull();
+  });
+
+  it('returns null on an unknown operand name', () => {
+    const r = repo({ 'm.py': mc({ exprs: { X: [lit('/a'), ref('MISSING')] } }) });
+    expect(resolveConstant('m.py', 'X', r)).toBeNull();
+  });
+
+  it('returns null for an unknown name', () => {
+    const r = repo({ 'm.py': mc({ literals: { X: '/a' } }) });
+    expect(resolveConstant('m.py', 'NOPE', r)).toBeNull();
+  });
+
+  it('returns null when a package __init__ re-export hop is not a .py module', () => {
+    const r = repo({
+      'app/constants/__init__.py': mc({ literals: { X: '/a' } }),
+      'app/routes.py': mc({ imports: { X: { module: '.constants', originalName: 'X' } } }),
+    });
+    // `.constants` resolves to `app/constants.py`, which does not exist (it is a
+    // package dir). Package __init__ re-exports are deferred (#2391 scope).
+    expect(resolveConstant('app/routes.py', 'X', r)).toBeNull();
+  });
+});
+
+describe('resolveImportToFileKey', () => {
+  const keys = new Set(['a/constants.py', 'b/constants.py', 'app/pkg/mod.py', 'app/routes.py']);
+
+  it('resolves a relative import against the importing file package', () => {
+    expect(resolveImportToFileKey('a/routes.py', '.constants', keys)).toBe('a/constants.py');
+  });
+
+  it('walks up one level per extra leading dot', () => {
+    expect(resolveImportToFileKey('app/pkg/routes.py', '..routes', keys)).toBe('app/routes.py');
+  });
+
+  it('returns null for an ambiguous absolute suffix', () => {
+    expect(resolveImportToFileKey('a/routes.py', 'constants', keys)).toBeNull();
+  });
+
+  it('resolves an unambiguous absolute multi-segment import', () => {
+    expect(resolveImportToFileKey('a/routes.py', 'app.pkg.mod', keys)).toBe('app/pkg/mod.py');
+  });
+
+  it('returns null when the target file does not exist', () => {
+    expect(resolveImportToFileKey('a/routes.py', '.missing', keys)).toBeNull();
+  });
+});

--- a/gitnexus/test/unit/python-const-resolver.test.ts
+++ b/gitnexus/test/unit/python-const-resolver.test.ts
@@ -267,3 +267,45 @@ describe('extractPythonModuleConstants', () => {
     expect(cloned.imports.get('Y')).toEqual({ module: '.c', originalName: 'Y' });
   });
 });
+
+describe('extractPythonModuleConstants — binding mutual-exclusivity (#2393)', () => {
+  it('drops an imported name that is then rebound to a dynamic value (never the stale import)', () => {
+    // Python: ROUTE's live value is the getenv result → unknowable → must DROP,
+    // not resolve to the stale import (the skip-floor / wrong-path invariant).
+    const mcs = extract('from .constants import ROUTE\nROUTE = os.getenv("X")\n');
+    expect(mcs.imports.has('ROUTE')).toBe(false);
+    expect(mcs.literals.has('ROUTE')).toBe(false);
+    expect(mcs.exprs.has('ROUTE')).toBe(false);
+    const r = repoFrom({
+      'app/constants.py': 'ROUTE = "/imported"\n',
+      'app/routes.py': 'from .constants import ROUTE\nROUTE = os.getenv("X")\n',
+    });
+    expect(resolveConstant('app/routes.py', 'ROUTE', r)).toBeNull();
+  });
+
+  it('uses the local literal when a later assignment shadows an import', () => {
+    const r = repoFrom({
+      'app/constants.py': 'ROUTE = "/imported"\n',
+      'app/routes.py': 'from .constants import ROUTE\nROUTE = "/local"\n',
+    });
+    expect(resolveConstant('app/routes.py', 'ROUTE', r)).toBe('/local');
+  });
+
+  it('uses the import when it shadows an earlier local assignment (source order)', () => {
+    const r = repoFrom({
+      'app/constants.py': 'ROUTE = "/imported"\n',
+      'app/routes.py': 'ROUTE = "/local"\nfrom .constants import ROUTE\n',
+    });
+    expect(resolveConstant('app/routes.py', 'ROUTE', r)).toBe('/imported');
+  });
+
+  it('drops (never stale-import) an augmented assignment onto an imported base', () => {
+    // Deferred: folding `imported_base + "/v1"` would need currentOps to follow
+    // the import binding. Until then the skip floor drops it — never the stale "/api".
+    const r = repoFrom({
+      'app/constants.py': 'BASE = "/api"\n',
+      'app/routes.py': 'from .constants import BASE\nBASE += "/v1"\n',
+    });
+    expect(resolveConstant('app/routes.py', 'BASE', r)).toBeNull();
+  });
+});

--- a/gitnexus/test/unit/python-const-resolver.test.ts
+++ b/gitnexus/test/unit/python-const-resolver.test.ts
@@ -1,6 +1,6 @@
 /**
  * Unit tests for the PURE half of the Python constant resolver (#2391):
- * {@link resolveConstant} / {@link resolveOperands} / {@link resolveImportToFileKey}.
+ * {@link resolveConstant} / {@link resolveOperands} / {@link resolvePythonImport}.
  *
  * These operate on a hand-built {@link RepoConstants} map, so no tree-sitter is
  * involved — the tree → ModuleConstants extraction is covered separately in the
@@ -16,7 +16,7 @@ import Python from 'tree-sitter-python';
 import {
   resolveConstant,
   resolveOperands,
-  resolveImportToFileKey,
+  resolvePythonImport,
   extractPythonModuleConstants,
   type ModuleConstants,
   type Operand,
@@ -177,27 +177,27 @@ describe('resolveConstant — unresolvable → null', () => {
   });
 });
 
-describe('resolveImportToFileKey', () => {
+describe('resolvePythonImport', () => {
   const keys = new Set(['a/constants.py', 'b/constants.py', 'app/pkg/mod.py', 'app/routes.py']);
 
   it('resolves a relative import against the importing file package', () => {
-    expect(resolveImportToFileKey('a/routes.py', '.constants', keys)).toBe('a/constants.py');
+    expect(resolvePythonImport('a/routes.py', '.constants', keys)).toBe('a/constants.py');
   });
 
   it('walks up one level per extra leading dot', () => {
-    expect(resolveImportToFileKey('app/pkg/routes.py', '..routes', keys)).toBe('app/routes.py');
+    expect(resolvePythonImport('app/pkg/routes.py', '..routes', keys)).toBe('app/routes.py');
   });
 
   it('returns null for an ambiguous absolute suffix', () => {
-    expect(resolveImportToFileKey('a/routes.py', 'constants', keys)).toBeNull();
+    expect(resolvePythonImport('a/routes.py', 'constants', keys)).toBeNull();
   });
 
   it('resolves an unambiguous absolute multi-segment import', () => {
-    expect(resolveImportToFileKey('a/routes.py', 'app.pkg.mod', keys)).toBe('app/pkg/mod.py');
+    expect(resolvePythonImport('a/routes.py', 'app.pkg.mod', keys)).toBe('app/pkg/mod.py');
   });
 
   it('returns null when the target file does not exist', () => {
-    expect(resolveImportToFileKey('a/routes.py', '.missing', keys)).toBeNull();
+    expect(resolvePythonImport('a/routes.py', '.missing', keys)).toBeNull();
   });
 });
 

--- a/gitnexus/test/unit/python-decorator-arg-capture.test.ts
+++ b/gitnexus/test/unit/python-decorator-arg-capture.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Pins the FastAPI/route decorator argument capture in `PYTHON_QUERIES` (#2391).
+ *
+ * The parse worker branches on exactly these captures to decide a route's path:
+ *   • `decorator.arg_str` present  → string-literal path (routePath = the content,
+ *     or '' for the empty literal `""` which has no `string_content`);
+ *   • `decorator.arg_expr` present → non-literal (identifier / `+`-concat) →
+ *     resolved cross-file by the constant resolver;
+ *   • neither                      → no capturable path arg (attribute access,
+ *     no-arg decorator) → the worker skips it (never a phantom `POST /`).
+ *
+ * A regression in the query — e.g. dropping the empty-literal case or matching a
+ * keyword argument instead of the first positional — silently mis-indexes routes,
+ * so it must fail here first.
+ */
+
+import { describe, it, expect } from 'vitest';
+import Parser from 'tree-sitter';
+import Python from 'tree-sitter-python';
+import { PYTHON_QUERIES } from '../../src/core/ingestion/tree-sitter-queries.js';
+
+const parser = new Parser();
+parser.setLanguage(Python);
+const query = new Parser.Query(Python, PYTHON_QUERIES);
+
+/** Capture name → node text, for the single decorator in `src`. */
+function decoratorCaptures(src: string): Record<string, string> {
+  const matches = query.matches(parser.parse(src).rootNode);
+  const out: Record<string, string> = {};
+  for (const m of matches) {
+    const hasDecorator = m.captures.some((c) => c.name === 'decorator');
+    if (!hasDecorator) continue;
+    for (const c of m.captures) out[c.name] = c.node.text;
+  }
+  return out;
+}
+
+describe('PYTHON_QUERIES decorator arg capture (#2391)', () => {
+  it('captures a string-literal path via decorator.arg (quote-free)', () => {
+    const caps = decoratorCaptures('@router.get("/x")\ndef f(): pass\n');
+    expect(caps['decorator.arg']).toBe('/x');
+    expect(caps['decorator.arg_expr']).toBeUndefined();
+  });
+
+  it('captures the empty-literal path via arg_str with no arg content', () => {
+    const caps = decoratorCaptures('@router.get("")\ndef f(): pass\n');
+    expect(caps['decorator.arg_str']).toBe('""');
+    expect(caps['decorator.arg']).toBeUndefined();
+    expect(caps['decorator.arg_expr']).toBeUndefined();
+  });
+
+  it('captures a bare constant name via decorator.arg_expr', () => {
+    const caps = decoratorCaptures('@router.post(API_V1_WIDGETS_GET)\ndef f(): pass\n');
+    expect(caps['decorator.arg_expr']).toBe('API_V1_WIDGETS_GET');
+    expect(caps['decorator.arg']).toBeUndefined();
+  });
+
+  it('captures a + concatenation via decorator.arg_expr', () => {
+    const caps = decoratorCaptures('@router.put(API_V1 + "/widgets")\ndef f(): pass\n');
+    expect(caps['decorator.arg_expr']).toBe('API_V1 + "/widgets"');
+  });
+
+  it('captures the FIRST positional arg, ignoring keyword args', () => {
+    const strCaps = decoratorCaptures('@router.get("/x", response_model=Foo)\ndef f(): pass\n');
+    expect(strCaps['decorator.arg']).toBe('/x');
+    const exprCaps = decoratorCaptures('@router.post(NAME, status_code=201)\ndef f(): pass\n');
+    expect(exprCaps['decorator.arg_expr']).toBe('NAME');
+  });
+
+  it('captures neither for an attribute-access arg (skip floor)', () => {
+    const caps = decoratorCaptures('@router.get(settings.PATH)\ndef f(): pass\n');
+    expect(caps['decorator.arg_str']).toBeUndefined();
+    expect(caps['decorator.arg_expr']).toBeUndefined();
+    expect(caps['decorator']).toContain('settings.PATH');
+  });
+
+  it('still matches a no-arg decorator (tool detection preserved)', () => {
+    const caps = decoratorCaptures('@app.tool()\ndef f(): pass\n');
+    expect(caps['decorator.name']).toBe('tool');
+    expect(caps['decorator.arg_str']).toBeUndefined();
+    expect(caps['decorator.arg_expr']).toBeUndefined();
+  });
+});

--- a/gitnexus/test/unit/result-merge.test.ts
+++ b/gitnexus/test/unit/result-merge.test.ts
@@ -80,6 +80,37 @@ describe('mergeResult', () => {
     expect(target.springTypes).toBeUndefined();
   });
 
+  it('unions moduleConstants across sub-batch results, initializing the target when absent (#2391)', () => {
+    const mkConst = (filePath: string, name: string) => ({
+      filePath,
+      constants: {
+        literals: new Map([[name, '/a']]),
+        exprs: new Map(),
+        imports: new Map(),
+      },
+    });
+    // Regression: the worker-side accumulator dropped this field, so composed
+    // FastAPI route constants never reached parse-impl and resolved to `POST /`.
+    const target = emptyResult(); // no moduleConstants on the target (the `??=` path)
+    mergeResult(target, {
+      ...emptyResult(),
+      moduleConstants: [mkConst('a.py', 'A')],
+      fileCount: 1,
+    });
+    mergeResult(target, {
+      ...emptyResult(),
+      moduleConstants: [mkConst('b.py', 'B')],
+      fileCount: 1,
+    });
+    expect(target.moduleConstants?.map((m) => m.filePath)).toEqual(['a.py', 'b.py']);
+  });
+
+  it('leaves moduleConstants undefined when no source carries any (#2391)', () => {
+    const target = emptyResult();
+    mergeResult(target, { ...emptyResult(), fileCount: 1 });
+    expect(target.moduleConstants).toBeUndefined();
+  });
+
   it('also sums skippedLanguages and appends node arrays (sanity of the rest of the merge)', () => {
     const target = { ...emptyResult(), skippedLanguages: { rust: 1 } };
     mergeResult(target, {


### PR DESCRIPTION
Fixes #2391.

## Problem

FastAPI route decorators whose path is a **non-string-literal** — an imported constant (`@router.post(API_V1_WIDGETS_GET)`) or a `+`-concatenation — were indexed with an empty path that normalized to `POST /`. `api_impact` / `route_map` then couldn't resolve the endpoint, and the group HTTP-contract layer dropped the route entirely.

Root cause: two independent literal-only gates (the Python decorator tree-sitter query and the group `FASTAPI_ROUTER_PATTERNS`), plus a fallback that conflated "no argument" with "non-literal argument" — both collapsing to `/`.

## Fix

A shared, transitive, multi-module Python string-constant resolver that both extraction subsystems consume, so provider contracts and graph Route nodes agree on the path.

- **`route-extractors/python-const-resolver.ts`** (new, pure): folds `+`-concatenations of string literals/constants across arbitrarily deep import chains. Keyed by **unique file path** and resolves relative imports package-relative, so two packages' same-named `constants.py` never cross-resolve (a wrong path would be worse than an unresolved one). Cycle-guarded, depth-capped. Reuses the `django.ts` `binary_operator` fold + `MAX_INCLUDE_DEPTH` prior art.
- **Ingestion** (`tree-sitter-queries.ts`, `parse-worker.ts`, `parse-impl.ts`): the query now captures a non-literal first arg; the worker emits the expression + operands and each file's module constants; parse-impl resolves them cross-file before the `include_router`/`APIRouter` prefix pass.
- **Group** (`http-patterns/python.ts`): matches and resolves non-literal decorator args over the **same file closure** ingestion uses (cost-gated — a literal-only repo pays zero extra parse), for provider/graph parity.
- **Correctness floor**: an argument that can't be folded to a literal is **skipped** in both subsystems — no Route node, never `POST /`, never a garbage raw-expression URL.
- **`parse-cache.ts` `SCHEMA_BUMP` 10 → 11**: the new `ParseWorkerResult` fields change the cache shape, so warm caches invalidate — otherwise a same-version re-analyze would silently replay pre-upgrade shards and keep serving `POST /`.

## Out of scope (deferred)

f-strings, `.format()`/`%`, `os.path.join`, `Enum`/`settings.X` attribute references, `__init__.py` package re-exports, and conditional/non-top-level assignments — all fold to the skip floor (never a wrong path).

## Tests

- Pure resolver + tree extractor (literals, concat, `+=`, rebind, multi-hop, aliasing, **package collision**, cycle, depth cap, unknown → null)
- Decorator query capture (literal, empty-literal `""`, identifier, concat, attribute-skip, no-arg)
- `mergeResult` field coverage (regression lock for the worker-accumulator drop)
- End-to-end pipeline: the issue repro, prefix stacking, multi-hop chain, **ingestion↔group parity**, and a **warm parse-cache** round-trip proving the new Map fields survive serialization
- Group provider resolution + cost gate

The original repro now indexes `POST /api/v1/widgets/get`. Full blast-radius suite green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
