### PR TITLE
test(ci): disposable same-repo canary for review agent validation

### DIFF
--- a/gitnexus/src/core/group/group-path-utils.ts
+++ b/gitnexus/src/core/group/group-path-utils.ts
@@ -1,6 +1,7 @@
 /**
  * Shared service-path normalization for group tools (`service` monorepo filter)
  * and subgroup membership checks.
+ * (Review-agent activation canary: disposable same-repo validation PR; close unmerged.)
  *
  * Inputs may originate from tree-sitter, the OS file API, or user-supplied
  * MCP arguments, so both `\` and `/` separators are accepted. Internally we


### PR DESCRIPTION
Disposable same-repo PR for the review-agent activation checklist (comment-only change). Used to validate the `workflow_dispatch` lane against a same-repo head; **close without merging** once the validation run is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Va5uu9Ar3e45QZ5xFsG4AZ