### PR TITLE
fix(lbug): persist Go function-local variables

### DIFF
--- a/gitnexus/src/core/lbug/schema.ts
+++ b/gitnexus/src/core/lbug/schema.ts
@@ -297,6 +297,7 @@ CREATE REL TABLE ${REL_TABLE_NAME} (
   FROM Function TO \`Typedef\`,
   FROM Function TO \`Union\`,
   FROM Function TO \`Property\`,
+  FROM Function TO \`Variable\`,
   FROM Function TO CodeElement,
   FROM Class TO Method,
   FROM Class TO Function,

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -687,8 +687,13 @@ export interface RepoMeta {
  * Numbered 34, not 33: `main` took 33 for Spring AOP (#2416) mid-flight, landing
  * on exactly this branch's number — the seventh collision in this series and the
  * first exact clash. Re-check against origin/main before merge.
+ *
+ * v35: Go function-local variables emit Function→Variable containment edges
+ * (#2789). LadybugDB fixes endpoint pairs when the relation table is created,
+ * so a pre-v35 index cannot persist these edges through incremental writeback.
+ * Force a full re-analyze.
  */
-export const INCREMENTAL_SCHEMA_VERSION = 34;
+export const INCREMENTAL_SCHEMA_VERSION = 35;
 
 export interface IndexedRepo {
   repoPath: string;

--- a/gitnexus/test/unit/call-summary-schema-version.test.ts
+++ b/gitnexus/test/unit/call-summary-schema-version.test.ts
@@ -73,12 +73,12 @@ describe('CALL_SUMMARY relation-type exclusion (U-C1)', () => {
 });
 
 describe('CALL_SUMMARY incremental reuse gate (U-C5)', () => {
-  it('INCREMENTAL_SCHEMA_VERSION is bumped to 34 (Spring AOP relation pairs #2416, then receiver-chain wire format v2)', () => {
+  it('INCREMENTAL_SCHEMA_VERSION is bumped to 35 (Go function-local variable relation pair #2789)', () => {
     // Moves with every bump BY DESIGN — that is the point of pinning it. A
     // change that alters emitted ids or edges without bumping would otherwise
     // ship silently, and an existing index would keep serving the old graph
     // through the reuse gate below.
-    expect(INCREMENTAL_SCHEMA_VERSION).toBe(34);
+    expect(INCREMENTAL_SCHEMA_VERSION).toBe(35);
   });
 
   it('a pre-current stamp fails the `=== INCREMENTAL_SCHEMA_VERSION` reuse gate → forces full re-analyze', () => {
@@ -223,7 +223,10 @@ describe('CALL_SUMMARY incremental reuse gate (U-C5)', () => {
     // would silently fall back to the text cascade for every chain-carrying
     // site → must NOT reuse.
     expect(passesReuseGate(33)).toBe(false);
+    // A pre-v35 (v34) index lacks Function→Variable in the LadybugDB DDL,
+    // so it cannot persist Go function-local variable containment edges.
+    expect(passesReuseGate(34)).toBe(false);
     // The current stamp passes the gate (incremental top-up eligible).
-    expect(passesReuseGate(34)).toBe(true);
+    expect(passesReuseGate(35)).toBe(true);
   });
 });

--- a/gitnexus/test/unit/schema.test.ts
+++ b/gitnexus/test/unit/schema.test.ts
@@ -215,6 +215,11 @@ describe('LadybugDB Schema', () => {
       expect(RELATION_SCHEMA).toContain('FROM Interface TO CodeElement');
     });
 
+    it('declares the Go function-local variable containment pair (#2789)', () => {
+      const declaredPairs = parseRelationSchemaPairs(RELATION_SCHEMA);
+      expect(declaredPairs.has('Function|Variable')).toBe(true);
+    });
+
     it('declares the Swift enum/property member-containment pairs (#2769)', () => {
       // Asserted through the runtime's own parser, not raw strings, so a
       // cosmetic DDL formatting change cannot fail this without a semantic


### PR DESCRIPTION
## What changed

- declare the `Function→Variable` LadybugDB relation pair emitted for Go function-local variables
- bump the incremental schema version so existing databases are rebuilt with the expanded relation DDL
- pin both the declared pair and the reuse-gate transition in unit tests

Closes #2789.

## Verification

- `npm test -- --run test/unit/schema.test.ts test/unit/call-summary-schema-version.test.ts`
- `npx tsc --noEmit`
- `npx prettier --check src/core/lbug/schema.ts src/storage/repo-manager.ts test/unit/schema.test.ts test/unit/call-summary-schema-version.test.ts`
- `git diff --check`
- built the local CLI and indexed `scrypster/muninndb`; analysis completed with 22,199 nodes and 82,651 edges instead of aborting at relation routing

## Risk

Low. The runtime change only expands the endpoint pairs allowed by the shared relation table. The schema bump intentionally forces one full rebuild for existing indexes.
