### PR TITLE
Expose call-site locations in context calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Commands and gotchas live under **Repo reference** below and in **[CONTRIBUTING.
 ## Reference docs
 
 - **[ARCHITECTURE.md](ARCHITECTURE.md)**, **[CONTRIBUTING.md](CONTRIBUTING.md)**, **[GUARDRAILS.md](GUARDRAILS.md)**
+- **[cdefine-inspector integration](CDEFINE_INSPECTOR_INTEGRATION.md):** public call-site-location contract, cross-repo reproduction, and regression commands. Read this before changing `CodeRelation` persistence or `context` outgoing calls.
 - **Call & inheritance resolution (RFC #909 Ring 3):** See ARCHITECTURE.md § Scope-Resolution Pipeline. All languages resolve calls and inheritance through the scope-resolution pipeline (`Registry.lookup`, `preEmitInheritanceEdges`, `emitHeritageEdges`, `buildMro` → `MethodDispatchIndex`). **Shared code in `gitnexus/src/core/ingestion/` must not name languages** — plug language behavior in via `LanguageProvider` / `ScopeResolver` hooks. A language plugs in by implementing `ScopeResolver` (`scope-resolution/contract/scope-resolver.ts`) and registering it in `SCOPE_RESOLVERS`. (The legacy call-resolution DAG + `@heritage` capture path were removed in RING4-1 #942.)
 - **Cursor:** `.cursor/index.mdc` (always-on); `.cursor/rules/*.mdc` (glob-scoped). Legacy `.cursorrules` deprecated.
 - **GitNexus:** standard skills in `.claude/skills/gitnexus-*/`; MCP rules in `gitnexus:start` block below.

--- a/CDEFINE_INSPECTOR_INTEGRATION.md
+++ b/CDEFINE_INSPECTOR_INTEGRATION.md
@@ -1,0 +1,55 @@
+# cdefine-inspector integration contract
+
+GitNexus provides the configuration-independent candidate graph; the compiler
+remains authoritative for C preprocessor branches. `cdefine-inspector` consumes
+the public `context` result and filters candidates by compiler-proven call-site
+activity. This is an integration between two repositories, not a new GitNexus
+indexing mode.
+
+## Contract
+
+For every `outgoing.calls` item returned by `context`, GitNexus preserves and
+returns these optional fields when the edge originates at a source call site:
+
+- `callSiteFilePath` — repository-relative caller file;
+- `callSiteLine` — 1-based source line;
+- `callSiteColumn` — 1-based source column.
+
+Consumers must reject a candidate without `callSiteFilePath` or a positive
+`callSiteLine`; declaration locations are not a safe substitute. The fields
+are persisted on the existing `CodeRelation` row, so no shadow repository,
+alternate graph, or configuration-specific re-index is involved.
+
+## Reproduce against cdefine-inspector
+
+1. Build this checkout: `cd gitnexus; npm run build`.
+2. In the cdefine-inspector checkout, index its original source once with this
+   build:
+
+   ```powershell
+   node <GitNexus>\gitnexus\dist\cli\index.js analyze --force .
+   ```
+
+3. Run its fixed example with the same executable:
+
+   ```powershell
+   python -m cdefine_inspector.cli active-calls --config examples/conditional-flow-16k.json --source-root . --function mapping_write --gitnexus-command node <GitNexus>\gitnexus\dist\cli\index.js
+   python -m cdefine_inspector.cli compare-flow --left examples/conditional-flow-16k.json --right examples/conditional-flow-4k.json --source-root . --function mapping_write --gitnexus-command node <GitNexus>\gitnexus\dist\cli\index.js
+   ```
+
+The first command must classify `mapping_16k_write` as active and
+`mapping_4k_write` as inactive. The second must report a removal of the 16K
+call and an addition of the 4K call. Switching configuration must not run
+`analyze` again.
+
+## Regression checks
+
+- `npm test -- test/unit/pdg-callee-id-capture.test.ts` checks the C free-call
+  materializer retains source location.
+- `npm test -- test/integration/local-backend-calltool.test.ts` checks the
+  real `context` backend returns persisted location metadata.
+- The cdefine-inspector repository owns compiler branch truth and the two
+  configuration flow assertions; see its `docs/gitnexus-method3.md`.
+
+When changing relation schema, CSV output, call materializers, or the context
+response, update both sides of this contract and run both repositories' checks.

--- a/gitnexus-shared/src/graph/types.ts
+++ b/gitnexus-shared/src/graph/types.ts
@@ -232,6 +232,9 @@ export interface GraphRelationship {
   confidence: number;
   reason: string;
   step?: number;
+  callSiteFilePath?: string;
+  callSiteLine?: number;
+  callSiteColumn?: number;
   /**
    * Per-signal evidence trace for edges emitted by the scope-based
    * resolution pipeline (RFC #909 Ring 2 PKG #925). Populated by

--- a/gitnexus/src/core/ingestion/emit-references.ts
+++ b/gitnexus/src/core/ingestion/emit-references.ts
@@ -108,7 +108,7 @@ export function emitReferencesToGraph(input: EmitReferencesInput): EmitStats {
         skippedNoCaller++;
         continue;
       }
-      graph.addRelationship(buildRelationship(ref, callerId, targetDef, sourceLabel));
+      graph.addRelationship(buildRelationship(ref, callerId, targetDef, sourceLabel, scopes.scopeTree.getScope(fromScope)?.filePath));
       edgesEmitted++;
     }
   }
@@ -248,6 +248,7 @@ function buildRelationship(
   callerId: string,
   targetDef: SymbolDefinition,
   sourceLabel: string,
+  callSiteFilePath: string | undefined,
 ): Parameters<KnowledgeGraph['addRelationship']>[0] {
   const type = mapKindToType(ref.kind);
   const reason = `${sourceLabel}: ${ref.kind} | confidence ${ref.confidence.toFixed(3)}`;
@@ -262,6 +263,9 @@ function buildRelationship(
     confidence: ref.confidence,
     reason,
     evidence: ref.evidence.map(serializeEvidence),
+    callSiteFilePath,
+    callSiteLine: ref.atRange.startLine,
+    callSiteColumn: ref.atRange.startCol + 1,
     ...(step !== undefined ? { step } : {}),
   };
 }

--- a/gitnexus/src/core/ingestion/scope-resolution/graph-bridge/edges.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/graph-bridge/edges.ts
@@ -136,6 +136,9 @@ export function tryEmitEdge(
     type: edgeType,
     confidence,
     reason,
+    callSiteFilePath: scopes.scopeTree.getScope(site.inScope)?.filePath,
+    callSiteLine: site.atRange.startLine,
+    callSiteColumn: site.atRange.startCol + 1,
   });
   return true;
 }
@@ -199,6 +202,9 @@ export function tryEmitEdgeWithExplicitTargetId(
     type: edgeType,
     confidence,
     reason,
+    callSiteFilePath: scopes.scopeTree.getScope(site.inScope)?.filePath,
+    callSiteLine: site.atRange.startLine,
+    callSiteColumn: site.atRange.startCol + 1,
   });
   return true;
 }

--- a/gitnexus/src/core/ingestion/scope-resolution/graph-bridge/references-to-edges.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/graph-bridge/references-to-edges.ts
@@ -112,6 +112,9 @@ export function emitReferencesViaLookup(
         type: edgeType,
         confidence: ref.confidence,
         reason: `scope-resolution: ${ref.kind}`,
+        callSiteFilePath: fromFilePath,
+        callSiteLine: ref.atRange.startLine,
+        callSiteColumn: ref.atRange.startCol + 1,
       });
       emitted++;
     }

--- a/gitnexus/src/core/ingestion/scope-resolution/passes/free-call-fallback.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/passes/free-call-fallback.ts
@@ -594,6 +594,9 @@ export function emitFreeCallFallback(
         // Match legacy DAG's reason convention so consumers that
         // assert `reason === 'import-resolved'` keep working.
         reason: fnDef.filePath !== parsed.filePath ? 'import-resolved' : 'local-call',
+        callSiteFilePath: parsed.filePath,
+        callSiteLine: site.atRange.startLine,
+        callSiteColumn: site.atRange.startCol + 1,
       });
       emitted++;
     }

--- a/gitnexus/src/core/lbug/csv-generator.ts
+++ b/gitnexus/src/core/lbug/csv-generator.ts
@@ -330,7 +330,7 @@ class BufferedCSVWriter {
 
 /** Canonical relationship CSV header — shared by the emit pass and the
  * `splitRelCsvByLabelPair` differential oracle. */
-export const REL_CSV_HEADER = 'from,to,type,confidence,reason,step';
+export const REL_CSV_HEADER = 'from,to,type,confidence,reason,step,callSiteFilePath,callSiteLine,callSiteColumn';
 
 /** Build the escaped CSV row (no trailing newline) for one relationship.
  * Single source of the relationship row bytes — used by the emit pass and by
@@ -343,6 +343,9 @@ export const buildRelRow = (rel: GraphRelationship): string =>
     escapeCSVNumber(rel.confidence, 1.0),
     escapeCSVField(rel.reason),
     escapeCSVNumber(rel.step, 0),
+    escapeCSVField(rel.callSiteFilePath ?? ''),
+    escapeCSVNumber(rel.callSiteLine, 0),
+    escapeCSVNumber(rel.callSiteColumn, 0),
   ].join(',');
 
 /** Canonical BasicBlock node CSV header — taint/PDG substrate (issue #2080).

--- a/gitnexus/src/core/lbug/schema.ts
+++ b/gitnexus/src/core/lbug/schema.ts
@@ -458,7 +458,10 @@ CREATE REL TABLE ${REL_TABLE_NAME} (
   type STRING,
   confidence DOUBLE,
   reason STRING,
-  step INT32
+  step INT32,
+  callSiteFilePath STRING,
+  callSiteLine INT64,
+  callSiteColumn INT64
 )`;
 
 // ============================================================================

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -3391,7 +3391,8 @@ export class LocalBackend {
       `
       MATCH (n {id: $symId})-[r:CodeRelation]->(target)
       WHERE r.type IN ['CALLS', 'IMPORTS', 'EXTENDS', 'IMPLEMENTS', 'USES', 'HAS_METHOD', 'HAS_PROPERTY', 'METHOD_OVERRIDES', 'OVERRIDES', 'METHOD_IMPLEMENTS', 'ACCESSES']
-      RETURN r.type AS relType, target.id AS uid, target.name AS name, target.filePath AS filePath, labels(target)[0] AS kind
+      RETURN r.type AS relType, target.id AS uid, target.name AS name, target.filePath AS filePath, labels(target)[0] AS kind,
+             r.callSiteFilePath AS callSiteFilePath, r.callSiteLine AS callSiteLine, r.callSiteColumn AS callSiteColumn
       LIMIT 30
     `,
       { symId },
@@ -3422,6 +3423,11 @@ export class LocalBackend {
           name: row.name || row[2],
           filePath: row.filePath || row[3],
           kind: row.kind || row[4],
+          ...(Number(row.callSiteLine || row[6]) > 0 ? {
+            callSiteFilePath: row.callSiteFilePath || row[5],
+            callSiteLine: Number(row.callSiteLine || row[6]),
+            callSiteColumn: Number(row.callSiteColumn || row[7]),
+          } : {}),
         };
         if (!cats[relType]) cats[relType] = [];
         cats[relType].push(entry);

--- a/gitnexus/test/fixtures/local-backend-seed.ts
+++ b/gitnexus/test/fixtures/local-backend-seed.ts
@@ -26,7 +26,7 @@ export const LOCAL_BACKEND_SEED_DATA = [
   `CREATE (p:Process {id: 'proc:beta-flow', label: 'BetaFlow', heuristicLabel: 'Beta Flow', processType: 'intra_community', stepCount: 3, communities: ['tools'], entryPointId: 'func:beta', terminalId: 'func:validate'})`,
   // Relationships
   `MATCH (a:Function), (b:Function) WHERE a.id = 'func:login' AND b.id = 'func:validate'
-   CREATE (a)-[:CodeRelation {type: 'CALLS', confidence: 1.0, reason: 'direct', step: 0}]->(b)`,
+   CREATE (a)-[:CodeRelation {type: 'CALLS', confidence: 1.0, reason: 'direct', step: 0, callSiteFilePath: 'src/auth.ts', callSiteLine: 4, callSiteColumn: 3}]->(b)`,
   `MATCH (a:Function), (b:Function) WHERE a.id = 'func:login' AND b.id = 'func:hash'
    CREATE (a)-[:CodeRelation {type: 'CALLS', confidence: 0.9, reason: 'import-resolved', step: 0}]->(b)`,
   `MATCH (a:Function), (c:Community) WHERE a.id = 'func:login' AND c.id = 'comm:auth'

--- a/gitnexus/test/integration/local-backend-calltool.test.ts
+++ b/gitnexus/test/integration/local-backend-calltool.test.ts
@@ -85,6 +85,12 @@ withTestLbugDB(
         const calleeNames = result.outgoing.calls.map((c: any) => c.name);
         expect(calleeNames).toContain('validate');
         expect(calleeNames).toContain('hash');
+        expect(result.outgoing.calls).toContainEqual(expect.objectContaining({
+          name: 'validate',
+          callSiteFilePath: 'src/auth.ts',
+          callSiteLine: 4,
+          callSiteColumn: 3,
+        }));
       });
 
       it('impact tool returns upstream dependents', async () => {

--- a/gitnexus/test/unit/pdg-callee-id-capture.test.ts
+++ b/gitnexus/test/unit/pdg-callee-id-capture.test.ts
@@ -559,6 +559,11 @@ describe('callee-id capture — emitFreeCallFallback (inline addRelationship)', 
     expect(emitted).toBe(1);
     const callsEdge = graph.relationships.find((r) => r.type === 'CALLS')!;
     expect(callsEdge.targetId).toBe('fn:helper');
+    expect(callsEdge).toMatchObject({
+      callSiteFilePath: FREE_FILE,
+      callSiteLine: 3,
+      callSiteColumn: 3,
+    });
     expect(snapshot(acc, FREE_FILE)).toEqual({
       [calleeIdPosKey(3, 2)]: ['fn:helper'],
     });


### PR DESCRIPTION
Persists existing call-site metadata on CodeRelation rows and returns it from context outgoing calls. Covers direct C free-call fallback plus the shared scope-resolution emitters; enables configuration-aware consumers to filter candidates without guessing declaration locations.