### PR TITLE
test(cli): lock native load guard for analyze

### DIFF
--- a/gitnexus/test/unit/lazy-action.test.ts
+++ b/gitnexus/test/unit/lazy-action.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createLazyAction } from '../../src/cli/lazy-action.js';
 
+const { checkLbugNativeMock } = vi.hoisted(() => ({
+  checkLbugNativeMock: vi.fn(() => ({ ok: true })),
+}));
+
+vi.mock('../../src/core/lbug/native-check.js', () => ({
+  checkLbugNative: checkLbugNativeMock,
+}));
+
 describe('createLazyAction', () => {
   it('does not import target module until invoked', async () => {
     const loader = vi.fn(async () => ({
@@ -17,5 +25,36 @@ describe('createLazyAction', () => {
   it('throws a clear error when export is not a function', async () => {
     const action = createLazyAction(async () => ({ notAFunction: 'string-value' }), 'notAFunction');
     await expect(action()).rejects.toThrow('notAFunction');
+  });
+});
+
+describe('createLbugLazyAction', () => {
+  it('fails before importing the target module when LadybugDB native cannot load', async () => {
+    checkLbugNativeMock.mockReturnValueOnce({
+      ok: false,
+      message:
+        'LadybugDB native binary (lbugjs.node) exists but failed to load:\n' + '  dlopen failed',
+    });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    process.exitCode = undefined;
+    const loader = vi.fn(async () => ({
+      run: vi.fn(async () => 'ok'),
+    }));
+
+    try {
+      const { createLbugLazyAction } = await import('../../src/cli/lazy-action.js');
+      const action = createLbugLazyAction(loader, 'run');
+
+      await expect(action('arg-1')).resolves.toBeUndefined();
+
+      expect(loader).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('LadybugDB native binary (lbugjs.node) exists but failed to load:'),
+      );
+    } finally {
+      stderrSpy.mockRestore();
+      process.exitCode = undefined;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add regression coverage for the LadybugDB native-load guard used by analyze/serve/mcp lazy actions
- assert native-load failure sets a non-zero exit code, writes the diagnostic, and does not import the target command module

## Why
This locks the behavior relevant to #2441: a broken lbugjs.node must stop before command import instead of allowing analyze to look successful while writing no index. Current main already routes analyze through createLbugLazyAction; this test keeps that contract from regressing.

## Tests
- npm test -- --run test/unit/lazy-action.test.ts
- git diff --check
- npm run build