### PR TITLE
feat: make MAX_PROPERTY_DISPATCH_FANOUT configurable via env

### DIFF
--- a/gitnexus/.env.example
+++ b/gitnexus/.env.example
@@ -23,3 +23,10 @@
 # Personal Access Token with Code (Read) scope for cloning private repos.
 # Used for both self-hosted and cloud (dev.azure.com) Azure DevOps.
 # AZURE_DEVOPS_PAT=your-pat-here
+
+# Scope-resolution property-key dispatch cap (default 32). Per-property-key
+# registration cap in the property-dispatch scope-resolution pass. Raise for
+# repos whose provider/hook tables lose CALLS coverage on a legitimate key.
+# Positive integer only — non-integer or < 1 values fall back to 32.
+# See README § "Scope-resolution property-key dispatch cap".
+# GITNEXUS_MAX_PROPERTY_DISPATCH_FANOUT=32

--- a/gitnexus/README.md
+++ b/gitnexus/README.md
@@ -662,6 +662,29 @@ After scope resolution, analyze prunes inert block-local value symbols (a functi
 
 Programmatic callers can pass `keepLocalValueSymbols: true` in `PipelineOptions` instead of setting the env var.
 
+### Scope-resolution property-key dispatch cap
+
+During scope resolution GitNexus synthesizes CALLS edges through *property-key
+dispatch* — call sites like `hooks.emitScopeCaptures()` where a property key is
+registered by multiple definitions across the codebase. To keep this fan-in
+bounded, each property key is capped at **32 registrations**: a key registered
+by more than 32 distinct functions is skipped entirely (no CALLS are synthesized
+through it), and the dropped key names are surfaced in the analyze log for
+operator visibility. The cap is calibrated at 2× this repo's own provider table
+(16 legitimate registrations, one per language provider).
+
+| Variable                                | Default | Effect                                                                                                                                                                                                                                                                                                                |
+| --------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GITNEXUS_MAX_PROPERTY_DISPATCH_FANOUT` | `32`    | Per-property-key registration cap in the property-dispatch scope-resolution pass. Set to a positive integer to raise it for repositories whose provider/hook tables exceed the default and lose CALLS coverage on a legitimate key; non-integer or `< 1` values fall back to `32`. Lowering it tightens the overflow budget. |
+
+```bash
+# A property key registered by 40 functions overflows the default 32 and drops
+# all CALLS through it — raise the cap for that repo and rebuild so scope
+# resolution reruns.
+export GITNEXUS_MAX_PROPERTY_DISPATCH_FANOUT=64
+npx gitnexus analyze --force
+```
+
 ### Hook augmentation and skip diagnostics
 
 The Claude Code / Antigravity hooks keep their **stderr** silent on normal skip

--- a/gitnexus/src/core/ingestion/scope-resolution/passes/property-dispatch.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/passes/property-dispatch.ts
@@ -52,8 +52,15 @@ import { findCallableBindingInScope } from '../scope/walkers.js';
  * 2× that — dropping the motivating key was the failure the first value (8)
  * had. ponytail: flat cap; revisit with per-receiver narrowing if real
  * repos show useful keys being dropped (§12 of the #2437 plan).
+ *
+ * Override via `GITNEXUS_MAX_PROPERTY_DISPATCH_FANOUT` env var for repos with
+ * legitimate high-fanout property keys (e.g. large Vue codebases where
+ * `validator` exceeds the default).
  */
-export const MAX_PROPERTY_DISPATCH_FANOUT = 32;
+export const MAX_PROPERTY_DISPATCH_FANOUT = (() => {
+  const env = Number(process.env.GITNEXUS_MAX_PROPERTY_DISPATCH_FANOUT);
+  return Number.isInteger(env) && env >= 1 ? env : 32;
+})();
 
 /** Below the 0.85 resolved baseline; same discount idea as interface-dispatch. */
 export const PROPERTY_DISPATCH_CONFIDENCE = 0.7;

--- a/gitnexus/test/unit/scope-resolution/property-dispatch-fanout-env.test.ts
+++ b/gitnexus/test/unit/scope-resolution/property-dispatch-fanout-env.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, afterEach } from 'vitest';
+
+/**
+ * Verifies that MAX_PROPERTY_DISPATCH_FANOUT reads the
+ * GITNEXUS_MAX_PROPERTY_DISPATCH_FANOUT environment variable at module load time
+ * and falls back to the default (32) when unset.
+ */
+
+const MODULE_PATH = '../../../src/core/ingestion/scope-resolution/passes/property-dispatch.js';
+
+async function loadWithEnv(envValue: string | undefined): Promise<number> {
+  const { vi } = await import('vitest');
+  vi.resetModules();
+
+  if (envValue === undefined) {
+    delete process.env.GITNEXUS_MAX_PROPERTY_DISPATCH_FANOUT;
+  } else {
+    process.env.GITNEXUS_MAX_PROPERTY_DISPATCH_FANOUT = envValue;
+  }
+
+  const mod = await import(MODULE_PATH);
+  return mod.MAX_PROPERTY_DISPATCH_FANOUT;
+}
+
+describe('MAX_PROPERTY_DISPATCH_FANOUT env override', () => {
+  afterEach(() => {
+    delete process.env.GITNEXUS_MAX_PROPERTY_DISPATCH_FANOUT;
+  });
+
+  it('defaults to 32 when the env var is not set', async () => {
+    const cap = await loadWithEnv(undefined);
+    expect(cap).toBe(32);
+  });
+
+  it('respects a valid positive integer override', async () => {
+    const cap = await loadWithEnv('48');
+    expect(cap).toBe(48);
+  });
+
+  it('falls back to default for non-integer values', async () => {
+    expect(await loadWithEnv('not-a-number')).toBe(32);
+  });
+
+  it('falls back to default for values below 1', async () => {
+    expect(await loadWithEnv('0')).toBe(32);
+    expect(await loadWithEnv('-1')).toBe(32);
+  });
+});


### PR DESCRIPTION
## Problem

The 32-registration cap was calibrated on GitNexus's own repo (16 providers × 2). Larger repos with different patterns hit the limit — e.g. a large Vue codebase where `validator` has 33+ component registrations is silently dropped.

## Solution

Make the cap configurable via `GITNEXUS_MAX_PROPERTY_DISPATCH_FANOUT`, defaulting to 32 (unchanged behaviour).

## Test coverage

- Default value (32) when env not set
- Valid override (48)
- Invalid input fallback
- Below-1 guard

---
*Contributed by [卫宁健康科技集团](https://www.winning.com.cn) — WiNEX门诊医生站团队*