### PR TITLE
fix(analyze): degrade FTS search instead of aborting analyze on index-build failure

### DIFF
--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -36,6 +36,7 @@ import {
 } from './lbug/lbug-adapter.js';
 import { escapeCypherString } from './lbug/cypher-escape.js';
 import {
+  buildSearchIndexesOrDegrade,
   createSearchFTSIndexes,
   initialiseSearchFTSStemmer,
   verifySearchFTSIndexes,
@@ -1624,7 +1625,11 @@ export async function runFullAnalysis(
       policy: resolveAnalyzeInstallPolicy(),
     });
     if (ftsAvailable) {
-      await createSearchFTSIndexes({
+      // Degrade rather than throw: createSearchFTSIndexes re-tokenizes every
+      // stored row on every run, so a native tokenizer error on a single
+      // pre-existing row (#2544/#2546) must not discard this run's otherwise-
+      // successful graph/embeddings work — only keyword search degrades.
+      const ftsResult = await buildSearchIndexesOrDegrade(executeQuery, {
         onIndexStart: options.verbose
           ? (table, indexName) => log(`FTS: creating ${table}.${indexName}`)
           : undefined,
@@ -1632,14 +1637,15 @@ export async function runFullAnalysis(
           ? (table, indexName) => log(`FTS: ready ${table}.${indexName}`)
           : undefined,
       });
-      const missingIndexNames = await verifySearchFTSIndexes(executeQuery);
-      if (missingIndexNames.length > 0) {
-        throw new Error(
-          `FTS verification failed - missing indexes after analyze: ${missingIndexNames.join(', ')}. ` +
-            'Check FTS extension availability, then retry `gitnexus analyze --force` for a full rebuild.',
+      if (ftsResult.ok) {
+        progress('fts', 90, 'Search indexes ready');
+      } else {
+        log(
+          `FTS index build failed (${ftsResult.error}) — keyword search degraded this run. ` +
+            'Graph and embeddings analysis completed successfully. Run `gitnexus analyze --repair-fts` to retry.',
         );
+        progress('fts', 90, 'Search indexes skipped (build failed)');
       }
-      progress('fts', 90, 'Search indexes ready');
     } else {
       // For a missing runtime dependency (#2374) the file is present, so the
       // generic "install it with network access" tail in FTS_UNAVAILABLE_MESSAGE

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -1624,6 +1624,11 @@ export async function runFullAnalysis(
     const ftsAvailable = await loadFTSExtension(undefined, {
       policy: resolveAnalyzeInstallPolicy(),
     });
+    // Tracks whether search indexes actually ended up usable this run — starts
+    // as ftsAvailable (extension loaded) but flips to false below when the
+    // build/verify step itself fails, so capabilities.fts.status / ftsSkipped
+    // stay honest even though that failure no longer aborts the whole analyze.
+    let ftsReady = ftsAvailable;
     if (ftsAvailable) {
       // Degrade rather than throw: createSearchFTSIndexes re-tokenizes every
       // stored row on every run, so a native tokenizer error on a single
@@ -1640,6 +1645,7 @@ export async function runFullAnalysis(
       if (ftsResult.ok) {
         progress('fts', 90, 'Search indexes ready');
       } else {
+        ftsReady = false;
         log(
           `FTS index build failed (${ftsResult.error}) — keyword search degraded this run. ` +
             'Graph and embeddings analysis completed successfully. Run `gitnexus analyze --repair-fts` to retry.',
@@ -2042,7 +2048,7 @@ export async function runFullAnalysis(
         // meta.json / `gitnexus doctor` honest about degraded search.
         fts: {
           provider: 'ladybugdb-fts',
-          status: ftsAvailable ? runtimeCapabilities.fts : 'unavailable',
+          status: ftsReady ? runtimeCapabilities.fts : 'unavailable',
         },
         vectorSearch: {
           provider: effectiveSemanticMode === 'vector-index' ? 'ladybugdb-vector' : 'exact-scan',
@@ -2222,7 +2228,7 @@ export async function runFullAnalysis(
       repoPath,
       stats: meta.stats,
       pipelineResult,
-      ftsSkipped: !ftsAvailable,
+      ftsSkipped: !ftsReady,
       isPrimaryBranch: !placement.branch,
     };
   } catch (err) {

--- a/gitnexus/src/core/search/fts-indexes.ts
+++ b/gitnexus/src/core/search/fts-indexes.ts
@@ -178,3 +178,34 @@ export async function verifySearchFTSIndexes(
   }
   return missing;
 }
+
+export interface BuildSearchIndexesResult {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * Build + verify FTS indexes, catching any failure instead of letting it
+ * propagate. `createSearchFTSIndexes` re-tokenizes every stored row on every
+ * analyze run (see the `ponytail:` comment above) — a native LadybugDB
+ * tokenizer error on a single pre-existing row (e.g. a "Failed calling
+ * LOWER: Invalid UTF-8", #2544/#2546) must not discard an otherwise-
+ * successful analyze's graph/embeddings work. The caller degrades keyword
+ * search for this run instead, mirroring the existing FTS-extension-
+ * unavailable degrade path in `run-analyze.ts`.
+ */
+export async function buildSearchIndexesOrDegrade(
+  executeQuery: (cypher: string) => Promise<unknown[]>,
+  options?: CreateSearchFTSIndexesOptions,
+): Promise<BuildSearchIndexesResult> {
+  try {
+    await createSearchFTSIndexes(options);
+    const missing = await verifySearchFTSIndexes(executeQuery);
+    if (missing.length > 0) {
+      return { ok: false, error: `missing indexes after build: ${missing.join(', ')}` };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/gitnexus/test/unit/fts-indexes.test.ts
+++ b/gitnexus/test/unit/fts-indexes.test.ts
@@ -15,9 +15,18 @@ vi.mock('../../src/core/lbug/lbug-adapter.js', () => ({
   ),
 }));
 
-const { createSearchFTSIndexes, getSearchFTSStemmer, initialiseSearchFTSStemmer } =
-  await import('../../src/core/search/fts-indexes.js');
+const {
+  buildSearchIndexesOrDegrade,
+  createSearchFTSIndexes,
+  getSearchFTSStemmer,
+  initialiseSearchFTSStemmer,
+} = await import('../../src/core/search/fts-indexes.js');
 const { FTS_INDEXES } = await import('../../src/core/search/fts-schema.js');
+const { createFTSIndex } = await import('../../src/core/lbug/lbug-adapter.js');
+
+/** SHOW_INDEXES rows covering every configured FTS index's expected properties. */
+const fullCoverageRows = () =>
+  FTS_INDEXES.map((i) => ({ index_name: i.indexName, property_names: [...i.properties] }));
 
 afterEach(() => {
   calls.length = 0;
@@ -62,6 +71,37 @@ describe('createSearchFTSIndexes', () => {
 
     await expect(createSearchFTSIndexes()).rejects.toThrow('Invalid GITNEXUS_FTS_STEMMER');
     expect(calls).toEqual([]);
+  });
+});
+
+describe('buildSearchIndexesOrDegrade', () => {
+  it('returns ok:true when every index builds and verifies (#2544/#2546)', async () => {
+    const executeQuery = vi.fn(async () => fullCoverageRows());
+
+    const result = await buildSearchIndexesOrDegrade(executeQuery);
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('returns ok:false instead of throwing when a single index build rejects (#2544/#2546)', async () => {
+    vi.mocked(createFTSIndex).mockRejectedValueOnce(
+      new Error('Runtime exception: Failed calling LOWER: Invalid UTF-8.'),
+    );
+    const executeQuery = vi.fn(async () => fullCoverageRows());
+
+    const result = await buildSearchIndexesOrDegrade(executeQuery);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Invalid UTF-8');
+  });
+
+  it('returns ok:false when verification finds a missing index, without throwing', async () => {
+    const executeQuery = vi.fn(async () => fullCoverageRows().slice(1));
+
+    const result = await buildSearchIndexesOrDegrade(executeQuery);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('missing indexes');
   });
 });
 

--- a/gitnexus/test/unit/run-analyze-fts-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-fts-repair.test.ts
@@ -459,7 +459,11 @@ describe('runFullAnalysis FTS repair and verification failure paths', () => {
     }
   });
 
-  it('fails full analyze when FTS verification reports missing indexes after creation', async () => {
+  it('degrades gracefully (no throw, warns, ftsSkipped) when FTS verification reports missing indexes after creation (#2544/#2546)', async () => {
+    // A native tokenizer error on one pre-existing row (the #2544/#2546
+    // failure mode) must not abort an otherwise-successful full analyze —
+    // it degrades keyword search for this run instead, same contract as the
+    // FTS-extension-unavailable sibling test below.
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
       initLbug: vi.fn(async () => undefined),
       loadGraphToLbug: vi.fn(async () => undefined),
@@ -480,34 +484,42 @@ describe('runFullAnalysis FTS repair and verification failure paths', () => {
       deleteAllCommunitiesAndProcesses: vi.fn(async () => undefined),
       queryImporters: vi.fn(async () => []),
       queryImportersBatch: vi.fn(async () => []),
-      // FTS extension loads → analyze proceeds to create + verify indexes.
+      // FTS extension loads → analyze proceeds to build + verify indexes.
       loadFTSExtension: vi.fn(async () => true),
     }));
     vi.doMock('../../src/core/search/fts-indexes.js', () => ({
       initialiseSearchFTSStemmer: vi.fn(() => 'porter'),
-      createSearchFTSIndexes: vi.fn(async () => undefined),
-      verifySearchFTSIndexes: vi.fn(async () => ['Function.function_fts']),
+      buildSearchIndexesOrDegrade: vi.fn(async () => ({
+        ok: false,
+        error: 'missing indexes after build: Function.function_fts',
+      })),
     }));
     vi.doMock('../../src/core/ingestion/pipeline.js', () => ({
       runPipelineFromRepo: vi.fn(async (repoPath: string) => ({
         repoPath,
-        // Full-analyze path only needs `forEachNode` before the FTS verify guard.
+        // Full-analyze path only needs `forEachNode` before the FTS phase.
         graph: { forEachNode: () => undefined },
       })),
     }));
 
     const tmpRepo = await createTempDir('gitnexus-run-analyze-full-verify-fail-');
     try {
+      const logs: string[] = [];
       const { runFullAnalysis } = await import('../../src/core/run-analyze.js');
-      await expect(
-        runFullAnalysis(
-          tmpRepo.dbPath,
-          { force: true },
-          {
-            onProgress: () => {},
-          },
-        ),
-      ).rejects.toThrow(/FTS verification failed - missing indexes after analyze/i);
+      const result = await runFullAnalysis(
+        tmpRepo.dbPath,
+        { force: true },
+        { onProgress: () => {}, onLog: (msg: string) => logs.push(msg) },
+      );
+
+      expect(result.ftsSkipped).toBe(true);
+      expect(logs.join('\n')).toMatch(
+        /FTS index build failed.*missing indexes after build.*keyword search degraded this run/i,
+      );
+
+      const { storagePath } = getStoragePaths(tmpRepo.dbPath);
+      const meta = JSON.parse(await fs.readFile(`${storagePath}/meta.json`, 'utf-8'));
+      expect(meta.capabilities.fts.status).toBe('unavailable');
     } finally {
       await tmpRepo.cleanup();
     }


### PR DESCRIPTION
## Summary

Fixes #2544, #2546.

Both issues report `analyze` crashing mid-run with a LadybugDB error — a duplicated primary-key error on `CodeEmbedding` (#2544, and part of #2546) and "Runtime exception: Failed calling LOWER: Invalid UTF-8." (#2546) — and having to fall back to a full rebuild every time.

**#2544 / the embedding PK part of #2546** is already fixed on `main` by #2453 ("make batch inserts retry-safe", merged 2026-07-16) — both reporters are on `gitnexus@1.6.9`, which predates that merge. No code change needed here; it ships in the next release.

**#2546's second report** (the FTS "Invalid UTF-8" crash) is a real, separate gap this PR fixes:

- `createSearchFTSIndexes()` drops and rebuilds *every* FTS index from *all* stored rows on *every* `analyze` run (full or incremental) — a deliberate tradeoff already marked with a `ponytail:` comment. LadybugDB's native tokenizer runs `LOWER()` over every row's `content`/`name`/`description` columns each time, including rows nothing in the current run touched.
- `run-analyze.ts`'s main FTS phase had **no try/catch** around this call, so any native tokenizer error — on a single pre-existing row — propagated uncaught and aborted the whole `analyze` run, discarding an otherwise-successful graph/embeddings build. This is asymmetric with the sibling "FTS extension unavailable" branch three lines below, which already degrades gracefully.

I traced (and ruled out) the reporter's own "torn concurrent read" theory and a UTF-16 surrogate-pair-splitting-truncation theory — see the plan doc for the evidence trail. Neither can actually produce invalid UTF-8 through this codebase's write path (`sanitizeUTF8` already strips all surrogates before every CSV/COPY write). The exact original byte-corruption mechanism remains unresolved (native LadybugDB internals, out of this repo) — this PR bounds the blast radius regardless of cause, which is what both issues actually asked for.

## Changes

- Add `buildSearchIndexesOrDegrade()` (`gitnexus/src/core/search/fts-indexes.ts`): wraps `createSearchFTSIndexes` + `verifySearchFTSIndexes` in a try/catch, returning `{ ok, error? }` instead of throwing.
- `run-analyze.ts`: the main FTS phase now calls this helper. On failure it logs a warning and continues — graph/embeddings results are preserved, only keyword search degrades for that run. `--repair-fts`'s dedicated FTS-only path is untouched (still fails loudly, as intended — its sole job is FTS).
- Track actual FTS readiness (`ftsReady`) separately from extension availability (`ftsAvailable`) so `capabilities.fts.status` / `ftsSkipped` in `meta.json` stay honest when the build itself fails, not just when the extension can't load.
- Updated `run-analyze-fts-repair.test.ts`'s coverage of this path from asserting the old throw to asserting the new degrade contract; added unit tests for `buildSearchIndexesOrDegrade` in `fts-indexes.test.ts`.

## Test plan

- [x] `npx vitest run test/unit/fts-indexes.test.ts` — 11/11 pass (3 new)
- [x] `npx vitest run test/unit/run-analyze-fts-repair.test.ts` — 15/15 pass (1 rewritten for the new contract)
- [x] `npx vitest run test/unit/run-analyze.test.ts` — no new failures vs. a pre-fix baseline (1 pre-existing, unrelated env failure: missing built worker script in this worktree)
- [x] `detect_changes` (staged + compare vs. main) — only the 4 expected files / `runFullAnalysis` touched, one affected process, medium risk, no surprises
- [x] `impact` on `runFullAnalysis` and `buildSearchIndexesOrDegrade` — both LOW risk before editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)