### PR TITLE
test(skills-e2e): raise the Idempotency setup-hook budget to 120s (Windows shard timeout)

### DIFF
--- a/gitnexus/test/integration/skills-e2e.test.ts
+++ b/gitnexus/test/integration/skills-e2e.test.ts
@@ -2371,7 +2371,13 @@ export function createEntry(level: string, msg: string) {
     });
     result1 = runSkillsCli(tmpDir);
     result2 = runSkillsCli(tmpDir);
-  }, 90000);
+    // 120s to match the other describe hooks in this file. This hook runs
+    // runSkillsCli TWICE, each capped at 45s, so a 90s budget has no headroom
+    // over two worst-case analyzes plus fixture setup and git init — it times
+    // out the *hook* on slow Windows runners (the test below already tolerates
+    // an individual analyze hitting its own 45s timeout via status === null,
+    // but a hook timeout fails before that tolerance can apply).
+  }, 120000);
 
   afterAll(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## What

Give the `Idempotency` `beforeAll` in `skills-e2e.test.ts` the same **120s** hook budget every other describe hook in the file already uses (it was the only one at 90s).

## Why

The hook runs `runSkillsCli` (a full `analyze --skills`) **twice**, and `runSkillsCli` caps each spawn at **45s**. So the 90s budget is *exactly* 2× the per-call timeout with **zero headroom** for `createFixtureRepo` + `git init/add/commit`. On slow Windows CI runners the two analyzes plus setup exceed 90s and the hook fails with `Hook timed out in 90000ms` — which fails the whole `windows-latest (platform-sensitive)` shard.

Notably, the test body already tolerates an *individual* analyze hitting its own 45s timeout (`if (result1.status === null || result2.status === null) return`), but a **hook** timeout fails before that tolerance can apply — so the budget itself has to be big enough for the setup to finish.

Observed failure: run 29746413645, job `ci / tests / windows-latest (platform-sensitive) 1/3`.

## Scope

Test-only, one hook's timeout constant. No production code changes. Verified locally: the Idempotency test passes (~11s) with the 120s budget on a stock 2 GiB-pool build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
