### PR TITLE
fix(cli): LadybugDB native-load failures fail closed, incl. truncated-binary SIGBUS (#2441)

### DIFF
--- a/gitnexus/src/core/lbug/native-check.ts
+++ b/gitnexus/src/core/lbug/native-check.ts
@@ -1,6 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 import { createRequire } from 'node:module';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+
+/** Cap the out-of-process native load probe so a hung filesystem cannot wedge a
+ *  CLI startup gate (same bounding rationale as the extension probe below). */
+const NATIVE_LOAD_PROBE_TIMEOUT_MS = 15_000;
 
 export interface NativeCheckResult {
   ok: boolean;
@@ -59,35 +64,73 @@ export function checkLbugNative(overridePkgDir?: string): NativeCheckResult {
     };
   }
 
-  try {
-    const _require = createRequire(import.meta.url);
-    _require(binaryPath);
-  } catch (err: unknown) {
-    const nativeError = err instanceof Error ? err.message : String(err);
-    return {
-      ok: false,
-      binaryPath,
-      message: [
-        'LadybugDB native binary (lbugjs.node) exists but failed to load:',
-        `  ${nativeError}`,
-        '',
-        'This can happen with a truncated file, ABI mismatch, or wrong-platform binary.',
-        '',
-        'To repair:',
-        `  node ${path.join(pkgDir, 'install.js')}`,
-        '',
-        'If install scripts were skipped (pnpm dlx / pnpx / ignore-scripts):',
-        '  pnpm --allow-build=@ladybugdb/core --allow-build=gitnexus --allow-build=tree-sitter \\',
-        '    dlx gitnexus@latest serve',
-        '  pnpm add -g --allow-build=@ladybugdb/core --allow-build=gitnexus --allow-build=tree-sitter gitnexus',
-        '',
-        'If using bun, add to package.json and reinstall:',
-        '  "trustedDependencies": ["@ladybugdb/core"]',
-      ].join('\n'),
-    };
+  // Validate loadability in a THROWAWAY CHILD PROCESS, not in-process. A merely
+  // truncated or corrupted .node (valid header, missing pages) does not throw a
+  // catchable error — it SIGBUSes the dynamic loader mid-dlopen, which would take
+  // the whole CLI down with a raw exit 135 and no guidance (#2441). Loading it in
+  // a child lets us observe that crash (a non-zero exit or a kill signal) and turn
+  // it into the same actionable failure as a clean load error. The child requires
+  // the binary by absolute path, exactly as the former in-process load did.
+  const probe = spawnSync(process.execPath, ['-e', 'require(process.argv[1])', binaryPath], {
+    encoding: 'utf8',
+    timeout: NATIVE_LOAD_PROBE_TIMEOUT_MS,
+    stdio: ['ignore', 'ignore', 'pipe'],
+    // Run as Node even if process.execPath is an Electron/embedder binary.
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+  });
+
+  // Only a child that actually RAN and failed proves the binary is bad. If the
+  // probe could not run at all — a spawn error or a timeout, e.g. a sandbox that
+  // forbids subprocesses or a non-Node execPath — we could not test the binary,
+  // so we stay out of the way and let the command's own load be the authority
+  // rather than condemn a healthy binary. (#2441 still holds: a genuinely broken
+  // binary loaded in-process later still exits non-zero.)
+  if (probe.error || probe.status === 0) {
+    return { ok: true, binaryPath };
   }
 
-  return { ok: true, binaryPath };
+  return {
+    ok: false,
+    binaryPath,
+    message: [
+      'LadybugDB native binary (lbugjs.node) exists but failed to load:',
+      `  ${describeNativeLoadFailure(probe)}`,
+      '',
+      'This can happen with a truncated file, ABI mismatch, or wrong-platform binary.',
+      '',
+      'To repair:',
+      `  node ${path.join(pkgDir, 'install.js')}`,
+      '',
+      'If install scripts were skipped (pnpm dlx / pnpx / ignore-scripts):',
+      '  pnpm --allow-build=@ladybugdb/core --allow-build=gitnexus --allow-build=tree-sitter \\',
+      '    dlx gitnexus@latest serve',
+      '  pnpm add -g --allow-build=@ladybugdb/core --allow-build=gitnexus --allow-build=tree-sitter gitnexus',
+      '',
+      'If using bun, add to package.json and reinstall:',
+      '  "trustedDependencies": ["@ladybugdb/core"]',
+    ].join('\n'),
+  };
+}
+
+/**
+ * Describe a child-observed native load failure. Reached only after a probe that
+ * actually ran and failed: a fatal signal (SIGBUS/SIGSEGV ⇒ truncated/corrupt
+ * binary), otherwise the child's own load error lifted from its stderr.
+ */
+function describeNativeLoadFailure(probe: SpawnSyncReturns<string>): string {
+  if (probe.signal) {
+    return `crashed while loading (signal ${probe.signal}) — the binary is likely truncated or corrupted`;
+  }
+  const lines = (probe.stderr ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const errorLine = lines.find((line) => /^\w*Error: /.test(line));
+  return (
+    errorLine?.replace(/^\w*Error:\s*/, '') ??
+    lines.at(-1) ??
+    `exited with code ${probe.status ?? 'unknown'}`
+  );
 }
 
 export interface FtsProbeResult {

--- a/gitnexus/test/unit/lazy-action.test.ts
+++ b/gitnexus/test/unit/lazy-action.test.ts
@@ -90,4 +90,46 @@ describe('createAnalyzerLbugLazyAction', () => {
     expect(events).toEqual(['identity-module', 'receipt-captured', 'analyzer-module']);
     expect(run).toHaveBeenCalledWith(receipt, 'repo', { force: true });
   });
+
+  it('sets exit code 1 and skips the analyzer import when native load fails', async () => {
+    // Regression guard for #2441: a LadybugDB native-load failure must fail
+    // closed — no analyzer import, no index write, non-zero exit — not the
+    // pre-fix "print help then exit 0" silent success. Mirrors the
+    // createLbugLazyAction failure test above for the analyze-only wrapper.
+    checkLbugNativeMock.mockReturnValueOnce({
+      ok: false,
+      message:
+        'LadybugDB native binary (lbugjs.node) exists but failed to load:\n' + '  dlopen failed',
+    });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    process.exitCode = undefined;
+    const run = vi.fn(async () => undefined);
+    const analyzerLoader = vi.fn(async () => ({ run }));
+    const identityLoader = vi.fn(async () => ({
+      captureAnalyzerIdentityBeforeLoad: async (_url: string, loader: () => Promise<unknown>) => {
+        const loaded = await loader();
+        return { runnerIdentity: { schemaVersion: 4 }, loaded };
+      },
+    }));
+    const action = createAnalyzerLbugLazyAction(
+      identityLoader as never,
+      analyzerLoader,
+      'run',
+      'file:///fixture/dist/cli/index.js',
+    );
+
+    try {
+      await expect(action('repo', { force: true })).resolves.toBeUndefined();
+
+      expect(analyzerLoader).not.toHaveBeenCalled();
+      expect(run).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('LadybugDB native binary (lbugjs.node) exists but failed to load:'),
+      );
+    } finally {
+      stderrSpy.mockRestore();
+      process.exitCode = undefined;
+    }
+  });
 });

--- a/gitnexus/test/unit/lbug-native-check.test.ts
+++ b/gitnexus/test/unit/lbug-native-check.test.ts
@@ -49,4 +49,49 @@ describe('checkLbugNative', () => {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it('returns ok:false when lbugjs.node is truncated (loader crashes with a signal)', async () => {
+    // A partially written .node (valid header, missing pages) SIGBUSes dlopen — a
+    // signal, not a catchable throw. The out-of-process probe must observe the
+    // crash and report it, instead of the whole process dying with exit 135 (#2441).
+    const realPath = checkLbugNative().binaryPath;
+    expect(realPath).toBeDefined();
+    const truncated = (await fs.readFile(realPath!)).subarray(0, 300_000);
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lbug-check-'));
+    try {
+      await fs.writeFile(path.join(tmpDir, 'install.js'), '');
+      await fs.writeFile(path.join(tmpDir, 'lbugjs.node'), truncated);
+
+      const result = checkLbugNative(tmpDir);
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('failed to load');
+      expect(result.message).toContain('install.js');
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns ok:true when the load probe cannot be spawned (inconclusive, not a broken binary)', async () => {
+    // The binary is present, but the child probe cannot launch — a sandbox that
+    // forbids subprocesses, or a non-Node execPath. We could not test the binary,
+    // so a healthy one must not be condemned; the command's own load stays
+    // authoritative. (Binary content is irrelevant here — the probe never runs.)
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lbug-check-'));
+    const originalExecPath = process.execPath;
+    try {
+      await fs.writeFile(path.join(tmpDir, 'lbugjs.node'), Buffer.from('content-irrelevant'));
+      await fs.writeFile(path.join(tmpDir, 'install.js'), '');
+      process.execPath = path.join(tmpDir, 'definitely-not-node');
+
+      const result = checkLbugNative(tmpDir);
+
+      expect(result.ok).toBe(true);
+      expect(result.message).toBeUndefined();
+    } finally {
+      process.execPath = originalExecPath;
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Makes `gitnexus analyze` (and every other native-gated command) **fail closed** on any LadybugDB native-load failure — including the truncated-binary case that previously crashed the CLI with a raw `exit 135` — and adds regression tests locking the behavior.

Issue #2441 reported `analyze` exiting **0** after a native-load failure (no index, but "success"). The exit-code half was already fixed on `main`: `checkLbugNative()` validates the binary and `analyze` routes through `createAnalyzerLbugLazyAction`, which sets `process.exitCode = 1` and writes nothing on failure. This PR closes the two remaining gaps.

## What changed

**1. Out-of-process native load probe** — `gitnexus/src/core/lbug/native-check.ts`
`checkLbugNative()` used to `require()` the binary **in-process** to test loadability. That catches clean failures (missing dylib, zero-byte, garbage → `file too short`), but a merely **truncated/corrupted** `.node` (valid header, missing pages) doesn't throw — it **SIGBUSes** the dynamic loader mid-`dlopen`, a signal that can't be caught in-process, taking the whole CLI down with a raw `exit 135` and no guidance.

The check now loads the binary in a **throwaway child process** (`spawnSync(node, ['-e','require(process.argv[1])', binaryPath])`, ~20ms, bounded by a timeout). A crash — non-zero exit *or* a kill signal — is turned into the same actionable "failed to load" message + repair instructions, with a clean non-zero exit and no index written. The redundant in-process pre-load is removed.

**2. Regression tests**
- `gitnexus/test/unit/lazy-action.test.ts` — `createAnalyzerLbugLazyAction` (the wrapper `analyze` uses) previously had only a happy-path test; adds its native-load-failure path: analyzer module **not** imported, `process.exitCode === 1`, repair message to stderr.
- `gitnexus/test/unit/lbug-native-check.test.ts` — adds a **truncated-binary** case (truncates the real `lbugjs.node`, asserts `ok:false`), which SIGBUSes in-process and would have escaped the old check.

## Reproduction / verification (origin/main base)

Isolated `@ladybugdb/core` copy so the shared `node_modules` was never touched:

| Native-binary state | Before | After |
|---|---|---|
| truncated mid-file (valid ELF header) | **exit 135** (raw SIGBUS crash) | **exit 1** + "crashed while loading (signal SIGBUS) — likely truncated or corrupted" |
| garbage / non-ELF | exit 1 + repair message | exit 1 (preserved) |
| zero-byte | exit 1 | exit 1 (preserved) |
| existing index + broken native | exit 1, stale index preserved | preserved |
| good native | exit 0, indexed | exit 0, indexed |

No `.gitnexus/` is ever produced on failure. Both new tests were verified to discriminate (they fail without the corresponding guard).

- `npm test -- test/unit/lbug-native-check.test.ts test/unit/lazy-action.test.ts` → 9/9 pass
- `npx tsc --noEmit` → clean; pre-commit eslint/prettier/typecheck → pass

Closes #2441

🤖 Generated with [Claude Code](https://claude.com/claude-code)
