### PR TITLE
ci: update setup composites to setup-node v6

### DIFF
--- a/.github/actions/setup-gitnexus-web/action.yml
+++ b/.github/actions/setup-gitnexus-web/action.yml
@@ -4,7 +4,7 @@ description: Setup Node.js 22, build gitnexus-shared, install web dependencies
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         # Vite 7 requires Node ^20.19.0 || >=22.12.0 (require(esm) support).
         node-version: 22

--- a/.github/actions/setup-gitnexus/action.yml
+++ b/.github/actions/setup-gitnexus/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 22
         cache: npm


### PR DESCRIPTION
Closes #2450.

## Summary

- update the shared GitNexus setup composite from `actions/setup-node` v4 to the repository's existing v6.4.0 pin
- update the matching web setup composite to the same pin
- retain Node 22 as the application/test runtime in both composites

## Why

GitHub now warns that the v4 action runtime targets deprecated Node 20 and is being forced onto Node 24. Direct workflow usages in this repository already use the v6.4.0 SHA; these two composites were the remaining stale surfaces.

## Validation

- `git diff --check`
- parsed both composite action manifests and asserted `runs.using == composite` plus the exact v6.4.0 pin
- two-line-only diff (`2` additions, `2` deletions)

No application dependency, package runtime, release workflow, or publication behavior changes.