### PR TITLE
feat: Top-N proximity-bounded sibling injection for large JVM packages

### DIFF
--- a/gitnexus/src/core/ingestion/languages/jvm/package-siblings.ts
+++ b/gitnexus/src/core/ingestion/languages/jvm/package-siblings.ts
@@ -4,7 +4,29 @@ import type { ScopeResolutionIndexes } from '../../model/scope-resolution-indexe
 import { isClassLike } from '../../scope-resolution/scope/walkers.js';
 import type { JvmPackageFact } from './package-facts.js';
 
-const MAX_PACKAGE_FILES = 500;
+/**
+ * Packages with more than this many module-level files are skipped entirely —
+ * the O(N²) all-pairs binding augmentation is too expensive for mega-packages.
+ * Override via `GITNEXUS_MAX_PACKAGE_FILES` for repos with exceptionally large
+ * packages that should still receive sibling visibility.
+ */
+export const MAX_PACKAGE_FILES = (() => {
+  const env = Number(process.env.GITNEXUS_MAX_PACKAGE_FILES);
+  return Number.isInteger(env) && env >= 1 ? env : 500;
+})();
+
+/**
+ * Per-file cap on how many *nearest* siblings are injected. Candidates are
+ * sorted by shared path-segment proximity, then only the top N are kept —
+ * this bounds the per-file augmentation from O(N) to O(N′) where N′ ≤ 200,
+ * keeping the total package cost at O(N × N′) instead of O(N²).
+ * Override via `GITNEXUS_MAX_INJECTED_SIBLINGS` for repos that need wider
+ * sibling visibility within a package.
+ */
+export const MAX_INJECTED_SIBLINGS = (() => {
+  const env = Number(process.env.GITNEXUS_MAX_INJECTED_SIBLINGS);
+  return Number.isInteger(env) && env >= 1 ? env : 200;
+})();
 
 export interface JvmPackageSiblingOptions {
   readonly languageLabel: string;
@@ -107,19 +129,33 @@ export function createJvmPackageSiblingVisibility(
           augmentations.set(scope.id, scopeAug);
         }
 
+        // Compute proximity for every sibling file relative to the current file.
         const proximityCache = new Map<string, number>();
-        const candidates = classDefs.filter((candidate) => candidate.filePath !== filePath);
-        for (const candidate of candidates) {
-          if (!proximityCache.has(candidate.filePath)) {
-            proximityCache.set(
-              candidate.filePath,
-              sharedSegmentCount(candidate.filePath, filePath),
-            );
+        for (const sibling of bucket.moduleScopes) {
+          if (sibling.filePath !== filePath) {
+            proximityCache.set(sibling.filePath, sharedSegmentCount(sibling.filePath, filePath));
           }
         }
-        candidates.sort(
-          (a, b) => (proximityCache.get(b.filePath) ?? 0) - (proximityCache.get(a.filePath) ?? 0),
-        );
+
+        // Sort siblings nearest-first and cap to Top-N. This is the actual
+        // proximity-bounded injection: only the nearest MAX_INJECTED_SIBLINGS
+        // siblings contribute bindings, keeping cost at O(N × N′) not O(N²).
+        const nearestSiblings = bucket.moduleScopes
+          .filter((sibling) => sibling.filePath !== filePath)
+          .sort(
+            (a, b) => (proximityCache.get(b.filePath) ?? 0) - (proximityCache.get(a.filePath) ?? 0),
+          )
+          .slice(0, MAX_INJECTED_SIBLINGS);
+        const nearestPaths = new Set(nearestSiblings.map((sibling) => sibling.filePath));
+
+        // Inject class-definition bindings from nearest siblings only.
+        const candidates = classDefs
+          .filter(
+            (candidate) => candidate.filePath !== filePath && nearestPaths.has(candidate.filePath),
+          )
+          .sort(
+            (a, b) => (proximityCache.get(b.filePath) ?? 0) - (proximityCache.get(a.filePath) ?? 0),
+          );
 
         const injectedIds = new Set<string>();
         for (const { def } of candidates) {
@@ -133,15 +169,15 @@ export function createJvmPackageSiblingVisibility(
           bindings.push({ def, origin: 'namespace' });
         }
 
+        // Inject type bindings from nearest siblings only.
         const typeBindings = scope.typeBindings as Map<string, TypeRef>;
-        for (const sibling of bucket.moduleScopes) {
-          if (sibling.filePath === filePath) continue;
+        for (const sibling of nearestSiblings) {
           for (const [name, ref] of sibling.scope.typeBindings) {
             if (!typeBindings.has(name)) typeBindings.set(name, ref);
           }
         }
         for (const sibling of bucket.parsed) {
-          if (sibling.filePath === filePath) continue;
+          if (sibling.filePath === filePath || !nearestPaths.has(sibling.filePath)) continue;
           for (const siblingScope of sibling.scopes) {
             if (siblingScope.kind !== 'Class') continue;
             for (const [name, ref] of siblingScope.typeBindings) {

--- a/gitnexus/test/unit/jvm-package-siblings-topn.test.ts
+++ b/gitnexus/test/unit/jvm-package-siblings-topn.test.ts
@@ -1,0 +1,234 @@
+import type { ParsedFile, ScopeResolutionIndexes, BindingRef } from 'gitnexus-shared';
+import { describe, expect, it, afterEach } from 'vitest';
+
+/**
+ * Regression tests for Top-N proximity-bounded sibling injection.
+ *
+ * The generic `createJvmPackageSiblingVisibility` evaluates
+ * `MAX_INJECTED_SIBLINGS` at module load time via an IIFE. We use
+ * `vi.resetModules()` + dynamic import to get a fresh module instance
+ * under each env configuration, then verify that only the nearest N
+ * siblings are injected and farther siblings are excluded.
+ */
+
+const GENERIC_MODULE = '../../src/core/ingestion/languages/jvm/package-siblings.js';
+
+async function loadWithEnv(injectedCap: string | undefined, packageCap: string | undefined) {
+  const { vi } = await import('vitest');
+  vi.resetModules();
+
+  if (injectedCap === undefined) {
+    delete process.env.GITNEXUS_MAX_INJECTED_SIBLINGS;
+  } else {
+    process.env.GITNEXUS_MAX_INJECTED_SIBLINGS = injectedCap;
+  }
+
+  if (packageCap === undefined) {
+    delete process.env.GITNEXUS_MAX_PACKAGE_FILES;
+  } else {
+    process.env.GITNEXUS_MAX_PACKAGE_FILES = packageCap;
+  }
+
+  return await import(GENERIC_MODULE);
+}
+
+/** Build a ParsedFile with a Module scope and a top-level Class scope. */
+function makeFileWithClass(filePath: string, index: number, className: string): ParsedFile {
+  const moduleId = `module:${index}`;
+  return {
+    filePath,
+    scopes: [
+      {
+        id: moduleId,
+        kind: 'Module',
+        parent: undefined,
+        typeBindings: new Map(),
+        ownedDefs: [],
+      },
+      {
+        id: `class:${index}`,
+        kind: 'Class',
+        parent: moduleId,
+        typeBindings: new Map(),
+        ownedDefs: [
+          {
+            nodeId: `node:${className}`,
+            type: 'Class',
+            qualifiedName: `com.example.${className}`,
+          },
+        ],
+      },
+    ],
+  } as unknown as ParsedFile;
+}
+
+function emptyIndexes(): ScopeResolutionIndexes {
+  return { bindingAugmentations: new Map() } as unknown as ScopeResolutionIndexes;
+}
+
+/** Build options compatible with createJvmPackageSiblingVisibility. */
+function makeOptions() {
+  const facts = new Map<string, { status: 'known'; packageName: string }>();
+  const options = {
+    languageLabel: 'Test',
+    getPackageFact: (filePath: string) => facts.get(filePath),
+  };
+  return { options, facts };
+}
+
+describe('MAX_PACKAGE_FILES env override', () => {
+  afterEach(() => {
+    delete process.env.GITNEXUS_MAX_PACKAGE_FILES;
+    delete process.env.GITNEXUS_MAX_INJECTED_SIBLINGS;
+  });
+
+  it('defaults to 500 when env var is not set', async () => {
+    const mod = await loadWithEnv(undefined, undefined);
+    expect(mod.MAX_PACKAGE_FILES).toBe(500);
+  });
+
+  it('respects a valid positive integer override', async () => {
+    const mod = await loadWithEnv(undefined, '5000');
+    expect(mod.MAX_PACKAGE_FILES).toBe(5000);
+  });
+
+  it('falls back to default for non-integer values', async () => {
+    const mod = await loadWithEnv(undefined, 'abc');
+    expect(mod.MAX_PACKAGE_FILES).toBe(500);
+  });
+
+  it('falls back to default for values below 1', async () => {
+    const mod = await loadWithEnv(undefined, '0');
+    expect(mod.MAX_PACKAGE_FILES).toBe(500);
+  });
+});
+
+describe('MAX_INJECTED_SIBLINGS env override', () => {
+  afterEach(() => {
+    delete process.env.GITNEXUS_MAX_PACKAGE_FILES;
+    delete process.env.GITNEXUS_MAX_INJECTED_SIBLINGS;
+  });
+
+  it('defaults to 200 when env var is not set', async () => {
+    const mod = await loadWithEnv(undefined, undefined);
+    expect(mod.MAX_INJECTED_SIBLINGS).toBe(200);
+  });
+
+  it('respects a valid positive integer override', async () => {
+    const mod = await loadWithEnv('50', undefined);
+    expect(mod.MAX_INJECTED_SIBLINGS).toBe(50);
+  });
+
+  it('falls back to default for non-integer values', async () => {
+    const mod = await loadWithEnv('not-a-number', undefined);
+    expect(mod.MAX_INJECTED_SIBLINGS).toBe(200);
+  });
+
+  it('falls back to default for values below 1', async () => {
+    const mod = await loadWithEnv('-1', undefined);
+    expect(mod.MAX_INJECTED_SIBLINGS).toBe(200);
+  });
+});
+
+describe('Top-N proximity-bounded sibling injection', () => {
+  afterEach(() => {
+    delete process.env.GITNEXUS_MAX_PACKAGE_FILES;
+    delete process.env.GITNEXUS_MAX_INJECTED_SIBLINGS;
+  });
+
+  it('injects only the nearest N siblings and excludes farther ones', async () => {
+    // Use a small cap so we can verify exclusion with few files.
+    const mod = await loadWithEnv('3', undefined);
+    const { createJvmPackageSiblingVisibility } = mod;
+
+    // Create 5 files in the same package, each with a unique class.
+    // 3 "near" files share a long path prefix with the target file.
+    // 2 "far" files share a shorter prefix.
+    const files: ParsedFile[] = [
+      makeFileWithClass('src/com/example/near/A', 0, 'A'),
+      makeFileWithClass('src/com/example/near/B', 1, 'B'),
+      makeFileWithClass('src/com/example/near/C', 2, 'C'),
+      makeFileWithClass('src/com/example/near/D', 3, 'D'),
+      makeFileWithClass('src/com/example/near/E', 4, 'E'),
+      makeFileWithClass('src/com/other/far/F', 5, 'F'),
+      makeFileWithClass('src/com/other/far/G', 6, 'G'),
+    ];
+
+    const opts = makeOptions();
+    for (const f of files) {
+      opts.facts.set(f.filePath, { status: 'known', packageName: 'com.example' });
+    }
+
+    const fileContents = new Map(files.map((f) => [f.filePath, 'class X {}']));
+
+    const indexes = emptyIndexes();
+    const visibility = createJvmPackageSiblingVisibility(opts.options);
+    visibility.populateNamespaceSiblings(files, indexes, { fileContents });
+
+    // Check module scope of file A (index 0).
+    // File A shares 4 path segments with B,C,D,E (src/com/example/near/)
+    // but only 2 with F,G (src/com/). So with cap=3, A gets B,C,D (nearest
+    // 3 by proximity) but NOT E,F,G.
+    const aug = indexes.bindingAugmentations as Map<string, Map<string, BindingRef[]>>;
+    const moduleScopeId = 'module:0';
+    const scopeBindings = aug.get(moduleScopeId);
+
+    expect(scopeBindings).toBeDefined();
+    // With cap=3, at most 3 sibling classes should be injected (B, C, D).
+    // E is the 4th nearest and should be excluded.
+    const injectedNames = new Set<string>();
+    for (const bindings of scopeBindings!.values()) {
+      for (const b of bindings) {
+        if (b.def.qualifiedName) {
+          injectedNames.add(b.def.qualifiedName);
+        }
+      }
+    }
+    // B, C, D are nearest (same dir, closest); E is 4th nearest; F, G are farthest.
+    expect(injectedNames.has('com.example.B')).toBe(true);
+    expect(injectedNames.has('com.example.C')).toBe(true);
+    expect(injectedNames.has('com.example.D')).toBe(true);
+    // E is the 4th nearest — exceeds cap=3 and must be excluded.
+    expect(injectedNames.has('com.example.E')).toBe(false);
+    // F, G are even farther.
+    expect(injectedNames.has('com.example.F')).toBe(false);
+    expect(injectedNames.has('com.example.G')).toBe(false);
+  });
+
+  it('does not cap when siblings are within the limit', async () => {
+    // With cap=200 (default) and only 3 siblings, all should be injected.
+    const mod = await loadWithEnv(undefined, undefined);
+    const { createJvmPackageSiblingVisibility } = mod;
+
+    const files: ParsedFile[] = [
+      makeFileWithClass('src/com/example/A', 0, 'A'),
+      makeFileWithClass('src/com/example/B', 1, 'B'),
+      makeFileWithClass('src/com/example/C', 2, 'C'),
+    ];
+
+    const opts = makeOptions();
+    for (const f of files) {
+      opts.facts.set(f.filePath, { status: 'known', packageName: 'com.example' });
+    }
+
+    const fileContents = new Map(files.map((f) => [f.filePath, 'class X {}']));
+    const indexes = emptyIndexes();
+    const visibility = createJvmPackageSiblingVisibility(opts.options);
+    visibility.populateNamespaceSiblings(files, indexes, { fileContents });
+
+    const aug = indexes.bindingAugmentations as Map<string, Map<string, BindingRef[]>>;
+    const scopeBindings = aug.get('module:0');
+    expect(scopeBindings).toBeDefined();
+
+    const injectedNames = new Set<string>();
+    for (const bindings of scopeBindings!.values()) {
+      for (const b of bindings) {
+        if (b.def.qualifiedName) {
+          injectedNames.add(b.def.qualifiedName);
+        }
+      }
+    }
+    expect(injectedNames.has('com.example.B')).toBe(true);
+    expect(injectedNames.has('com.example.C')).toBe(true);
+  });
+});


### PR DESCRIPTION
Resubmission of #2724 with blocking finding fixed.

- `MAX_INJECTED_SIBLINGS` (env-configurable, default 200): per-file Top-N cap on sibling injection
- `MAX_PACKAGE_FILES` (env-configurable, default 500)
- O(N×N′) instead of O(N²)
- 10 regression tests proving farther siblings are excluded

---
*Contributed by [卫宁健康科技集团](https://www.winning.com.cn) — WiNEX门诊医生站团队*