### PR TITLE
perf(lbug): size the buffer pool to the repo (adaptive, COPY-safe)

### DIFF
--- a/gitnexus/src/core/lbug/lbug-config.ts
+++ b/gitnexus/src/core/lbug/lbug-config.ts
@@ -321,6 +321,16 @@ const resolveCheckpointThreshold = (): number => {
 const DEFAULT_BUFFER_POOL_CAP = 2 * 1024 * 1024 * 1024;
 const BUFFER_POOL_FLOOR = 64 * 1024 * 1024;
 
+// COPY-safety floor for the adaptive hint (below). LadybugDB's bulk COPY needs
+// working buffer-pool memory that scales with the repo: a 64 MiB pool fails
+// ("buffer pool is full and no memory could be freed") on any non-trivial repo,
+// and even the ~1800-file GitNexus checkout needs ≥256 MiB. So the adaptive
+// size never drops a repo below this — a distinct, higher floor than
+// BUFFER_POOL_FLOOR, which only guards defaultBufferPoolSize on tiny-RAM
+// machines. It is still clamped up to defaultBufferPoolSize, so a machine whose
+// default is below this floor keeps its default rather than over-committing.
+const ADAPTIVE_POOL_FLOOR = 256 * 1024 * 1024;
+
 const parseBufferPoolSize = (raw: string | undefined): number | undefined => {
   if (raw === undefined) return undefined;
   const normalized = raw.trim();
@@ -333,41 +343,49 @@ const parseBufferPoolSize = (raw: string | undefined): number | undefined => {
 const defaultBufferPoolSize = (): number =>
   Math.min(DEFAULT_BUFFER_POOL_CAP, Math.max(BUFFER_POOL_FLOOR, Math.floor(os.totalmem() * 0.8)));
 
-/** Clamp a requested pool size to [floor, default] — never above the 2 GiB / 80%-RAM default. */
+/**
+ * Clamp an adaptive pool request to [ADAPTIVE_POOL_FLOOR, default]. The lower
+ * bound keeps LadybugDB's COPY viable; the upper bound (defaultBufferPoolSize)
+ * means the hint can only shrink the pool from today's default and can never
+ * exceed the 2 GiB / 80%-RAM cap — and on a machine whose default is below the
+ * COPY floor, the default wins, so the pool is never over-committed.
+ */
 const clampBufferPool = (bytes: number): number =>
-  Math.min(defaultBufferPoolSize(), Math.max(BUFFER_POOL_FLOOR, Math.floor(bytes)));
+  Math.min(defaultBufferPoolSize(), Math.max(ADAPTIVE_POOL_FLOOR, Math.floor(bytes)));
 
 /**
  * Buffer-pool bytes to provision per graph element (node + relationship).
  *
- * LadybugDB eagerly commits the buffer pool at DB open, so an oversized pool
- * costs a fixed penalty on every analyze regardless of repo size (measured:
- * ~2.8 s extra for a pool ≥128 MiB vs the 64 MiB floor, on a 3-file repo).
- * The pool is only a page cache over the on-disk index, and the index scales
- * with node/edge count — so a per-element budget lets a small repo run with a
- * small, fast-to-commit pool while a large repo still reaches the 2 GiB cap.
- * Kept deliberately generous (holds the working set without thrash): tuned by
- * timing a full `analyze --force` of a large repo at this factor vs a forced
- * 2 GiB pool and confirming no wall-time regression (the pool is a native
- * eager allocation, so it is measured with a real analyze, not a build-free
- * bench — see the emit-path `COPY` timing note in bench/emit-persistence).
+ * The fixed 2 GiB default is far larger than most repos' working set, and
+ * LadybugDB eagerly commits the pool at DB open — measured: a full
+ * `analyze --force` of the GitNexus checkout takes ~51 s with the 2 GiB pool
+ * vs ~35 s with the ~414 MiB this factor yields (31% faster; the oversized
+ * pool's commit dominates). The pool is a page cache over the on-disk index,
+ * which scales with node/edge count, so a per-element budget sizes it to the
+ * repo. Kept generous so the whole index stays resident (no COPY thrash) and
+ * always clamped to at least ADAPTIVE_POOL_FLOOR; tuned by timing a real
+ * large-repo `analyze --force` at this factor vs a forced 2 GiB pool (the pool
+ * is a native eager allocation, measured with a real analyze, not a build-free
+ * bench — see the emit-path COPY timing note in bench/emit-persistence).
  */
 const POOL_BYTES_PER_ELEMENT = 4 * 1024;
 
 /**
  * Size the buffer pool to an estimated graph size (node + relationship count),
- * clamped to [BUFFER_POOL_FLOOR, defaultBufferPoolSize()]. The estimate can
- * only *shrink* the pool from the default — it never exceeds the 2 GiB / 80%-RAM
- * cap — so a large repo is never under the default it gets today.
+ * clamped to [ADAPTIVE_POOL_FLOOR, defaultBufferPoolSize()]. The estimate can
+ * only *shrink* the pool from the default — never above the 2 GiB / 80%-RAM cap,
+ * never below the COPY-safety floor — so no repo is under-sized or gets more
+ * than the default it would have today.
  */
 export const estimateBufferPool = (graphElementCount: number): number =>
   clampBufferPool(graphElementCount * POOL_BYTES_PER_ELEMENT);
 
 /**
  * Optional per-run buffer-pool size hint (bytes). The analyze orchestrator sets
- * it once the graph size is known (after the pipeline, before the DB open) so a
- * small repo opens with a small pool, and clears it at run end. Non-analyze
- * opens (MCP serve, `native-check` `:memory:`) never set it and keep the default.
+ * it once the graph size is known (after the pipeline, before the DB open) so
+ * the pool is sized to the repo instead of the fixed 2 GiB default, and clears
+ * it at run end. Non-analyze opens (MCP serve, `native-check` `:memory:`) never
+ * set it and keep the default.
  */
 let bufferPoolSizeHint: number | undefined;
 

--- a/gitnexus/src/core/lbug/lbug-config.ts
+++ b/gitnexus/src/core/lbug/lbug-config.ts
@@ -346,8 +346,11 @@ const clampBufferPool = (bytes: number): number =>
  * The pool is only a page cache over the on-disk index, and the index scales
  * with node/edge count — so a per-element budget lets a small repo run with a
  * small, fast-to-commit pool while a large repo still reaches the 2 GiB cap.
- * Kept deliberately generous (holds the working set without thrash); tuned by
- * `bench/buffer-pool/measure.mjs` against a large-repo analyze.
+ * Kept deliberately generous (holds the working set without thrash): tuned by
+ * timing a full `analyze --force` of a large repo at this factor vs a forced
+ * 2 GiB pool and confirming no wall-time regression (the pool is a native
+ * eager allocation, so it is measured with a real analyze, not a build-free
+ * bench — see the emit-path `COPY` timing note in bench/emit-persistence).
  */
 const POOL_BYTES_PER_ELEMENT = 4 * 1024;
 

--- a/gitnexus/src/core/lbug/lbug-config.ts
+++ b/gitnexus/src/core/lbug/lbug-config.ts
@@ -333,16 +333,62 @@ const parseBufferPoolSize = (raw: string | undefined): number | undefined => {
 const defaultBufferPoolSize = (): number =>
   Math.min(DEFAULT_BUFFER_POOL_CAP, Math.max(BUFFER_POOL_FLOOR, Math.floor(os.totalmem() * 0.8)));
 
+/** Clamp a requested pool size to [floor, default] — never above the 2 GiB / 80%-RAM default. */
+const clampBufferPool = (bytes: number): number =>
+  Math.min(defaultBufferPoolSize(), Math.max(BUFFER_POOL_FLOOR, Math.floor(bytes)));
+
+/**
+ * Buffer-pool bytes to provision per graph element (node + relationship).
+ *
+ * LadybugDB eagerly commits the buffer pool at DB open, so an oversized pool
+ * costs a fixed penalty on every analyze regardless of repo size (measured:
+ * ~2.8 s extra for a pool ≥128 MiB vs the 64 MiB floor, on a 3-file repo).
+ * The pool is only a page cache over the on-disk index, and the index scales
+ * with node/edge count — so a per-element budget lets a small repo run with a
+ * small, fast-to-commit pool while a large repo still reaches the 2 GiB cap.
+ * Kept deliberately generous (holds the working set without thrash); tuned by
+ * `bench/buffer-pool/measure.mjs` against a large-repo analyze.
+ */
+const POOL_BYTES_PER_ELEMENT = 4 * 1024;
+
+/**
+ * Size the buffer pool to an estimated graph size (node + relationship count),
+ * clamped to [BUFFER_POOL_FLOOR, defaultBufferPoolSize()]. The estimate can
+ * only *shrink* the pool from the default — it never exceeds the 2 GiB / 80%-RAM
+ * cap — so a large repo is never under the default it gets today.
+ */
+export const estimateBufferPool = (graphElementCount: number): number =>
+  clampBufferPool(graphElementCount * POOL_BYTES_PER_ELEMENT);
+
+/**
+ * Optional per-run buffer-pool size hint (bytes). The analyze orchestrator sets
+ * it once the graph size is known (after the pipeline, before the DB open) so a
+ * small repo opens with a small pool, and clears it at run end. Non-analyze
+ * opens (MCP serve, `native-check` `:memory:`) never set it and keep the default.
+ */
+let bufferPoolSizeHint: number | undefined;
+
+/** Set (bytes) or clear (`undefined`) the per-run buffer-pool size hint. */
+export const setBufferPoolSizeHint = (bytes: number | undefined): void => {
+  bufferPoolSizeHint = bytes;
+};
+
 /**
  * Resolve the `bufferManagerSize` passed to every `new lbug.Database(...)`.
- * `GITNEXUS_LBUG_BUFFER_POOL_SIZE` (bytes) overrides the default; `0` is a
+ * `GITNEXUS_LBUG_BUFFER_POOL_SIZE` (bytes) overrides everything; `0` is a
  * deliberate escape hatch that restores LadybugDB's native unbounded
- * 80%-of-RAM default. Resolved at call time (not module load) so tests can
- * stub the env var and `os.totalmem`.
+ * 80%-of-RAM default. With no env override, a per-run `setBufferPoolSizeHint`
+ * (clamped to [floor, default]) sizes the pool to the repo; otherwise the
+ * default. Resolved at call time (not module load) so tests can stub the env
+ * var, the hint, and `os.totalmem`.
  */
 const resolveBufferManagerSize = (): number => {
   const raw = process.env.GITNEXUS_LBUG_BUFFER_POOL_SIZE;
-  if (raw === undefined) return defaultBufferPoolSize();
+  if (raw === undefined) {
+    return bufferPoolSizeHint !== undefined
+      ? clampBufferPool(bufferPoolSizeHint)
+      : defaultBufferPoolSize();
+  }
   const parsed = parseBufferPoolSize(raw);
   if (parsed !== undefined) return parsed;
   // Non-empty but unparseable input: warn the operator and fall back —

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -1381,10 +1381,11 @@ export async function runFullAnalysis(
   }
 
   // Size the buffer pool to the graph just built by the pipeline (a page cache
-  // over the on-disk index, which scales with node/edge count). A small repo
-  // opens with the fast 64 MiB floor instead of eagerly committing the full
-  // 2 GiB default; a large repo still reaches the cap. env override / no-hint
-  // paths are unchanged. See resolveBufferManagerSize / estimateBufferPool.
+  // over the on-disk index, which scales with node/edge count) instead of the
+  // fixed 2 GiB default, whose eager commit dominates large-repo analyze. The
+  // size is clamped to [COPY-safety floor, default], so it only ever shrinks
+  // the pool; env override / no-hint paths are unchanged. See
+  // resolveBufferManagerSize / estimateBufferPool.
   setBufferPoolSizeHint(
     estimateBufferPool(pipelineResult.graph.nodeCount + pipelineResult.graph.relationshipCount),
   );

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -34,6 +34,7 @@ import {
   LbugWipeError,
   DELETE_FILES_CHUNK_SIZE,
 } from './lbug/lbug-adapter.js';
+import { estimateBufferPool, setBufferPoolSizeHint } from './lbug/lbug-config.js';
 import { escapeCypherString } from './lbug/cypher-escape.js';
 import {
   buildSearchIndexesOrDegrade,
@@ -644,6 +645,11 @@ export async function runFullAnalysis(
   // (parse-cache, parsedfile-store) and the kuzu-migration cleanup live there
   // and are shared across branches (#2106 KTD7).
   const { storagePath } = getStoragePaths(repoPath);
+
+  // Start each analyze with a clean buffer-pool hint: any pre-pipeline DB open
+  // (e.g. the embeddings-cache open) falls back to the default until the hint is
+  // set from the built graph below, so a prior run's size can't leak in.
+  setBufferPoolSizeHint(undefined);
 
   // Clean up stale KuzuDB files from before the LadybugDB migration.
   const kuzuResult = await cleanupOldKuzuFiles(storagePath);
@@ -1373,6 +1379,15 @@ export async function runFullAnalysis(
     // a still-populated DB this run believes it wiped.
     await wipeLbugDbFiles(lbugPath);
   }
+
+  // Size the buffer pool to the graph just built by the pipeline (a page cache
+  // over the on-disk index, which scales with node/edge count). A small repo
+  // opens with the fast 64 MiB floor instead of eagerly committing the full
+  // 2 GiB default; a large repo still reaches the cap. env override / no-hint
+  // paths are unchanged. See resolveBufferManagerSize / estimateBufferPool.
+  setBufferPoolSizeHint(
+    estimateBufferPool(pipelineResult.graph.nodeCount + pipelineResult.graph.relationshipCount),
+  );
 
   await initLbug(lbugPath);
 

--- a/gitnexus/test/unit/lbug-config-wal.test.ts
+++ b/gitnexus/test/unit/lbug-config-wal.test.ts
@@ -263,7 +263,8 @@ describe('adaptive buffer pool hint', () => {
 
   describe('estimateBufferPool', () => {
     it.each([
-      ['tiny graph clamps up to the 64 MiB floor', 41, 64 * MiB],
+      ['tiny graph clamps up to the 256 MiB COPY-safety floor', 41, 256 * MiB],
+      ['a graph under the floor still clamps up to 256 MiB', 40_000, 256 * MiB],
       ['mid graph scales linearly (100k elements * 4 KiB = 400 MiB)', 100_000, 100_000 * 4 * 1024],
       ['huge graph caps at the 2 GiB / 80%-RAM default', 10_000_000, 2 * GiB],
     ])('%s', (_label, elements, expected) => {
@@ -277,8 +278,8 @@ describe('adaptive buffer pool hint', () => {
   });
 
   it.each([
-    ['a hint within range passes through', 128 * MiB, 128 * MiB],
-    ['a hint below the floor clamps up to 64 MiB', 1 * MiB, 64 * MiB],
+    ['a hint within range passes through', 512 * MiB, 512 * MiB],
+    ['a hint below the COPY-safety floor clamps up to 256 MiB', 100 * MiB, 256 * MiB],
     ['a hint above the default clamps down to the 2 GiB cap', 8 * GiB, 2 * GiB],
   ])(
     'createLbugDatabase uses the clamped hint when no env override is set: %s',

--- a/gitnexus/test/unit/lbug-config-wal.test.ts
+++ b/gitnexus/test/unit/lbug-config-wal.test.ts
@@ -1,9 +1,11 @@
 import os from 'os';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createLbugDatabase,
+  estimateBufferPool,
   isLbugCheckpointIoError,
   isWalCorruptionError,
+  setBufferPoolSizeHint,
 } from '../../src/core/lbug/lbug-config.js';
 import { _captureLogger } from '../../src/core/logger.js';
 
@@ -248,6 +250,73 @@ describe('createLbugDatabase buffer pool size (#2557)', () => {
     } finally {
       vi.unstubAllEnvs();
       cap.restore();
+    }
+  });
+});
+
+describe('adaptive buffer pool hint', () => {
+  const GiB = 1024 * 1024 * 1024;
+  const MiB = 1024 * 1024;
+  const bufferPoolArg = (Database: ReturnType<typeof vi.fn>): unknown => Database.mock.calls[0][1];
+
+  afterEach(() => setBufferPoolSizeHint(undefined));
+
+  describe('estimateBufferPool', () => {
+    it.each([
+      ['tiny graph clamps up to the 64 MiB floor', 41, 64 * MiB],
+      ['mid graph scales linearly (100k elements * 4 KiB = 400 MiB)', 100_000, 100_000 * 4 * 1024],
+      ['huge graph caps at the 2 GiB / 80%-RAM default', 10_000_000, 2 * GiB],
+    ])('%s', (_label, elements, expected) => {
+      const totalmemSpy = vi.spyOn(os, 'totalmem').mockReturnValue(32 * GiB);
+      try {
+        expect(estimateBufferPool(elements)).toBe(expected);
+      } finally {
+        totalmemSpy.mockRestore();
+      }
+    });
+  });
+
+  it.each([
+    ['a hint within range passes through', 128 * MiB, 128 * MiB],
+    ['a hint below the floor clamps up to 64 MiB', 1 * MiB, 64 * MiB],
+    ['a hint above the default clamps down to the 2 GiB cap', 8 * GiB, 2 * GiB],
+  ])(
+    'createLbugDatabase uses the clamped hint when no env override is set: %s',
+    (_label, hint, expected) => {
+      const totalmemSpy = vi.spyOn(os, 'totalmem').mockReturnValue(32 * GiB);
+      try {
+        setBufferPoolSizeHint(hint);
+        const Database = vi.fn(function (this: any) {});
+        createLbugDatabase({ Database } as any, '/tmp/lbug-hint');
+        expect(bufferPoolArg(Database)).toBe(expected);
+      } finally {
+        totalmemSpy.mockRestore();
+      }
+    },
+  );
+
+  it('env override wins over the hint (including 0 = native default)', () => {
+    try {
+      setBufferPoolSizeHint(128 * MiB);
+      vi.stubEnv('GITNEXUS_LBUG_BUFFER_POOL_SIZE', '0');
+      const Database = vi.fn(function (this: any) {});
+      createLbugDatabase({ Database } as any, '/tmp/lbug-hint-env');
+      expect(bufferPoolArg(Database)).toBe(0);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('falls back to the default when the hint is cleared', () => {
+    const totalmemSpy = vi.spyOn(os, 'totalmem').mockReturnValue(32 * GiB);
+    try {
+      setBufferPoolSizeHint(128 * MiB);
+      setBufferPoolSizeHint(undefined);
+      const Database = vi.fn(function (this: any) {});
+      createLbugDatabase({ Database } as any, '/tmp/lbug-hint-cleared');
+      expect(bufferPoolArg(Database)).toBe(2 * GiB);
+    } finally {
+      totalmemSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## What

Size the LadybugDB buffer pool to the repo being analyzed instead of always allocating the fixed `min(2 GiB, 80%×RAM)` default. LadybugDB **eagerly commits** the buffer pool at DB open, so the oversized default wastes wall-time on every analyze — most visibly on large repos.

**Measured (GitNexus checkout itself, full `analyze --force`):**

| Buffer pool | Wall time |
|---|---|
| 2 GiB (current default) | **50.8s** |
| adaptive (~414 MiB here) | **35.3s** |

→ **31% faster** large-repo analyze, and every repo uses less memory.

## How

- `resolveBufferManagerSize()` gains a precedence chain: `GITNEXUS_LBUG_BUFFER_POOL_SIZE` env override (unchanged, still wins, `0` = native default) → a per-run **size hint** clamped to `[ADAPTIVE_POOL_FLOOR, default]` → the default. The hint can only *shrink* the pool from today's default, never grow past the 2 GiB / 80%-RAM cap.
- `runFullAnalysis` sets the hint from the built graph's `nodeCount + relationshipCount` (after the pipeline, before the DB open) and clears it at the top of each run. The pool is a page cache over the on-disk index, which scales with graph size.
- The DB-open path (`openLbugConnection`) is a 16-caller hub, so the hint is module-scoped rather than threaded through it — the diff stays confined to `lbug-config.ts` + one call site in `run-analyze.ts`.

## The COPY-safety floor (why `ADAPTIVE_POOL_FLOOR = 256 MiB`, not 64 MiB)

LadybugDB's bulk `COPY` needs working buffer-pool memory that scales with the repo. A pool that's too small fails with `Buffer manager exception: the buffer pool is full and no memory could be freed`. Empirically: a 6-file fixture needs ≥128 MiB; the ~1800-file GitNexus checkout needs ≥256 MiB. So the adaptive size never drops below a distinct 256 MiB floor (kept separate from `BUFFER_POOL_FLOOR = 64 MiB`, which only guards the default on tiny-RAM machines; the hint is still clamped up to the machine default, so it can never over-commit).

## Scope / honest notes

- This is a **large-repo optimization**. Small repos now open COPY-safely at 256 MiB instead of 2 GiB — same wall time on Linux (lazy overcommit), and the far cheaper eager commit should help on Windows, though that isn't verified here.
- Read-only opens (MCP serve, standalone `detect_changes`, `native-check :memory:`) don't set the hint and keep the default — unchanged. Sizing those from the on-disk index size is a possible follow-up.
- The `docs/plans/` plan started from a "small repos get a tiny fast pool" premise; implementation showed COPY needs ≥256 MiB, so the floor and framing were corrected (commit `fix(lbug): raise the adaptive pool floor to a COPY-safe 256 MiB`).

## Verification

- Full unit suite green: **503 files, 10327 passed**; new `lbug-config-wal` tests cover the precedence, clamping, and estimate boundaries.
- `skills-e2e` Idempotency integration test passes with **no env override** (previously failed `COPY: buffer pool is full` under the too-small floor).
- Large-repo benchmark above; env override + `0`-escape-hatch preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
