### PR TITLE
fix(eval): mount hooks/claude into the benchmark sandbox

### DIFF
--- a/eval/tests/test_workflow_bench_sessions.py
+++ b/eval/tests/test_workflow_bench_sessions.py
@@ -290,10 +290,12 @@ def test_mcp_config_uses_only_the_minimal_pinned_harness_runtime(monkeypatch, tm
         runtime / "dist" / "cli",
         runtime / "node_modules",
         runtime / "vendor",
+        runtime / "hooks" / "claude",
         shared / "dist",
     ):
         directory.mkdir(parents=True)
     (runtime / "dist" / "cli" / "index.js").write_text("")
+    (runtime / "hooks" / "claude" / "resolve-analyze-cmd.cjs").write_text("")
     (runtime / "package.json").write_text(json.dumps({"version": runner.PINNED_GITNEXUS_VERSION}))
     (runtime / "node_modules" / "gitnexus-shared").symlink_to(shared, target_is_directory=True)
     (shared / "package.json").write_text(json.dumps({"name": "gitnexus-shared"}))
@@ -316,6 +318,7 @@ def test_mcp_config_uses_only_the_minimal_pinned_harness_runtime(monkeypatch, tm
         (runtime / "vendor", f"{runner.SANDBOX_GITNEXUS}/vendor"),
         (shared / "dist", f"{runner.SANDBOX_GITNEXUS_SHARED}/dist"),
         (shared / "package.json", f"{runner.SANDBOX_GITNEXUS_SHARED}/package.json"),
+        (runtime / "hooks" / "claude", f"{runner.SANDBOX_GITNEXUS}/hooks/claude"),
     ]
     package = json.loads((runtime / "package.json").read_text())
     assert package["version"] == runner.PINNED_GITNEXUS_VERSION
@@ -329,6 +332,12 @@ def test_mcp_config_uses_only_the_minimal_pinned_harness_runtime(monkeypatch, tm
         assert f"{runner.SANDBOX_GITNEXUS}/{forbidden}" not in mounted_targets
         assert shared / forbidden not in mounted_sources
         assert f"{runner.SANDBOX_GITNEXUS_SHARED}/{forbidden}" not in mounted_targets
+
+    # Only hooks/claude is exposed, not the whole hooks/ directory (which also
+    # has an unrelated hooks/antigravity/ tree) and not the runtime root itself.
+    assert runtime / "hooks" not in mounted_sources
+    assert runtime / "hooks" / "antigravity" not in mounted_sources
+    assert f"{runner.SANDBOX_GITNEXUS}/hooks" not in mounted_targets
 
 
 @pytest.mark.skipif(
@@ -347,6 +356,7 @@ def test_real_bubblewrap_runtime_mount_imports_cli_without_exposing_checkout(tmp
         f"{runner.SANDBOX_GITNEXUS}/vendor",
         f"{runner.SANDBOX_GITNEXUS_SHARED}/dist/index.js",
         f"{runner.SANDBOX_GITNEXUS_SHARED}/package.json",
+        f"{runner.SANDBOX_GITNEXUS}/hooks/claude/resolve-analyze-cmd.cjs",
     ]
     forbidden = [
         f"{runner.SANDBOX_GITNEXUS}/{relative}"
@@ -376,9 +386,19 @@ def test_real_bubblewrap_runtime_mount_imports_cli_without_exposing_checkout(tmp
             ["/usr/local/bin/node", runner.SANDBOX_GITNEXUS_ENTRYPOINT, "--version"],
             timeout=10,
         )
+        # --version never reaches the `analyze` command, which is loaded via a
+        # lazy dynamic import and is the only path that pulls in
+        # resolve-invocation.ts's module-load-time require of hooks/claude/
+        # resolve-analyze-cmd.cjs. Require the compiled analyze module
+        # directly so this canary actually exercises that chain.
+        analyze_imported = sandbox.run(
+            ["/usr/local/bin/node", "-e", f"require('{runner.SANDBOX_GITNEXUS}/dist/cli/analyze.js')"],
+            timeout=10,
+        )
 
     assert visibility.ok, visibility.stderr_tail
     assert imported.ok, imported.stderr_tail
+    assert analyze_imported.ok, analyze_imported.stderr_tail
     assert imported.stdout_tail.strip() == runner.PINNED_GITNEXUS_VERSION
 
 

--- a/eval/workflow_bench/runtime_mounts.py
+++ b/eval/workflow_bench/runtime_mounts.py
@@ -217,6 +217,12 @@ def trusted_gitnexus_runtime_mounts() -> tuple[ReadOnlyMount, ...]:
             f"{SANDBOX_GITNEXUS_SHARED}/package.json",
             directory=False,
         ),
+        _validated_runtime_component(
+            runtime,
+            "hooks/claude",
+            f"{SANDBOX_GITNEXUS}/hooks/claude",
+            directory=True,
+        ),
     )
 
     entrypoint = mounts[0].source / "cli" / "index.js"


### PR DESCRIPTION
## Summary

Sixth blocker in the skill-evolution activation chain (after #2575, #2576, #2577, #2579 — all merged). Every benchmark-arm session in CI run 29742191562 failed identically:

```
Error: Cannot find module '../../hooks/claude/resolve-analyze-cmd.cjs'
Require stack:
- /opt/gitnexus/dist/cli/resolve-invocation.js
code: 'MODULE_NOT_FOUND'
```

`gitnexus/src/cli/resolve-invocation.ts` requires `hooks/claude/resolve-analyze-cmd.cjs` at module load time. That module is statically imported by `analyze.ts`, which `index.ts` only reaches via a lazy dynamic `import('./analyze.js')` — so only the `analyze` command triggers it, never `--version` or any other command. `eval/workflow_bench/runtime_mounts.py`'s `trusted_gitnexus_runtime_mounts()` curates an explicit allowlist of mounts for the pinned GitNexus package and never included `hooks/`.

- Appends a `hooks/claude` mount to the **end** of the tuple `trusted_gitnexus_runtime_mounts()` returns — the function's own post-construction validation reads `mounts[0]`, `[1]`, `[2]`, `[5]` by hardcoded index, so inserting anywhere earlier would silently corrupt those checks.
- Mounts `hooks/claude` only, not the whole `hooks/` directory (which also has an unrelated `hooks/antigravity/` tree) — matches the function's own "expose only what's needed" doc comment.
- Extends the existing mount-list unit test with the new entry plus explicit negative assertions (`hooks/` parent and `hooks/antigravity` are not mounted).
- Extends the gated real-Bubblewrap canary to `require()` `analyze.js` directly, since it previously only ran `--version` — which structurally can never reach this code path, so the canary could not have caught this bug or a regression of it.

## Test plan

- [x] `cd eval && uv run --locked pytest tests/ -q` — 303 passed, 10 skipped
- [x] Extended unit test proven to fail pre-fix (mount-count mismatch) and pass post-fix
- [x] Local non-bwrap repro: built `gitnexus/dist`, constructed an isolated scratch runtime (real file copies, not symlinks, to avoid Node's module resolution seeing through to the real repo), reproduced the exact `MODULE_NOT_FOUND` without the `hooks/claude` mount and confirmed a clean `require()` with it
- [x] Independent review (fresh agent, re-verified all claims against source + re-ran the repro + pulled the actual CI artifact) — READY, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Va5uu9Ar3e45QZ5xFsG4AZ