### PR TITLE
ci: sync plugin manifests on version bumps and widen the Windows shard watchdog

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -184,8 +184,10 @@ jobs:
         # spawns and Windows is ~5x slower than macOS at those, so the unsharded
         # run crept past the 15-min watchdog in run-cross-platform.ts. vitest
         # shards by file COUNT, not runtime, so the heaviest spawn suites can
-        # cluster on one shard; 3 shards keep even the busiest Windows shard
-        # comfortably under the watchdog (macOS had margin either way).
+        # cluster on one shard. The busiest Windows shard has grown to the old
+        # 15-minute watchdog (14m57s on the v1.6.10-rc.19 green run, one
+        # observed timeout since — #2449), so the job env below raises the
+        # per-shard watchdog to 20 minutes, still bounded by timeout-minutes.
         # Shard indices come from the shard-plan job (single source of truth):
         # its TOTAL drives this list and the /N in the job name + --shard arg.
         shard: ${{ fromJSON(needs.shard-plan.outputs.shards) }}
@@ -204,6 +206,10 @@ jobs:
     env:
       GITNEXUS_REQUIRE_FTS: '1'
       GITNEXUS_E2E_CLI: dist
+      # #2449: hosted Windows runners intermittently push the busiest shard past
+      # the default 15-minute watchdog. 20 minutes restores real headroom while
+      # the 25-minute job timeout above still bounds a genuine hang.
+      GITNEXUS_CROSS_PLATFORM_TIMEOUT_MINUTES: '20'
     steps:
       # persist-credentials: false — runs tests only, never pushes (zizmor
       # credential-persistence / artipacked audit).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -423,6 +423,10 @@ jobs:
             echo "::error::Tag version (v$TAG_VERSION) does not match package.json version ($PKG_VERSION)"
             exit 1
           fi
+          # Stable releases carry their version bump on main via the release
+          # PR, so the manifest surfaces must already be in sync — refuse to
+          # publish a stable whose manifests drifted (#2445).
+          node scripts/sync-plugin-manifests.mjs --check
           echo "Version verified: $PKG_VERSION"
 
       # ── RC-only: compute the next rc version against the live registry ──
@@ -584,6 +588,17 @@ jobs:
           npm version "${{ steps.rc-version.outputs.rc_version }}" \
             --no-git-tag-version --allow-same-version
 
+      # ── Verify the plugin manifest surfaces synced (#2445) ───────────────
+      # The npm `version` lifecycle script in gitnexus/package.json syncs all
+      # four manifest surfaces whenever `npm version` runs (the step above,
+      # and a maintainer's laptop alike). This step only verifies fail-closed
+      # so a future removal of that wiring cannot ship a drifted RC again.
+      - name: Verify plugin manifests (rc)
+        if: needs.route.outputs.mode == 'rc'
+        shell: bash
+        working-directory: gitnexus
+        run: node scripts/sync-plugin-manifests.mjs --check
+
       - name: Build gitnexus
         run: npm run build
         working-directory: gitnexus
@@ -669,6 +684,12 @@ jobs:
           # pristine, but the v-tag's tree matches the published package
           # exactly (release-integrity).
           git add package.json package-lock.json 2>/dev/null || git add package.json
+          # The synced manifest surfaces (#2445) belong in the same detached
+          # release commit so the tag's tree passes its own version contract.
+          git add ../gitnexus-claude-plugin/.claude-plugin/plugin.json \
+            ../.claude-plugin/marketplace.json \
+            ../gitnexus-claude-plugin/.codex-plugin/plugin.json \
+            ../.agents/plugins/marketplace.json
           git commit -m "release: ${VTAG}" --allow-empty
           RELEASE_SHA="$(git rev-parse HEAD)"
           echo "Detached release commit: $RELEASE_SHA"

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -52,7 +52,8 @@
     "postinstall": "node scripts/build-tree-sitter-grammars.cjs",
     "assert-publish-coverage": "node scripts/assert-publish-grammar-coverage.cjs",
     "prepare": "node scripts/build.js",
-    "prepack": "node scripts/assert-publish-grammar-coverage.cjs && node scripts/build.js"
+    "prepack": "node scripts/assert-publish-grammar-coverage.cjs && node scripts/build.js",
+    "version": "node scripts/sync-plugin-manifests.mjs"
   },
   "dependencies": {
     "@ladybugdb/core": "^0.18.0",

--- a/gitnexus/scripts/run-cross-platform.ts
+++ b/gitnexus/scripts/run-cross-platform.ts
@@ -48,10 +48,11 @@ try {
 
 // Per-shard watchdog, default 15 min. Sharding splits the file list by COUNT, not
 // runtime, so the heaviest spawn suites can cluster on one shard — what this
-// bounds is the *busiest* shard, not an even 1/n of wall-clock. With 3 shards
-// even that shard clears the watchdog, where the whole unsharded Windows run
-// used to trip it. Allow CI/manual runs to add headroom without editing the
-// script again.
+// bounds is the *busiest* shard, not an even 1/n of wall-clock. The busiest
+// Windows shard has grown to the default (14m57s on the v1.6.10-rc.19 green
+// run, one observed timeout since — #2449), so CI raises the budget to 20
+// minutes via GITNEXUS_CROSS_PLATFORM_TIMEOUT_MINUTES; the default stays 15
+// for local runs.
 const DEFAULT_TIMEOUT_MIN = 15;
 const timeoutMinutes = Number.parseInt(
   process.env.GITNEXUS_CROSS_PLATFORM_TIMEOUT_MINUTES ?? String(DEFAULT_TIMEOUT_MIN),
@@ -67,6 +68,7 @@ console.log(
     `${shardArg ? ` (${shardArg.replace('--shard=', 'shard ')})` : ''}...\n`,
 );
 
+const startedAt = Date.now();
 try {
   execFileSync('npx', ['vitest', 'run', ...ALL_CROSS_PLATFORM, ...(shardArg ? [shardArg] : [])], {
     cwd: ROOT,
@@ -76,9 +78,22 @@ try {
   });
 } catch (err) {
   // execFileSync sets `killed`/`signal` when the watchdog above kills vitest.
-  const e = err as { killed?: boolean; signal?: NodeJS.Signals | null };
+  const e = err as {
+    killed?: boolean;
+    signal?: NodeJS.Signals | null;
+    status?: number | null;
+    code?: string;
+  };
   if (e.killed || e.signal) {
     console.error(`vitest timed out after ${Math.round(timeoutMs / 60_000)} minutes`);
   }
+  // #2449: Windows shards have died with a bare `status: null`, empty stderr
+  // and nothing to triage from. Always leave the child's exit facts behind.
+  const elapsedSec = Math.round((Date.now() - startedAt) / 1000);
+  console.error(
+    `vitest exited abnormally: status=${e.status ?? 'null'} signal=${e.signal ?? 'none'} ` +
+      `killed=${e.killed === true} spawnCode=${e.code ?? 'none'} elapsed=${elapsedSec}s ` +
+      `budget=${Math.round(timeoutMs / 60_000)}min`,
+  );
   process.exit(1);
 }

--- a/gitnexus/scripts/sync-plugin-manifests.mjs
+++ b/gitnexus/scripts/sync-plugin-manifests.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Fail-closed version sync for the plugin manifest surfaces (#2445).
+ *
+ * `publish.yml` bumps only `gitnexus/package.json` when it cuts an RC, so
+ * every RC tag through v1.6.10-rc.28 shipped manifests frozen at the last
+ * stable version and failed its own unit suite (the cli-commands version
+ * contract). This script pins all four manifest surfaces to the package
+ * version:
+ *
+ *   - gitnexus-claude-plugin/.claude-plugin/plugin.json   (top-level version)
+ *   - .claude-plugin/marketplace.json                     (plugins[gitnexus])
+ *   - gitnexus-claude-plugin/.codex-plugin/plugin.json    (top-level version)
+ *   - .agents/plugins/marketplace.json                    (plugins[gitnexus])
+ *
+ * Modes:
+ *   node scripts/sync-plugin-manifests.mjs           rewrite stale surfaces
+ *   node scripts/sync-plugin-manifests.mjs --check   verify only, exit 1 on drift
+ *
+ * Fail-closed: a missing file, unparseable JSON, an absent version field, or
+ * anything other than exactly one `gitnexus` marketplace entry aborts with a
+ * non-zero exit rather than letting a release ship a partial sync.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MANIFEST_SURFACES = [
+  { file: 'gitnexus-claude-plugin/.claude-plugin/plugin.json', kind: 'plugin' },
+  { file: '.claude-plugin/marketplace.json', kind: 'marketplace' },
+  { file: 'gitnexus-claude-plugin/.codex-plugin/plugin.json', kind: 'plugin' },
+  { file: '.agents/plugins/marketplace.json', kind: 'marketplace' },
+];
+
+const PLUGIN_NAME = 'gitnexus';
+
+function readJson(filePath) {
+  let raw;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (err) {
+    throw new Error(`Cannot read manifest surface ${filePath}: ${err.message}`);
+  }
+  try {
+    return { raw, parsed: JSON.parse(raw) };
+  } catch (err) {
+    throw new Error(`Manifest surface ${filePath} is not valid JSON: ${err.message}`);
+  }
+}
+
+function versionTarget(manifest, kind, filePath) {
+  if (kind === 'plugin') {
+    if (typeof manifest.version !== 'string' || manifest.version.length === 0) {
+      throw new Error(`Manifest surface ${filePath} has no version field to sync`);
+    }
+    return manifest;
+  }
+  const entries = (Array.isArray(manifest.plugins) ? manifest.plugins : []).filter(
+    (plugin) => plugin?.name === PLUGIN_NAME,
+  );
+  if (entries.length !== 1) {
+    throw new Error(
+      `Manifest surface ${filePath} must contain exactly one "${PLUGIN_NAME}" plugin entry, found ${entries.length}`,
+    );
+  }
+  if (typeof entries[0].version !== 'string' || entries[0].version.length === 0) {
+    throw new Error(`Manifest surface ${filePath} has no version field to sync`);
+  }
+  return entries[0];
+}
+
+/**
+ * Sync (or with `check: true`, only inspect) every manifest surface under
+ * `rootDir`. Returns `{ version, synced, stale }` where `stale` lists the
+ * surfaces that did not match the package version when the run started.
+ */
+export function syncPluginManifests(rootDir, { check = false } = {}) {
+  const pkgPath = path.join(rootDir, 'gitnexus', 'package.json');
+  const version = readJson(pkgPath).parsed.version;
+  if (typeof version !== 'string' || version.length === 0) {
+    throw new Error(`No version found in ${pkgPath}`);
+  }
+
+  const synced = [];
+  const stale = [];
+  for (const { file, kind } of MANIFEST_SURFACES) {
+    const manifestPath = path.join(rootDir, file);
+    const { raw, parsed } = readJson(manifestPath);
+    const target = versionTarget(parsed, kind, manifestPath);
+    if (target.version === version) continue;
+
+    stale.push({ file, from: target.version });
+    if (check) continue;
+
+    // Textual surgery instead of re-serializing: JSON.stringify would refold
+    // arrays and fight prettier, turning a one-line version bump into
+    // formatting churn inside the release commit. The needle is built from
+    // the parsed current version, and anything other than exactly one
+    // occurrence aborts rather than guessing.
+    const needle = `"version": "${target.version}"`;
+    const occurrences = raw.split(needle).length - 1;
+    if (occurrences !== 1) {
+      throw new Error(
+        `Manifest surface ${manifestPath} has ${occurrences} occurrences of ${needle}; ` +
+          'expected exactly one, refusing to sync',
+      );
+    }
+    writeFileSync(manifestPath, raw.replace(needle, `"version": "${version}"`));
+    synced.push(file);
+  }
+
+  return { version, synced, stale };
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const check = process.argv.includes('--check');
+  const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+  const result = syncPluginManifests(rootDir, { check });
+
+  if (check && result.stale.length > 0) {
+    for (const { file, from } of result.stale) {
+      console.error(
+        `::error::${file} is at ${from} but gitnexus/package.json is at ${result.version}. ` +
+          'Run `node gitnexus/scripts/sync-plugin-manifests.mjs` and commit the result.',
+      );
+    }
+    process.exit(1);
+  }
+
+  for (const file of result.synced) {
+    console.log(`synced ${file} -> ${result.version}`);
+  }
+  console.log(
+    result.stale.length === 0 && result.synced.length === 0
+      ? `all plugin manifests already at ${result.version}`
+      : `plugin manifests now at ${result.version}`,
+  );
+}

--- a/gitnexus/test/unit/sync-plugin-manifests.test.ts
+++ b/gitnexus/test/unit/sync-plugin-manifests.test.ts
@@ -1,0 +1,155 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { syncPluginManifests } from '../../scripts/sync-plugin-manifests.mjs';
+
+const SURFACES = [
+  'gitnexus-claude-plugin/.claude-plugin/plugin.json',
+  '.claude-plugin/marketplace.json',
+  'gitnexus-claude-plugin/.codex-plugin/plugin.json',
+  '.agents/plugins/marketplace.json',
+] as const;
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function writeJson(root: string, file: string, value: unknown): void {
+  const filePath = path.join(root, file);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function makeRoot(packageVersion: string, manifestVersion: string): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'gitnexus-manifest-sync-'));
+  tempRoots.push(root);
+  writeJson(root, 'gitnexus/package.json', { name: 'gitnexus', version: packageVersion });
+  writeJson(root, SURFACES[0], { name: 'gitnexus', version: manifestVersion });
+  writeJson(root, SURFACES[1], {
+    name: 'gitnexus-marketplace',
+    plugins: [{ name: 'gitnexus', version: manifestVersion, source: './gitnexus-claude-plugin' }],
+  });
+  writeJson(root, SURFACES[2], { name: 'gitnexus', version: manifestVersion });
+  writeJson(root, SURFACES[3], {
+    name: 'gitnexus-marketplace',
+    plugins: [{ name: 'gitnexus', version: manifestVersion, category: 'Developer Tools' }],
+  });
+  return root;
+}
+
+function readVersions(root: string): string[] {
+  return SURFACES.map((file) => {
+    const manifest = JSON.parse(readFileSync(path.join(root, file), 'utf8')) as {
+      version?: string;
+      plugins?: Array<{ name: string; version: string }>;
+    };
+    return (
+      manifest.version ??
+      manifest.plugins?.find((plugin) => plugin.name === 'gitnexus')?.version ??
+      ''
+    );
+  });
+}
+
+describe('syncPluginManifests (#2445)', () => {
+  it('rewrites all four surfaces to the package version and reports them', () => {
+    const root = makeRoot('1.6.10-rc.29', '1.6.9');
+
+    const result = syncPluginManifests(root);
+
+    expect(result.version).toBe('1.6.10-rc.29');
+    expect(result.synced).toHaveLength(4);
+    expect(result.stale.map(({ from }) => from)).toEqual(['1.6.9', '1.6.9', '1.6.9', '1.6.9']);
+    expect(readVersions(root)).toEqual(Array(4).fill('1.6.10-rc.29'));
+  });
+
+  it('is idempotent once everything matches', () => {
+    const root = makeRoot('1.6.10-rc.29', '1.6.9');
+    syncPluginManifests(root);
+
+    const second = syncPluginManifests(root);
+
+    expect(second.synced).toHaveLength(0);
+    expect(second.stale).toHaveLength(0);
+  });
+
+  it('check mode reports drift without writing anything', () => {
+    const root = makeRoot('1.6.10-rc.29', '1.6.9');
+
+    const result = syncPluginManifests(root, { check: true });
+
+    expect(result.stale).toHaveLength(4);
+    expect(result.synced).toHaveLength(0);
+    expect(readVersions(root)).toEqual(Array(4).fill('1.6.9'));
+  });
+
+  it('changes only the version text and preserves the surrounding formatting', () => {
+    const root = makeRoot('1.6.10-rc.29', '1.6.9');
+    const inlineFormatted = `{
+  "name": "gitnexus",
+  "version": "1.6.9",
+  "keywords": ["code-intelligence", "knowledge-graph", "mcp"]
+}
+`;
+    writeFileSync(path.join(root, SURFACES[0]), inlineFormatted);
+
+    syncPluginManifests(root);
+
+    expect(readFileSync(path.join(root, SURFACES[0]), 'utf8')).toBe(
+      inlineFormatted.replace('"version": "1.6.9"', '"version": "1.6.10-rc.29"'),
+    );
+  });
+
+  it('fails closed when the current version text is ambiguous in the file', () => {
+    const root = makeRoot('1.6.10-rc.29', '1.6.9');
+    writeFileSync(
+      path.join(root, SURFACES[0]),
+      `{
+  "name": "gitnexus",
+  "version": "1.6.9",
+  "previous": { "version": "1.6.9" }
+}
+`,
+    );
+
+    expect(() => syncPluginManifests(root)).toThrow(/expected exactly one/);
+  });
+
+  it('fails closed when a marketplace has no gitnexus entry', () => {
+    const root = makeRoot('1.6.10-rc.29', '1.6.9');
+    writeJson(root, SURFACES[1], { name: 'gitnexus-marketplace', plugins: [] });
+
+    expect(() => syncPluginManifests(root)).toThrow(/exactly one "gitnexus" plugin entry/);
+  });
+
+  it('fails closed when a surface file is missing', () => {
+    const root = makeRoot('1.6.10-rc.29', '1.6.9');
+    rmSync(path.join(root, SURFACES[2]));
+
+    expect(() => syncPluginManifests(root)).toThrow(/Cannot read manifest surface/);
+  });
+
+  it('fails closed on unparseable JSON', () => {
+    const root = makeRoot('1.6.10-rc.29', '1.6.9');
+    writeFileSync(path.join(root, SURFACES[0]), '{ not json');
+
+    expect(() => syncPluginManifests(root)).toThrow(/not valid JSON/);
+  });
+
+  it('matches the real repository layout and passes the check on a synced tree', () => {
+    const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+    const result = syncPluginManifests(repoRoot, { check: true });
+
+    expect(result.stale).toEqual([]);
+  });
+
+  it('is wired into the npm version lifecycle so every bump syncs the manifests', async () => {
+    const pkg = await import('../../package.json', { with: { type: 'json' } });
+
+    expect(pkg.default.scripts.version).toBe('node scripts/sync-plugin-manifests.mjs');
+  });
+});


### PR DESCRIPTION
## What this fixes

Two release and CI hardening items from the RC validation batch.

### #2445: every RC tag failed its own unit suite

The RC path in publish.yml bumps only gitnexus/package.json, so every v1.6.10-rc tag through rc.28 shipped the four plugin manifest surfaces frozen at 1.6.9 and violated the cli-commands version contract.

The fix uses the standard npm version lifecycle hook: a fail-closed sync script now runs automatically whenever npm version executes, in CI or on a maintainer's laptop. publish.yml verifies the result (check only, so removing the hook later cannot silently ship a drifted RC), stages the four surfaces into the detached release commit, and the stable path refuses to publish a tag whose manifests drifted. The sync rewrites only the version text, so a release commit carries a one-line change per surface instead of reformatting churn.

Validated locally: 24 unit tests including fail-closed cases (missing file, bad JSON, missing or ambiguous entries), a live end-to-end RC simulation on the real tree (bump to rc.99, sync, check, one-line diffs, restore), and an npm version lifecycle test under the exact --no-git-tag-version flag the workflow uses.

Design follows the proposal by @100yenadmin in the issue, moved onto the npm version hook.

### #2449: Windows shard watchdog headroom

The busiest Windows platform shard reached 14m57s against the 15 minute watchdog on the rc.19 green run, and the failure mode has fired once since (a status null death in cli-limit-e2e, green on rerun). CI now sets GITNEXUS_CROSS_PLATFORM_TIMEOUT_MINUTES=20 while the 25 minute job timeout still bounds a genuine hang, the stale comfortably-under comment reflects reality, and the runner always logs status, signal, spawn code and elapsed time so the next opaque death is diagnosable.

Closes #2445, closes #2449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)