### PR TITLE
fix(eval): mount the node prefix for npx and catch nested Claude Code bootstrap noise

### DIFF
--- a/eval/tests/test_proposer_sandbox.py
+++ b/eval/tests/test_proposer_sandbox.py
@@ -21,6 +21,8 @@ from workflow_bench.proposer_sandbox import (
     MAX_BUNDLE_BYTES,
     MAX_EVIDENCE_FILE_BYTES,
     SANDBOX_NODE,
+    SANDBOX_NODE_PREFIX,
+    SANDBOX_PATH,
     SANDBOX_PYTHON3,
     SANDBOX_SHELL_PREFIX,
     SANDBOX_USER_SKILLS,
@@ -165,7 +167,7 @@ def test_sandbox_command_has_minimal_mounts_and_no_host_root_bind(tmp_path: Path
             check=False,
         )
         assert probe.returncode == 0, probe.stderr
-        assert probe.stdout == "/home/agent|/opt/claude:/usr/local/bin:/usr/bin:/bin"
+        assert probe.stdout == f"/home/agent|{SANDBOX_PATH}"
 
         # The evidence-provenance.mjs plan-writer's PATH-scan trusts a Python 3
         # candidate only if it (and its directory) is owned by root or by the
@@ -216,6 +218,45 @@ def test_runtime_mounts_bind_the_resolved_node_to_a_fresh_sandbox_path(monkeypat
     assert args[node_index - 1] == "--ro-bind"
     assert args[node_index + 1] == SANDBOX_NODE
     assert not any(SANDBOX_NODE.startswith(bound + "/") for bound in ("/usr", "/bin", "/lib", "/lib64"))
+
+
+def test_runtime_mounts_bind_the_node_prefix_so_npx_and_npm_resolve(monkeypatch) -> None:
+    # npx and npm are not standalone binaries -- they are symlinks into
+    # ../lib/node_modules/npm/bin/*-cli.js -- so binding the sibling files is
+    # not enough; the install prefix carrying both bin/ and lib/node_modules
+    # has to be mounted. Without this, a self-hosted runner (where
+    # actions/setup-node installs into its own tool cache, outside /usr) gets
+    # a sandbox with node but no npx, and every task verify command dies with
+    # "/bin/sh: 1: npx: not found" -- all 18 runs of skill-evolution run
+    # 29861768554 did exactly that.
+    monkeypatch.setattr(
+        "workflow_bench.proposer_sandbox.shutil.which",
+        lambda name: "/opt/hostedtoolcache/node/22.18.0/x64/bin/node" if name == "node" else None,
+    )
+    args = _runtime_mount_args()
+    prefix_index = args.index("/opt/hostedtoolcache/node/22.18.0/x64")
+    assert args[prefix_index - 1] == "--ro-bind"
+    assert args[prefix_index + 1] == SANDBOX_NODE_PREFIX
+    # the single-binary bind stays: sanitized_graph.py and runner_sessions.py
+    # invoke SANDBOX_NODE directly.
+    node_index = args.index("/opt/hostedtoolcache/node/22.18.0/x64/bin/node")
+    assert args[node_index + 1] == SANDBOX_NODE
+    # and the prefix's bin/ must actually be on PATH for npx to resolve.
+    assert f"{SANDBOX_NODE_PREFIX}/bin" in SANDBOX_PATH.split(":")
+
+
+def test_runtime_mounts_skip_the_prefix_bind_when_it_is_already_bound(monkeypatch) -> None:
+    # On an image where node genuinely lives in /usr/local/bin, the prefix is
+    # /usr/local -- already inside the wholesale /usr read-only bind. Binding
+    # it again would be redundant and would needlessly widen the argv, so the
+    # containment surface stays minimal.
+    monkeypatch.setattr(
+        "workflow_bench.proposer_sandbox.shutil.which",
+        lambda name: "/usr/local/bin/node" if name == "node" else None,
+    )
+    args = _runtime_mount_args()
+    assert SANDBOX_NODE_PREFIX not in args
+    assert args[args.index("/usr/local/bin/node") + 1] == SANDBOX_NODE
 
 
 def test_runtime_mounts_skip_the_node_bind_when_node_is_unresolvable(monkeypatch) -> None:
@@ -286,6 +327,41 @@ def test_real_bubblewrap_runs_node_from_outside_the_bound_trees(tmp_path: Path, 
     clone.mkdir()
     with prepare_sandbox(clone=clone, claude_bin=Path(sys.executable), preflight=True) as sandbox:
         result = sandbox.run([SANDBOX_NODE, "--version"], timeout=10)
+    assert result.ok, result.stderr_tail
+
+
+@pytest.mark.skipif(
+    os.environ.get("GITNEXUS_REQUIRE_BWRAP_CANARY") != "1",
+    reason="real Bubblewrap canary is mandatory in the named Ubuntu CI job",
+)
+def test_real_bubblewrap_runs_npx_from_outside_the_bound_trees(tmp_path: Path, monkeypatch) -> None:
+    # The npx half of the self-hosted-runner failure. Relocating a real node
+    # INSTALL (bin/ + lib/node_modules, not just the binary) to a fresh path
+    # outside /usr, /bin, /lib and /lib64 reproduces actions/setup-node's
+    # tool-cache convention. Every task verify command is
+    # "cd gitnexus && npx tsc ... && npx vitest ...", so npx must resolve
+    # inside the sandbox; argv assertions cannot prove a bwrap-level mount
+    # actually works, only a real invocation can.
+    real_node = shutil.which("node")
+    if not real_node:
+        pytest.skip("no node on PATH to relocate for this canary")
+    real_prefix = Path(real_node).resolve().parent.parent
+    if not (real_prefix / "lib" / "node_modules" / "npm").is_dir():
+        pytest.skip(f"node at {real_node} has no npm under its install prefix")
+    toolcache = tmp_path / "toolcache" / "node" / "22.18.0" / "x64"
+    shutil.copytree(real_prefix, toolcache, symlinks=True)
+    relocated_node = toolcache / "bin" / "node"
+    assert relocated_node.exists()
+    real_which = shutil.which
+    monkeypatch.setattr(
+        "workflow_bench.proposer_sandbox.shutil.which",
+        lambda name: str(relocated_node) if name == "node" else real_which(name),
+    )
+
+    clone = tmp_path / "clone"
+    clone.mkdir()
+    with prepare_sandbox(clone=clone, claude_bin=Path(sys.executable), preflight=True) as sandbox:
+        result = sandbox.run(["/bin/sh", "-c", "command -v npx && npx --version"], timeout=60)
     assert result.ok, result.stderr_tail
 
 

--- a/eval/tests/test_proposer_sandbox.py
+++ b/eval/tests/test_proposer_sandbox.py
@@ -233,6 +233,8 @@ def test_runtime_mounts_bind_the_node_prefix_so_npx_and_npm_resolve(monkeypatch,
     (prefix / "bin").mkdir(parents=True)
     (prefix / "bin" / "node").write_text("#!/bin/sh\nexit 0\n")
     (prefix / "lib" / "node_modules" / "npm" / "bin").mkdir(parents=True)
+    (prefix / "lib" / "node_modules" / "npm" / "bin" / "npx-cli.js").write_text("")
+    (prefix / "bin" / "npx").symlink_to("../lib/node_modules/npm/bin/npx-cli.js")
     monkeypatch.setattr(
         "workflow_bench.proposer_sandbox.shutil.which",
         lambda name: str(prefix / "bin" / "node") if name == "node" else None,
@@ -271,9 +273,9 @@ def test_runtime_mounts_skip_the_prefix_bind_for_an_unrecognized_node_layout(mon
     assert args[args.index(str(bare / "node")) + 1] == SANDBOX_NODE
 
 
-def test_runtime_mounts_skip_the_prefix_bind_without_npm_under_the_prefix(monkeypatch, tmp_path) -> None:
-    # Right <prefix>/bin/node shape, but no lib/node_modules/npm: binding it
-    # would widen the mount surface without making npx resolvable.
+def test_runtime_mounts_skip_the_prefix_bind_without_npx_beside_node(monkeypatch, tmp_path) -> None:
+    # Right <prefix>/bin/node shape, but no working npx beside it: binding the
+    # prefix would widen the mount surface without making npx resolvable.
     prefix = tmp_path / "x64"
     (prefix / "bin").mkdir(parents=True)
     (prefix / "bin" / "node").write_text("#!/bin/sh\nexit 0\n")
@@ -292,6 +294,8 @@ def test_runtime_mounts_bind_a_real_tool_cache_layout(monkeypatch, tmp_path) -> 
     (prefix / "bin").mkdir(parents=True)
     (prefix / "bin" / "node").write_text("#!/bin/sh\nexit 0\n")
     (prefix / "lib" / "node_modules" / "npm" / "bin").mkdir(parents=True)
+    (prefix / "lib" / "node_modules" / "npm" / "bin" / "npx-cli.js").write_text("")
+    (prefix / "bin" / "npx").symlink_to("../lib/node_modules/npm/bin/npx-cli.js")
     monkeypatch.setattr(
         "workflow_bench.proposer_sandbox.shutil.which",
         lambda name: str(prefix / "bin" / "node") if name == "node" else None,

--- a/eval/tests/test_proposer_sandbox.py
+++ b/eval/tests/test_proposer_sandbox.py
@@ -220,7 +220,7 @@ def test_runtime_mounts_bind_the_resolved_node_to_a_fresh_sandbox_path(monkeypat
     assert not any(SANDBOX_NODE.startswith(bound + "/") for bound in ("/usr", "/bin", "/lib", "/lib64"))
 
 
-def test_runtime_mounts_bind_the_node_prefix_so_npx_and_npm_resolve(monkeypatch) -> None:
+def test_runtime_mounts_bind_the_node_prefix_so_npx_and_npm_resolve(monkeypatch, tmp_path) -> None:
     # npx and npm are not standalone binaries -- they are symlinks into
     # ../lib/node_modules/npm/bin/*-cli.js -- so binding the sibling files is
     # not enough; the install prefix carrying both bin/ and lib/node_modules
@@ -229,20 +229,77 @@ def test_runtime_mounts_bind_the_node_prefix_so_npx_and_npm_resolve(monkeypatch)
     # a sandbox with node but no npx, and every task verify command dies with
     # "/bin/sh: 1: npx: not found" -- all 18 runs of skill-evolution run
     # 29861768554 did exactly that.
+    prefix = tmp_path / "hostedtoolcache" / "node" / "22.18.0" / "x64"
+    (prefix / "bin").mkdir(parents=True)
+    (prefix / "bin" / "node").write_text("#!/bin/sh\nexit 0\n")
+    (prefix / "lib" / "node_modules" / "npm" / "bin").mkdir(parents=True)
     monkeypatch.setattr(
         "workflow_bench.proposer_sandbox.shutil.which",
-        lambda name: "/opt/hostedtoolcache/node/22.18.0/x64/bin/node" if name == "node" else None,
+        lambda name: str(prefix / "bin" / "node") if name == "node" else None,
     )
     args = _runtime_mount_args()
-    prefix_index = args.index("/opt/hostedtoolcache/node/22.18.0/x64")
+    prefix_index = args.index(str(prefix))
     assert args[prefix_index - 1] == "--ro-bind"
     assert args[prefix_index + 1] == SANDBOX_NODE_PREFIX
     # the single-binary bind stays: sanitized_graph.py and runner_sessions.py
     # invoke SANDBOX_NODE directly.
-    node_index = args.index("/opt/hostedtoolcache/node/22.18.0/x64/bin/node")
+    node_index = args.index(str(prefix / "bin" / "node"))
     assert args[node_index + 1] == SANDBOX_NODE
     # and the prefix's bin/ must actually be on PATH for npx to resolve.
     assert f"{SANDBOX_NODE_PREFIX}/bin" in SANDBOX_PATH.split(":")
+
+
+def test_runtime_mounts_skip_the_prefix_bind_for_an_unrecognized_node_layout(monkeypatch, tmp_path) -> None:
+    # The prefix is derived from the node binary's path, so it must only be
+    # trusted when the layout really is <prefix>/bin/node carrying npm.
+    # Otherwise parent.parent names an unrelated ancestor: /opt/bin/node would
+    # bind ALL of /opt (every tool cache on a hosted runner) and a bare
+    # <dir>/node would bind <dir>'s parent -- an over-broad mount into a
+    # sandbox that runs untrusted model-authored code. The pre-existing
+    # real-Bubblewrap node canary builds exactly this bare <dir>/node shape.
+    bare = tmp_path / "toolcache"
+    bare.mkdir()
+    (bare / "node").write_text("#!/bin/sh\nexit 0\n")
+    monkeypatch.setattr(
+        "workflow_bench.proposer_sandbox.shutil.which",
+        lambda name: str(bare / "node") if name == "node" else None,
+    )
+    args = _runtime_mount_args()
+    assert SANDBOX_NODE_PREFIX not in args
+    assert str(tmp_path) not in args
+    # the node bind itself is unaffected -- SANDBOX_NODE still works.
+    assert args[args.index(str(bare / "node")) + 1] == SANDBOX_NODE
+
+
+def test_runtime_mounts_skip_the_prefix_bind_without_npm_under_the_prefix(monkeypatch, tmp_path) -> None:
+    # Right <prefix>/bin/node shape, but no lib/node_modules/npm: binding it
+    # would widen the mount surface without making npx resolvable.
+    prefix = tmp_path / "x64"
+    (prefix / "bin").mkdir(parents=True)
+    (prefix / "bin" / "node").write_text("#!/bin/sh\nexit 0\n")
+    monkeypatch.setattr(
+        "workflow_bench.proposer_sandbox.shutil.which",
+        lambda name: str(prefix / "bin" / "node") if name == "node" else None,
+    )
+    args = _runtime_mount_args()
+    assert SANDBOX_NODE_PREFIX not in args
+
+
+def test_runtime_mounts_bind_a_real_tool_cache_layout(monkeypatch, tmp_path) -> None:
+    # The positive counterpart: a genuine <prefix>/bin/node install carrying
+    # npm, outside the system trees, is bound so npx resolves.
+    prefix = tmp_path / "node" / "22.18.0" / "x64"
+    (prefix / "bin").mkdir(parents=True)
+    (prefix / "bin" / "node").write_text("#!/bin/sh\nexit 0\n")
+    (prefix / "lib" / "node_modules" / "npm" / "bin").mkdir(parents=True)
+    monkeypatch.setattr(
+        "workflow_bench.proposer_sandbox.shutil.which",
+        lambda name: str(prefix / "bin" / "node") if name == "node" else None,
+    )
+    args = _runtime_mount_args()
+    prefix_index = args.index(SANDBOX_NODE_PREFIX)
+    assert args[prefix_index - 2] == "--ro-bind"
+    assert args[prefix_index - 1] == str(prefix)
 
 
 def test_runtime_mounts_skip_the_prefix_bind_when_it_is_already_bound(monkeypatch) -> None:

--- a/eval/tests/test_runner_hardening.py
+++ b/eval/tests/test_runner_hardening.py
@@ -309,8 +309,6 @@ def test_phase_workspace_ignores_nested_claude_sandbox_bootstrap_noise(tmp_path)
     (nested / "settings.local.json").write_text("{}")
     before = runner_artifacts.workspace_snapshot(tmp_path)
     (nested / ".cc-writes").write_text("{}")
-    (nested / "agents").mkdir()
-    (nested / "commands").mkdir()
     artifact = tmp_path / "review-output.md"
     artifact.write_text("new review")
 
@@ -357,6 +355,27 @@ def test_phase_workspace_still_rejects_nested_package_json(tmp_path):
     manifest.write_text("{}")
     before = runner_artifacts.workspace_snapshot(tmp_path)
     manifest.write_text('{"version": "9.9.9"}')
+    artifact = tmp_path / "review-output.md"
+    artifact.write_text("new review")
+
+    with pytest.raises(ValueError, match="unauthorized workspace path"):
+        runner_artifacts.enforce_phase_workspace(tmp_path, before, allowed_artifact=artifact)
+
+
+def test_phase_workspace_still_sees_writes_under_a_pre_existing_nested_claude_dir(tmp_path):
+    # Every excluded name is a blind spot. .claude/agents and .claude/commands
+    # are deliberately NOT excluded at depth: once a .claude directory exists
+    # (gitnexus/.claude/settings.local.json is tracked), anything written
+    # underneath an excluded entry is invisible to this check, and Claude Code
+    # loads .claude/agents relative to its cwd -- which these tasks point at
+    # gitnexus/. A planning phase must not be able to plant a definition there
+    # for the later work phase to read.
+    nested = tmp_path / "gitnexus" / ".claude"
+    nested.mkdir(parents=True)
+    (nested / "settings.local.json").write_text("{}")
+    before = runner_artifacts.workspace_snapshot(tmp_path)
+    (nested / "agents").mkdir()
+    (nested / "agents" / "planted.md").write_text("planted agent definition")
     artifact = tmp_path / "review-output.md"
     artifact.write_text("new review")
 

--- a/eval/tests/test_runner_hardening.py
+++ b/eval/tests/test_runner_hardening.py
@@ -296,3 +296,69 @@ def test_phase_workspace_still_rejects_a_genuinely_unauthorized_change(tmp_path)
 
     with pytest.raises(ValueError, match="unauthorized workspace path"):
         runner_artifacts.enforce_phase_workspace(tmp_path, before, allowed_artifact=artifact)
+
+
+def test_phase_workspace_ignores_nested_claude_sandbox_bootstrap_noise(tmp_path):
+    # Claude Code bootstraps into whatever directory it is running in, not just
+    # the workspace root. The benchmark's task prompts cd into gitnexus/, so the
+    # same noise lands one level down -- observed verbatim in skill-evolution run
+    # 29861768554, where 13 of 18 sessions failed with
+    # "phase changed unauthorized workspace path(s): gitnexus/.claude/.cc-writes".
+    nested = tmp_path / "gitnexus" / ".claude"
+    nested.mkdir(parents=True)
+    (nested / "settings.local.json").write_text("{}")
+    before = runner_artifacts.workspace_snapshot(tmp_path)
+    (nested / ".cc-writes").write_text("{}")
+    (nested / "agents").mkdir()
+    (nested / "commands").mkdir()
+    artifact = tmp_path / "review-output.md"
+    artifact.write_text("new review")
+
+    runner_artifacts.enforce_phase_workspace(tmp_path, before, allowed_artifact=artifact)
+
+
+def test_phase_workspace_does_not_descend_into_nested_bootstrap_directories(tmp_path):
+    # The exclusion must skip an entry before it is queued for traversal, so
+    # content created *inside* the ignored directory stays invisible too.
+    nested = tmp_path / "gitnexus" / ".claude" / ".cc-writes"
+    nested.mkdir(parents=True)
+    before = runner_artifacts.workspace_snapshot(tmp_path)
+    (nested / "pending.json").write_text('{"writes": 1}')
+    artifact = tmp_path / "review-output.md"
+    artifact.write_text("new review")
+
+    runner_artifacts.enforce_phase_workspace(tmp_path, before, allowed_artifact=artifact)
+
+
+def test_phase_workspace_still_rejects_nested_real_claude_config(tmp_path):
+    # gitnexus/.claude/settings.local.json is real tracked repository content.
+    # Excluding ".claude" wholesale at depth would blind the check to it, so the
+    # exclusion must name only the entries Claude Code itself creates.
+    nested = tmp_path / "gitnexus" / ".claude"
+    nested.mkdir(parents=True)
+    settings = nested / "settings.local.json"
+    settings.write_text("{}")
+    before = runner_artifacts.workspace_snapshot(tmp_path)
+    settings.write_text('{"permissions": "changed"}')
+    artifact = tmp_path / "review-output.md"
+    artifact.write_text("new review")
+
+    with pytest.raises(ValueError, match="unauthorized workspace path"):
+        runner_artifacts.enforce_phase_workspace(tmp_path, before, allowed_artifact=artifact)
+
+
+def test_phase_workspace_still_rejects_nested_package_json(tmp_path):
+    # package.json is in WORKSPACE_SNAPSHOT_BOOTSTRAP_NOISE, but only as a
+    # workspace-root entry: gitnexus/package.json is real tracked content whose
+    # edits must still be caught.
+    nested = tmp_path / "gitnexus"
+    nested.mkdir()
+    manifest = nested / "package.json"
+    manifest.write_text("{}")
+    before = runner_artifacts.workspace_snapshot(tmp_path)
+    manifest.write_text('{"version": "9.9.9"}')
+    artifact = tmp_path / "review-output.md"
+    artifact.write_text("new review")
+
+    with pytest.raises(ValueError, match="unauthorized workspace path"):
+        runner_artifacts.enforce_phase_workspace(tmp_path, before, allowed_artifact=artifact)

--- a/eval/workflow_bench/proposer_sandbox.py
+++ b/eval/workflow_bench/proposer_sandbox.py
@@ -383,8 +383,19 @@ def _runtime_mount_args() -> list[str]:
         # ("cd gitnexus && npx tsc ... && npx vitest ...") died with
         # "/bin/sh: 1: npx: not found". Skip the redundant bind in the
         # already-covered case so the mount surface stays minimal.
-        node_prefix = Path(node_bin).resolve().parent.parent
-        if not any(node_prefix.is_relative_to(tree) for tree in system_trees):
+        #
+        # The prefix is only ever derived from a real <prefix>/bin/node layout
+        # that actually carries npm. Deriving it as parent.parent unconditionally
+        # would mount an unrelated ancestor whenever node sits somewhere else:
+        # /opt/bin/node would bind all of /opt (every tool cache on a hosted
+        # runner) and a bare <dir>/node would bind <dir>'s parent. This function
+        # exists to keep the sandbox surface minimal, so an unrecognized layout
+        # binds nothing extra and simply leaves npx unavailable, exactly as
+        # before.
+        node_bin_dir = Path(node_bin).resolve().parent
+        node_prefix = node_bin_dir.parent
+        provides_npm = node_bin_dir.name == "bin" and (node_prefix / "lib" / "node_modules" / "npm").is_dir()
+        if provides_npm and not any(node_prefix.is_relative_to(tree) for tree in system_trees):
             args += ["--ro-bind", str(node_prefix), SANDBOX_NODE_PREFIX]
     for raw in (
         "/etc/ssl",

--- a/eval/workflow_bench/proposer_sandbox.py
+++ b/eval/workflow_bench/proposer_sandbox.py
@@ -28,7 +28,8 @@ SANDBOX_CLAUDE = "/opt/claude/claude"
 SANDBOX_SHELL_PREFIX = "/opt/claude/shell-prefix"
 SANDBOX_PYTHON3 = "/opt/claude/python3"
 SANDBOX_NODE = "/opt/claude/node"
-SANDBOX_PATH = "/opt/claude:/usr/local/bin:/usr/bin:/bin"
+SANDBOX_NODE_PREFIX = "/opt/claude/nodejs"
+SANDBOX_PATH = f"/opt/claude:{SANDBOX_NODE_PREFIX}/bin:/usr/local/bin:/usr/bin:/bin"
 SANDBOX_GITNEXUS = "/opt/gitnexus"
 SANDBOX_GITNEXUS_SHARED = "/opt/gitnexus-shared"
 SANDBOX_GITNEXUS_REGISTRY = "/opt/gitnexus-registry"
@@ -351,7 +352,8 @@ def build_claude_settings() -> str:
 
 def _runtime_mount_args() -> list[str]:
     args: list[str] = []
-    for raw in ("/usr", "/bin", "/lib", "/lib64"):
+    system_trees = ("/usr", "/bin", "/lib", "/lib64")
+    for raw in system_trees:
         path = Path(raw)
         if path.exists():
             args += ["--ro-bind", raw, raw]
@@ -369,6 +371,21 @@ def _runtime_mount_args() -> list[str]:
     node_bin = shutil.which("node")
     if node_bin:
         args += ["--ro-bind", node_bin, SANDBOX_NODE]
+        # The single-binary bind above gives SANDBOX_NODE but NOT npm or npx:
+        # those are symlinks into ../lib/node_modules/npm/bin/*-cli.js, so the
+        # install prefix carrying both bin/ and lib/node_modules has to be
+        # mounted for them to resolve at all. When node really lives under a
+        # system tree (/usr/local/bin on GitHub-hosted images) the prefix is
+        # already inside the wholesale read-only binds above and npm/npx came
+        # along for free -- which is exactly why this gap stayed invisible
+        # until a self-hosted runner put node in actions/setup-node's tool
+        # cache, outside /usr, and every task verify command
+        # ("cd gitnexus && npx tsc ... && npx vitest ...") died with
+        # "/bin/sh: 1: npx: not found". Skip the redundant bind in the
+        # already-covered case so the mount surface stays minimal.
+        node_prefix = Path(node_bin).resolve().parent.parent
+        if not any(node_prefix.is_relative_to(tree) for tree in system_trees):
+            args += ["--ro-bind", str(node_prefix), SANDBOX_NODE_PREFIX]
     for raw in (
         "/etc/ssl",
         "/etc/hosts",

--- a/eval/workflow_bench/proposer_sandbox.py
+++ b/eval/workflow_bench/proposer_sandbox.py
@@ -394,8 +394,15 @@ def _runtime_mount_args() -> list[str]:
         # before.
         node_bin_dir = Path(node_bin).resolve().parent
         node_prefix = node_bin_dir.parent
-        provides_npm = node_bin_dir.name == "bin" and (node_prefix / "lib" / "node_modules" / "npm").is_dir()
-        if provides_npm and not any(node_prefix.is_relative_to(tree) for tree in system_trees):
+        # Test the property actually needed -- a working npx next to node in a
+        # real bin/ directory -- rather than a proxy like lib/node_modules/npm.
+        # .exists() follows the symlink, so a dangling npx correctly fails: it
+        # would not survive the mount either. Requiring the "bin" name keeps
+        # the parent.parent derivation honest; an npx sitting directly beside
+        # node in a flat directory would make that derivation name the wrong
+        # prefix.
+        provides_npx = node_bin_dir.name == "bin" and (node_bin_dir / "npx").exists()
+        if provides_npx and not any(node_prefix.is_relative_to(tree) for tree in system_trees):
             args += ["--ro-bind", str(node_prefix), SANDBOX_NODE_PREFIX]
     for raw in (
         "/etc/ssl",

--- a/eval/workflow_bench/runner_artifacts.py
+++ b/eval/workflow_bench/runner_artifacts.py
@@ -63,11 +63,21 @@ WORKSPACE_SNAPSHOT_BOOTSTRAP_NOISE = frozenset(
 # running in, so a task whose prompt cd's into a subdirectory gets the same
 # noise one level down. Observed in skill-evolution run 29861768554: 13 of 18
 # sessions failed with "phase changed unauthorized workspace path(s):
-# gitnexus/.claude/.cc-writes". These are the entries Claude Code creates
-# inside a .claude directory, and they are matched at ANY depth -- never
+# gitnexus/.claude/.cc-writes". That entry is matched at ANY depth -- never
 # ".claude" itself, which holds real configuration.
+#
+# Deliberately only .cc-writes. Every excluded name is a blind spot: once a
+# .claude directory already exists (gitnexus/.claude/settings.local.json is
+# tracked), anything a phase writes underneath an excluded entry becomes
+# invisible to this check, and Claude Code loads .claude/agents relative to
+# its cwd -- which these tasks point at gitnexus/. Adding "agents" and
+# "commands" here on the theory that they might also appear nested would let a
+# planning phase plant a definition that the later work phase reads, with no
+# evidence in the boundary check. Only .cc-writes was ever observed nested, so
+# only .cc-writes is excluded; extend this set from an observed failure, never
+# pre-emptively.
 CLAUDE_BOOTSTRAP_DIR = ".claude"
-CLAUDE_BOOTSTRAP_ENTRIES = frozenset({".cc-writes", "agents", "commands"})
+CLAUDE_BOOTSTRAP_ENTRIES = frozenset({".cc-writes"})
 
 IMPLEMENTATION_ARMS = frozenset(
     {

--- a/eval/workflow_bench/runner_artifacts.py
+++ b/eval/workflow_bench/runner_artifacts.py
@@ -55,6 +55,20 @@ WORKSPACE_SNAPSHOT_BOOTSTRAP_NOISE = frozenset(
     }
 )
 
+# The set above is matched at the workspace ROOT only, because most of its
+# entries (package.json, node_modules, the .env family) are also legitimate
+# repository content further down the tree -- gitnexus/package.json and
+# gitnexus/.claude/settings.local.json are both tracked files whose edits must
+# still be caught. But Claude Code bootstraps into whatever directory it is
+# running in, so a task whose prompt cd's into a subdirectory gets the same
+# noise one level down. Observed in skill-evolution run 29861768554: 13 of 18
+# sessions failed with "phase changed unauthorized workspace path(s):
+# gitnexus/.claude/.cc-writes". These are the entries Claude Code creates
+# inside a .claude directory, and they are matched at ANY depth -- never
+# ".claude" itself, which holds real configuration.
+CLAUDE_BOOTSTRAP_DIR = ".claude"
+CLAUDE_BOOTSTRAP_ENTRIES = frozenset({".cc-writes", "agents", "commands"})
+
 IMPLEMENTATION_ARMS = frozenset(
     {
         "workflow",
@@ -86,6 +100,15 @@ class VerificationResult:
         yield self.output
 
 
+def _is_bootstrap_noise(relative: PurePosixPath) -> bool:
+    """Report whether a walked entry is harness noise rather than workspace change."""
+
+    parts = relative.parts
+    if parts[0] == ".git" or parts[0] in WORKSPACE_SNAPSHOT_BOOTSTRAP_NOISE:
+        return True
+    return len(parts) >= 2 and parts[-2] == CLAUDE_BOOTSTRAP_DIR and parts[-1] in CLAUDE_BOOTSTRAP_ENTRIES
+
+
 def workspace_snapshot(worktree: Path) -> dict[str, str]:
     """Hash the workspace without following links, excluding Git internals
     and Claude Code's own sandbox-bootstrap noise (see
@@ -110,7 +133,7 @@ def workspace_snapshot(worktree: Path) -> dict[str, str]:
             raise ValueError(f"workspace snapshot directory is unreadable: {directory}: {exc}") from exc
         for entry in children:
             relative = relative_dir / entry.name
-            if relative.parts[0] == ".git" or relative.parts[0] in WORKSPACE_SNAPSHOT_BOOTSTRAP_NOISE:
+            if _is_bootstrap_noise(relative):
                 continue
             entry_count += 1
             path_bytes += len(relative.as_posix().encode())


### PR DESCRIPTION
## Why

Skill-evolution run [29861768554](https://github.com/abhigyanpatwari/GitNexus/actions/runs/29861768554) resolved **0/3 on every task and both arms**. That was not a bad candidate — the harness was broken in two independent ways, each fatal on its own. `runner.py`'s `broken_incumbent_arms` check and the promotion gate both behaved correctly; they were faithfully reporting a broken environment.

Evidence is the run's own artifact:

| symptom | count | field |
| --- | --- | --- |
| `/bin/sh: 1: npx: not found` | **18/18** | `verify_output` |
| `phase changed unauthorized workspace path(s): gitnexus/.claude/.cc-writes` | **13/18** | `error_detail` |

## Bug 1 — the sandbox had `node` but no `npx`/`npm`

`_runtime_mount_args()` bound only the `node` binary to `SANDBOX_NODE`. `npx` and `npm` are not standalone binaries — they are symlinks into `../lib/node_modules/npm/bin/*-cli.js` — so the **install prefix** (carrying both `bin/` and `lib/node_modules`) has to be mounted for them to resolve at all.

On GitHub-hosted images node lives in `/usr/local/bin`, whose prefix is already inside the wholesale `/usr` read-only bind, so `npm`/`npx` came along for free. That is exactly why this stayed invisible. A self-hosted runner's `actions/setup-node` installs into its own tool cache, outside `/usr`, so only the single `node` file was bound. Every task's verify command is `cd gitnexus && npx tsc --noEmit && npx vitest run <test>`, so no run could resolve regardless of model output. It reached the model too: 12 `npm: not found` failures across the session transcripts, with `gitnexus/scripts/build.js` dying on `npm ci` (status 127).

The fix binds the resolved prefix read-only at `/opt/claude/nodejs` and puts its `bin/` on `SANDBOX_PATH`. It is skipped when the prefix already sits inside `/usr`, `/bin`, `/lib` or `/lib64`, so the already-covered case does not widen the mount surface redundantly. `SANDBOX_NODE` is deliberately unchanged — `sanitized_graph.py` and `runner_sessions.py` invoke it directly.

The bind is gated on the property actually required: a working `npx` beside `node` in a real `bin/` directory. An earlier revision derived the prefix as `parent.parent` unconditionally, which read-only mounted an unrelated ancestor whenever node sat elsewhere — `/opt/bin/node` bound **all of `/opt`**, and a bare `<dir>/node` bound `<dir>`'s parent. That second shape is not hypothetical: the pre-existing `test_real_bubblewrap_runs_node_from_outside_the_bound_trees` canary builds exactly it, so `eval-containment-linux` would have silently over-mounted the whole pytest `tmp_path` inside a containment test.

## Bug 2 — the bootstrap-noise exclusion was root-anchored

`workspace_snapshot` tested only `relative.parts[0]` against `WORKSPACE_SNAPSHOT_BOOTSTRAP_NOISE`. Claude Code bootstraps into whatever directory it is **running in**, and the task prompts `cd gitnexus`, so the noise landed at `gitnexus/.claude/.cc-writes` — whose `parts[0]` is `"gitnexus"`, so it was never excluded. This is the same defect #2615 meant to fix; that change added the set but kept the root-anchored match, so it only ever covered workspace-root noise. The same code path also guards the review phase (`runner.py:499`), so review arms hit it as `review-evidence-invalid`.

Matching the whole set at any depth would be wrong — it also contains `package.json`, `package-lock.json`, `node_modules` and the `.env` family, and both `gitnexus/package.json` and `gitnexus/.claude/settings.local.json` are real tracked files whose edits must still be caught. So the root-anchored rule is untouched and one narrow rule matches `.cc-writes` inside a `.claude` directory at any depth.

Scoped to `.cc-writes` alone, deliberately. An earlier revision also excluded `agents` and `commands` on the theory they might appear nested; only `.cc-writes` ever was. Every excluded name is a blind spot: once a `.claude` directory exists, anything written under an excluded entry is invisible to the check, and Claude Code loads `.claude/agents` relative to its cwd — which these tasks point at `gitnexus/`. A planning phase could otherwise plant a definition the work phase reads, with no evidence in the boundary check.

## Verified on the actual self-hosted runner

The gated real-Bubblewrap canaries cannot run in a dev container (no unprivileged user namespaces, even under `sudo`), so every claim below was executed on the real runner over SSM:

- Guard predicate against the runner's real `which("node")` → `PREFIX BOUND = True`
- Real bwrap, before vs after: `npx: NOT FOUND` → `npx FOUND at /opt/claude/nodejs/bin/npx, 10.9.3`
- Full eval suite with `GITNEXUS_REQUIRE_BWRAP_CANARY=1` → **335 passed, 4 skipped**
- All five real-bwrap canaries pass, including the new `test_real_bubblewrap_runs_npx_from_outside_the_bound_trees`
- CI containment selection (the exact `eval-containment-linux` command) → 121 passed
- The real production command `cd gitnexus && npx tsc --noEmit` inside a real sandbox (read-only workspace, unshared network, PID namespace) → **passes**

Locally: 325 passed, 12 skipped; `ruff check` and `ruff format --check` clean.

## Known follow-up, not fixed here

Testing on the runner surfaced a **third, independent blocker** that `npx: not found` had been masking by short-circuiting the `&&` chain. With npx working, verify gets further and dies:

```
EROFS ... /workspace/gitnexus/node_modules/.vite-temp/vitest.config.ts.timestamp-*.mjs
```

Vite transpiles a TypeScript config before loading it, and the dependency `node_modules` is a read-only mount. This blocks the authored-test verify **and the hidden oracle** (same `run_verify(..., read_only_workspace=True)` path), so `resolved` will still be 0/N until it is addressed.

It is pre-existing and independent of this PR: it reproduces at the base commit with these changes stashed and npx bypassed entirely via `./node_modules/.bin/vitest`.

No fix is included because the obvious one does not generalize. Overlaying `--tmpfs <target>/.vite-temp` makes the complete verify pass (15/15 tests), but bwrap cannot create a mountpoint inside a read-only bind, so it only works where `.vite-temp` already exists on the host — it did for `gitnexus/node_modules`, not for `gitnexus-shared/node_modules`, and `npm ci` never creates it. The runner has bubblewrap 0.9.0, which predates `--tmp-overlay`/`--overlay-src`. Shipping a fix that passes by accident would be worse than none. Options, smallest first: create the empty `.vite-temp` in each dependency `node_modules` at staging time; upgrade bwrap to >= 0.10 and overlay the whole mount; or make the vitest config non-TS.

## Tests

Added to `test_proposer_sandbox.py` (the canary must live there — `test_workflow_bench.py` pins the set of files carrying the canary marker):
- tool-cache layout binds its prefix and keeps the `SANDBOX_NODE` bind
- already-bound prefix (`/usr/local`) emits no redundant bind
- unrecognized layout (bare `<dir>/node`) binds nothing extra
- `<prefix>/bin/node` without a working `npx` binds nothing extra
- gated real-bwrap canary running `npx --version` inside the sandbox

Added to `test_runner_hardening.py`:
- nested `gitnexus/.claude/.cc-writes` is ignored
- an excluded directory is not descended into
- nested `gitnexus/.claude/settings.local.json` edits are still rejected
- nested `gitnexus/package.json` edits are still rejected
- writes under a pre-existing nested `.claude/agents` are still caught

Exactly one pre-existing line changed across both test files: the hard-coded `SANDBOX_PATH` probe assertion, now derived from the constant so the two cannot drift. No test was weakened or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
