### PR TITLE
fix(eval): bind the resolved node binary into the sandbox on self-hosted runners

### DIFF
--- a/eval/tests/test_proposer_sandbox.py
+++ b/eval/tests/test_proposer_sandbox.py
@@ -24,6 +24,7 @@ from workflow_bench.proposer_sandbox import (
     SANDBOX_USER_SKILLS,
     ReadOnlyMount,
     SandboxError,
+    _runtime_mount_args,
     build_claude_settings,
     build_sandbox_environment,
     prepare_sandbox,
@@ -189,6 +190,30 @@ def test_sandbox_command_has_minimal_mounts_and_no_host_root_bind(tmp_path: Path
         assert argv[user_skills_index - 2] == "--ro-bind"
         private_root = sandbox.private_root
     assert not private_root.exists()
+
+
+def test_runtime_mounts_bind_the_resolved_node_wherever_path_puts_it(monkeypatch) -> None:
+    # sanitized_graph.py and runner_sessions.py invoke the sandboxed graph CLI
+    # at the fixed path /usr/local/bin/node. That's only covered by the /usr
+    # bind when node happens to live under /usr/local/bin on the host -- true
+    # on GitHub-hosted runner images, but not on a self-hosted runner where
+    # actions/setup-node installs into its own tool-cache directory instead
+    # (observed empirically: "bwrap: execvp /usr/local/bin/node: No such file
+    # or directory" on a fresh self-hosted runner).
+    monkeypatch.setattr(
+        "workflow_bench.proposer_sandbox.shutil.which",
+        lambda name: "/opt/hostedtoolcache/node/22.18.0/x64/bin/node" if name == "node" else None,
+    )
+    args = _runtime_mount_args()
+    node_index = args.index("/opt/hostedtoolcache/node/22.18.0/x64/bin/node")
+    assert args[node_index - 1] == "--ro-bind"
+    assert args[node_index + 1] == "/usr/local/bin/node"
+
+
+def test_runtime_mounts_skip_the_node_bind_when_node_is_unresolvable(monkeypatch) -> None:
+    monkeypatch.setattr("workflow_bench.proposer_sandbox.shutil.which", lambda name: None)
+    args = _runtime_mount_args()
+    assert "/usr/local/bin/node" not in args
 
 
 def test_stricter_prefix_freezes_evaluated_skills_and_can_unshare_network(tmp_path: Path) -> None:
@@ -772,4 +797,3 @@ for line in sys.stdin:
     assert bash_result.get("is_error") is not True, bash_result
     assert (clone / "bash-called").read_text() == "canary"
     assert (clone / "mcp-called").read_text() == "ok"
-

--- a/eval/workflow_bench/proposer_sandbox.py
+++ b/eval/workflow_bench/proposer_sandbox.py
@@ -354,6 +354,17 @@ def _runtime_mount_args() -> list[str]:
         path = Path(raw)
         if path.exists():
             args += ["--ro-bind", raw, raw]
+    # sanitized_graph.py and runner_sessions.py invoke the sandboxed graph
+    # CLI at the fixed path /usr/local/bin/node. That's only covered by the
+    # /usr bind above when node happens to live under /usr/local/bin on the
+    # host -- true on GitHub-hosted runner images, but not on a self-hosted
+    # runner where actions/setup-node installs into its own tool-cache
+    # directory instead. Bind whatever `node` actually resolves to on PATH
+    # to that same fixed sandbox path so both call sites keep working
+    # regardless of where the host actually put it.
+    node_bin = shutil.which("node")
+    if node_bin:
+        args += ["--ro-bind", node_bin, "/usr/local/bin/node"]
     for raw in (
         "/etc/ssl",
         "/etc/hosts",
@@ -398,7 +409,7 @@ def _create_python3_wrapper(private_root: Path) -> Path:
     """
 
     wrapper = private_root / "python3"
-    wrapper.write_text("#!/bin/bash\nset -eu\nexec /usr/bin/python3 \"$@\"\n")
+    wrapper.write_text('#!/bin/bash\nset -eu\nexec /usr/bin/python3 "$@"\n')
     wrapper.chmod(0o500)
     return wrapper
 


### PR DESCRIPTION
## Summary

The first real `workflow_dispatch` run against the new self-hosted runner (#2600) failed: every session hit `error_kind: infra-error` with `bwrap: execvp /usr/local/bin/node: No such file or directory`, tripping the outage-streak breaker after 5 consecutive failures. Run: https://github.com/abhigyanpatwari/GitNexus/actions/runs/29836411744

`sanitized_graph.py` and `runner_sessions.py` invoke the sandboxed graph CLI at the fixed path `/usr/local/bin/node`. `_runtime_mount_args` only binds `/usr`, `/bin`, `/lib`, `/lib64` wholesale, so that path resolves correctly when `node` happens to live under `/usr/local/bin` on the host -- true on GitHub-hosted runner images, but not on a self-hosted runner, where `actions/setup-node` installs into its own tool-cache directory instead (outside all four bound trees, invisible to the sandbox regardless of what `PATH` says on the host process).

Fix lives entirely in the mount construction: resolve `node` via `shutil.which` (correctly picks up wherever `actions/setup-node` put it, since its tool-cache dir is already on `PATH` by the time this runs) and bind it read-only to the same fixed sandbox path the two call sites already expect. Neither call site needed to change. Backward compatible with GitHub-hosted runners -- there this resolves to the same path and binds a harmless no-op self-mount.

## Test plan

- [x] `uv run --locked --extra dev python -m pytest tests -q` -- 313 passed, 10 skipped (pre-existing, real-bwrap-gated)
- [x] `ruff check` / `ruff format --check` clean
- [x] New tests cover both the self-hosted case (node resolved outside the bound trees) and the no-node-found case (bind skipped, not a hard error)
- [ ] Re-dispatch `workflow_dispatch` against the self-hosted runner with this fix to confirm the actual failure is resolved (next step after merge)