### PR TITLE
fix(eval): stop using --bare for arms that need Skill or MCP tools

### DIFF
--- a/eval/tests/test_workflow_bench_sessions.py
+++ b/eval/tests/test_workflow_bench_sessions.py
@@ -167,6 +167,56 @@ def test_run_claude_forwards_the_named_model_to_every_session(monkeypatch, tmp_p
     assert captured[captured.index("--model") + 1] == "claude-sonnet-4-20250514"
 
 
+def test_run_claude_restricts_tools_via_tools_flag_outside_bare(monkeypatch, tmp_path):
+    # Outside --bare, the built-in toolset defaults to everything (subagents,
+    # WebFetch, Task, ...) and --allowedTools only pre-approves within that —
+    # it does not narrow it. --tools is what actually restricts the set, so a
+    # non-bare arm session must pass it or it silently gets a far wider
+    # toolset than intended.
+    captured: list[str] = []
+
+    def fake_run(command, **kwargs):
+        captured.extend(command)
+        return fake_cli_result(VALID_REPORT)
+
+    monkeypatch.setattr(runner_sessions, "run_managed", fake_run)
+    runner.run_claude(
+        "task",
+        tmp_path,
+        claude_bin="claude",
+        timeout=5,
+        bare=False,
+        allowed_tools=["Read", "Edit", "Bash", "Skill"],
+    )
+    tools_idx = captured.index("--tools")
+    assert captured[tools_idx + 1 : tools_idx + 5] == ["Read", "Edit", "Bash", "Skill"]
+    allowed_idx = captured.index("--allowedTools")
+    assert captured[allowed_idx + 1 : allowed_idx + 5] == ["Read", "Edit", "Bash", "Skill"]
+
+
+def test_run_claude_omits_tools_flag_under_bare(monkeypatch, tmp_path):
+    # --bare already hard-restricts to Bash/Edit/Read on its own (a Claude
+    # Code design choice, not something --tools/--allowedTools can widen or
+    # narrow further), so bare sessions must not also pass --tools.
+    captured: list[str] = []
+
+    def fake_run(command, **kwargs):
+        captured.extend(command)
+        return fake_cli_result(VALID_REPORT)
+
+    monkeypatch.setattr(runner_sessions, "run_managed", fake_run)
+    runner.run_claude(
+        "task",
+        tmp_path,
+        claude_bin="claude",
+        timeout=5,
+        bare=True,
+        allowed_tools=["Read", "Edit", "Bash", "Skill"],
+    )
+    assert "--tools" not in captured
+    assert "--allowedTools" in captured
+
+
 @pytest.mark.parametrize(
     ("proc", "expected_kind"),
     [
@@ -281,6 +331,15 @@ def test_agent_tool_grants_are_exact_and_nomcp_has_no_graph_tools(monkeypatch, t
     assert captured[3]["allowed_tools"] == list(runner.BUILTIN_AGENT_TOOLS)
     assert captured[3]["mcp_config_json"] == '{"mcpServers":{}}'
     assert captured[3]["disallowed_tools"] == ["Skill", "mcp__gitnexus"]
+
+    # --bare hard-disables the Skill tool and every mcp__* tool regardless of
+    # --allowedTools (a Claude Code design choice, not something the harness
+    # can override) -- every arm here except baseline_nomcp needs Skill
+    # and/or MCP tools, so only baseline_nomcp may still run under --bare.
+    assert captured[0]["bare"] is False  # workflow: planning session
+    assert captured[1]["bare"] is False  # review
+    assert captured[2]["bare"] is False  # workflow_direct
+    assert captured[3]["bare"] is True  # baseline_nomcp
 
 
 def test_mcp_config_uses_only_the_minimal_pinned_harness_runtime(monkeypatch, tmp_path):

--- a/eval/workflow_bench/runner.py
+++ b/eval/workflow_bench/runner.py
@@ -402,6 +402,13 @@ def run_arm(
         auth_token=args.auth_token,
         base_url=args.base_url,
     )
+    # --bare hard-disables the Skill tool and every mcp__* tool — by Claude
+    # Code design, not a bug (--allowedTools can't restore what --bare
+    # removes). Every arm except baseline_nomcp needs Skill and/or MCP tools,
+    # so only baseline_nomcp can keep --bare's tighter isolation; the rest
+    # rely on ANTHROPIC_API_KEY alone (the sandboxed HOME has no OAuth/
+    # keychain state to conflict with it).
+    bare = arm == "baseline_nomcp"
     common = {
         "claude_bin": sandbox.claude_bin,
         "timeout": args.timeout,
@@ -412,7 +419,7 @@ def run_arm(
             read_only_paths=_evaluated_skill_roots(worktree, arm),
         ),
         "require_pid_namespace": True,
-        "bare": True,
+        "bare": bare,
         "settings_json": sandbox.settings_json,
         "strict_mcp_config": True,
         "mcp_config_json": sandbox_mcp_config(),

--- a/eval/workflow_bench/runner_sessions.py
+++ b/eval/workflow_bench/runner_sessions.py
@@ -377,6 +377,13 @@ def run_claude(
     if strict_mcp_config:
         cmd += ["--strict-mcp-config", "--mcp-config", mcp_config_json or '{"mcpServers":{}}']
     if allowed_tools:
+        # --bare's own hard-coded Bash/Edit/Read ceiling already scopes bare
+        # sessions; outside --bare the built-in toolset defaults to
+        # everything (subagents, WebFetch, Task, ...), so --tools is needed
+        # to actually restrict it — --allowedTools only pre-approves within
+        # whatever set is available, it does not narrow that set.
+        if not bare:
+            cmd += ["--tools", *allowed_tools]
         cmd += ["--allowedTools", *allowed_tools]
     if disable_slash_commands:
         cmd.append("--disable-slash-commands")


### PR DESCRIPTION
## Summary

The last skill-evolution run ([run 29754004954](https://github.com/abhigyanpatwari/GitNexus/actions/runs/29754004954/job/88391579361)) scored 0/3 resolution on both the incumbent and candidate arms across every task, with `error_kind: "skill-not-invoked"` on all 18 benchmark sessions. That looked like a candidate-quality result but wasn't: the benchmark harness could never invoke either arm's skill at all.

Root cause, confirmed directly against the pinned `claude-code@2.1.214` binary: **`--bare` hard-disables the `Skill` tool and every `mcp__*` tool by Claude Code design** — `--allowedTools` cannot restore what `--bare` removes (this is documented behavior, not a bug; a GitHub feature request asking for it was closed "Not planned"). Every `workflow_bench` arm except `baseline_nomcp` needs `Skill` and/or the GitNexus MCP tools (`gitnexus-plan`, `gitnexus-work`, `gitnexus-review`, the CE comparator skills, and even plain `baseline`'s read-only graph tools), so those sessions have silently never been able to invoke their skill since `--bare` was adopted for auth isolation.

- Only `baseline_nomcp` keeps `--bare` — it's the one arm that explicitly wants zero Skill/MCP access anyway.
- Every other arm drops `--bare` and relies on `ANTHROPIC_API_KEY` alone. The sandboxed `HOME` has no OAuth/keychain state to conflict with it, and there's no committed `.claude/settings.json` in this repo for dropping `--bare` to newly pick up.
- Outside `--bare` the built-in toolset defaults to everything (WebFetch, Task, subagents, ...), and `--allowedTools` only pre-approves within whatever's available — it doesn't narrow it. Added `--tools` for non-bare sessions so the intended per-arm scope is still enforced instead of silently widening.

## Test plan

- [x] `uv run pytest eval/tests/ -q` — 306 passed, 9 skipped, 0 failures
- [x] `uv run ruff check` on changed files — clean
- [x] Verified `--tools`/`--allowedTools`/skill auto-discovery behavior directly against the pinned binary (space- and comma-separated forms, MCP tool names silently ignored by `--tools`, project-local `.claude/skills/*` auto-discovers without `--bare` and without `--add-dir`)
- [ ] Live CI run of `gitnexus-skill-evolution` to confirm `ANTHROPIC_API_KEY` auth still works cleanly without `--bare` and that `Skill`/MCP tool calls aren't blocked by `build_claude_settings()`'s `permissions.allow` list (currently `Read/Grep/Glob/Bash` only — untested whether `--permission-mode dontAsk` covers the newly-available tools too, though it evidently already covers `Edit`, which also isn't allow-listed, based on real diffs produced in past `--bare` runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Va5uu9Ar3e45QZ5xFsG4AZ