### PR TITLE
fix(eval): drop tags from the benchmark's per-arm clone

### DIFF
--- a/eval/tests/test_workflow_bench_sessions.py
+++ b/eval/tests/test_workflow_bench_sessions.py
@@ -1025,3 +1025,55 @@ def test_review_phase_rejects_workspace_or_skill_mutation(
     assert rec["resolved"] is False
     assert rec["error_kind"] == "review-evidence-invalid"
     assert expected_detail in rec["error_detail"]
+
+
+def _git(repo, *args, check=True):
+    return subprocess.run(["git", "-C", str(repo), *args], check=check, capture_output=True, text=True)
+
+
+def _git_commit(repo, message):
+    _git(
+        repo,
+        "-c",
+        "user.name=test",
+        "-c",
+        "user.email=test@invalid",
+        "commit",
+        "--quiet",
+        "--allow-empty",
+        "-m",
+        message,
+    )
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def test_make_worktree_clone_has_no_tags_but_keeps_all_branches(tmp_path):
+    # oracle_assets.MAX_CLONE_REFS refuses to sanitize a clone with more than
+    # 1024 refs; this repo's own history has 1000+ release-candidate tags, so
+    # a plain `git clone` of it (inheriting every tag) trips that cap on every
+    # benchmark session. make_worktree must not carry tags into its throwaway
+    # clone, but callers pass a bare SHA or "HEAD" as `ref` (never a branch
+    # name -- see evolve.py:476, runner.py:1037, sanitized_graph.py:345), so
+    # branch-fetching itself must stay untouched: a commit reachable only from
+    # a non-default branch must still resolve via the existing
+    # checkout(ref) -> checkout(origin/{ref}) fallback.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--quiet")
+    _git(repo, "checkout", "--quiet", "-b", "main")
+    _git_commit(repo, "base")
+    _git(repo, "tag", "v1.0.0-rc.1")
+
+    _git(repo, "checkout", "--quiet", "-b", "other")
+    other_sha = _git_commit(repo, "only on other")
+    _git(repo, "checkout", "--quiet", "main")
+
+    clones = tmp_path / "clones"
+    clones.mkdir()
+    target = runner.make_worktree(repo, other_sha, clones)
+
+    tags = _git(target, "tag").stdout.split()
+    assert tags == [], f"clone must carry no tags, found: {tags}"
+
+    current = _git(target, "rev-parse", "HEAD").stdout.strip()
+    assert current == other_sha

--- a/eval/workflow_bench/runner_artifacts.py
+++ b/eval/workflow_bench/runner_artifacts.py
@@ -240,6 +240,7 @@ def make_worktree(repo: Path, ref: str, parent: Path) -> Path:
                 "clone",
                 "--no-local",
                 "--no-hardlinks",
+                "--no-tags",
                 "--quiet",
                 str(repo),
                 str(target),


### PR DESCRIPTION
## What

Fourth (and, per the evidence so far, final) layer of the skill-evolution activation chain — after node_modules install (#2575), the Task/Agent permission-mode fix (#2576), and stdout diagnostics (#2577). After #2576/the corrected `GITNEXUS_BENCH_AUTH_TOKEN` secret landed, the proposer session succeeded end-to-end for the first time ([run 29738099937](https://github.com/abhigyanpatwari/GitNexus/actions/runs/29738099937): real Opus turn, $0.81 cost, valid overlay written) — but every benchmark-arm session then failed identically:

```
error_kind: "infra-error"
error_detail: "RuntimeError: sanitized graph snapshot preparation failed: clone has more than 1024 references; refusing incomplete sanitization"
```

## Why

`make_worktree()` (`eval/workflow_bench/runner_artifacts.py`) creates each benchmark arm's throwaway clone via a plain `git clone`, which inherits every tag and branch from the source repo. This repository's history has grown to **1144 tags** (a `v1.6.9-rc.N` release-candidate series) out of 1650 total refs — verified directly (`git for-each-ref | wc -l`) — exceeding `oracle_assets.MAX_CLONE_REFS = 1024`, a fail-closed safety guard in `sanitize_clone_for_hidden_oracles()` that refuses to proceed unless it can enumerate and delete *every* ref before handing a sanitized snapshot to a benchmark session (so an agent can never discover oracle test answers via a ref the sanitization missed).

## How

`ref` at every call site (`evolve.py:476`, `runner.py:1037`, `sanitized_graph.py:345`) is always a bare SHA or the literal `"HEAD"` — never a branch name — so `--single-branch --branch <ref>` isn't viable (`git clone --branch` requires a name). Tags are never used by the existing `checkout(ref)` → `checkout(origin/{ref})` fallback or by sanitization's own delete-everything behavior, so dropping them via `--no-tags` removes the 1144-ref majority without touching branch-fetch behavior, without weakening `MAX_CLONE_REFS` itself, and without touching any real repository tags or branches.

## Testing

- New regression test `test_make_worktree_clone_has_no_tags_but_keeps_all_branches`: builds a small repo with a tag and a second branch holding a commit unreachable from the default branch, clones it via the fixed `make_worktree()`, and asserts the clone has zero tags while the non-default-branch commit still resolves via the existing fallback. **Mutation-verified** two ways: fails pre-fix (tag present), and separately fails if `--single-branch` were added (proving branch-fetch isn't accidentally restricted).
- **Verified against the real repository**, not just the fixture: cloning `/workspace` itself (1650 refs, 1144 tags) via the fixed `make_worktree()` now produces a clone with 237 total refs and 0 tags.
- `cd eval && uv run --locked pytest tests/test_workflow_bench_sessions.py tests/test_sanitized_graph.py -q` → 72 passed, 1 skipped (unrelated real-binary canary). Ruff clean.

## Post-Deploy Monitoring & Validation

After merge, re-dispatch the skill-evolution workflow (`workflow_dispatch` on `main`) and confirm a benchmark-arm session actually runs (no `SandboxError`/`RuntimeError` at task binding or clone-sanitization) and a `promotion.json` decision is reached based on real, non-excluded runs. This is the first change in this chain with the chance to observe a complete propose → benchmark → gate cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Va5uu9Ar3e45QZ5xFsG4AZ