### PR TITLE
fix(ci): unblock the review agent dispatch and publisher lanes

### DIFF
--- a/.github/workflows/gitnexus-review-agent.yml
+++ b/.github/workflows/gitnexus-review-agent.yml
@@ -232,7 +232,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22.16.0'
-          cache: false
 
       - name: Install and preflight Claude subprocess isolation
         id: isolation
@@ -1878,8 +1877,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       actions: read # Download the immutable review artifact from the analyze job.
-      pull-requests: read # Reject publication when the PR tuple moved.
-      issues: write # Upsert the bounded bot review comment.
+      pull-requests: write # Reject publication when the PR tuple moved; upsert the bounded bot review comment on the PR.
+      issues: write # Issue-comment scope for non-PR fallbacks.
     steps:
       - name: Download review artifact
         id: download

--- a/gitnexus/test/unit/review-agent-workflow.test.ts
+++ b/gitnexus/test/unit/review-agent-workflow.test.ts
@@ -1045,7 +1045,8 @@ describe('gitnexus review-agent workflow security contract', () => {
     expect(analyze).toContain('pull-requests: read');
     expect(analyze).not.toContain('issues: write');
     expect(publish).toContain('issues: write');
-    expect(publish).toContain('pull-requests: read');
+    expect(publish).toContain('pull-requests: write');
+    expect(publish).not.toContain('contents: write');
     expect(publish).not.toContain('actions/checkout@');
     expect(publish).not.toContain('ANTHROPIC_API_KEY');
     expect(publish).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');


### PR DESCRIPTION
The first `workflow_dispatch` validation run of the review agent ([run 29691584093](https://github.com/abhigyanpatwari/GitNexus/actions/runs/29691584093), reviewing PR #2494) surfaced two defects that block the activation checklist:

## 1. Analyze job dies at "Set up pinned Node.js"

`actions/setup-node` receives the YAML boolean `cache: false` as the string `'false'` and v6 hard-fails with `Caching for 'false' is not supported`. Every downstream step (isolation preflight, Claude runtime, indexing, review) skipped, so the run could only assemble a failure artifact.

**Fix:** drop the `cache` input — omitting it is the supported way to disable caching.

## 2. Publisher cannot post the comment

The publish job held `issues: write` + `pull-requests: read`, but GITHUB_TOKEN needs `pull-requests: write` to create issue comments on a pull request (the `issues` scope only covers non-PR issues). Even the safe-failure comment died with `Resource not accessible by integration`.

**Fix:** grant the publisher `pull-requests: write`. This stays within the security design — the publisher remains secretless, and the scope is required for its one write: the bounded same-SHA comment upsert.

## Post-merge

Both trigger lanes execute the default-branch copy of this workflow, so after merging the activation checklist continues:

1. Re-run `gh workflow run gitnexus-review-agent.yml -f pr=2494` (fork-PR item) plus one same-repo PR dispatch.
2. Once both are green: `gh variable set GITNEXUS_REVIEW_COMMENT_ENABLED --body true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Va5uu9Ar3e45QZ5xFsG4AZ