### PR TITLE
fix(fts): stop warning "FTS extension unavailable" on the run that installs it

### DIFF
--- a/gitnexus/src/core/lbug/extension-loader.ts
+++ b/gitnexus/src/core/lbug/extension-loader.ts
@@ -43,6 +43,18 @@ export interface ExtensionCapability {
 export interface ExtensionEnsureOptions {
   policy?: ExtensionInstallPolicy;
   installTimeoutMs?: number;
+  /**
+   * Speculative probe: log an unavailable outcome at debug level instead of
+   * warn, and do not consume the once-per-(extension, reason) warn budget.
+   *
+   * Set only by callers that do NOT own the extension's lifecycle and know a
+   * later owner will retry with an install-capable policy — currently the
+   * writable `initLbug` pre-load, whose miss on a cold cache is expected and
+   * is fixed moments later by analyze Phase 3. Never set it on a path where
+   * the failure is the final answer (serve/MCP read paths), or a real
+   * degradation goes unreported.
+   */
+  quiet?: boolean;
 }
 
 export interface ExtensionManagerOptions {
@@ -230,9 +242,10 @@ export class ExtensionManager {
     const timeoutMs =
       opts.installTimeoutMs ?? this.options.installTimeoutMs ?? getExtensionInstallTimeoutMs();
     const warn = this.options.warn ?? ((msg: string) => logger.warn(msg));
+    const quiet = opts.quiet === true;
 
     if (policy === 'never') {
-      this.markUnavailable(name, label, 'extension install policy is "never"', warn);
+      this.markUnavailable(name, label, 'extension install policy is "never"', warn, quiet);
       return false;
     }
 
@@ -248,6 +261,7 @@ export class ExtensionManager {
         label,
         `load-only policy (no install attempted); LOAD ${name} failed: ${loadError}`,
         warn,
+        quiet,
       );
       return false;
     }
@@ -267,6 +281,7 @@ export class ExtensionManager {
         label,
         `${install.message}; LOAD ${name} had failed: ${loadError}`,
         warn,
+        quiet,
       );
       return false;
     }
@@ -282,6 +297,7 @@ export class ExtensionManager {
       label,
       `LOAD ${name} failed after successful INSTALL: ${retryError}`,
       warn,
+      quiet,
     );
     return false;
   }
@@ -316,6 +332,7 @@ export class ExtensionManager {
     label: string,
     reason: string,
     warn: (message: string) => void,
+    quiet = false,
   ): void {
     // Classify once here (the single load-failure sink, run per Database not per
     // request) so the hot per-request warning path does no file I/O (#2383 F3).
@@ -325,12 +342,17 @@ export class ExtensionManager {
       reason,
       diagnosis: diagnoseExtensionLoad(reason, label),
     });
+    const message = `GitNexus: ${label} extension unavailable; continuing without ${label} features. ${reason}`;
+    // A quiet probe must not register the dedup key: the owning caller may hit
+    // the identical reason later, and that one is the real degradation report.
+    if (quiet) {
+      logger.debug(message);
+      return;
+    }
     const key = `${name}:${reason}`;
     if (this.warnedKeys.has(key)) return;
     this.warnedKeys.add(key);
-    warn(
-      `GitNexus: ${label} extension unavailable; continuing without ${label} features. ${reason}`,
-    );
+    warn(message);
   }
 }
 

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -922,7 +922,13 @@ const doInitLbug = async (dbPath: string, readOnly: boolean = false) => {
   // FTS powers baseline search, so initialize it with the core DB. Read-only
   // serve/MCP paths must never run DDL or trigger network INSTALL; analyze owns
   // schema/index creation and extension installation.
-  await loadFTSExtension(undefined, readOnly ? { policy: 'load-only' } : {});
+  //
+  // `quiet` on the writable branch: on a cold machine this pre-load is EXPECTED
+  // to miss (default policy is load-only, extension not yet on disk) and analyze
+  // Phase 3 installs it moments later in the same run. Warning here reported a
+  // degradation that never happened — the run went on to build every FTS index.
+  // Phase 3 (and the read-only branch) still warn for real failures.
+  await loadFTSExtension(undefined, readOnly ? { policy: 'load-only' } : { quiet: true });
 
   currentDbPath = dbPath;
   return { db, conn };

--- a/gitnexus/test/unit/lbug-extension-loader.test.ts
+++ b/gitnexus/test/unit/lbug-extension-loader.test.ts
@@ -258,6 +258,41 @@ describe('ExtensionManager — observability', () => {
 
     expect(warn).toHaveBeenCalledTimes(1);
   });
+
+  // initLbug's writable FTS pre-load is a speculative probe — on a cold
+  // machine it misses, then analyze Phase 3 installs and every FTS index builds.
+  // The probe must not report a degradation that the same run repairs.
+  it('stays silent on a quiet probe that a later install-capable call repairs', async () => {
+    const installExtension = vi.fn().mockResolvedValue(okInstall);
+    const warn = vi.fn();
+    const manager = new ExtensionManager({ installExtension, warn });
+    const query = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Extension "fts" not found'))
+      .mockRejectedValueOnce(new Error('Extension "fts" not found'))
+      .mockResolvedValueOnce({});
+
+    await expect(
+      manager.ensure(query, 'fts', 'FTS', { policy: 'load-only', quiet: true }),
+    ).resolves.toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+
+    await expect(manager.ensure(query, 'fts', 'FTS', { policy: 'auto' })).resolves.toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+    expect(manager.getCapabilities()).toEqual([{ name: 'fts', loaded: true }]);
+  });
+
+  it('still warns on a genuine load-only miss that follows a quiet probe of the same reason', async () => {
+    const warn = vi.fn();
+    const manager = new ExtensionManager({ policy: 'load-only', warn });
+    const query = vi.fn().mockRejectedValue(new Error('Extension "fts" not found'));
+
+    await manager.ensure(query, 'fts', 'FTS', { quiet: true });
+    await manager.ensure(query, 'fts', 'FTS');
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('continuing without FTS features'));
+  });
 });
 
 describe('ExtensionManager — input validation', () => {


### PR DESCRIPTION
## Problem

On a machine with no cached LadybugDB extension, the **first** `gitnexus analyze` logs a WARN:

```
{"level":40,"name":"gitnexus","msg":"GitNexus: FTS extension unavailable; continuing without FTS features. load-only policy (no install attempted); LOAD fts failed: ..."}
FTS: creating File.file_fts
FTS: ready File.file_fts
... (all ~20 FTS indexes created successfully)
```

…and then installs FTS and builds every search index **in that same run**. Nothing is degraded — the log line is wrong. It reads as a broken install path, which is what makes it expensive: it sends users (and reviewers) looking for a failure that never happened. The same false line is the *first* of the two warns in #2184, where only the second one is real.

This is a **log-correctness fix, not a functional FTS fix.** There is no broken install path here.

## Root cause

`initLbug` pre-loads FTS with the writable branch's default policy (`load-only` — analyze owns extension installation, read paths must never trigger a network INSTALL). On a cold cache that pre-load is *expected* to miss; `run-analyze` Phase 3 retries with `auto` moments later and succeeds:

```
initLbug            → loadFTSExtension(..., {})       → load-only → LOAD fails → WARN   ← the bug
run-analyze Phase 3 → loadFTSExtension(..., 'auto')   → INSTALL + LOAD succeed          ← the truth
createSearchFTSIndexes()                              → all indexes built
```

`ExtensionManager.markUnavailable` had no way to distinguish that speculative probe from a final answer, so it reported every miss as a user-facing degradation.

## Change

- `ExtensionEnsureOptions` gains `quiet?: boolean`. The capability entry is still recorded; the message goes to `logger.debug`, and the probe does **not** consume the once-per-`(extension, reason)` warn budget — so an identical reason arriving later from a caller that *does* own the outcome still warns.
- The writable `initLbug` pre-load is the only caller that sets it.

Install policy is deliberately left alone: the writable branch still resolves from env, so `GITNEXUS_LBUG_EXTENSION_INSTALL=never` keeps short-circuiting as before. Only the log level of a speculative probe changes.

**Untouched, still warn loudly:** the read-only serve/MCP branch (`{ policy: 'load-only' }`, no later retry — that warning is accurate), analyze Phase 3, `--repair-fts`, pool read paths, and genuinely-offline installs (#2184, whose "INSTALL fts timed out" warn is unaffected).

## Considered and rejected

- **Dropping the writable pre-load entirely.** Writable callers that reach FTS query functions without going through Phase 3 rely on the extension being LOADed on that connection.
- **Giving the writable branch `auto`.** That moves a network INSTALL into DB initialisation, contradicting the documented split where analyze owns extension installation.

## Testing

`test/unit/lbug-extension-loader.test.ts` (+2 cases, 25 pass):

- quiet probe misses → returns `false`, **no warn**; a following `auto` call installs, loads, reports `{ fts, loaded: true }` — still no warn. *(Verified this case fails on `main`.)*
- a genuine non-quiet `load-only` miss with the **same reason** after a quiet probe still warns exactly once — the dedup key must not be consumed by the probe.
- existing "warns when policy=load-only" / "warns at most once per (extension, reason)" cases unchanged, so serve/MCP keeps its warning.

Also ran `lbug-extension-loader`, `incremental-fts-drop-ordering`, `incremental-vector-extension-ordering` (28 pass), lint (0 errors) and the pre-commit typecheck gate.

End-to-end, cold cache against a temp `HOME` with no `~/.lbdb`:

```
$ HOME=$tmp gitnexus analyze --verbose 2>&1 | grep -iE 'fts|extension'
FTS: creating File.file_fts
FTS: ready File.file_fts
...                                    # no "FTS extension unavailable" line
$ ls $tmp/.lbdb/extension/*/*/fts/
libfts.lbug_extension
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
