### PR TITLE
fix(ai-context): emit compact markdown tables

### DIFF
--- a/gitnexus/src/cli/ai-context.ts
+++ b/gitnexus/src/cli/ai-context.ts
@@ -175,7 +175,7 @@ export function generateGitNexusContent(
   const tableBody = [standardSkillsRows, generatedRows].filter(Boolean).join('\n');
   const skillsTable = tableBody
     ? `| Task | Read this skill file |
-|------|---------------------|
+| --- | --- |
 ${tableBody}`
     : '';
   // Docs reference the project-local runner `gitnexus analyze` writes (#1945):
@@ -222,7 +222,7 @@ This project is indexed by GitNexus as **${projectName}**${noStats ? '' : ` (${s
 ## Resources
 
 | Resource | Use for |
-|----------|---------|
+| --- | --- |
 | \`gitnexus://repo/${projectName}/context\` | Codebase overview, check index freshness |
 | \`gitnexus://repo/${projectName}/clusters\` | All functional areas |
 | \`gitnexus://repo/${projectName}/processes\` | All execution flows |

--- a/gitnexus/test/unit/ai-context.test.ts
+++ b/gitnexus/test/unit/ai-context.test.ts
@@ -166,6 +166,19 @@ describe('generateAIContextFiles', () => {
     expect(withoutPdg).toContain('explain(');
   });
 
+  it('emits MD060-compatible compact tables in generated docs (#2709)', () => {
+    const content = generateGitNexusContent('MarkdownProject', {
+      nodes: 50,
+      edges: 100,
+      processes: 5,
+    });
+
+    expect(content).toContain('| Resource | Use for |\n| --- | --- |\n');
+    expect(content).toContain('| Task | Read this skill file |\n| --- | --- |\n');
+    expect(content).not.toContain('|----------|---------|');
+    expect(content).not.toContain('|------|---------------------|');
+  });
+
   it('degrades gracefully when the runner copy fails (#1945)', async () => {
     // A read-only/full-disk storage dir must not abort generation. The copy is
     // best-effort + logged; the generated docs still carry the inline bootstrap


### PR DESCRIPTION
## Summary
- Makes generated GitNexus AI-context Markdown tables use compact MD060-compatible delimiter rows (`| --- | --- |`).
- Covers both generated Resources and CLI skill tables with a focused regression test.

Closes #2709.

## Test plan
- `npx vitest run test/unit/ai-context.test.ts --testTimeout=120000`
- `npm run build` in `gitnexus-shared`
- `npx tsc --noEmit` in `gitnexus`
- `npx prettier --check --ignore-unknown src/cli/ai-context.ts test/unit/ai-context.test.ts`
- `npx eslint src/cli/ai-context.ts test/unit/ai-context.test.ts` (no errors; one existing warning in the test file)

## Review notes
- Impact analysis: LOW risk; affected process `runFullAnalysis`; no affected processes in `detect_changes()`.
- Pre-PR review: branch hygiene and test/CI lanes passed; synthesis found no code-level blocker. Some optional review lanes failed to start due transient subagent errors, so the final PR should rely on normal CI before merge.