### PR TITLE
fix(eval): pre-approve proposer tools under Claude Code 2.1.214 ENV_SCRUB hardening

### DIFF
--- a/eval/tests/test_proposer_sandbox.py
+++ b/eval/tests/test_proposer_sandbox.py
@@ -58,6 +58,11 @@ def test_environment_is_allowlisted_and_shell_children_are_credential_free(monke
     assert settings["sandbox"]["failIfUnavailable"] is True
     assert settings["sandbox"]["allowUnsandboxedCommands"] is False
     assert settings["sandbox"]["network"]["deniedDomains"] == ["*"]
+    # ENV_SCRUB forces "default" mode; the proposer's tools (Bash writes the
+    # overlay) run headless only because they are explicitly pre-approved.
+    # Requesting a non-default defaultMode would merely warn, so it must be gone.
+    assert settings["permissions"]["allow"] == ["Read", "Grep", "Glob", "Bash"]
+    assert "defaultMode" not in settings["permissions"]
 
 
 @pytest.mark.parametrize(
@@ -716,8 +721,10 @@ for line in sys.stdin:
                     "--strict-mcp-config",
                     "--mcp-config",
                     mcp_config,
-                    "--permission-mode",
-                    "dontAsk",
+                    # No --permission-mode: mirrors production (run_proposer).
+                    # ENV_SCRUB forces "default"; Bash runs only because
+                    # settings permissions.allow pre-approves it. This is the
+                    # authoritative empirical gate for that behavior.
                     "--model",
                     "claude-canary-20260718",
                     "--allowedTools",

--- a/eval/workflow_bench/evolve.py
+++ b/eval/workflow_bench/evolve.py
@@ -501,7 +501,10 @@ def run_proposer(
                         auth_token=args.auth_token,
                         base_url=args.base_url,
                     ),
-                    permission_mode="dontAsk",
+                    # No permission_mode: CLAUDE_CODE_SUBPROCESS_ENV_SCRUB
+                    # forces "default", so requesting dontAsk only warns. Tools
+                    # are pre-approved via settings permissions.allow
+                    # (proposer_sandbox.build_claude_settings).
                     command_prefix=sandbox.command_prefix,
                     require_pid_namespace=True,
                     bare=True,

--- a/eval/workflow_bench/proposer_sandbox.py
+++ b/eval/workflow_bench/proposer_sandbox.py
@@ -329,7 +329,14 @@ def build_claude_settings() -> str:
             },
         },
         "permissions": {
-            "defaultMode": "dontAsk",
+            # CLAUDE_CODE_SUBPROCESS_ENV_SCRUB forces permission mode to
+            # "default" (allowed_non_write_users hardening), so requesting a
+            # non-default mode only emits a warning and never takes effect.
+            # Under "default" a tool runs without a prompt only if it matches an
+            # allow rule, so pre-approve the proposer's exact tool surface. Bash
+            # is the only writable tool under --bare (it writes the candidate
+            # overlay) and stays sandbox-confined by the sandbox.* policy above.
+            "allow": ["Read", "Grep", "Glob", "Bash"],
             "disableBypassPermissionsMode": "disable",
         },
         "env": {


### PR DESCRIPTION
## What

Third and (as far as known) last activation blocker of the skill-evolution workflow. The first real `workflow_dispatch` run ([29729691731](https://github.com/abhigyanpatwari/GitNexus/actions/runs/29729691731)) got **past task binding** (thanks to the earlier `~/GitNexus` and monorepo-root-node_modules fixes), into the benchmark, then the **proposer session** exited 1:

```
⚠ Permission mode forced to default — CLAUDE_CODE_SUBPROCESS_ENV_SCRUB is set
  (allowed_non_write_users hardening). Declare allowedTools explicitly, or set
  CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0 to opt out.
```

## Why (root cause, binary-confirmed)

On the pinned Claude Code **2.1.214**, the permission resolver **unconditionally forces permission mode to `default`** whenever `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` is set — `--permission-mode dontAsk`, settings `permissions.defaultMode`, and `autoAllowBashIfSandboxed` are all ignored for the mode decision (the allowedTools term only gates the warning). The proposer runs headless `-p --bare`, where **Bash is its only writable tool** (it writes the candidate skill overlay); under forced `default` that Bash was no longer auto-approved, so the session blocked.

## How

We must **not** set `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0` — it scrubs the Anthropic auth token / parent env from the sandboxed proposer's Bash subprocesses. So instead of fighting the hardening, align with it:

- Add settings `permissions.allow: ["Read","Grep","Glob","Bash"]` in `proposer_sandbox.build_claude_settings` — under `default` mode a tool runs headless without a prompt only if it matches an allow rule.
- Drop `permission_mode="dontAsk"` from `evolve.run_proposer` so no forced-default warning fires.
- `ENV_SCRUB=1` and the full sandbox filesystem/network lockdown are **unchanged**.
- Update the real-binary containment canary (`test_proposer_sandbox.py::test_real_claude_bare_auth_inner_sandbox_and_mcp_permissions`) to the new invocation (no `--permission-mode`), so the CI job is the authoritative empirical gate, and add a fast unit assertion pinning the new `permissions.allow` / absent `defaultMode`.

## Testing

`uv run --locked pytest eval/tests/test_proposer_sandbox.py eval/tests/test_evolve.py` → **52 passed, 6 skipped**; ruff clean. The token-scrubbing contracts (env allowlist + a real Bash subprocess asserting the token env vars are empty) are unchanged and still pass.

## Known residual risk (CI-gated by design)

The proposer already passed `--allowedTools ["Read","Grep","Glob","Bash"]` (CLI) and still failed, so this fix rests on the empirical assumption that a settings `permissions.allow` rule pre-approves Bash under forced-`default` where the CLI allowlist did not — plus dropping the `dontAsk` request, which removes the warning / any hard-reject-on-mode path. That end-to-end behavior **cannot be verified without the API key** (which lives only in the CI canary job). The updated real-binary canary is the empirical gate: a wrong hypothesis fails loudly there, not silently in production.

## Post-Deploy Monitoring & Validation

After merge, re-dispatch the skill-evolution workflow (`workflow_dispatch` on `main`) and confirm the proposer session **exits 0 and writes a candidate overlay** (no "Permission mode forced to default" failure) — watch the "Run the propose → benchmark → gate loop" step. The mandatory Ubuntu CI job that runs the real-binary canary is the pre-merge signal. Bills real API usage on `GITNEXUS_BENCH_AUTH_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Va5uu9Ar3e45QZ5xFsG4AZ