### PR TITLE
feat(deploy): add Render Blueprint and Deploy to Render button

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,6 +912,14 @@ After this, attempting to deploy an unsigned image — or one signed by anything
 
 </details>
 
+### Deploy on Render
+
+Deploy the GitNexus server and web UI from this repository's ready-to-use Blueprint:
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/abhigyanpatwari/GitNexus)
+
+Render reads [`render.yaml`](render.yaml) and provisions a private API server with persistent storage for indexes, cloned repos, and the registry, plus a public web UI that reverse-proxies to it over the private network. No API key is required and no secret is committed. Private services and persistent disks require paid Render instances. To index a large repo, raise the `gitnexus-server` `plan` to `pro` (4 GB) or `pro plus` (8 GB).
+
 ## Enterprise
 
 GitNexus is available as an **enterprise offering** — fully managed **SaaS** or **self-hosted** deployment. Commercial use of the OSS version is also available with proper licensing.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,73 @@
+# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
+#
+# One-click deploy of GitNexus on Render. See README § Deploy on Render.
+#
+#   gitnexus-server — the code-intelligence API, deployed as a PRIVATE service
+#     so the repo-indexing endpoints are never reachable from the internet.
+#     Indexes, cloned repos, and the registry live on a persistent disk, which
+#     pins the service to a single instance.
+#   gitnexus-web    — the public UI. Serves the built frontend AND reverse-
+#     proxies /api/* to the private server, so the browser only ever makes
+#     same-origin calls: no CORS to configure, no public API server.
+#
+# No secret is committed here. The core (index / graph / query / impact) needs
+# no API key; the in-app LLM chat is bring-your-own-key and client-side only.
+
+previews:
+  generation: off
+
+services:
+  # ── Private API server (internal only) ────────────────────────────────
+  - type: pserv
+    name: gitnexus-server
+    runtime: docker
+    region: oregon
+    # Indexing is the peak-RAM step and OOMs on 512MB. `standard` (2GB) handles
+    # small and mid-sized repos; bump to `pro` (4GB) or `pro plus` (8GB) for a
+    # large one. An over-memory repo fails that job cleanly rather than taking
+    # the service down.
+    plan: standard
+    dockerfilePath: ./Dockerfile.cli
+    dockerContext: .
+    # No dockerCommand: the image CMD already binds Render's injected $PORT.
+    # Render runs dockerCommand through its own shell, so an `sh -c` wrapper
+    # here would double-wrap into one unfound token and exit 127.
+    autoDeploy: false
+    disk:
+      name: gitnexus-data
+      mountPath: /data/gitnexus
+      sizeGB: 10
+    envVars:
+      # Public, session-isolated demo mode. Off unless set to true in the
+      # dashboard. `sync: false` keeps it dashboard-managed so a Blueprint
+      # sync never overrides it. Must be set on THIS service — gitnexus-web
+      # learns the flag via GET /api/info.
+      - key: DEMO
+        sync: false
+      # Optional Azure DevOps Server integration. Leave unset to skip.
+      - key: AZURE_DEVOPS_URL
+        sync: false
+      - key: AZURE_DEVOPS_PAT
+        sync: false
+
+  # ── Public web UI + same-origin API proxy ─────────────────────────────
+  - type: web
+    name: gitnexus-web
+    runtime: docker
+    region: oregon
+    plan: starter
+    dockerfilePath: ./Dockerfile.web
+    dockerContext: .
+    healthCheckPath: /
+    autoDeploy: false
+    envVars:
+      # Internal address of the private server. docker-server.mjs proxies
+      # /api/* here and prepends http:// to the host:port.
+      - key: GITNEXUS_UPSTREAM_URL
+        fromService:
+          type: pserv
+          name: gitnexus-server
+          property: hostport
+      # GITNEXUS_BACKEND_URL is deliberately unset: docker-server.mjs falls
+      # back to RENDER_EXTERNAL_URL (this service's own public origin) so the
+      # browser makes same-origin /api calls that the proxy forwards.


### PR DESCRIPTION
## Summary

Adds a `render.yaml` Blueprint and a Deploy to Render button, so GitNexus can be self-hosted in one click. No application code changes — the existing `Dockerfile.cli` and `Dockerfile.web` build unmodified.

## Motivation / context

`docker compose up -d` already runs the server and web UI side by side, but there's no hosted equivalent. This adds one: the Blueprint provisions the same two containers, so self-hosting doesn't require managing a box.

## Areas touched

- [x] Docs / agent config only — plus a new root-level `render.yaml`

*(None of the existing checkboxes cover deploy config at the repo root; noting explicitly per `DoD.md` §30.)*

## Scope & constraints

**In scope**

- `render.yaml` — private `gitnexus-server` (`standard`, 10 GB disk at `/data/gitnexus`) + public `gitnexus-web` (`starter`), wired over the private network.
- A short `### Deploy on Render` subsection at the end of `## Docker`.

**Explicitly out of scope / not done here**

- No changes to Dockerfiles, `docker-compose.yaml`, or any application code.
- `CHANGELOG.md` not touched — owned by the release process (`DoD.md` §138).
- No CI changes; nothing validates `render.yaml` in this repo.

## Implementation notes

- `gitnexus-server` is a **private** service, so the repo-indexing endpoints are never publicly reachable. `gitnexus-web` reverse-proxies `/api/*` to it via `GITNEXUS_UPSTREAM_URL` (`fromService … property: hostport`), so the browser only makes same-origin calls — no CORS, no public API server.
- Both services are pinned to `oregon`; private networking requires a shared region.
- `previews: generation: off` so PRs against this repo don't spin up paid preview services.
- `autoDeploy: false` so a deploy is never triggered unexpectedly. Tradeoff: deployed instances won't pick up upstream fixes without a manual deploy.
- No secret is committed. `DEMO`, `AZURE_DEVOPS_URL`, and `AZURE_DEVOPS_PAT` are `sync: false` (dashboard-entered, unset by default).
- Two comments in the file record non-obvious constraints worth preserving: why there's no `dockerCommand` (Render runs it through its own shell, so an `sh -c` wrapper exits 127), and why `GITNEXUS_BACKEND_URL` is deliberately unset.

## Testing & verification

None of the repo's test suites apply — no executable code changed.

- `render blueprints validate render.yaml` → `valid: true`, `totalActions: 2`
- Verified `plan: pro plus` (recommended in the README) is a valid plan string
- Prettier clean under repo config; `*.md` is prettier-ignored

**The button in the README won't work until this merges** — it points at this repo's default branch, which has no `render.yaml` yet. To try it from this branch:

https://render.com/deploy?repo=https://github.com/Ho1yShif/GitNexus/tree/feat/render-blueprint

## Risk & rollout

No breaking changes, no migration, no index refresh. The Blueprint is inert unless someone deploys it. Deploying is **not free tier** — private services and persistent disks both require paid instance types, which the README states plainly.

## Checklist

- [x] PR body meets repo minimum length
- [x] `AGENTS.md` / overlays unchanged — N/A
- [x] No secrets, tokens, or machine-specific paths committed
