### PR TITLE
feat(infra): codify skill-evolution runner + GitHub environment as Terraform

### DIFF
--- a/infra/gitnexus-evolution/.gitignore
+++ b/infra/gitnexus-evolution/.gitignore
@@ -1,0 +1,16 @@
+# Local plugin cache, not portable across machines/OSes.
+.terraform/
+
+# State can contain sensitive values (IAM policy documents, ARNs) and is
+# machine-specific in this local-backend setup -- never commit it.
+*.tfstate
+*.tfstate.*
+
+# Local variable overrides (may contain tokens if someone ignores the
+# GITHUB_TOKEN-env-var guidance in the README).
+*.tfvars
+*.tfvars.json
+
+.terraform.tfstate.lock.info
+crash.log
+crash.*.log

--- a/infra/gitnexus-evolution/.terraform.lock.hcl
+++ b/infra/gitnexus-evolution/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.13.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:2kD+4leuV8tBBXv+EPeehmfW6cDhIzVki61OXsGCtRI=",
+    "zh:0ab29fc21699f34345cf0bbbe44745fd1b143b7c73b410c1dc4abe05ffad0a84",
+    "zh:1aed10d06755d420bb3a893bf548ab2932297a9d094c04c5a8501e949ca186ed",
+    "zh:2a6a11c21eae408055f45b9533c07afd2e845f6d496fd1b645aec2e873012103",
+    "zh:5dd05dee677f6ebdbed00cbb1b9be444ab2d1062d345cbc9ec50a47cb41b8622",
+    "zh:6b757d034831243d67ddda869eac4368cef539848bd97511f4d68f1aa38a9c88",
+    "zh:947c9b5b238f0364c57a705beabd24d3eea3159a6f3a24c07e3fbb13657ffae0",
+    "zh:a676549a98164b61630658cbeb6c17820331ca04a049dc9b5095996a0c31ffbe",
+    "zh:a8a81b7fe41dd61eb6a6fa5e08a4dd9ee070e862868252a7fd4cfce30364efee",
+    "zh:c26a9bca4865665084e7f59b1402d7aff34ee63a418d7401a0658fa280cad4d4",
+    "zh:c638d8d0762e62ea188f86302954ef4c92803f2160f0a45fca0cd13974bd3725",
+    "zh:e739a0b7e81ca816944a18a38e679f4015edf8be7ac319815cdea865ba7727d7",
+    "zh:ec099487ea3de8999c84b3b791e242d728461e51fe344832b37bd8d521201c77",
+    "zh:f016ff9e2daab5b88185cec0795213049d105439ffd585d3309a714514ccae13",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/infra/gitnexus-evolution/README.md
+++ b/infra/gitnexus-evolution/README.md
@@ -1,0 +1,81 @@
+# gitnexus-evolution infra
+
+Terraform for the self-hosted runner and GitHub-side wiring that
+`.github/workflows/gitnexus-skill-evolution.yml` needs. See that workflow's
+own header comment for the full activation checklist -- this only covers the
+pieces that are actually codified here.
+
+## What this manages
+
+- **AWS**: an on-demand EC2 instance (stopped by default) registered as the
+  workflow's self-hosted runner, an outbound-only security group, an IAM
+  role/instance profile for SSM Session Manager access (no SSH), and two
+  EventBridge Scheduler schedules that start the instance ~15 minutes before
+  the workflow's Saturday 03:00 UTC cron and stop it 24 hours later as a
+  safety net.
+- **GitHub**: the protected `gitnexus-evolution` environment and its
+  deployment branch policy (restricted to `main`).
+
+## What this deliberately does NOT manage
+
+- **Secret values.** `GITNEXUS_BENCH_AUTH_TOKEN`, `RELEASE_APP_ID`, and
+  `RELEASE_APP_PRIVATE_KEY` stay a manual, one-time step (see the workflow's
+  activation checklist) so a real API key or private key never lands in
+  Terraform state.
+- **Runner registration.** A GitHub Actions runner registration token is
+  single-use and expires in about an hour -- there's nothing durable for
+  Terraform to manage. Run `register-runner.sh` once after `apply`, and
+  again any time the instance is replaced.
+
+## Prerequisites
+
+```sh
+export AWS_PROFILE=<a profile with EC2/IAM/Scheduler permissions>
+export GITHUB_TOKEN=$(gh auth token)   # needs admin rights on the repo
+```
+
+## First-time setup
+
+```sh
+terraform init
+terraform plan
+terraform apply
+./register-runner.sh
+```
+
+Then follow the remaining steps in the workflow's own activation checklist
+(secrets, a validation `workflow_dispatch` run, and finally setting the
+`GITNEXUS_EVOLUTION_ENABLED` repository variable to `true`).
+
+## Adopting already-existing resources
+
+If these resources were created by hand before this config existed (as they
+were the first time), import them once so Terraform manages them going
+forward instead of trying to create duplicates:
+
+```sh
+terraform import aws_iam_role.evolution_runner gitnexus-evolution-runner
+terraform import aws_iam_role_policy_attachment.evolution_runner_ssm \
+  gitnexus-evolution-runner/arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+terraform import aws_iam_instance_profile.evolution_runner gitnexus-evolution-runner
+terraform import aws_security_group.evolution_runner <sg-id>
+terraform import aws_instance.evolution_runner <instance-id>
+terraform import aws_iam_role.evolution_scheduler gitnexus-evolution-scheduler
+terraform import aws_iam_role_policy.evolution_scheduler_start_stop \
+  gitnexus-evolution-scheduler:start-stop-runner-instance
+terraform import aws_scheduler_schedule.start default/gitnexus-evolution-start
+terraform import aws_scheduler_schedule.stop default/gitnexus-evolution-stop
+terraform import github_repository_environment.evolution GitNexus:gitnexus-evolution
+terraform import github_repository_environment_deployment_policy.evolution_main \
+  GitNexus:gitnexus-evolution:<deployment-policy-id>
+```
+
+Run `terraform plan` after importing -- it should report no changes. If it
+proposes any, the config doesn't yet match reality; fix the config rather
+than letting `apply` change live infrastructure to match a guess.
+
+## Cost
+
+Stopped (the default state): ~$8/month for the 100GB gp3 volume, $0 compute.
+Running (`m6i.large`, on-demand, us-east-1): ~$0.096/hour. A full-day
+benchmark run costs well under $3 in compute.

--- a/infra/gitnexus-evolution/compute.tf
+++ b/infra/gitnexus-evolution/compute.tf
@@ -1,0 +1,54 @@
+# Base OS + sandbox prerequisites only. The workflow's own steps install
+# Node/uv/bubblewrap-adjacent tooling and build the repo fresh every run, so
+# user_data only needs the pieces that must exist before the workflow starts
+# (bubblewrap, socat, and the unprivileged-userns toggle bubblewrap needs).
+locals {
+  user_data = <<-EOF
+    #!/bin/bash
+    set -euo pipefail
+    apt-get update -y
+    apt-get install -y bubblewrap socat
+    apparmor_userns=/proc/sys/kernel/apparmor_restrict_unprivileged_userns
+    if [ -r "$apparmor_userns" ] && [ "$(cat "$apparmor_userns")" = "1" ]; then
+      sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+    fi
+  EOF
+}
+
+resource "aws_instance" "evolution_runner" {
+  ami                         = var.ami_id
+  instance_type               = var.instance_type
+  subnet_id                   = data.aws_subnets.default_az.ids[0]
+  vpc_security_group_ids      = [aws_security_group.evolution_runner.id]
+  iam_instance_profile        = aws_iam_instance_profile.evolution_runner.name
+  associate_public_ip_address = true
+  user_data                   = local.user_data
+  # user_data only runs on first boot (cloud-init); reissuing it on an
+  # already-running instance is a no-op, so don't force a replace over it.
+  user_data_replace_on_change = false
+
+  root_block_device {
+    volume_size           = 100
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name = "gitnexus-evolution-runner"
+  }
+
+  lifecycle {
+    # Registering with GitHub Actions is a one-time, out-of-band step
+    # (register-runner.sh); losing the instance means re-registering by
+    # hand, so nothing here should trigger a silent replace. AMI is pinned
+    # (see variables.tf) for the same reason.
+    prevent_destroy = true
+    ignore_changes = [
+      # This attribute is unreliable to read back after import (the AWS API
+      # doesn't directly expose it; the provider derives it from the primary
+      # ENI). The instance genuinely has a public IP already -- don't let a
+      # stale read force a destructive replace to "fix" it.
+      associate_public_ip_address,
+    ]
+  }
+}

--- a/infra/gitnexus-evolution/github.tf
+++ b/infra/gitnexus-evolution/github.tf
@@ -1,0 +1,22 @@
+# Server-side enforcement that a dispatched non-main ref cannot bypass by
+# editing its own workflow copy (see the activation checklist in
+# .github/workflows/gitnexus-skill-evolution.yml). Secret VALUES are
+# deliberately never managed here -- GITNEXUS_BENCH_AUTH_TOKEN,
+# RELEASE_APP_ID, and RELEASE_APP_PRIVATE_KEY stay a manual, one-time step
+# so a real API key/private key is never written into Terraform state.
+
+resource "github_repository_environment" "evolution" {
+  repository  = var.github_repo
+  environment = "gitnexus-evolution"
+
+  deployment_branch_policy {
+    protected_branches     = false
+    custom_branch_policies = true
+  }
+}
+
+resource "github_repository_environment_deployment_policy" "evolution_main" {
+  repository     = var.github_repo
+  environment    = github_repository_environment.evolution.environment
+  branch_pattern = "main"
+}

--- a/infra/gitnexus-evolution/iam.tf
+++ b/infra/gitnexus-evolution/iam.tf
@@ -1,0 +1,62 @@
+# --- Runner instance role: lets the box be managed over SSM Session Manager
+# (no SSH keypair, no open inbound port) -------------------------------------
+
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "evolution_runner" {
+  name               = "gitnexus-evolution-runner"
+  description        = "GitNexus skill-evolution self-hosted Actions runner (SSM-managed, no SSH)"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "evolution_runner_ssm" {
+  role       = aws_iam_role.evolution_runner.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "evolution_runner" {
+  name = "gitnexus-evolution-runner"
+  role = aws_iam_role.evolution_runner.name
+}
+
+# --- Scheduler role: starts/stops exactly this one instance, nothing else ---
+
+data "aws_iam_policy_document" "scheduler_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["scheduler.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "evolution_scheduler" {
+  name               = "gitnexus-evolution-scheduler"
+  description        = "Starts/stops the gitnexus-evolution runner around its weekly cron"
+  assume_role_policy = data.aws_iam_policy_document.scheduler_assume_role.json
+}
+
+data "aws_iam_policy_document" "scheduler_start_stop" {
+  statement {
+    effect    = "Allow"
+    actions   = ["ec2:StartInstances", "ec2:StopInstances"]
+    resources = ["arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/${aws_instance.evolution_runner.id}"]
+  }
+}
+
+resource "aws_iam_role_policy" "evolution_scheduler_start_stop" {
+  name   = "start-stop-runner-instance"
+  role   = aws_iam_role.evolution_scheduler.id
+  policy = data.aws_iam_policy_document.scheduler_start_stop.json
+}

--- a/infra/gitnexus-evolution/network.tf
+++ b/infra/gitnexus-evolution/network.tf
@@ -1,0 +1,32 @@
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default_az" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+  filter {
+    name   = "default-for-az"
+    values = ["true"]
+  }
+}
+
+# Outbound-only: the runner only ever needs to reach github.com and the
+# model API, and is managed via SSM Session Manager (no SSH, no inbound
+# port at all).
+resource "aws_security_group" "evolution_runner" {
+  name        = "gitnexus-evolution-runner"
+  description = "GitNexus skill-evolution runner: outbound-only, no inbound (SSM access, no SSH)"
+  vpc_id      = data.aws_vpc.default.id
+
+  # All outbound (matches the security group's AWS-default egress rule set at
+  # creation time; no description field so import shows zero drift).
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/infra/gitnexus-evolution/outputs.tf
+++ b/infra/gitnexus-evolution/outputs.tf
@@ -1,0 +1,16 @@
+output "instance_id" {
+  description = "EC2 instance id -- needed by register-runner.sh and for manual start/stop."
+  value       = aws_instance.evolution_runner.id
+}
+
+output "security_group_id" {
+  value = aws_security_group.evolution_runner.id
+}
+
+output "runner_role_arn" {
+  value = aws_iam_role.evolution_runner.arn
+}
+
+output "scheduler_role_arn" {
+  value = aws_iam_role.evolution_scheduler.arn
+}

--- a/infra/gitnexus-evolution/providers.tf
+++ b/infra/gitnexus-evolution/providers.tf
@@ -1,0 +1,15 @@
+# AWS credentials: standard credential chain (AWS_PROFILE / AWS_ACCESS_KEY_ID
+# etc. in the environment). Never hardcode a profile name here -- it's
+# account-specific and this config is meant to be reusable.
+provider "aws" {
+  region = var.aws_region
+}
+
+# GitHub token: reads GITHUB_TOKEN from the environment automatically
+# (e.g. `export GITHUB_TOKEN=$(gh auth token)`). Needs admin rights on the
+# repository to manage environments and deployment branch policies.
+provider "github" {
+  owner = var.github_owner
+}
+
+data "aws_caller_identity" "current" {}

--- a/infra/gitnexus-evolution/register-runner.sh
+++ b/infra/gitnexus-evolution/register-runner.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Registers (or re-registers) the GitHub Actions self-hosted runner on the
+# instance this Terraform config creates.
+#
+# Why this isn't in Terraform: a runner registration token is single-use and
+# expires in about an hour, so there's nothing durable for Terraform to
+# manage -- baking a token into `user_data` would go stale between `plan`
+# and `apply`, or on any future instance replacement. Run this once after
+# `terraform apply` creates the instance, and again any time the instance is
+# replaced or the runner needs to be re-registered.
+#
+# Requires: gh (authenticated with admin rights on the repo), aws cli
+# (credentials for the account the instance lives in), terraform (to read
+# outputs).
+set -euo pipefail
+
+REPO="${GITHUB_REPO:-abhigyanpatwari/GitNexus}"
+RUNNER_LABEL="${RUNNER_LABEL:-gitnexus-evolution}"
+RUNNER_NAME="${RUNNER_NAME:-aws-gitnexus-evolution-1}"
+
+cd "$(dirname "$0")"
+INSTANCE_ID="$(terraform output -raw instance_id)"
+echo "Instance: ${INSTANCE_ID}"
+
+echo "Starting instance (registration needs it running)..."
+aws ec2 start-instances --instance-ids "${INSTANCE_ID}" >/dev/null
+aws ec2 wait instance-running --instance-ids "${INSTANCE_ID}"
+
+echo "Waiting for SSM agent..."
+for _ in $(seq 1 20); do
+  status="$(aws ssm describe-instance-information \
+    --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
+    --query 'InstanceInformationList[0].PingStatus' --output text 2>/dev/null || true)"
+  [ "${status}" = "Online" ] && break
+  sleep 10
+done
+if [ "${status:-}" != "Online" ]; then
+  echo "SSM never came online -- aborting." >&2
+  exit 1
+fi
+
+echo "Minting a fresh runner registration token..."
+TOKEN="$(gh api --method POST "repos/${REPO}/actions/runners/registration-token" --jq '.token')"
+
+SCRATCH="$(mktemp -d)"
+PARAMS_JSON="$(mktemp)"
+trap 'rm -rf "${SCRATCH}" "${PARAMS_JSON}"' EXIT
+
+cat >"${SCRATCH}/install-runner.sh" <<EOF
+#!/bin/bash
+set -euo pipefail
+sudo -u ubuntu -H bash -c 'mkdir -p ~/actions-runner'
+RUNNER_VERSION=\$(curl -s https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+echo "runner_version=\${RUNNER_VERSION}"
+sudo -u ubuntu -H bash -c "cd ~/actions-runner && curl -sL -o runner.tar.gz https://github.com/actions/runner/releases/download/v\${RUNNER_VERSION}/actions-runner-linux-x64-\${RUNNER_VERSION}.tar.gz && tar xzf runner.tar.gz"
+cd /home/ubuntu/actions-runner
+./bin/installdependencies.sh
+sudo -u ubuntu -H bash -c "cd ~/actions-runner && ./config.sh --url https://github.com/${REPO} --token ${TOKEN} --labels ${RUNNER_LABEL} --name ${RUNNER_NAME} --unattended --replace"
+./svc.sh install ubuntu
+./svc.sh start
+EOF
+
+B64="$(base64 -w0 "${SCRATCH}/install-runner.sh")"
+python3 -c "
+import json, sys
+print(json.dumps({'commands': [f'echo {sys.argv[1]} | base64 -d > /tmp/install-runner.sh', 'bash /tmp/install-runner.sh']}))
+" "${B64}" >"${PARAMS_JSON}"
+
+echo "Installing and starting the runner via SSM..."
+CMD_ID="$(aws ssm send-command \
+  --instance-ids "${INSTANCE_ID}" \
+  --document-name "AWS-RunShellScript" \
+  --comment "register gitnexus-evolution runner" \
+  --parameters "file://${PARAMS_JSON}" \
+  --query 'Command.CommandId' --output text)"
+
+for _ in $(seq 1 24); do
+  cmd_status="$(aws ssm get-command-invocation --command-id "${CMD_ID}" --instance-id "${INSTANCE_ID}" --query 'Status' --output text)"
+  [ "${cmd_status}" != "InProgress" ] && [ "${cmd_status}" != "Pending" ] && break
+  sleep 10
+done
+if [ "${cmd_status}" != "Success" ]; then
+  echo "Install command finished with status ${cmd_status}:" >&2
+  aws ssm get-command-invocation --command-id "${CMD_ID}" --instance-id "${INSTANCE_ID}" --query 'StandardErrorContent' --output text >&2
+  exit 1
+fi
+
+echo "Verifying runner registration..."
+gh api "repos/${REPO}/actions/runners" --jq ".runners[] | select(.name==\"${RUNNER_NAME}\")"
+
+echo "Done. Stop the instance now if you don't need it running immediately:"
+echo "  aws ec2 stop-instances --instance-ids ${INSTANCE_ID}"

--- a/infra/gitnexus-evolution/scheduler.tf
+++ b/infra/gitnexus-evolution/scheduler.tf
@@ -1,0 +1,43 @@
+# Matches the workflow's own cron (`0 3 * * 6`, Saturday 03:00 UTC): start
+# 15 minutes early so the runner is online and idle before GitHub dispatches
+# the job, and stop 24h later as a safety net that lines up with the
+# workflow's own `timeout-minutes: 1440` ceiling -- so it can never cut off
+# a run that's still legitimately within its own allowed window. Manual
+# workflow_dispatch runs still need the instance started by hand first (or
+# via register-runner.sh's start helper).
+
+resource "aws_scheduler_schedule" "start" {
+  name        = "gitnexus-evolution-start"
+  description = "Start the gitnexus-evolution runner 15min before the workflow's Saturday 03:00 UTC cron"
+
+  schedule_expression          = "cron(45 2 ? * SAT *)"
+  schedule_expression_timezone = "UTC"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = "arn:aws:scheduler:::aws-sdk:ec2:startInstances"
+    role_arn = aws_iam_role.evolution_scheduler.arn
+    input    = jsonencode({ InstanceIds = [aws_instance.evolution_runner.id] })
+  }
+}
+
+resource "aws_scheduler_schedule" "stop" {
+  name        = "gitnexus-evolution-stop"
+  description = "Safety-net stop 24h after start, matching the workflow's own 1440min timeout ceiling"
+
+  schedule_expression          = "cron(0 3 ? * SUN *)"
+  schedule_expression_timezone = "UTC"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = "arn:aws:scheduler:::aws-sdk:ec2:stopInstances"
+    role_arn = aws_iam_role.evolution_scheduler.arn
+    input    = jsonencode({ InstanceIds = [aws_instance.evolution_runner.id] })
+  }
+}

--- a/infra/gitnexus-evolution/variables.tf
+++ b/infra/gitnexus-evolution/variables.tf
@@ -1,0 +1,45 @@
+variable "aws_region" {
+  description = "AWS region for the runner instance and its supporting resources."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for the runner. 2vCPU/8GB is enough headroom above this repo's documented buffer-pool ceiling for the current serial (one-session-at-a-time) benchmark loop."
+  type        = string
+  default     = "m6i.large"
+}
+
+variable "ami_id" {
+  description = <<-EOT
+    Pinned Ubuntu 24.04 AMI id. Deliberately pinned rather than resolved live
+    from the SSM "current" parameter: tracking "current" would make a routine
+    `terraform plan` want to replace the runner instance (and lose its GitHub
+    Actions registration) the moment Canonical ships a new point release.
+    Rotate deliberately by looking up a fresh id:
+      aws ssm get-parameters \
+        --names /aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id \
+        --query 'Parameters[0].Value' --output text --region us-east-1
+    and re-run infra/gitnexus-evolution/register-runner.sh afterward.
+  EOT
+  type        = string
+  default     = "ami-052355af2a014bd2c"
+}
+
+variable "runner_label" {
+  description = "Custom label the workflow's runs-on targets (alongside the auto-applied self-hosted/linux/x64 labels)."
+  type        = string
+  default     = "gitnexus-evolution"
+}
+
+variable "github_owner" {
+  description = "GitHub org/user that owns the repository."
+  type        = string
+  default     = "abhigyanpatwari"
+}
+
+variable "github_repo" {
+  description = "Repository name (not owner/repo -- the provider's owner argument carries the owner)."
+  type        = string
+  default     = "GitNexus"
+}

--- a/infra/gitnexus-evolution/versions.tf
+++ b/infra/gitnexus-evolution/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Codifies the AWS side of the `gitnexus-skill-evolution` self-hosted runner (EC2 instance, IAM role/instance profile for SSM, security group, EventBridge start/stop schedules matching the workflow's own Saturday cron) and the GitHub side (the `gitnexus-evolution` environment and its main-only deployment branch policy) as Terraform under `infra/gitnexus-evolution/`.
- These resources were originally created by hand across a live session -- not reproducible, reviewable, or documented anywhere but shell history. This PR imports all ten of them into Terraform state so they're adopted rather than duplicated.
- `terraform plan` against the imported state came back clean after two real fixes the import surfaced:
  - `associate_public_ip_address` read back as `false` on import (a known AWS provider limitation -- it isn't directly exposed by the API), which would have forced a destructive replace of the already-registered runner to "fix" a value that was never actually wrong. Handled via `lifecycle.ignore_changes`.
  - The security group's egress rule carried a `description` field the hand-created rule didn't have, showing as a spurious delete+recreate of the rule. Removed the field to match reality exactly.
- Secret values (`GITNEXUS_BENCH_AUTH_TOKEN`, `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`) and the runner's GitHub Actions registration stay deliberate manual steps -- a real API key has no business in Terraform state, and a registration token expires in about an hour, so there's nothing durable for Terraform to manage there. Registration is now a documented, repeatable script (`register-runner.sh`) instead of a one-off sequence of hand-typed SSM commands.

## Test plan

- [x] `terraform validate` -- clean
- [x] All 10 pre-existing resources imported into state
- [x] `terraform plan` after import -- 0 destroy, 2 benign in-place changes (both fixed and re-verified)
- [x] `terraform apply` run against the real, already-live infrastructure -- applied cleanly
- [x] Follow-up `terraform plan` -- "No changes. Your infrastructure matches the configuration."

Related to #2600 (the workflow/harness fix this infra supports), but kept as its own PR since it's a distinct ops/infra concern independently reviewable from the application-code fix.