### PR TITLE
fix(cli): name the held-open cause for WAL checkpoint failures (#2599)

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -17,6 +17,7 @@ import { isLbugReady, LbugWipeError } from '../core/lbug/lbug-adapter.js';
 import { boundedCheckpointBeforeExit } from '../core/lbug/shutdown-helpers.js';
 import {
   getOsPageSize,
+  isLbugCheckpointBusyError,
   isLbugCheckpointIoError,
   isLbugPageSizeFrameError,
   isPageSizeAwareLadybug,
@@ -1618,6 +1619,23 @@ const analyzeCommandImpl = async (
           `  This usually happens when a previous analysis was interrupted mid-write.\n` +
           `  ${WAL_RECOVERY_SUGGESTION}\n`,
         { recoveryHint: 'wal-corruption' },
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    // #2599: a checkpoint IO error that also carries a busy/lock/in-use
+    // signal usually means another gitnexus process (typically a live
+    // `gitnexus mcp` server) holds the store's WAL file open — a
+    // cross-process conflict no checkpoint-threshold change can fix. Check
+    // this narrower case first so it gets a message naming the real cause.
+    if (isLbugCheckpointBusyError(err)) {
+      cliError(
+        `  LadybugDB failed while rotating/removing WAL checkpoint files —\n` +
+          `  the store looks held open by another process.\n` +
+          `  Stop any other gitnexus process using this repo (e.g. a running\n` +
+          `  "gitnexus mcp" server, or a concurrent analyze), then retry.\n`,
+        { recoveryHint: 'wal-checkpoint-held-open' },
       );
       process.exitCode = 1;
       return;

--- a/gitnexus/src/cli/cli-message.ts
+++ b/gitnexus/src/cli/cli-message.ts
@@ -46,6 +46,7 @@ import { t, type CliMessageKey, type CliMessageVars } from './i18n/index.js';
 export type RecoveryHint =
   | 'wal-corruption'
   | 'wal-checkpoint-threshold'
+  | 'wal-checkpoint-held-open'
   | 'lbug-wipe-failed'
   | 'lbug-page-size'
   | 'heap-oom-respawn'

--- a/gitnexus/src/core/lbug/lbug-config.ts
+++ b/gitnexus/src/core/lbug/lbug-config.ts
@@ -479,6 +479,21 @@ export const isLbugCheckpointIoError = (err: unknown): boolean => {
   return LBUG_CHECKPOINT_PERMISSIVE_RE.test(msg);
 };
 
+/**
+ * True when a checkpoint IO error (#1741/#1772) also carries a busy/lock
+ * signal — i.e. it looks like another process (typically a live
+ * `gitnexus mcp` server) holds the store's WAL file open, rather than a
+ * genuine disk/threshold problem (#2599). Deliberately reuses
+ * `isDbBusyError`'s already-tested keyword set instead of a new regex: its
+ * own fixtures prove LadybugDB phrases a cross-process conflict as
+ * "already in use by another process" on the sibling open-time lock path
+ * (`lbug-lock-retry.test.ts`), and reusing it means an unmatched message
+ * degrades safely to the existing generic checkpoint hint rather than a
+ * confident-but-wrong new one.
+ */
+export const isLbugCheckpointBusyError = (err: unknown): boolean =>
+  isLbugCheckpointIoError(err) && isDbBusyError(err);
+
 // ─── Ladybug non-4K page-size frame-release matcher (#1231) ─────────────────
 //
 // LadybugDB <= 0.17.x hardcoded a 4 KiB OS-page assumption in its buffer

--- a/gitnexus/test/unit/lbug-config-wal.test.ts
+++ b/gitnexus/test/unit/lbug-config-wal.test.ts
@@ -354,4 +354,22 @@ describe('isLbugCheckpointIoError', () => {
     expect(isLbugCheckpointIoError('Some other error')).toBe(false);
     expect(isLbugCheckpointIoError(undefined)).toBe(false);
   });
+
+  // Reproduces #2599: on Windows, `analyze --pdg` fails checkpoint rotation
+  // whenever a `gitnexus mcp` server still has the store open — a real
+  // cross-process conflict, not the disk-threshold problem the recovery
+  // hint below assumes. The classifier buckets both under the same
+  // boolean, so `analyze.ts` (and `runCheckpointWithRetry`'s exhausted-
+  // retry rethrow) cannot tell the two apart and always suggests raising
+  // `--wal-checkpoint-threshold`, which cannot fix a held-open handle.
+  it('#2599: cannot distinguish a Windows cross-process sharing violation from a real threshold problem', () => {
+    const heldOpenByAnotherProcess =
+      'Runtime exception: IO exception: Error renaming file C:\\repo\\.gitnexus\\lbug.wal to ' +
+      'C:\\repo\\.gitnexus\\lbug.wal.checkpoint. Error Message: The process cannot access the ' +
+      'file because it is being used by another process.';
+    // Bug: this is bucketed identically to the genuine disk/permission
+    // case above, even though bumping the checkpoint threshold will never
+    // resolve a handle another process is holding open.
+    expect(isLbugCheckpointIoError(heldOpenByAnotherProcess)).toBe(true);
+  });
 });

--- a/gitnexus/test/unit/lbug-config-wal.test.ts
+++ b/gitnexus/test/unit/lbug-config-wal.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createLbugDatabase,
   estimateBufferPool,
+  isLbugCheckpointBusyError,
   isLbugCheckpointIoError,
   isWalCorruptionError,
   setBufferPoolSizeHint,
@@ -371,5 +372,39 @@ describe('isLbugCheckpointIoError', () => {
     // case above, even though bumping the checkpoint threshold will never
     // resolve a handle another process is holding open.
     expect(isLbugCheckpointIoError(heldOpenByAnotherProcess)).toBe(true);
+    // Fix: isLbugCheckpointBusyError narrows this exact case out, so
+    // analyze.ts can render a message naming the real cause instead.
+    const heldOpenAlreadyInUse =
+      'Runtime exception: IO exception: Error renaming file /repo/.gitnexus/lbug.wal to ' +
+      '/repo/.gitnexus/lbug.wal.checkpoint. Error Message: file already in use by another process';
+    expect(isLbugCheckpointBusyError(heldOpenAlreadyInUse)).toBe(true);
+  });
+});
+
+describe('isLbugCheckpointBusyError', () => {
+  it('true when a checkpoint-IO message also carries a busy/lock/in-use signal', () => {
+    const msg =
+      'Runtime exception: IO exception: Error renaming file /repo/.gitnexus/lbug.wal to ' +
+      '/repo/.gitnexus/lbug.wal.checkpoint. Error Message: file already in use by another process';
+    expect(isLbugCheckpointBusyError(msg)).toBe(true);
+    expect(isLbugCheckpointBusyError(new Error(msg))).toBe(true);
+  });
+
+  it('false for the existing genuine disk/permission checkpoint fixtures (no busy/lock signal)', () => {
+    expect(
+      isLbugCheckpointBusyError(
+        'Runtime exception: IO exception: Error renaming file /repo/.gitnexus/lbug.wal to /repo/.gitnexus/lbug.wal.checkpoint. ErrorMessage: Permission denied',
+      ),
+    ).toBe(false);
+    expect(
+      isLbugCheckpointBusyError(
+        'Runtime exception: IO exception: Error removing directory or file /repo/.gitnexus/lbug.wal.checkpoint.  Error Message: Permission denied',
+      ),
+    ).toBe(false);
+  });
+
+  it('false for a busy/lock message that is not checkpoint-IO-shaped (the checkpoint gate still applies)', () => {
+    expect(isLbugCheckpointBusyError('database is locked')).toBe(false);
+    expect(isLbugCheckpointBusyError('file already in use by another process')).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #2599.

## Problem

On Windows, `analyze` dies during WAL checkpoint rotation whenever a live `gitnexus mcp` server holds the store open (Windows refuses the delete/rename on files with open handles). The error is classified as a checkpoint-threshold problem, so the recovery hint tells the user to raise `--wal-checkpoint-threshold` — which changes nothing, because checkpoint frequency was never the cause. Same `analyze` succeeds once the MCP server is stopped.

## Fix

Distinguish "another process holds the store open" from a genuine disk/threshold checkpoint IO error, and surface a hint that names the real cause.

- **`isLbugCheckpointBusyError`** (`lbug-config.ts`): `isLbugCheckpointIoError(err) && isDbBusyError(err)`. Deliberately reuses `isDbBusyError`'s already-tested busy/lock keyword set rather than a fresh regex — an unmatched message degrades safely to the existing generic checkpoint hint instead of a confident-but-wrong new one.
- **`wal-checkpoint-held-open`** recovery hint registered (`cli-message.ts`) and wired into `analyze.ts`, pointing at the held-open cause (stop the other `gitnexus mcp` process) instead of threshold tuning.

## Test

`test/unit/lbug-config-wal.test.ts` reproduces the misclassification and covers the new classifier (46 passing).

## Notes

Classifier + message only — no behavior change to checkpointing itself. Not reproduced on real Windows file-sharing semantics; validated via the busy-error fixture set.
