### PR TITLE
fix: index staleness — false-stale status after analyze (#2668) + inline staleness in query/context/impact/cypher tools (#2655)

### DIFF
--- a/.claude/skills/gitnexus-guide/SKILL.md
+++ b/.claude/skills/gitnexus-guide/SKILL.md
@@ -81,6 +81,18 @@ list_repos { offset: 400 }  → repos 401–437,                 hasMore false  
 
 Notes: `offset` ≥ `total` returns an empty page (with `total` still reported). Out-of-range or malformed `limit`/`offset` (non-integer, `limit` outside `[1, 200]`, `offset < 0`) are rejected with a clear error — `limit` above the max is rejected, not silently capped. The order is deterministic (lower-cased name, then path), so paging never skips or duplicates an entry while the registry is unchanged.
 
+### Inline staleness signal (`query` / `context` / `impact` / `cypher`)
+
+These four hot read tools attach a non-blocking `staleness` field to their response when the index is behind the checkout's current HEAD — the same `{ commitsBehind, hint }` shape `list_repos` already reports — so a direct tool call surfaces a behind-HEAD index without a separate `list_repos` call:
+
+```jsonc
+{ /* …the tool's normal result… */
+  "staleness": { "commitsBehind": 3, "hint": "⚠️ Index is 3 commits behind HEAD. Run analyze tool to update." }
+}
+```
+
+The field is **absent when the index is current** (or when the freshness check can't run), so its presence is the signal. It is only ever added to object results — raw-array `cypher` output and error envelopes are returned unchanged. `@group`-targeted calls do not carry it (multi-repo staleness is ill-defined). When you see it, the graph may be behind the working tree — re-run `analyze` before trusting blast-radius or dependence answers.
+
 ### Taint findings (`explain`)
 
 `explain` returns taint findings recorded by `gitnexus analyze --pdg` — intra-procedural `TAINTED` edges plus cross-function `TAINT_PATH` hops where the interprocedural taint phase found a function-level source→sink chain. Each finding includes a sink category (command-injection, code-injection, path-traversal, sql-injection, xss), source/sink lines, and the ordered hop path with the variable carried on each hop.

--- a/gitnexus-claude-plugin/skills/gitnexus-guide/SKILL.md
+++ b/gitnexus-claude-plugin/skills/gitnexus-guide/SKILL.md
@@ -81,6 +81,18 @@ list_repos { offset: 400 }  → repos 401–437,                 hasMore false  
 
 Notes: `offset` ≥ `total` returns an empty page (with `total` still reported). Out-of-range or malformed `limit`/`offset` (non-integer, `limit` outside `[1, 200]`, `offset < 0`) are rejected with a clear error — `limit` above the max is rejected, not silently capped. The order is deterministic (lower-cased name, then path), so paging never skips or duplicates an entry while the registry is unchanged.
 
+### Inline staleness signal (`query` / `context` / `impact` / `cypher`)
+
+These four hot read tools attach a non-blocking `staleness` field to their response when the index is behind the checkout's current HEAD — the same `{ commitsBehind, hint }` shape `list_repos` already reports — so a direct tool call surfaces a behind-HEAD index without a separate `list_repos` call:
+
+```jsonc
+{ /* …the tool's normal result… */
+  "staleness": { "commitsBehind": 3, "hint": "⚠️ Index is 3 commits behind HEAD. Run analyze tool to update." }
+}
+```
+
+The field is **absent when the index is current** (or when the freshness check can't run), so its presence is the signal. It is only ever added to object results — raw-array `cypher` output and error envelopes are returned unchanged. `@group`-targeted calls do not carry it (multi-repo staleness is ill-defined). When you see it, the graph may be behind the working tree — re-run `analyze` before trusting blast-radius or dependence answers.
+
 ### Taint findings (`explain`)
 
 `explain` returns taint findings recorded by `gitnexus analyze --pdg` — intra-procedural `TAINTED` edges plus cross-function `TAINT_PATH` hops where the interprocedural taint phase found a function-level source→sink chain. Each finding includes a sink category (command-injection, code-injection, path-traversal, sql-injection, xss), source/sink lines, and the ordered hop path with the variable carried on each hop.

--- a/gitnexus/scripts/cross-platform-tests.ts
+++ b/gitnexus/scripts/cross-platform-tests.ts
@@ -36,6 +36,12 @@ const PLATFORM_LOGIC = [
   // must exercise the Windows backslash branch, so run it on the OS matrix (#2394).
   'test/unit/cli-entry.test.ts',
   'test/unit/platform-capabilities.test.ts',
+  // Windows drive-letter case variance in the analyzer runner-identity path
+  // fields (#2668): normalizeAnalyzerRootPath is a POSIX no-op, so the
+  // "identity path fields are normalizer-stable" fixpoint guard only bites on
+  // the windows-latest matrix — the file must run there, not just in the
+  // Ubuntu full-suite where it's trivially green.
+  'test/unit/analyzer-identity.test.ts',
   // getconf page-size probe: explicit process.platform gate (win32 short-circuit)
   // plus a live-probe test whose only real non-4K coverage is macos-arm64's
   // 16 KiB pages — the exact hardware class #1231 targets (#2424 review).

--- a/gitnexus/scripts/cross-platform-tests.ts
+++ b/gitnexus/scripts/cross-platform-tests.ts
@@ -39,9 +39,12 @@ const PLATFORM_LOGIC = [
   // Windows drive-letter case variance in the analyzer runner-identity path
   // fields (#2668): normalizeAnalyzerRootPath is a POSIX no-op, so the
   // "identity path fields are normalizer-stable" fixpoint guard only bites on
-  // the windows-latest matrix — the file must run there, not just in the
-  // Ubuntu full-suite where it's trivially green.
-  'test/unit/analyzer-identity.test.ts',
+  // the windows-latest matrix — it must run there, not just in the Ubuntu
+  // full-suite where it's trivially green. Deliberately the split-out
+  // normalization file, NOT analyzer-identity.test.ts: the latter's fixture
+  // tests compare identity fields against raw temp-dir paths and fail on macOS,
+  // where /var/... realpaths to /private/var/....
+  'test/unit/analyzer-identity-path-normalization.test.ts',
   // getconf page-size probe: explicit process.platform gate (win32 short-circuit)
   // plus a live-probe test whose only real non-4K coverage is macos-arm64's
   // 16 KiB pages — the exact hardware class #1231 targets (#2424 review).

--- a/gitnexus/src/core/analyzer-identity.ts
+++ b/gitnexus/src/core/analyzer-identity.ts
@@ -381,7 +381,14 @@ const LIBC_VARIANT = detectLibcVariant();
 
 function resolveRuntimeVariant(): RuntimeVariant {
   return {
-    executablePath: resolveExistingPath(process.execPath),
+    // Normalized like build.rootPath (#2668): executablePath is a compared
+    // identity field (only invokedArtifact is stripped in the comparison), and
+    // process.execPath carries the same Windows drive-letter case ambiguity —
+    // so leaving it un-normalized would reintroduce the false-stale via runtime.
+    executablePath: normalizeAnalyzerRootPath(
+      resolveExistingPath(process.execPath),
+      process.platform,
+    ),
     nodeVersion: process.version,
     platform: process.platform,
     architecture: process.arch,
@@ -524,6 +531,36 @@ function resolveExistingPath(candidate: string): string {
   return realpathSync.native(path.resolve(candidate));
 }
 
+/**
+ * Case-stabilize a path's Windows drive letter so two processes that observed
+ * the same directory under different drive-letter casing (`c:\…` vs `C:\…`)
+ * produce byte-identical analyzer-identity path fields (#2668).
+ *
+ * `realpathSync.native` canonicalizes 8.3 short names and symlinks but does not
+ * guarantee the drive-letter case it returns — it can preserve whatever casing
+ * the caller's path carried, and `import.meta.url` casing depends on how each
+ * entry process (CLI shim vs `npx`/npm wrapper vs server worker) was launched.
+ * When `analyze` stamps `build.rootPath` under one casing and `status`
+ * recomputes it under another, `analyzerRunnerIdentitiesEqual` deep-compares
+ * unequal and `status` reports a freshly-analyzed, untouched repo as stale.
+ * Uppercasing the drive letter (drive letters are case-insensitive; uppercase
+ * is the conventional form) collapses that variance. POSIX paths are returned
+ * unchanged. `platform` is explicit so the transform is unit-testable off
+ * Windows.
+ *
+ * The optional `\\?\` extended-length prefix (which `realpathSync.native` can
+ * emit for paths over MAX_PATH) is preserved and the drive letter after it is
+ * still normalized; UNC paths (`\\server\share`, `\\?\UNC\...`) have no drive
+ * letter and are left untouched.
+ */
+export function normalizeAnalyzerRootPath(p: string, platform: NodeJS.Platform): string {
+  if (platform !== 'win32') return p;
+  return p.replace(
+    /^(\\\\\?\\)?([a-z]):/,
+    (_match, prefix: string | undefined, drive: string) => `${prefix ?? ''}${drive.toUpperCase()}:`,
+  );
+}
+
 function isFile(candidate: string): boolean {
   try {
     return statSync(candidate).isFile();
@@ -570,9 +607,14 @@ function resolveBuildRoot(analyzerModulePath: string): {
       const packageRoot = path.dirname(cursor);
       const packageJson = path.join(packageRoot, 'package.json');
       if (lstatSync(packageJson).isFile()) {
+        // Normalize the drive-letter case at this single upstream source so
+        // every derived identity path field — build.rootPath, identityCacheKey,
+        // and (via collectDependencyInputs) dependencyRuntime.manifestPath /
+        // lockfilePath — inherits a case-stable root and analyze-stamp equals
+        // status-recompute regardless of launch-path casing (#2668).
         return {
-          packageRoot,
-          buildRoot: cursor,
+          packageRoot: normalizeAnalyzerRootPath(packageRoot, process.platform),
+          buildRoot: normalizeAnalyzerRootPath(cursor, process.platform),
           kind: base === 'src' ? 'source' : 'distribution',
         };
       }

--- a/gitnexus/src/core/analyzer-identity.ts
+++ b/gitnexus/src/core/analyzer-identity.ts
@@ -612,6 +612,10 @@ function resolveBuildRoot(analyzerModulePath: string): {
         // and (via collectDependencyInputs) dependencyRuntime.manifestPath /
         // lockfilePath — inherits a case-stable root and analyze-stamp equals
         // status-recompute regardless of launch-path casing (#2668).
+        // Migration: a Windows index stamped before this fix carries the old,
+        // un-normalized casing, so the first post-upgrade `status` sees one
+        // spurious "stale" flip — self-healing on the next `analyze`, which
+        // re-stamps the normalized (idempotent) form.
         return {
           packageRoot: normalizeAnalyzerRootPath(packageRoot, process.platform),
           buildRoot: normalizeAnalyzerRootPath(cursor, process.platform),

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -1792,7 +1792,12 @@ export class LocalBackend {
    */
   private async withToolStaleness(repo: RepoHandle, result: unknown): Promise<unknown> {
     if (!canCarryStaleness(result)) return result;
-    return attachToolStaleness(result, await this.stalenessForTool(repo));
+    // Defensive: `checkStalenessAsync` self-catches today, but a rejection here
+    // must never fail the tool — degrade to no-staleness. Paired with the
+    // evict-on-reject in `stalenessForTool`, a transient failure also can't
+    // poison the TTL cache entry (#2655 review F1).
+    const staleness = await this.stalenessForTool(repo).catch(() => undefined);
+    return attachToolStaleness(result, staleness);
   }
 
   /**
@@ -1811,9 +1816,26 @@ export class LocalBackend {
     if (cached && now - cached.at < LocalBackend.TOOL_STALENESS_TTL_MS) {
       return cached.value;
     }
-    const value = checkStalenessAsync(repo.repoPath, repo.lastCommit);
-    this.toolStalenessCache.set(repo.lbugPath, { at: now, value });
-    return value;
+    // Evict the entry if the check rejects so a transient failure isn't served
+    // (as a permanently-rejecting promise) for the rest of the TTL window; the
+    // next call then re-runs. A resolving promise is never evicted, so happy-path
+    // dedup is untouched (#2655 review F1). `Promise.resolve` wraps the call so a
+    // non-thenable return can't throw at this boundary — a no-op for the real
+    // async `checkStalenessAsync`, robust defense-in-depth otherwise.
+    const entry: { at: number; value: Promise<StalenessInfo> } = {
+      at: now,
+      // Only evict if THIS entry is still current — a later call may have
+      // installed a fresh (resolving) entry for the same key before a slow
+      // rejection lands, and that newer entry must not be dropped.
+      value: Promise.resolve(checkStalenessAsync(repo.repoPath, repo.lastCommit)).catch((err) => {
+        if (this.toolStalenessCache.get(repo.lbugPath) === entry) {
+          this.toolStalenessCache.delete(repo.lbugPath);
+        }
+        throw err;
+      }),
+    };
+    this.toolStalenessCache.set(repo.lbugPath, entry);
+    return entry.value;
   }
 
   async callTool(method: string, params: any): Promise<any> {

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -71,7 +71,11 @@ import {
   isSupportedCjkSegmentationMode,
   MAX_CJK_SEGMENTATION_QUERY_LENGTH,
 } from '../../core/search/cjk-segmentation.js';
-import { checkStalenessAsync, checkCwdMatch } from '../../core/git-staleness.js';
+import {
+  checkStalenessAsync,
+  checkCwdMatch,
+  type StalenessInfo,
+} from '../../core/git-staleness.js';
 import { logger } from '../../core/logger.js';
 import {
   isLocalEmbeddingRuntimeBlockerMessage,
@@ -712,12 +716,60 @@ export function parseListReposPagination(
   return { limit, offset };
 }
 
+/**
+ * #2655: a tool result can carry a `staleness` field only if it is a plain
+ * object that isn't an error envelope and doesn't already carry one. Raw-array
+ * results (non-tabular `cypher` rows) are excluded because the CLI's `--limit`
+ * and other consumers branch on `Array.isArray`, so wrapping them would break
+ * that contract. Shared by `attachToolStaleness` and the dispatch site, which
+ * uses it to skip the freshness `git` spawn for results that can't carry it.
+ */
+function canCarryStaleness(result: unknown): result is Record<string, unknown> {
+  return (
+    result !== null &&
+    typeof result === 'object' &&
+    !Array.isArray(result) &&
+    !('error' in result) &&
+    !('staleness' in result)
+  );
+}
+
+/**
+ * #2655: attach a non-blocking `staleness` signal to a tool result when the
+ * index is behind HEAD, mirroring the `list_repos` `{commitsBehind, hint}`
+ * shape. Only ever ADDS a field to a carryable object result (see
+ * {@link canCarryStaleness}) — it never changes an existing result's shape.
+ */
+export function attachToolStaleness(
+  result: unknown,
+  staleness: StalenessInfo | undefined,
+): unknown {
+  if (!staleness?.isStale || !canCarryStaleness(result)) {
+    return result;
+  }
+  return {
+    ...result,
+    staleness: { commitsBehind: staleness.commitsBehind, hint: staleness.hint },
+  };
+}
+
 export class LocalBackend {
+  private static readonly TOOL_STALENESS_TTL_MS = 5000;
   private repos: Map<string, RepoHandle> = new Map();
   private contextCache: Map<string, CodebaseContext> = new Map();
   private initializedRepos: Set<string> = new Set();
   private reinitPromises: Map<string, Promise<void>> = new Map();
   private lastStalenessCheck: Map<string, number> = new Map();
+  // #2655: commit-behind freshness for the hot read tools. Stores the IN-FLIGHT
+  // promise (not just a timestamp) so N concurrent tool calls arriving before
+  // the first `git rev-list` resolves share one subprocess instead of each
+  // spawning their own; the resolved value is reused for TOOL_STALENESS_TTL_MS.
+  // Keyed by lbugPath (like lastStalenessCheck) — NOT repoPath — because flat
+  // and branch handles for one repo share a repoPath but carry different
+  // lastCommit values, so a repoPath key would serve one handle's freshness for
+  // the other; lbugPath is unique per flat/branch index.
+  private toolStalenessCache: Map<string, { at: number; value: Promise<StalenessInfo> }> =
+    new Map();
   // Last meta.indexedAt observed for an open pool, keyed by lbugPath. Keyed by
   // pool (not stored on the handle) because branch handles are produced fresh
   // by applyBranchScope on every resolveRepo call, so mutating the handle would
@@ -1064,6 +1116,7 @@ export class LocalBackend {
       if (liveLbugPaths.has(key)) continue;
       this.initializedRepos.delete(key);
       this.lastStalenessCheck.delete(key);
+      this.toolStalenessCache.delete(key);
       this.lastObservedIndexedAt.delete(key);
       this.lastObservedDbIdentity.delete(key);
       this.reinitPromises.delete(key);
@@ -1731,6 +1784,38 @@ export class LocalBackend {
 
   // ─── Tool Dispatch ───────────────────────────────────────────────
 
+  /**
+   * #2655: attach a commits-behind freshness signal to a hot-read-tool result,
+   * skipping the `git` spawn entirely for results that can't carry it (error
+   * envelopes, arrays, non-objects — see {@link canCarryStaleness}) so an
+   * error-returning call pays nothing.
+   */
+  private async withToolStaleness(repo: RepoHandle, result: unknown): Promise<unknown> {
+    if (!canCarryStaleness(result)) return result;
+    return attachToolStaleness(result, await this.stalenessForTool(repo));
+  }
+
+  /**
+   * #2655: commits-behind freshness for the hot read tools, deduped per index.
+   * Returns a shared in-flight promise so concurrent tool calls spawn at most
+   * one `git rev-list` per index per TTL window; the resolved value is cached
+   * for TOOL_STALENESS_TTL_MS. Keyed by lbugPath so flat and branch handles
+   * (same repoPath, different lastCommit) don't share an entry. Non-blocking by
+   * construction: `checkStalenessAsync` swallows git failures to
+   * `{ isStale: false }`, so a git error never fails the tool — it just omits
+   * the `staleness` field.
+   */
+  private stalenessForTool(repo: RepoHandle): Promise<StalenessInfo> {
+    const now = Date.now();
+    const cached = this.toolStalenessCache.get(repo.lbugPath);
+    if (cached && now - cached.at < LocalBackend.TOOL_STALENESS_TTL_MS) {
+      return cached.value;
+    }
+    const value = checkStalenessAsync(repo.repoPath, repo.lastCommit);
+    this.toolStalenessCache.set(repo.lbugPath, { at: now, value });
+    return value;
+  }
+
   async callTool(method: string, params: any): Promise<any> {
     if (method === 'list_repos') {
       // Paginated tool surface (#2119). `listRepos()` is unchanged for internal
@@ -1773,19 +1858,19 @@ export class LocalBackend {
 
     switch (method) {
       case 'query':
-        return this.query(repo, p);
+        return this.withToolStaleness(repo, await this.query(repo, p));
       case 'cypher': {
         const raw = await this.cypher(repo, p);
-        return this.formatCypherAsMarkdown(raw);
+        return this.withToolStaleness(repo, this.formatCypherAsMarkdown(raw));
       }
       case 'context':
-        return this.context(repo, p);
+        return this.withToolStaleness(repo, await this.context(repo, p));
       case 'explain':
         return this.explain(repo, p);
       case 'pdg_query':
         return this.pdgQuery(repo, p);
       case 'impact':
-        return this.impact(repo, p as unknown as ImpactParams);
+        return this.withToolStaleness(repo, await this.impact(repo, p as unknown as ImpactParams));
       case 'detect_changes':
         return this.detectChanges(repo, p);
       case 'check':

--- a/gitnexus/test/unit/analyzer-identity-path-normalization.test.ts
+++ b/gitnexus/test/unit/analyzer-identity-path-normalization.test.ts
@@ -5,20 +5,20 @@
  * `normalizeAnalyzerRootPath` is a POSIX no-op, so these assertions only bite on
  * windows-latest; the file is registered in `scripts/cross-platform-tests.ts` for
  * exactly that reason. It is deliberately separate from `analyzer-identity.test.ts`,
- * whose fixture-based tests compare identity fields against raw temp-dir paths and
- * are therefore not portable to macOS (where `/var/...` realpaths to `/private/var/...`).
- * Everything here is either a pure-function assertion with an explicit `platform`
- * argument, or a self-referential fixpoint check — both portable to every runner.
+ * and holds ONLY pure-function assertions that pass an explicit `platform` argument
+ * — no fixture, no filesystem. That restriction is load-bearing: the fixture-based
+ * identity tests cannot run on this matrix, for two independent reasons observed in
+ * CI on this PR —
+ *   - macOS: they compare identity fields against the raw temp-dir path while the
+ *     identity realpaths it, so `/var/...` comes back as `/private/var/...`;
+ *   - Windows: the GH runner puts the repo on `D:` and temp fixtures on `C:`, and
+ *     `isInside()` misjudges cross-drive paths (`path.win32.relative` returns the
+ *     absolute target, which does not start with `..`), so `resolveInvokedArtifact`
+ *     picks the vitest fork worker and identity resolution throws.
+ * Keep this file fixture-free so it stays green on every runner.
  */
 import { describe, it, expect } from 'vitest';
-import { mkdir, writeFile } from 'node:fs/promises';
-import path from 'node:path';
-import { pathToFileURL } from 'node:url';
-import {
-  normalizeAnalyzerRootPath,
-  resolveAnalyzerRunnerIdentity,
-} from '../../src/core/analyzer-identity.js';
-import { createTempDir } from '../helpers/test-db.js';
+import { normalizeAnalyzerRootPath } from '../../src/core/analyzer-identity.js';
 
 // #2668: `status` reported a freshly-analyzed, untouched repo as stale on
 // Windows because `build.rootPath` (and the other compared identity path
@@ -66,41 +66,5 @@ describe('normalizeAnalyzerRootPath (#2668)', () => {
       '/home/user/gitnexus/dist',
     );
     expect(normalizeAnalyzerRootPath('/Home/User/Dist', 'darwin')).toBe('/Home/User/Dist');
-  });
-
-  // #2668 threading guard: the produced identity's path fields must already be
-  // normalizer-stable, i.e. resolveBuildRoot/resolveRuntimeVariant actually route
-  // build.rootPath and runtime.executablePath through normalizeAnalyzerRootPath.
-  // On POSIX the normalizer is a no-op, so this is a trivially-true fixpoint here
-  // and a real regression guard on Windows CI (where an un-threaded call site
-  // would leave a lowercase drive that the normalizer would change). It compares
-  // each field against ITSELF normalized — never against the raw fixture path —
-  // so it is immune to the macOS /var → /private/var realpath difference.
-  it('produces identity path fields that are already normalizer-stable', async () => {
-    const fixture = await createTempDir();
-    try {
-      const sourceRoot = path.join(fixture.dbPath, 'src');
-      const modulePath = path.join(sourceRoot, 'core', 'analyzer.ts');
-      await mkdir(path.dirname(modulePath), { recursive: true });
-      await writeFile(
-        path.join(fixture.dbPath, 'package.json'),
-        '{"name":"fixture-analyzer","version":"1.0.0"}\n',
-      );
-      await writeFile(path.join(fixture.dbPath, 'package-lock.json'), '{"lockfileVersion":3}\n');
-      await writeFile(modulePath, 'export const analyzer = 1;\n');
-
-      const identity = resolveAnalyzerRunnerIdentity(pathToFileURL(modulePath).href, {
-        cacheDirectory: path.join(fixture.dbPath, 'identity-cache'),
-      });
-
-      expect(identity.build.rootPath).toBe(
-        normalizeAnalyzerRootPath(identity.build.rootPath, process.platform),
-      );
-      expect(identity.runtime.executablePath).toBe(
-        normalizeAnalyzerRootPath(identity.runtime.executablePath, process.platform),
-      );
-    } finally {
-      await fixture.cleanup();
-    }
   });
 });

--- a/gitnexus/test/unit/analyzer-identity-path-normalization.test.ts
+++ b/gitnexus/test/unit/analyzer-identity-path-normalization.test.ts
@@ -1,0 +1,106 @@
+/**
+ * #2668 path-normalization guard — split out of `analyzer-identity.test.ts` so it
+ * can run on the Windows/macOS matrix.
+ *
+ * `normalizeAnalyzerRootPath` is a POSIX no-op, so these assertions only bite on
+ * windows-latest; the file is registered in `scripts/cross-platform-tests.ts` for
+ * exactly that reason. It is deliberately separate from `analyzer-identity.test.ts`,
+ * whose fixture-based tests compare identity fields against raw temp-dir paths and
+ * are therefore not portable to macOS (where `/var/...` realpaths to `/private/var/...`).
+ * Everything here is either a pure-function assertion with an explicit `platform`
+ * argument, or a self-referential fixpoint check — both portable to every runner.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  normalizeAnalyzerRootPath,
+  resolveAnalyzerRunnerIdentity,
+} from '../../src/core/analyzer-identity.js';
+import { createTempDir } from '../helpers/test-db.js';
+
+// #2668: `status` reported a freshly-analyzed, untouched repo as stale on
+// Windows because `build.rootPath` (and the other compared identity path
+// fields) carried the drive-letter case that `realpathSync.native` did not
+// normalize — so `analyze` and `status`, launched under different casing,
+// stamped vs recomputed unequal identities. `normalizeAnalyzerRootPath`
+// collapses that variance at the single upstream source (resolveBuildRoot).
+describe('normalizeAnalyzerRootPath (#2668)', () => {
+  it('uppercases a Windows drive letter so case-variant roots collapse', () => {
+    expect(normalizeAnalyzerRootPath('c:\\gitnexus\\dist', 'win32')).toBe('C:\\gitnexus\\dist');
+    expect(normalizeAnalyzerRootPath('c:\\gitnexus\\dist', 'win32')).toBe(
+      normalizeAnalyzerRootPath('C:\\gitnexus\\dist', 'win32'),
+    );
+    // Forward-slash drive form (as some resolvers emit) is normalized too.
+    expect(normalizeAnalyzerRootPath('d:/build', 'win32')).toBe('D:/build');
+  });
+
+  it('is idempotent and leaves an already-uppercase drive unchanged', () => {
+    expect(normalizeAnalyzerRootPath('C:\\build', 'win32')).toBe('C:\\build');
+    expect(
+      normalizeAnalyzerRootPath(normalizeAnalyzerRootPath('c:\\build', 'win32'), 'win32'),
+    ).toBe('C:\\build');
+  });
+
+  it('only touches a leading drive letter, not other path bytes', () => {
+    // A UNC path has no drive letter; interior case is preserved.
+    expect(normalizeAnalyzerRootPath('\\\\server\\Share\\Repo', 'win32')).toBe(
+      '\\\\server\\Share\\Repo',
+    );
+    expect(normalizeAnalyzerRootPath('C:\\Repo\\subDir', 'win32')).toBe('C:\\Repo\\subDir');
+  });
+
+  it('normalizes the drive under an extended-length \\\\?\\ prefix, preserving the prefix', () => {
+    expect(normalizeAnalyzerRootPath('\\\\?\\c:\\gitnexus\\dist', 'win32')).toBe(
+      '\\\\?\\C:\\gitnexus\\dist',
+    );
+    // Extended UNC form has no drive letter — left untouched.
+    expect(normalizeAnalyzerRootPath('\\\\?\\UNC\\server\\Share', 'win32')).toBe(
+      '\\\\?\\UNC\\server\\Share',
+    );
+  });
+
+  it('is a no-op on POSIX (case-sensitive paths must not be mutated)', () => {
+    expect(normalizeAnalyzerRootPath('/home/user/gitnexus/dist', 'linux')).toBe(
+      '/home/user/gitnexus/dist',
+    );
+    expect(normalizeAnalyzerRootPath('/Home/User/Dist', 'darwin')).toBe('/Home/User/Dist');
+  });
+
+  // #2668 threading guard: the produced identity's path fields must already be
+  // normalizer-stable, i.e. resolveBuildRoot/resolveRuntimeVariant actually route
+  // build.rootPath and runtime.executablePath through normalizeAnalyzerRootPath.
+  // On POSIX the normalizer is a no-op, so this is a trivially-true fixpoint here
+  // and a real regression guard on Windows CI (where an un-threaded call site
+  // would leave a lowercase drive that the normalizer would change). It compares
+  // each field against ITSELF normalized — never against the raw fixture path —
+  // so it is immune to the macOS /var → /private/var realpath difference.
+  it('produces identity path fields that are already normalizer-stable', async () => {
+    const fixture = await createTempDir();
+    try {
+      const sourceRoot = path.join(fixture.dbPath, 'src');
+      const modulePath = path.join(sourceRoot, 'core', 'analyzer.ts');
+      await mkdir(path.dirname(modulePath), { recursive: true });
+      await writeFile(
+        path.join(fixture.dbPath, 'package.json'),
+        '{"name":"fixture-analyzer","version":"1.0.0"}\n',
+      );
+      await writeFile(path.join(fixture.dbPath, 'package-lock.json'), '{"lockfileVersion":3}\n');
+      await writeFile(modulePath, 'export const analyzer = 1;\n');
+
+      const identity = resolveAnalyzerRunnerIdentity(pathToFileURL(modulePath).href, {
+        cacheDirectory: path.join(fixture.dbPath, 'identity-cache'),
+      });
+
+      expect(identity.build.rootPath).toBe(
+        normalizeAnalyzerRootPath(identity.build.rootPath, process.platform),
+      );
+      expect(identity.runtime.executablePath).toBe(
+        normalizeAnalyzerRootPath(identity.runtime.executablePath, process.platform),
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+});

--- a/gitnexus/test/unit/analyzer-identity.test.ts
+++ b/gitnexus/test/unit/analyzer-identity.test.ts
@@ -11,7 +11,6 @@ import {
   analyzerRunnerIdentitiesEqual,
   captureAnalyzerIdentityBeforeLoad,
   finalizeAnalyzerRunnerIdentity,
-  normalizeAnalyzerRootPath,
   normalizeAnalyzerRunnerIdentityForComparison,
   resolveAnalyzerRunnerIdentity,
 } from '../../src/core/analyzer-identity.js';
@@ -1508,87 +1507,4 @@ describe('analyzer runner identity', () => {
       await repo.cleanup();
     }
   }, 300_000);
-});
-
-// #2668: `status` reported a freshly-analyzed, untouched repo as stale on
-// Windows because `build.rootPath` (and the other compared identity path
-// fields) carried the drive-letter case that `realpathSync.native` did not
-// normalize — so `analyze` and `status`, launched under different casing,
-// stamped vs recomputed unequal identities. `normalizeAnalyzerRootPath`
-// collapses that variance at the single upstream source (resolveBuildRoot).
-describe('normalizeAnalyzerRootPath (#2668)', () => {
-  it('uppercases a Windows drive letter so case-variant roots collapse', () => {
-    expect(normalizeAnalyzerRootPath('c:\\gitnexus\\dist', 'win32')).toBe('C:\\gitnexus\\dist');
-    expect(normalizeAnalyzerRootPath('c:\\gitnexus\\dist', 'win32')).toBe(
-      normalizeAnalyzerRootPath('C:\\gitnexus\\dist', 'win32'),
-    );
-    // Forward-slash drive form (as some resolvers emit) is normalized too.
-    expect(normalizeAnalyzerRootPath('d:/build', 'win32')).toBe('D:/build');
-  });
-
-  it('is idempotent and leaves an already-uppercase drive unchanged', () => {
-    expect(normalizeAnalyzerRootPath('C:\\build', 'win32')).toBe('C:\\build');
-    expect(
-      normalizeAnalyzerRootPath(normalizeAnalyzerRootPath('c:\\build', 'win32'), 'win32'),
-    ).toBe('C:\\build');
-  });
-
-  it('only touches a leading drive letter, not other path bytes', () => {
-    // A UNC path has no drive letter; interior case is preserved.
-    expect(normalizeAnalyzerRootPath('\\\\server\\Share\\Repo', 'win32')).toBe(
-      '\\\\server\\Share\\Repo',
-    );
-    expect(normalizeAnalyzerRootPath('C:\\Repo\\subDir', 'win32')).toBe('C:\\Repo\\subDir');
-  });
-
-  it('normalizes the drive under an extended-length \\\\?\\ prefix, preserving the prefix', () => {
-    expect(normalizeAnalyzerRootPath('\\\\?\\c:\\gitnexus\\dist', 'win32')).toBe(
-      '\\\\?\\C:\\gitnexus\\dist',
-    );
-    // Extended UNC form has no drive letter — left untouched.
-    expect(normalizeAnalyzerRootPath('\\\\?\\UNC\\server\\Share', 'win32')).toBe(
-      '\\\\?\\UNC\\server\\Share',
-    );
-  });
-
-  it('is a no-op on POSIX (case-sensitive paths must not be mutated)', () => {
-    expect(normalizeAnalyzerRootPath('/home/user/gitnexus/dist', 'linux')).toBe(
-      '/home/user/gitnexus/dist',
-    );
-    expect(normalizeAnalyzerRootPath('/Home/User/Dist', 'darwin')).toBe('/Home/User/Dist');
-  });
-
-  // #2668 threading guard: the produced identity's path fields must already be
-  // normalizer-stable, i.e. resolveBuildRoot/resolveRuntimeVariant actually route
-  // build.rootPath and runtime.executablePath through normalizeAnalyzerRootPath.
-  // On POSIX the normalizer is a no-op, so this is a trivially-true fixpoint here
-  // and a real regression guard on Windows CI (where an un-threaded call site
-  // would leave a lowercase drive that the normalizer would change).
-  it('produces identity path fields that are already normalizer-stable', async () => {
-    const fixture = await createTempDir();
-    try {
-      const sourceRoot = path.join(fixture.dbPath, 'src');
-      const modulePath = path.join(sourceRoot, 'core', 'analyzer.ts');
-      await mkdir(path.dirname(modulePath), { recursive: true });
-      await writeFile(
-        path.join(fixture.dbPath, 'package.json'),
-        '{"name":"fixture-analyzer","version":"1.0.0"}\n',
-      );
-      await writeFile(path.join(fixture.dbPath, 'package-lock.json'), '{"lockfileVersion":3}\n');
-      await writeFile(modulePath, 'export const analyzer = 1;\n');
-
-      const identity = resolveAnalyzerRunnerIdentity(pathToFileURL(modulePath).href, {
-        cacheDirectory: path.join(fixture.dbPath, 'identity-cache'),
-      });
-
-      expect(identity.build.rootPath).toBe(
-        normalizeAnalyzerRootPath(identity.build.rootPath, process.platform),
-      );
-      expect(identity.runtime.executablePath).toBe(
-        normalizeAnalyzerRootPath(identity.runtime.executablePath, process.platform),
-      );
-    } finally {
-      await fixture.cleanup();
-    }
-  });
 });

--- a/gitnexus/test/unit/analyzer-identity.test.ts
+++ b/gitnexus/test/unit/analyzer-identity.test.ts
@@ -11,6 +11,7 @@ import {
   analyzerRunnerIdentitiesEqual,
   captureAnalyzerIdentityBeforeLoad,
   finalizeAnalyzerRunnerIdentity,
+  normalizeAnalyzerRootPath,
   normalizeAnalyzerRunnerIdentityForComparison,
   resolveAnalyzerRunnerIdentity,
 } from '../../src/core/analyzer-identity.js';
@@ -1507,4 +1508,42 @@ describe('analyzer runner identity', () => {
       await repo.cleanup();
     }
   }, 300_000);
+});
+
+// #2668 threading guard: the produced identity's path fields must already be
+// normalizer-stable, i.e. resolveBuildRoot/resolveRuntimeVariant actually route
+// build.rootPath and runtime.executablePath through normalizeAnalyzerRootPath.
+// Ubuntu-only by necessity: this needs a real fixture identity, and the fixture
+// harness cannot run on the Windows matrix (the runner's repo is on D: while temp
+// is on C:, and isInside() misjudges cross-drive paths so resolveInvokedArtifact
+// picks the vitest fork worker). The pure-transform assertions that DO run on
+// windows-latest live in analyzer-identity-path-normalization.test.ts.
+describe('analyzer identity path threading (#2668)', () => {
+  it('produces identity path fields that are already normalizer-stable', async () => {
+    const fixture = await createTempDir();
+    try {
+      const sourceRoot = path.join(fixture.dbPath, 'src');
+      const modulePath = path.join(sourceRoot, 'core', 'analyzer.ts');
+      await mkdir(path.dirname(modulePath), { recursive: true });
+      await writeFile(
+        path.join(fixture.dbPath, 'package.json'),
+        '{"name":"fixture-analyzer","version":"1.0.0"}\n',
+      );
+      await writeFile(path.join(fixture.dbPath, 'package-lock.json'), '{"lockfileVersion":3}\n');
+      await writeFile(modulePath, 'export const analyzer = 1;\n');
+
+      const identity = resolveAnalyzerRunnerIdentity(pathToFileURL(modulePath).href, {
+        cacheDirectory: path.join(fixture.dbPath, 'identity-cache'),
+      });
+
+      expect(identity.build.rootPath).toBe(
+        normalizeAnalyzerRootPath(identity.build.rootPath, process.platform),
+      );
+      expect(identity.runtime.executablePath).toBe(
+        normalizeAnalyzerRootPath(identity.runtime.executablePath, process.platform),
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
 });

--- a/gitnexus/test/unit/analyzer-identity.test.ts
+++ b/gitnexus/test/unit/analyzer-identity.test.ts
@@ -11,6 +11,7 @@ import {
   analyzerRunnerIdentitiesEqual,
   captureAnalyzerIdentityBeforeLoad,
   finalizeAnalyzerRunnerIdentity,
+  normalizeAnalyzerRootPath,
   normalizeAnalyzerRunnerIdentityForComparison,
   resolveAnalyzerRunnerIdentity,
 } from '../../src/core/analyzer-identity.js';
@@ -1507,4 +1508,53 @@ describe('analyzer runner identity', () => {
       await repo.cleanup();
     }
   }, 300_000);
+});
+
+// #2668: `status` reported a freshly-analyzed, untouched repo as stale on
+// Windows because `build.rootPath` (and the other compared identity path
+// fields) carried the drive-letter case that `realpathSync.native` did not
+// normalize — so `analyze` and `status`, launched under different casing,
+// stamped vs recomputed unequal identities. `normalizeAnalyzerRootPath`
+// collapses that variance at the single upstream source (resolveBuildRoot).
+describe('normalizeAnalyzerRootPath (#2668)', () => {
+  it('uppercases a Windows drive letter so case-variant roots collapse', () => {
+    expect(normalizeAnalyzerRootPath('c:\\gitnexus\\dist', 'win32')).toBe('C:\\gitnexus\\dist');
+    expect(normalizeAnalyzerRootPath('c:\\gitnexus\\dist', 'win32')).toBe(
+      normalizeAnalyzerRootPath('C:\\gitnexus\\dist', 'win32'),
+    );
+    // Forward-slash drive form (as some resolvers emit) is normalized too.
+    expect(normalizeAnalyzerRootPath('d:/build', 'win32')).toBe('D:/build');
+  });
+
+  it('is idempotent and leaves an already-uppercase drive unchanged', () => {
+    expect(normalizeAnalyzerRootPath('C:\\build', 'win32')).toBe('C:\\build');
+    expect(
+      normalizeAnalyzerRootPath(normalizeAnalyzerRootPath('c:\\build', 'win32'), 'win32'),
+    ).toBe('C:\\build');
+  });
+
+  it('only touches a leading drive letter, not other path bytes', () => {
+    // A UNC path has no drive letter; interior case is preserved.
+    expect(normalizeAnalyzerRootPath('\\\\server\\Share\\Repo', 'win32')).toBe(
+      '\\\\server\\Share\\Repo',
+    );
+    expect(normalizeAnalyzerRootPath('C:\\Repo\\subDir', 'win32')).toBe('C:\\Repo\\subDir');
+  });
+
+  it('normalizes the drive under an extended-length \\\\?\\ prefix, preserving the prefix', () => {
+    expect(normalizeAnalyzerRootPath('\\\\?\\c:\\gitnexus\\dist', 'win32')).toBe(
+      '\\\\?\\C:\\gitnexus\\dist',
+    );
+    // Extended UNC form has no drive letter — left untouched.
+    expect(normalizeAnalyzerRootPath('\\\\?\\UNC\\server\\Share', 'win32')).toBe(
+      '\\\\?\\UNC\\server\\Share',
+    );
+  });
+
+  it('is a no-op on POSIX (case-sensitive paths must not be mutated)', () => {
+    expect(normalizeAnalyzerRootPath('/home/user/gitnexus/dist', 'linux')).toBe(
+      '/home/user/gitnexus/dist',
+    );
+    expect(normalizeAnalyzerRootPath('/Home/User/Dist', 'darwin')).toBe('/Home/User/Dist');
+  });
 });

--- a/gitnexus/test/unit/analyzer-identity.test.ts
+++ b/gitnexus/test/unit/analyzer-identity.test.ts
@@ -1557,4 +1557,38 @@ describe('normalizeAnalyzerRootPath (#2668)', () => {
     );
     expect(normalizeAnalyzerRootPath('/Home/User/Dist', 'darwin')).toBe('/Home/User/Dist');
   });
+
+  // #2668 threading guard: the produced identity's path fields must already be
+  // normalizer-stable, i.e. resolveBuildRoot/resolveRuntimeVariant actually route
+  // build.rootPath and runtime.executablePath through normalizeAnalyzerRootPath.
+  // On POSIX the normalizer is a no-op, so this is a trivially-true fixpoint here
+  // and a real regression guard on Windows CI (where an un-threaded call site
+  // would leave a lowercase drive that the normalizer would change).
+  it('produces identity path fields that are already normalizer-stable', async () => {
+    const fixture = await createTempDir();
+    try {
+      const sourceRoot = path.join(fixture.dbPath, 'src');
+      const modulePath = path.join(sourceRoot, 'core', 'analyzer.ts');
+      await mkdir(path.dirname(modulePath), { recursive: true });
+      await writeFile(
+        path.join(fixture.dbPath, 'package.json'),
+        '{"name":"fixture-analyzer","version":"1.0.0"}\n',
+      );
+      await writeFile(path.join(fixture.dbPath, 'package-lock.json'), '{"lockfileVersion":3}\n');
+      await writeFile(modulePath, 'export const analyzer = 1;\n');
+
+      const identity = resolveAnalyzerRunnerIdentity(pathToFileURL(modulePath).href, {
+        cacheDirectory: path.join(fixture.dbPath, 'identity-cache'),
+      });
+
+      expect(identity.build.rootPath).toBe(
+        normalizeAnalyzerRootPath(identity.build.rootPath, process.platform),
+      );
+      expect(identity.runtime.executablePath).toBe(
+        normalizeAnalyzerRootPath(identity.runtime.executablePath, process.platform),
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
 });

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -8,6 +8,7 @@
  * the dispatch and error handling logic in isolation.
  */
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import type { StalenessInfo } from '../../src/core/git-staleness.js';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import fsPromises from 'fs/promises';
 import os from 'os';
@@ -4105,6 +4106,84 @@ describe('LocalBackend tool-staleness signal (#2655 review)', () => {
     await backend.callTool('query', { search_query: 'x', repo: 'r' });
     expect(check).toHaveBeenCalledTimes(2); // recomputed after expiry
 
+    dateSpy.mockRestore();
+  });
+
+  // @group-routed calls forward to callToolAtGroupRepo BEFORE the wrapping
+  // switch, so they deliberately never get the staleness signal (multi-repo,
+  // single-commit staleness is ill-defined). Pin that so it can't silently flip.
+  it('does not attach staleness to an @group-routed call', async () => {
+    const groupSpy = vi
+      .spyOn(backend as any, 'callToolAtGroupRepo')
+      .mockResolvedValue({ ok: true });
+    const freshSpy = vi.spyOn(backend as any, 'stalenessForTool');
+    await stubStale(); // stale — but @group must skip the signal regardless
+
+    const res = await backend.callTool('query', { search_query: 'x', repo: '@grp' });
+
+    expect(groupSpy).toHaveBeenCalledOnce();
+    expect(freshSpy).not.toHaveBeenCalled();
+    expect(res).not.toHaveProperty('staleness');
+  });
+
+  // The freshness check is deduped by sharing the IN-FLIGHT promise, not merely
+  // by reusing an already-resolved value: two calls that arrive before the first
+  // `checkStalenessAsync` settles must still spawn only one.
+  it('shares one in-flight freshness check across truly concurrent calls', async () => {
+    stubResolve();
+    vi.spyOn(backend as any, 'query').mockResolvedValue({ ok: true });
+    const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(2000);
+    const { checkStalenessAsync } = await import('../../src/core/git-staleness.js');
+    let settle: (v: StalenessInfo) => void = () => {};
+    const pending = new Promise<StalenessInfo>((res) => {
+      settle = res;
+    });
+    (checkStalenessAsync as any).mockClear();
+    (checkStalenessAsync as any).mockReturnValue(pending);
+
+    // Both dispatched before the check resolves — they must share the entry.
+    const p1 = backend.callTool('query', { search_query: 'x', repo: 'r' });
+    const p2 = backend.callTool('query', { search_query: 'x', repo: 'r' });
+    await new Promise((r) => setTimeout(r, 0)); // let both reach stalenessForTool
+    settle({ isStale: true, commitsBehind: 1, hint: '1 behind' });
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(checkStalenessAsync).toHaveBeenCalledTimes(1); // one spawn, shared
+    expect(r1).toMatchObject({ staleness: { commitsBehind: 1 } });
+    expect(r2).toMatchObject({ staleness: { commitsBehind: 1 } });
+    dateSpy.mockRestore();
+  });
+
+  // The evict-on-reject is guarded by object identity (=== entry), so a LATE
+  // rejection from a superseded entry must not drop the newer entry that
+  // replaced it after the TTL rolled over.
+  it('a late rejection does not evict the newer cache entry', async () => {
+    stubResolve();
+    vi.spyOn(backend as any, 'query').mockResolvedValue({ ok: true });
+    const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(1000);
+    const { checkStalenessAsync } = await import('../../src/core/git-staleness.js');
+    let rejectFirst: (e: unknown) => void = () => {};
+    const first = new Promise<StalenessInfo>((_res, rej) => {
+      rejectFirst = rej;
+    });
+    (checkStalenessAsync as any)
+      .mockReturnValueOnce(first) // entry 1 — held open, will reject late
+      .mockResolvedValue({ isStale: true, commitsBehind: 7, hint: '7 behind' }); // entry 2+
+
+    const p1 = backend.callTool('query', { search_query: 'x', repo: 'r' }); // installs entry1 @1000
+    await new Promise((r) => setTimeout(r, 0)); // entry1 installed, awaiting `first`
+
+    dateSpy.mockReturnValue(1000 + 5000 + 1); // past TTL → next call installs entry2
+    const r2 = await backend.callTool('query', { search_query: 'x', repo: 'r' });
+    expect(r2).toMatchObject({ staleness: { commitsBehind: 7 } });
+
+    rejectFirst(new Error('late git failure')); // entry1's guarded catch must NOT evict entry2
+    await p1.catch(() => {}); // p1 degrades to no-staleness
+
+    const callsBefore = (checkStalenessAsync as any).mock.calls.length;
+    const r3 = await backend.callTool('query', { search_query: 'x', repo: 'r' }); // still within entry2 TTL
+    expect((checkStalenessAsync as any).mock.calls.length).toBe(callsBefore); // cache hit → entry2 survived
+    expect(r3).toMatchObject({ staleness: { commitsBehind: 7 } });
     dateSpy.mockRestore();
   });
 });

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -3893,3 +3893,62 @@ describe('LocalBackend.resolveRepo branch scope (#2106)', () => {
     expect(closedPaths.some((p) => p.includes(path.join('.gitnexus', 'branches')))).toBe(true);
   });
 });
+
+// #2655 review: the per-index tool-staleness cache must key by lbugPath, not
+// repoPath — flat and branch handles for one repo share a repoPath but carry
+// different lastCommit values, so a repoPath key would serve one handle's
+// freshness for the other within the TTL window.
+describe('LocalBackend tool-staleness cache keying (#2655 review)', () => {
+  let backend: LocalBackend;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    backend = new LocalBackend();
+    setupSingleRepo();
+    await backend.init();
+  });
+
+  it('does not share a staleness entry between flat and branch handles of one repo', async () => {
+    const flat = {
+      id: 'r',
+      name: 'r',
+      repoPath: '/r',
+      storagePath: '/r/.gitnexus',
+      lbugPath: '/r/.gitnexus/lbug',
+      indexedAt: '',
+      lastCommit: 'FLATSHA',
+    };
+    const branch = {
+      ...flat,
+      lbugPath: `/r/.gitnexus/${path.join('branches', 'x', 'lbug')}`,
+      lastCommit: 'BRANCHSHA',
+    };
+    vi.spyOn(backend, 'resolveRepo')
+      .mockResolvedValueOnce(flat as any)
+      .mockResolvedValueOnce(branch as any);
+    // The tool itself returns a plain (staleness-carryable) object.
+    vi.spyOn(backend as any, 'query').mockResolvedValue({ ok: true });
+
+    const { checkStalenessAsync } = await import('../../src/core/git-staleness.js');
+    (checkStalenessAsync as any).mockImplementation((_repoPath: string, lastCommit: string) =>
+      Promise.resolve(
+        lastCommit === 'FLATSHA'
+          ? { isStale: true, commitsBehind: 5, hint: '5 behind' }
+          : { isStale: false, commitsBehind: 0 },
+      ),
+    );
+
+    const flatRes = await backend.callTool('query', { search_query: 'x', repo: 'r' });
+    const branchRes = await backend.callTool('query', {
+      search_query: 'x',
+      repo: 'r',
+      branch: 'x',
+    });
+
+    // Flat index (lastCommit=FLATSHA) is 5 behind -> field present.
+    expect(flatRes).toMatchObject({ staleness: { commitsBehind: 5 } });
+    // Branch index (different lbugPath + lastCommit) is current; it must NOT
+    // inherit the flat handle's cached staleness (the pre-fix repoPath-keyed bug).
+    expect(branchRes).not.toHaveProperty('staleness');
+  });
+});

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -3952,3 +3952,159 @@ describe('LocalBackend tool-staleness cache keying (#2655 review)', () => {
     expect(branchRes).not.toHaveProperty('staleness');
   });
 });
+
+// #2655 review F1–F4: the staleness signal wired into query/cypher/context/impact
+// must degrade gracefully on a rejecting freshness check, attach on every wrapped
+// tool (not just query), leave the adjacent read tools alone, and dedupe/expire
+// its per-index cache.
+describe('LocalBackend tool-staleness signal (#2655 review)', () => {
+  let backend: LocalBackend;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    backend = new LocalBackend();
+    setupSingleRepo();
+    await backend.init();
+  });
+
+  const handle = {
+    id: 'r',
+    name: 'r',
+    repoPath: '/r',
+    storagePath: '/r/.gitnexus',
+    lbugPath: '/r/.gitnexus/lbug',
+    indexedAt: '',
+    lastCommit: 'HEADSHA',
+  };
+
+  const stubResolve = () => vi.spyOn(backend, 'resolveRepo').mockResolvedValue(handle as any);
+
+  const stubStale = async () => {
+    const { checkStalenessAsync } = await import('../../src/core/git-staleness.js');
+    (checkStalenessAsync as any).mockResolvedValue({
+      isStale: true,
+      commitsBehind: 3,
+      hint: '3 behind',
+    });
+    return checkStalenessAsync as unknown as ReturnType<typeof vi.fn>;
+  };
+
+  // F1: a rejecting checkStalenessAsync must never fail the tool nor poison the
+  // 5s cache entry — the result comes back without a staleness field, and a
+  // later call (after the poisoned entry is evicted) still works.
+  it('degrades to no-staleness when the freshness check rejects, then recovers', async () => {
+    stubResolve();
+    vi.spyOn(backend as any, 'query').mockResolvedValue({ ok: true });
+    const { checkStalenessAsync } = await import('../../src/core/git-staleness.js');
+    (checkStalenessAsync as any)
+      .mockRejectedValueOnce(new Error('git blew up'))
+      .mockResolvedValue({ isStale: true, commitsBehind: 2, hint: '2 behind' });
+
+    const rejected = await backend.callTool('query', { search_query: 'x', repo: 'r' });
+    expect(rejected).toMatchObject({ ok: true });
+    expect(rejected).not.toHaveProperty('staleness');
+
+    // The rejected entry must not be cached — the next call re-runs and attaches.
+    const recovered = await backend.callTool('query', { search_query: 'x', repo: 'r' });
+    expect(recovered).toMatchObject({ ok: true, staleness: { commitsBehind: 2 } });
+  });
+
+  // F2: every wrapped tool attaches the field on a carryable object result.
+  it('attaches staleness on query, context, and impact object results', async () => {
+    stubResolve();
+    await stubStale();
+    vi.spyOn(backend as any, 'query').mockResolvedValue({ ok: true });
+    vi.spyOn(backend as any, 'context').mockResolvedValue({ symbol: 'x' });
+    vi.spyOn(backend as any, 'impact').mockResolvedValue({ impactedCount: 0 });
+
+    expect(await backend.callTool('query', { search_query: 'x', repo: 'r' })).toMatchObject({
+      staleness: { commitsBehind: 3, hint: '3 behind' },
+    });
+    expect(await backend.callTool('context', { name: 'x', repo: 'r' })).toMatchObject({
+      staleness: { commitsBehind: 3 },
+    });
+    expect(await backend.callTool('impact', { target: 'x', repo: 'r' })).toMatchObject({
+      staleness: { commitsBehind: 3 },
+    });
+  });
+
+  // F2: cypher's tabular {markdown,row_count} object gets the field; a raw-array
+  // (non-tabular) result keeps its shape untouched so Array.isArray consumers work.
+  it('attaches staleness to the cypher table object but never to a raw-array result', async () => {
+    stubResolve();
+    await stubStale();
+
+    // Non-empty array of keyed objects -> formatCypherAsMarkdown returns {markdown,row_count}.
+    lbugMocks.executeParameterized.mockResolvedValueOnce([{ a: 1 }]);
+    const tabular = await backend.callTool('cypher', {
+      statement: 'MATCH (n) RETURN n',
+      repo: 'r',
+    });
+    expect(tabular).toMatchObject({ row_count: 1, staleness: { commitsBehind: 3 } });
+
+    // Empty result -> formatCypherAsMarkdown passes the raw array through unchanged.
+    lbugMocks.executeParameterized.mockResolvedValueOnce([]);
+    const raw = await backend.callTool('cypher', { statement: 'MATCH (n) RETURN n', repo: 'r' });
+    expect(Array.isArray(raw)).toBe(true);
+    expect(raw).toHaveLength(0);
+  });
+
+  // F3: drift guard — exactly the four read tools route through stalenessForTool;
+  // the adjacent read-ish tools must not, so a future tool added without staleness
+  // (or one dropped) is caught.
+  it('routes only query/cypher/context/impact through the freshness check', async () => {
+    stubResolve();
+    await stubStale();
+    const spy = vi.spyOn(backend as any, 'stalenessForTool');
+    // Stub each tool to a benign object so dispatch reaches withToolStaleness.
+    for (const m of [
+      'query',
+      'context',
+      'impact',
+      'explain',
+      'pdgQuery',
+      'detectChanges',
+      'check',
+    ]) {
+      vi.spyOn(backend as any, m).mockResolvedValue({ ok: true });
+    }
+    // cypher runs its real path; a keyed-object row makes formatCypherAsMarkdown
+    // return a carryable {markdown,row_count} so the freshness check is reached.
+    lbugMocks.executeParameterized.mockResolvedValue([{ a: 1 }]);
+
+    await backend.callTool('query', { search_query: 'x', repo: 'r' });
+    await backend.callTool('cypher', { statement: 'RETURN 1', repo: 'r' });
+    await backend.callTool('context', { name: 'x', repo: 'r' });
+    await backend.callTool('impact', { target: 'x', repo: 'r' });
+    const wrappedCalls = spy.mock.calls.length;
+
+    await backend.callTool('explain', { target: 'x', repo: 'r' });
+    await backend.callTool('pdg_query', { anchor: 'x', repo: 'r' });
+    await backend.callTool('detect_changes', { scope: 'unstaged', repo: 'r' });
+    await backend.callTool('check', { cycles: true, repo: 'r' });
+
+    expect(wrappedCalls).toBe(4);
+    expect(spy.mock.calls.length).toBe(4);
+  });
+
+  // F4: the per-index freshness result is deduped within TOOL_STALENESS_TTL_MS and
+  // recomputed once the window elapses. Drive time via Date.now (not fake timers,
+  // which would entangle the awaited async dispatch with the microtask queue).
+  it('dedupes the freshness check within the TTL and recomputes after it expires', async () => {
+    stubResolve();
+    vi.spyOn(backend as any, 'query').mockResolvedValue({ ok: true });
+    const check = await stubStale();
+    check.mockClear();
+
+    const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(1000);
+    await backend.callTool('query', { search_query: 'x', repo: 'r' });
+    await backend.callTool('query', { search_query: 'x', repo: 'r' });
+    expect(check).toHaveBeenCalledTimes(1); // deduped within the window
+
+    dateSpy.mockReturnValue(1000 + 5000 + 1); // past TOOL_STALENESS_TTL_MS
+    await backend.callTool('query', { search_query: 'x', repo: 'r' });
+    expect(check).toHaveBeenCalledTimes(2); // recomputed after expiry
+
+    dateSpy.mockRestore();
+  });
+});

--- a/gitnexus/test/unit/tool-staleness.test.ts
+++ b/gitnexus/test/unit/tool-staleness.test.ts
@@ -1,0 +1,73 @@
+/**
+ * #2655: `query`/`context`/`impact`/`cypher` tool responses carry a non-blocking
+ * `staleness` signal when the index is behind HEAD, mirroring `list_repos`.
+ *
+ * These tests cover `attachToolStaleness` — the shape contract that guarantees
+ * the signal is only ever ADDED to an object result and never mutates an
+ * existing result's shape (so the CLI's `Array.isArray`-based `--limit` on
+ * raw-array cypher rows, and any consumer's shape assumptions, keep working).
+ */
+import { describe, it, expect } from 'vitest';
+import type { StalenessInfo } from '../../src/core/git-staleness.js';
+import { attachToolStaleness } from '../../src/mcp/local/local-backend.js';
+
+const STALE: StalenessInfo = {
+  isStale: true,
+  commitsBehind: 3,
+  hint: '⚠️ Index is 3 commits behind HEAD. Run analyze tool to update.',
+};
+const FRESH: StalenessInfo = { isStale: false, commitsBehind: 0 };
+
+describe('attachToolStaleness (#2655)', () => {
+  it('adds a list_repos-shaped staleness field to an object result when stale', () => {
+    const out = attachToolStaleness({ processes: [], total: 0 }, STALE);
+    expect(out).toMatchObject({
+      processes: [],
+      total: 0,
+      staleness: { commitsBehind: 3, hint: STALE.hint },
+    });
+  });
+
+  it('leaves the result untouched when the index is fresh', () => {
+    const result = { processes: [], total: 0 };
+    expect(attachToolStaleness(result, FRESH)).toBe(result);
+  });
+
+  it('never changes the shape of a raw-array result (CLI --limit relies on Array.isArray)', () => {
+    const rows = [{ a: 1 }, { a: 2 }];
+    const out = attachToolStaleness(rows, STALE);
+    expect(Array.isArray(out)).toBe(true);
+    expect(out).toBe(rows);
+  });
+
+  it('does not annotate an error envelope', () => {
+    const err = { error: 'LadybugDB not ready. Index may be corrupted.' };
+    expect(attachToolStaleness(err, STALE)).toBe(err);
+  });
+
+  it('is idempotent — a result that already has staleness is left as-is', () => {
+    const already = { total: 1, staleness: { commitsBehind: 9, hint: 'x' } };
+    expect(attachToolStaleness(already, STALE)).toBe(already);
+  });
+
+  it('leaves non-object results (null / primitives) unchanged', () => {
+    expect(attachToolStaleness(null, STALE)).toBeNull();
+    expect(attachToolStaleness('markdown text', STALE)).toBe('markdown text');
+  });
+
+  it('is null-safe — a missing staleness info never throws or mutates the result', () => {
+    const result = { total: 0 };
+    expect(attachToolStaleness(result, undefined)).toBe(result);
+  });
+
+  it('carries hint through as-is (may be undefined on a stale-without-hint info)', () => {
+    const out = attachToolStaleness(
+      { ok: true },
+      {
+        isStale: true,
+        commitsBehind: 1,
+      },
+    ) as { staleness: { commitsBehind: number; hint?: string } };
+    expect(out.staleness).toMatchObject({ commitsBehind: 1 });
+  });
+});


### PR DESCRIPTION
Fixes two related index-staleness issues.

## #2668 — `status` reports stale immediately after a successful `analyze`

`gitnexus status` reported a freshly-analyzed, untouched working tree as **stale** (observed on econia/aptos-core, Windows). Root cause: `status`'s up-to-date check gates on `runnerIdentityIsCurrent`, which deep-compares the stamped runner identity against a freshly recomputed one. That comparison includes `build.rootPath`, `dependencyRuntime.manifestPath`/`lockfilePath`, and `runtime.executablePath` (only `invokedArtifact` is stripped), and `identityCacheKey` hashes `packageRoot`/`buildRoot` — all derived from paths that flow through `realpathSync.native`, which canonicalizes 8.3 names and symlinks but **does not normalize the Windows drive-letter case**. When `analyze` and `status` are launched under different drive-letter casing (`c:\…` vs `C:\…`, plausible across a CLI shim / `npx` / server-worker entry), the identities differ by that one byte and `status` reports stale.

**Fix:** a small `normalizeAnalyzerRootPath(p, platform)` uppercases the Windows drive letter (POSIX no-op; preserves a `\\?\` extended-length prefix), applied at the single upstream source — `resolveBuildRoot`'s returned `{packageRoot, buildRoot}` — so every derived identity path field and the cache key inherit a case-stable root, plus at `runtime.executablePath`. The freshness gate is kept intact: a genuine analyzer change still differs in `build.digest`/`dependencyRuntime`, and `analyze` still rebuilds on a real mismatch.

> **Note:** I don't have a Windows host to reproduce the exact drive-letter divergence, so the mechanical chain is verified in source and the fix is a correct defensive normalization (a no-op on POSIX). If a `status --json` identity field-diff ever shows `build.digest`/`dependencyRuntime`/`cliVersion` diverging instead, that's a genuinely different install (where "stale" is correct), not this bug.

> **Migration:** on Windows, an existing index stamped under the old (non-normalized) casing will mismatch the normalized recompute once, triggering a single forced full re-analyze on first upgrade (and a one-time identity-cache recompute). One-time, Windows-only, POSIX no-op.

## #2655 — inline staleness in `query`/`context`/`impact`/`cypher` tool responses

`checkStalenessAsync` already computes how far an index is behind HEAD, and `list_repos` returns it as `staleness: {commitsBehind, hint}` — but the four hot read tools an agent actually calls never surfaced it (`resolveRepo` only runs `maybeWarnSiblingDrift`, stderr-only, sibling-clone drift only).

This threads the existing signal into those four tools at the single `callTool` chokepoint, reusing the `list_repos` shape:

- `stalenessForTool` — `checkStalenessAsync` behind an in-flight-promise cache (5s TTL) **keyed by lbugPath**, so concurrent calls share one `git rev-list` and flat/branch handles (same `repoPath`, different `lastCommit`) don't collide; evicted with the repo's other per-index state on registry removal.
- `withToolStaleness` — skips the `git` spawn entirely for results that can't carry the field, so error-returning calls pay nothing.
- `attachToolStaleness` — adds `staleness` to an object result only when behind HEAD; **never changes an existing result's shape** (raw-array cypher rows, error envelopes, and already-annotated results are returned untouched, so the CLI's `Array.isArray`-based `--limit` and other consumers keep working). Non-blocking: a git failure just omits the field.

Out of scope (deliberately): `@group`-targeted calls (multi-repo, single-commit staleness is ill-defined), the legacy `search`/`explore` aliases, and `list_repos`/the `context` resource (already carry the signal). Not a duplicate of #2438.

## Tests

- `normalizeAnalyzerRootPath` matrix — drive-letter uppercase, idempotence, drive-only scope, `\\?\` extended-length prefix, POSIX no-op.
- `attachToolStaleness` matrix — stale object → field; fresh/array/error-envelope/already-annotated/non-object → unchanged; null-safe.
- flat-vs-branch cache-key regression test (fails when the cache is keyed by `repoPath`).

Sequenced #2668 before #2655 since #2655 surfaces the signal #2668 makes correct.
