### PR TITLE
feat(ci): review agent on Sonnet 5 with structured, linked reviews

### DIFF
--- a/.github/workflows/gitnexus-review-agent.yml
+++ b/.github/workflows/gitnexus-review-agent.yml
@@ -1175,11 +1175,20 @@ jobs:
             gate. Adapt the skill's checkout/index steps to this pre-aligned environment.
 
             Return one structured field named body containing the complete Markdown
-            review: prioritized findings with file:line evidence, change and blast-radius
-            summary, coverage and residual risk, and the skill's verdict wording. Do not
+            review, structured exactly as: first a short opening paragraph that leads
+            with the skill's verdict wording and a plain-language summary of what the
+            PR does; then "### Findings" ordered by severity (CRITICAL, HIGH, MEDIUM,
+            LOW), one bold-severity bullet per finding stating the one-sentence claim
+            followed by an indented evidence line; then "### Change summary and blast
+            radius"; then "### Coverage and residual risk". Every file, line, or symbol
+            reference anywhere in the body must be a clickable Markdown link — never
+            bare `path:line` text. Link head files as
+            https://github.com/${{ github.repository }}/blob/${{ steps.context.outputs.head_sha }}/PATH#L10-L20
+            (exact analyzed head SHA, real line range) and deleted or rename-old paths
+            as the same URL shape at ${{ steps.inputs.outputs.merge_base }}. Do not
             include an HTML publication marker and do not mention users or teams.
           claude_args: |
-            --model claude-sonnet-4-5-20250929
+            --model claude-sonnet-5
             --add-dir "${{ runner.temp }}/gitnexus-review-pr-target"
             --setting-sources user
             --disable-slash-commands


### PR DESCRIPTION
Two improvements to the review agent, prompted by the first published review on #2494 ([comment](https://github.com/abhigyanpatwari/GitNexus/pull/2494#issuecomment-5016444313)):

## 1. Model: `claude-sonnet-4-5-20250929` → `claude-sonnet-5`

Current-generation Sonnet. Verified locally against the exact pinned Claude Code runtime (2.1.214) with subscription OAuth auth and `--json-schema` structured output — all paths work.

## 2. Structured, navigable review output

The prompt previously asked only for "prioritized findings with file:line evidence", which produced a flat, hard-to-navigate comment. The body spec now requires:

- Verdict-first opening paragraph with a plain-language summary of the PR
- `### Findings` ordered by severity (CRITICAL → LOW), one bold-severity bullet each
- Fixed section order: findings → change summary and blast radius → coverage and residual risk
- **Every file/line/symbol reference as a GitHub permalink** pinned to the analyzed head SHA (merge-base SHA for deleted/rename-old paths) — clickable, and same-repo links render inline code previews. Bare `path:line` text is banned.

All 38 workflow security-contract tests pass unchanged (the contract doesn't pin the model).

Both trigger lanes execute the default-branch copy of the workflow, so this takes effect on merge; the next dispatch against #2494 will upsert the existing review comment in the new format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Va5uu9Ar3e45QZ5xFsG4AZ