### PR TITLE
fix(eval): surface stdout tail on proposer session failure

### DIFF
--- a/eval/tests/test_workflow_bench_sessions.py
+++ b/eval/tests/test_workflow_bench_sessions.py
@@ -192,9 +192,22 @@ def test_run_claude_keeps_raw_subtype_and_stderr_tail(monkeypatch, tmp_path):
         "returncode": 1,
         "process_state": "exited",
         "stderr_tail": "rate limit hit",
+        "stdout_tail": VALID_REPORT,
         "process_detail": None,
         "event_stream_error": None,
     }
+
+
+def test_run_claude_surfaces_stdout_tail_on_empty_stderr(monkeypatch, tmp_path):
+    # A session can exit non-zero with an EMPTY stderr (e.g. a pre-flight
+    # sandbox failure before any model turn ever runs) -- stdout_tail is then
+    # the only place the actual event stream is visible, so it must not be
+    # dropped just because stderr had nothing to say.
+    proc = fake_cli_result(VALID_REPORT, returncode=1, stderr="")
+    monkeypatch.setattr(runner_sessions, "run_managed", lambda *a, **k: proc)
+    rec = runner.run_claude("task", tmp_path, claude_bin="claude", timeout=5)
+    assert rec["error_detail"]["stderr_tail"] == ""
+    assert rec["error_detail"]["stdout_tail"] == VALID_REPORT
 
 
 def test_run_arm_labels_completed_but_unverified_runs_verify_failed(monkeypatch, tmp_path):

--- a/eval/workflow_bench/runner_sessions.py
+++ b/eval/workflow_bench/runner_sessions.py
@@ -434,6 +434,14 @@ def run_claude(
                 "returncode": proc.returncode,
                 "process_state": proc.state,
                 "stderr_tail": proc.stderr_tail[-2000:],
+                # A session can exit non-zero with an empty stderr (e.g. a
+                # pre-flight sandbox failure before any model turn): the tail
+                # of raw stdout is the only place the actual event stream
+                # (permission_denials, tool_use/tool_result, is_error) shows
+                # up, so surface it here rather than leaving the failure
+                # opaque. Callers already redact this record before it is
+                # written to disk or an uploaded artifact.
+                "stdout_tail": proc.stdout_tail[-2000:],
                 "process_detail": proc.detail,
                 "event_stream_error": event_stream_error,
             }


### PR DESCRIPTION
## What

Follow-up to #2576. After that fix landed and the workflow was re-dispatched ([run 29735080342](https://github.com/abhigyanpatwari/GitNexus/actions/runs/29735080342)), the proposer session got past the "forced to default" permission warning (confirming #2576 works) but still exited 1 — this time with `subtype: "success"` and an **empty** `stderr_tail`, giving no clue why.

Downloading the run's own uploaded evidence artifact showed:

```json
{
  "ok": false, "error_kind": "session-error",
  "error_detail": {"subtype": "success", "returncode": 1, "process_state": "exited",
                    "stderr_tail": "", "process_detail": null, "event_stream_error": null},
  "num_turns": 1, "cost_usd": 0.0, "duration_s": 0.1,
  "input_tokens": 0, "output_tokens": 0
}
```

`num_turns: 1` with zero cost/tokens and a 0.1s duration means the session terminated before any real model turn completed — consistent with an early, pre-flight-style failure (most likely in Claude Code's own nested sandbox setup for the Bash tool, gated by `sandbox.failIfUnavailable`), not a mid-conversation permission denial. But the persisted record gives no signal *why*, because only `stderr_tail` is captured — and this failure mode produces nothing on stderr.

## How

`run_managed` already captures a bounded stdout tail (`proc.stdout_tail`) for every session — it just never made it into `error_detail`. The actual JSON event stream (`permission_denials`, `tool_use`/`tool_result`, `is_error`) lives there. Add it alongside `stderr_tail`, bounded and truncated identically. It flows through `evolve.py`'s existing whole-record redaction before being written to disk or the uploaded artifact, so nothing new is exposed — it just closes the diagnostic gap.

## Why this instead of guessing at another fix

I could not reproduce the exact failure locally: this dev container has no working `bwrap` (unprivileged user namespaces are disabled entirely), so the harness's `--unshare-pid` sandbox wrapper — and Claude Code's own nested Bash sandbox — can't be exercised here at all. Four separate local probes against the pinned 2.1.214 binary (trivial command, full production sandbox settings, a heredoc-shaped command matching the real proposer's instructed pattern, and a genuinely denied `Write` tool call) all confirmed the #2576 permission-mode fix works correctly and none reproduced this second failure — strongly suggesting the root cause is in the sandbox/process layer, not permission mode. Rather than land a third speculative fix for an unconfirmed cause, this PR makes the *next* occurrence diagnosable from the artifact alone.

## Testing

`uv run --locked pytest eval/tests/test_workflow_bench_sessions.py eval/tests/test_evolve.py` → 99 passed, 2 skipped (real-binary canary). Ruff clean. New test `test_run_claude_surfaces_stdout_tail_on_empty_stderr` pins the exact empty-stderr case this failure produced.

## Post-Deploy Monitoring & Validation

After merge, re-dispatch the skill-evolution workflow once more. If the proposer fails again, download the run's evidence artifact and read `gen-0/proposer-session.json` — `error_detail.stdout_tail` should now show the actual event stream (in particular, whether a `tool_result` with `is_error: true` appears before the terminal `result` event, which would confirm the sandbox pre-flight hypothesis and point directly at the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Va5uu9Ar3e45QZ5xFsG4AZ