### PR TITLE
fix(eval): size the buffered-fallback budget for the real graph index

### DIFF
--- a/eval/tests/test_task_assets.py
+++ b/eval/tests/test_task_assets.py
@@ -113,6 +113,27 @@ def test_small_assets_use_a_bounded_buffered_fallback(monkeypatch, tmp_path: Pat
     assert (clone / "second").read_bytes() == b"def"
 
 
+def test_default_buffered_fallback_budget_covers_a_realistic_large_asset(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    # 20 MiB exceeds the old 16 MiB default but must fit comfortably under
+    # the current default, proving the real (non-monkeypatched) budget
+    # constant is sized for a realistic large sandbox_copy asset such as the
+    # harness's own pre-built graph index, not just tiny fixtures.
+    payload = os.urandom(20 * 1024 * 1024)
+    repo, task = _repo_and_task(tmp_path, {"large": payload})
+    clone = tmp_path / "clone"
+    clone.mkdir()
+    monkeypatch.setattr(task_assets, "_try_reflink", lambda *_args: False)
+
+    with TaskAssetCache(tmp_path / "cache") as cache:
+        snapshot = cache.prepare(task, repo=repo, resolved_sha=SHA)
+        snapshot.materialize(clone)
+
+    assert (clone / "large").read_bytes() == payload
+
+
 def test_large_asset_without_reflink_fails_before_publish_and_cleans_staging(
     monkeypatch,
     tmp_path: Path,

--- a/eval/workflow_bench/task_assets.py
+++ b/eval/workflow_bench/task_assets.py
@@ -39,9 +39,14 @@ MAX_TASK_ASSET_ENTRIES = 100_000
 MAX_TASK_ASSET_PATH_BYTES = 4_096
 MAX_TASK_ASSET_BYTES = 2 * 1024 * 1024 * 1024
 
-# A filesystem without reflink support may still run tiny fixtures.  Large
-# assets fail closed instead of silently returning to one full copy per arm.
-MAX_BUFFERED_FALLBACK_BYTES = 16 * 1024 * 1024
+# The largest known real sandbox_copy asset in this harness is the shipped
+# index above (~428 MiB estimated, ~290 MiB measured); budget comfortably
+# above that so it can still materialize via buffered copy on a filesystem
+# that cannot reflink (ext4 CI runners, 9p-backed dev mounts), while staying
+# well below MAX_TASK_ASSET_BYTES so a genuinely oversized or malformed
+# declaration still fails closed instead of silently paying for a slow full
+# copy.
+MAX_BUFFERED_FALLBACK_BYTES = 512 * 1024 * 1024
 COPY_CHUNK_BYTES = 1024 * 1024
 
 # linux/fs.h: #define FICLONE _IOW(0x94, 9, int)


### PR DESCRIPTION
## Summary

Seventh blocker in the skill-evolution activation chain (after #2575, #2576, #2577, #2579, #2580 — all merged). After #2580 fixed the hooks-mount blocker, the proposer session now succeeds completely (real 13-turn Opus session, genuine proposal produced), but every benchmark-arm session failed identically in CI run 29750271566:

```
"error_kind": "infra-error",
"error_detail": "SandboxError: task asset filesystem cannot reflink the snapshot and the buffered fallback limit would be exceeded"
```

`eval/workflow_bench/sanitized_graph.py` captures a pre-built GitNexus graph index (`.gitnexus/lbug`, measured 290 MiB in this checkout, historically estimated up to ~428 MiB) as a `TaskAssetCache` snapshot, then reflinks it into every benchmark-arm clone. When the underlying filesystem can't do copy-on-write reflink (`FICLONE`), materialization falls back to a buffered copy bounded by `MAX_BUFFERED_FALLBACK_BYTES` — previously 16 MiB, sized only for tiny fixtures.

`FICLONE` reflink is btrfs/XFS-only — never ext4 (GitHub-hosted runners' work disk) or 9p (this dev container's own `/workspace` mount, confirmed via `mount`). So in both real environments this harness runs in, reflink always fails and the real ~290 MiB index must go through the buffered path, instantly blowing the old 16 MiB cap.

- Raises `MAX_BUFFERED_FALLBACK_BYTES` to 512 MiB — clears the real (290 MiB) and historically-estimated (428 MiB) index size with headroom, while staying a full 4x below the existing 2 GiB `MAX_TASK_ASSET_BYTES` total-capture ceiling, so a genuinely oversized or malformed future declaration still fails closed.
- Adds a test that exercises the real (non-monkeypatched) default constant against a 20 MiB payload with `_try_reflink` forced unavailable — proven to fail under the old default and pass under the new one.

## Test plan

- [x] `cd eval && uv run --locked pytest tests/ -q` — 304 passed, 10 skipped
- [x] New test proven to fail pre-fix with the exact production error string, pass post-fix
- [x] Empirically confirmed this container's `/workspace` (9p) genuinely cannot `FICLONE` (raw ioctl → `EXDEV`)
- [x] Ran the real, fully unmocked production code path end-to-end against the actual 290 MiB `.gitnexus/lbug` — captured and materialized successfully under the new budget
- [x] Independent review (fresh agent, re-verified all claims against source, independently re-derived the discrimination proof) — READY, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Va5uu9Ar3e45QZ5xFsG4AZ