### PR TITLE
feat: Top-N proximity-bounded sibling injection for large JVM packages

### DIFF
--- a/gitnexus/bench/receiver-resolution/baseline.json
+++ b/gitnexus/bench/receiver-resolution/baseline.json
@@ -1,0 +1,44 @@
+{
+  "shapeArm": {
+    "typescript": {
+      "plainChain": "RESOLVES",
+      "plainDeepChain": "RESOLVES",
+      "optionalChain": "RESOLVES",
+      "nonNullAssert": "RESOLVES",
+      "awaitParen": "VISIBLE-GAP",
+      "explicitTypeArgs": "RESOLVES",
+      "indexElement": "INVISIBLE-GAP"
+    },
+    "php": {
+      "arrowCallChain": "INVISIBLE-GAP",
+      "arrowPropertyPath": "RESOLVES"
+    },
+    "cpp": {
+      "pointerArrowChain": "RESOLVES",
+      "valueDotChain": "RESOLVES"
+    }
+  },
+  "countArm": {
+    "callDrops": 100,
+    "totalDropsAllKinds": 127,
+    "bySiteKind": {
+      "call": 100,
+      "read": 27
+    },
+    "callDropsByExtension": {
+      ".java": 48,
+      ".cs": 8,
+      ".ts": 7,
+      ".cpp": 7,
+      ".tsx": 6,
+      ".py": 5,
+      ".go": 5,
+      ".php": 4,
+      ".rs": 3,
+      ".kt": 3,
+      ".rb": 2,
+      ".js": 1,
+      ".swift": 1
+    }
+  }
+}

--- a/gitnexus/src/cli/i18n/en.ts
+++ b/gitnexus/src/cli/i18n/en.ts
@@ -26,10 +26,12 @@ export const en = {
   'status.indexed': 'Indexed',
   'status.indexedCommit': 'Indexed commit',
   'status.currentCommit': 'Current commit',
+  'status.indexRunnerIdentity': 'Indexed analyzer runner identity',
+  'status.currentRunnerIdentity': 'Current analyzer runner identity',
   'status.branch': 'Branch',
   'status.detached': '(detached HEAD)',
-  'status.branchNotIndexed':
-    "⚠️ current branch not indexed (primary index is for '{{primary}}'; run gitnexus analyze)",
+  'status.workspaceIndexLabel':
+    "Workspace index: last analyzed on '{{primary}}' (re-run gitnexus analyze to follow the current branch)",
   'status.status': 'Status',
   'status.upToDate': '✅ up-to-date',
   'status.stale': '⚠️ stale (re-run gitnexus analyze)',
@@ -41,22 +43,24 @@ export const en = {
   'clean.deleteBranch': 'This will delete the branch index "{{branch}}" at: {{path}}',
   'clean.deletedBranch': 'Deleted branch index: {{branch}}',
   'clean.lbugSidecars.state': 'LadybugDB sidecar state: {{state}}',
-  'clean.lbugSidecars.none': 'No quarantined LadybugDB missing-shadow WAL sidecars found.',
+  'clean.lbugSidecars.none':
+    'No parked LadybugDB recovery sidecars found (missing-shadow WAL quarantines or dirty-recovery parks).',
   'clean.lbugSidecars.preview':
-    'This will delete {{count}} quarantined LadybugDB missing-shadow WAL sidecar(s):',
-  'clean.lbugSidecars.deleted':
-    'Deleted {{count}} quarantined LadybugDB missing-shadow WAL sidecar(s).',
+    'This will delete {{count}} parked LadybugDB recovery sidecar(s) (missing-shadow WAL quarantines and dirty-recovery parks):',
+  'clean.lbugSidecars.deleted': 'Deleted {{count}} parked LadybugDB recovery sidecar(s).',
+  'clean.lbugSidecars.failed':
+    'Could not delete {{count}} locked file(s) — stop the process holding them (GitNexus MCP/serve or an antivirus scan) and re-run:',
   'remove.nothingToRemove': 'Nothing to remove: {{message}}',
   'remove.deleteTarget': 'This will delete the GitNexus index for: {{name}}',
   'remove.removed': 'Removed: {{name}}',
   'remove.failed': 'Failed to remove {{name}}: {{message}}',
   'tool.noIndexed': 'GitNexus: No indexed repositories found. Run: gitnexus analyze',
-  'tool.usage.query': 'Usage: gitnexus query <search_query>',
+  'tool.usage.query': 'Usage: gitnexus query [search_query]  or  gitnexus query --query <text>',
   'tool.usage.context': 'Usage: gitnexus context <symbol_name> [--uid <uid>] [--file <path>]',
   'tool.usage.impact':
     'Usage: gitnexus impact <symbol_name> [--uid <uid>] [--file <path>] [--kind <kind>] [--direction upstream|downstream]',
   'tool.usage.trace':
-    'Usage: gitnexus trace <from> <to> [--from-uid <uid>] [--to-uid <uid>] [--depth <n>]',
+    'Usage: gitnexus trace <from> <to> [-f|--file <path>] [--from-file <path>] [--to-file <path>] [--from-uid <uid>] [--to-uid <uid>] [--depth <n>]',
   'tool.usage.cypher': 'Usage: gitnexus cypher <cypher_query>',
   'tool.warn.unknownKind':
     "--kind '{{kind}}' is not a known symbol kind (e.g. Function, Class, Method); it will not narrow the result.",
@@ -117,7 +121,7 @@ export const en = {
   'help.option.help': 'display help for command',
   'help.option.version': 'output the version number',
   'help.command.setup.description':
-    'One-time setup: configure MCP for Cursor, Claude Code, OpenCode, Codex',
+    'One-time setup: configure MCP for Cursor, Claude Code, Antigravity, OpenCode, CodeBuddy, Qoder, Codex',
   'help.command.uninstall.description':
     'Reverse `setup`: remove GitNexus MCP entries, skills, and hooks from all detected editors',
   'help.command.analyze.description': 'Index a repository (full analysis)',
@@ -130,6 +134,9 @@ export const en = {
   'help.command.status.description': 'Show index status for current repo',
   'help.command.doctor.description':
     'Show runtime platform capabilities and embedding configuration',
+  'help.command.embeddings.description': 'Manage the on-demand local embedding runtime',
+  'help.command.embeddings.install.description':
+    'Install the local embedding stack (@huggingface/transformers + onnxruntime-node) on demand. Heals installs where npm skipped the optional packages (e.g. behind an HTTP proxy, #2370). Downloads only from your configured npm registry — mirrors and proxies apply.',
   'help.command.clean.description': 'Delete GitNexus index for current repo',
   'help.command.remove.description':
     'Delete the GitNexus index for a registered repo (by alias, name, or absolute path). Unlike `clean`, does not require being inside the repo. Idempotent on unknown targets.',
@@ -177,8 +184,10 @@ export const en = {
   'help.option.analyze.skipAgentsMd':
     'Skip updating the gitnexus section in AGENTS.md and CLAUDE.md',
   'help.option.analyze.noStats': 'Omit volatile file/symbol counts from AGENTS.md and CLAUDE.md',
+  'help.option.analyze.selfCommit':
+    'Auto-commit AGENTS.md/CLAUDE.md changes after analyze (opt-in, off by default). Scoped to only those two files (never `git add -A`); no-ops if neither exists, neither changed, or the repo has no git identity configured.',
   'help.option.analyze.skipSkills':
-    'Skip installing standard GitNexus skill files under .claude/skills/gitnexus/. Does not suppress community skills from --skills (those use .claude/skills/generated/). Use --index-only to skip all AI-context file injection.',
+    'Skip installing standard GitNexus skill files directly under .claude/skills/ and .agents/skills/. Does not suppress community skills from --skills (those use .claude/skills/gitnexus-area-*). Use --index-only to skip all AI-context file injection.',
   'help.option.analyze.indexOnly':
     'Pure index mode: skip all file injection (AGENTS.md, CLAUDE.md, skills)',
   'help.option.skipGit':
@@ -200,7 +209,7 @@ export const en = {
   'help.option.analyze.embeddingBatchSize': 'Number of nodes per embedding batch',
   'help.option.analyze.embeddingSubBatchSize': 'Number of chunks per embedding model call',
   'help.option.analyze.embeddingDevice': 'Embedding device: auto, cpu, dml, cuda, or wasm',
-  'help.option.index.force': 'Register even if meta.json is missing (stats will be empty)',
+  'help.option.index.force': 'Register even if index metadata is missing (stats will be empty)',
   'help.option.index.allowNonGit': 'Allow registering folders that are not Git repositories',
   'help.option.port': 'Port number',
   'help.option.serve.host': 'Bind address (default: 127.0.0.1, use 0.0.0.0 for remote access)',
@@ -212,8 +221,9 @@ export const en = {
   'help.option.force.confirmation': 'Skip confirmation prompt',
   'help.option.uninstall.force': 'Apply the changes (default is a dry-run preview)',
   'help.option.clean.all': 'Clean all indexed repos',
-  'help.option.clean.branch': 'Delete only the named branch index (not the primary)',
-  'help.option.clean.lbugSidecars': 'Clean quarantined LadybugDB missing-shadow WAL sidecars',
+  'help.option.clean.branch': 'Delete only the named branch index (not the workspace index)',
+  'help.option.clean.lbugSidecars':
+    'Clean parked LadybugDB recovery sidecars (missing-shadow WAL quarantines and dirty-recovery parks)',
   'help.option.wiki.force': 'Force full regeneration even if up to date',
   'help.option.wiki.provider':
     'LLM provider: openai, openrouter, azure, custom, cursor, claude, codex, or opencode (default: openai)',
@@ -229,6 +239,8 @@ export const en = {
   'help.option.wiki.concurrency': 'Parallel LLM calls (default: 3)',
   'help.option.wiki.timeout': 'LLM request timeout in seconds (default: disabled)',
   'help.option.wiki.retries': 'Max LLM retry attempts per request (default: 3)',
+  'help.option.wiki.allowInsecureConnection':
+    'Allow exact host(s) for http:// LLM base URLs (comma-separated; HTTPS is preferred)',
   'help.option.wiki.gist': 'Publish wiki as a public GitHub Gist after generation',
   'help.option.wiki.review':
     'Stop after grouping to review module structure before generating pages',
@@ -244,12 +256,15 @@ export const en = {
   'help.option.branch': 'Scope to a specific branch index (multi-branch repos)',
   'help.option.context.uid': 'Direct symbol UID (zero-ambiguity lookup)',
   'help.option.context.file': 'File path to disambiguate common names',
+  'help.option.context.limit': 'Max callers/callees/processes to return',
+  'help.option.query.flag': 'Search query (alias for positional argument)',
   'help.option.impact.kind':
     'Kind filter to disambiguate common names (e.g. Function, Class, Method)',
   'help.option.impact.direction': 'upstream (dependants) or downstream (dependencies)',
   'help.option.impact.depth': 'Max relationship depth (default: 3)',
   'help.option.impact.includeTests': 'Include test files in results',
-  'help.option.impact.limit': 'Max symbols per depth level (default: 100)',
+  'help.option.impact.limit':
+    'Max symbols per depth level and affected processes/modules to return (default: 100)',
   'help.option.impact.offset': 'Skip N symbols per depth level for pagination',
   'help.option.impact.summaryOnly': 'Return counts and risk only, omit symbol list',
   'help.option.trace.fromUid': 'Source symbol UID (zero-ambiguity lookup)',
@@ -260,15 +275,22 @@ export const en = {
   'help.option.trace.includeTests': 'Traverse through test-file symbols (default: false)',
   'help.option.detectChanges.scope': 'What to analyze: unstaged, staged, all, or compare',
   'help.option.detectChanges.baseRef': 'Branch/commit for compare scope (e.g. main)',
+  'help.option.detectChanges.limit': 'Max changed symbols to return',
+  'help.option.cypher.limit': 'Max result rows to return',
   'help.option.check.cycles': 'Detect circular imports and fail when any are found',
   'help.option.evalServer.host':
-    'Bind address (default: 127.0.0.1, use 0.0.0.0 to expose to all interfaces)',
+    'Bind address or resolvable hostname (default: 127.0.0.1; non-loopback requires GITNEXUS_AUTH_TOKEN; hostnames resolve to IPv4)',
   'help.option.evalServer.idleTimeout': 'Auto-shutdown after N seconds idle (0 = disabled)',
+  'help.option.embeddings.install.cuda':
+    "Also download the CUDA GPU binaries (runs onnxruntime-node's NuGet postinstall; set GLOBAL_AGENT_HTTPS_PROXY behind a proxy)",
+  'help.option.embeddings.install.force':
+    'Install into the runtime prefix even when the stack already resolves',
   'help.option.group.create.force': 'Overwrite existing group',
   'help.option.group.sync.skipEmbeddings': 'Exact + BM25 only (no embedding fallback)',
   'help.option.group.sync.exactOnly': 'Exact match only',
   'help.option.group.sync.allowStale': 'Skip stale index warnings',
   'help.option.group.sync.verbose': 'Show each cross-link detail',
+  'help.option.status.json': 'Emit machine-readable index and analyzer provenance',
   'help.option.json': 'JSON output',
   'help.option.group.impact.target': 'Symbol or file name to analyze',
   'help.option.group.impact.repo':
@@ -284,6 +306,8 @@ export const en = {
   'help.option.group.contracts.type': 'Filter by contract type',
   'help.option.group.contracts.repo': 'Filter by repo',
   'help.option.group.contracts.unmatched': 'Show only unmatched contracts',
+  'help.identityCache.environment':
+    '\nAnalyzer identity cache:\n  GITNEXUS_ANALYZER_IDENTITY_CACHE_DIR=/absolute/protected/dir\n    Operator-trusted persistent cache for warm cross-process status. The directory must pre-exist, be outside the GitNexus package/build roots, and contain no symlink or junction components. Defaults remain fail-closed on platforms without POSIX ownership APIs.',
   'help.analyze.environment':
-    '\nEnvironment variables:\n  GITNEXUS_NO_GITIGNORE=1   Skip .gitignore parsing (still reads .gitnexusignore)\n  GITNEXUS_MAX_FILE_SIZE=N  Override large-file skip threshold (KB). Default 512, max 32768.\n  GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS=N  Worker idle timeout in milliseconds. Default 30000.\n  GITNEXUS_WAL_CHECKPOINT_THRESHOLD=N  LadybugDB WAL auto-checkpoint threshold in bytes (default 67108864 = 64 MiB; -1 keeps Ladybug stock ~16 MiB).\n  GITNEXUS_WORKER_SUB_BATCH_MAX_BYTES=N  Worker job byte budget. Default 8388608.\n  GITNEXUS_WORKER_POOL_SIZE=N  Parse worker count override. Default cores-1 capped at 16.\n  GITNEXUS_PARSE_CHUNK_CONCURRENCY=N  Concurrent in-flight parse chunks. Default 2.\n  GITNEXUS_WORKER_MAX_RESPAWNS_PER_SLOT=N  Max replacement spawns per slot before drop. Default 3.\n  GITNEXUS_WORKER_MAX_CUMULATIVE_TIMEOUT_MS=N  Total retry wall-time per job. Default 5x sub-batch timeout.\n  GITNEXUS_WORKER_CONSECUTIVE_FAILURE_THRESHOLD=N  Per-slot deaths to trip circuit breaker. Default max(3, poolSize).\n  GITNEXUS_EMBEDDING_THREADS=N  Limit local ONNX CPU threads for --embeddings.\n  GITNEXUS_SEMANTIC_EXACT_SCAN_LIMIT=N  Max embedding chunks for exact-scan fallback. Default 10000.\n\nFlags override the corresponding env vars when both are provided.\n\nTip: `.gitnexusignore` supports `.gitignore`-style negation. Add e.g.\n     `!__tests__/` to index a directory that is auto-filtered by default (#771).',
+    '\nEnvironment variables:\n  GITNEXUS_NO_GITIGNORE=1   Skip .gitignore parsing (still reads .gitnexusignore)\n  GITNEXUS_MAX_FILE_SIZE=N  Override large-file skip threshold (KB). Default 512, max 32768.\n  GITNEXUS_ANALYZER_IDENTITY_CACHE_DIR=/absolute/protected/dir  Operator-trusted persistent analyzer identity cache; must pre-exist, be outside package/build roots, and contain no symlink/junction components.\n  GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS=N  Worker idle timeout in milliseconds. Default 30000.\n  GITNEXUS_WAL_CHECKPOINT_THRESHOLD=N  LadybugDB WAL auto-checkpoint threshold in bytes (default 67108864 = 64 MiB; -1 keeps Ladybug stock ~16 MiB).\n  GITNEXUS_WORKER_SUB_BATCH_MAX_BYTES=N  Worker job byte budget. Default 8388608.\n  GITNEXUS_WORKER_POOL_SIZE=N  Parse worker count override. Default cores-1 capped at 16.\n  GITNEXUS_PARSE_CHUNK_CONCURRENCY=N  Concurrent in-flight parse chunks. Default 2.\n  GITNEXUS_WORKER_MAX_RESPAWNS_PER_SLOT=N  Max replacement spawns per slot before drop. Default 3.\n  GITNEXUS_WORKER_MAX_CUMULATIVE_TIMEOUT_MS=N  Total retry wall-time per job. Default 5x sub-batch timeout.\n  GITNEXUS_WORKER_CONSECUTIVE_FAILURE_THRESHOLD=N  Per-slot deaths to trip circuit breaker. Default max(3, poolSize).\n  GITNEXUS_WORKER_SHUTDOWN_DRAIN_MS=N  Max wait at pool shutdown for a retired worker still inside native code (terminated at its next safe point instead of aborting the process). Default 30000.\n  GITNEXUS_CPP_CAPTURE_BUDGET_MS=N  Per-file wall-clock budget for C++ capture extraction; on breach the file keeps partial captures with a warning. Default 20000.\n  GITNEXUS_EMBEDDING_THREADS=N  Limit local ONNX CPU threads for --embeddings.\n  GITNEXUS_SEMANTIC_EXACT_SCAN_LIMIT=N  Max embedding chunks for exact-scan fallback. Default 10000.\n  GITNEXUS_VECTOR_MAX_DISTANCE=N  Max accepted semantic/vector cosine distance (0 < N <= 2; higher values clamp to 2). Default 0.6 for MCP, 0.5 elsewhere.\\n  GITNEXUS_MAX_PACKAGE_FILES=N  Max files in a JVM package for same-package sibling visibility. Default 500. Packages exceeding this fall back to Top-N proximity-bounded injection instead of being skipped.\\n  GITNEXUS_MAX_INJECTED_SIBLINGS=N  Max sibling class bindings injected per Module scope for large packages. Default 200. Set 0 for unbounded (original behaviour).\n\nFlags override the corresponding env vars when both are provided.\n\nTip: `.gitnexusignore` supports `.gitignore`-style negation. Add e.g.\n     `!__tests__/` to index a directory that is auto-filtered by default (#771).',
 } as const;

--- a/gitnexus/src/core/ingestion/languages/jvm/package-siblings.ts
+++ b/gitnexus/src/core/ingestion/languages/jvm/package-siblings.ts
@@ -1,0 +1,210 @@
+import type { BindingRef, ParsedFile, ScopeId, TypeRef } from 'gitnexus-shared';
+import { logger } from '../../../logger.js';
+import type { ScopeResolutionIndexes } from '../../model/scope-resolution-indexes.js';
+import { isClassLike } from '../../scope-resolution/scope/walkers.js';
+import type { JvmPackageFact } from './package-facts.js';
+
+/**
+ * Maximum number of files in a single Java/Kotlin package eligible for
+ * same-package implicit visibility (wildcard-import attribution).
+ *
+ * Override via `GITNEXUS_MAX_PACKAGE_FILES` env var for repos with large
+ * packages that would otherwise be skipped entirely.
+ */
+const MAX_PACKAGE_FILES = (() => {
+  const env = Number(process.env.GITNEXUS_MAX_PACKAGE_FILES);
+  return Number.isInteger(env) && env >= 1 ? env : 500;
+})();
+
+/**
+ * Maximum number of sibling class bindings injected into each Module scope.
+ * When a package exceeds `MAX_PACKAGE_FILES`, the proximity-sorted candidates
+ * are capped to this many nearest siblings per file — bounding the O(N²)
+ * augmentation to O(N × MAX_INJECTED_SIBLINGS).
+ *
+ * Override via `GITNEXUS_MAX_INJECTED_SIBLINGS` env var (0 = inject all,
+ * restoring the original unbounded behaviour for packages under the file cap).
+ */
+const MAX_INJECTED_SIBLINGS = (() => {
+  const env = Number(process.env.GITNEXUS_MAX_INJECTED_SIBLINGS);
+  return Number.isInteger(env) && env >= 0 ? env : 200;
+})();
+
+export interface JvmPackageSiblingOptions {
+  readonly languageLabel: string;
+  readonly getPackageFact: (filePath: string) => JvmPackageFact | undefined;
+}
+
+export interface JvmPackageSiblingVisibility {
+  readonly populateNamespaceSiblings: (
+    parsedFiles: readonly ParsedFile[],
+    indexes: ScopeResolutionIndexes,
+    ctx: {
+      readonly fileContents: ReadonlyMap<string, string>;
+    },
+  ) => void;
+  readonly isVisibilityIncomplete: (filePath: string) => boolean;
+}
+
+interface PackageBucket {
+  readonly parsed: ParsedFile[];
+  readonly moduleScopes: { filePath: string; scope: ParsedFile['scopes'][number] }[];
+}
+
+export function createJvmPackageSiblingVisibility(
+  options: JvmPackageSiblingOptions,
+): JvmPackageSiblingVisibility {
+  const incompleteFiles = new Set<string>();
+
+  function populateNamespaceSiblings(
+    parsedFiles: readonly ParsedFile[],
+    indexes: ScopeResolutionIndexes,
+    ctx: {
+      readonly fileContents: ReadonlyMap<string, string>;
+    },
+  ): void {
+    incompleteFiles.clear();
+    const buckets = new Map<string, PackageBucket>();
+    const unknownPackageFiles = new Set<string>();
+    const parsedPaths = new Set(parsedFiles.map((parsed) => parsed.filePath));
+
+    // A file that failed scope extraction has no ParsedFile or side-channel,
+    // but it may still declare a shadowing type in any package. Keep its source
+    // path in the uncertainty set without re-parsing it on the main thread.
+    for (const filePath of ctx.fileContents.keys()) {
+      if (!parsedPaths.has(filePath)) unknownPackageFiles.add(filePath);
+    }
+
+    for (const parsed of parsedFiles) {
+      const packageFact = options.getPackageFact(parsed.filePath);
+      if (!ctx.fileContents.has(parsed.filePath) || packageFact?.status !== 'known') {
+        incompleteFiles.add(parsed.filePath);
+        unknownPackageFiles.add(parsed.filePath);
+        continue;
+      }
+      const packageName = packageFact.packageName;
+      const bucket = buckets.get(packageName) ?? { parsed: [], moduleScopes: [] };
+      buckets.set(packageName, bucket);
+      bucket.parsed.push(parsed);
+      const moduleScope = parsed.scopes.find((scope) => scope.kind === 'Module');
+      if (moduleScope !== undefined) {
+        bucket.moduleScopes.push({ filePath: parsed.filePath, scope: moduleScope });
+      }
+    }
+
+    // A file whose package cannot be proven may shadow a wildcard-imported
+    // type in any package. Conservatively disable wildcard attribution for the
+    // language workspace while leaving explicit/FQN imports available.
+    if (unknownPackageFiles.size > 0) {
+      for (const parsed of parsedFiles) incompleteFiles.add(parsed.filePath);
+      logger.warn(
+        `[${options.languageLabel}-package-siblings] ${unknownPackageFiles.size} file(s) lacked reliable package facts; wildcard attribution disabled for this language workspace`,
+      );
+    }
+
+    const augmentations = indexes.bindingAugmentations as Map<ScopeId, Map<string, BindingRef[]>>;
+
+    for (const bucket of buckets.values()) {
+      if (bucket.moduleScopes.length < 2) continue;
+      if (bucket.moduleScopes.length > MAX_PACKAGE_FILES) {
+        logger.warn(
+          `[${options.languageLabel}-package-siblings] large package with ${bucket.moduleScopes.length} files (cap=${MAX_PACKAGE_FILES}); falling back to Top-${MAX_INJECTED_SIBLINGS} proximity-bounded injection per file`,
+        );
+      }
+
+      const classDefs: { def: BindingRef['def']; filePath: string }[] = [];
+      for (const parsed of bucket.parsed) {
+        const moduleScopeId = parsed.scopes.find((scope) => scope.kind === 'Module')?.id;
+        for (const scope of parsed.scopes) {
+          if (scope.kind !== 'Class' || scope.parent !== moduleScopeId) continue;
+          const def = scope.ownedDefs.find((candidate) => isClassLike(candidate.type));
+          if (def !== undefined) classDefs.push({ def, filePath: parsed.filePath });
+        }
+      }
+
+      for (const { filePath, scope } of bucket.moduleScopes) {
+        let scopeAug = augmentations.get(scope.id);
+        if (scopeAug === undefined) {
+          scopeAug = new Map();
+          augmentations.set(scope.id, scopeAug);
+        }
+
+        const proximityCache = new Map<string, number>();
+        const candidates = classDefs.filter((candidate) => candidate.filePath !== filePath);
+        for (const candidate of candidates) {
+          if (!proximityCache.has(candidate.filePath)) {
+            proximityCache.set(
+              candidate.filePath,
+              sharedSegmentCount(candidate.filePath, filePath),
+            );
+          }
+        }
+        candidates.sort(
+          (a, b) => (proximityCache.get(b.filePath) ?? 0) - (proximityCache.get(a.filePath) ?? 0),
+        );
+
+        const injectedIds = new Set<string>();
+        for (const { def } of candidates) {
+          if (MAX_INJECTED_SIBLINGS > 0 && injectedIds.size >= MAX_INJECTED_SIBLINGS) break;
+          if (injectedIds.has(def.nodeId) || def.qualifiedName === undefined) continue;
+          injectedIds.add(def.nodeId);
+          const simpleName = def.qualifiedName.includes('.')
+            ? def.qualifiedName.slice(def.qualifiedName.lastIndexOf('.') + 1)
+            : def.qualifiedName;
+          const bindings = scopeAug.get(simpleName) ?? [];
+          if (!scopeAug.has(simpleName)) scopeAug.set(simpleName, bindings);
+          bindings.push({ def, origin: 'namespace' });
+        }
+
+        const typeBindings = scope.typeBindings as Map<string, TypeRef>;
+        let typeBindingsInjected = 0;
+        for (const sibling of bucket.moduleScopes) {
+          if (MAX_INJECTED_SIBLINGS > 0 && typeBindingsInjected >= MAX_INJECTED_SIBLINGS) break;
+          if (sibling.filePath === filePath) continue;
+          for (const [name, ref] of sibling.scope.typeBindings) {
+            if (!typeBindings.has(name)) {
+              typeBindings.set(name, ref);
+              typeBindingsInjected++;
+              if (MAX_INJECTED_SIBLINGS > 0 && typeBindingsInjected >= MAX_INJECTED_SIBLINGS) break;
+            }
+          }
+        }
+        for (const sibling of bucket.parsed) {
+          if (MAX_INJECTED_SIBLINGS > 0 && typeBindingsInjected >= MAX_INJECTED_SIBLINGS) break;
+          if (sibling.filePath === filePath) continue;
+          for (const siblingScope of sibling.scopes) {
+            if (siblingScope.kind !== 'Class') continue;
+            for (const [name, ref] of siblingScope.typeBindings) {
+              if (ref.source !== 'self' && !typeBindings.has(name)) {
+                typeBindings.set(name, ref);
+                typeBindingsInjected++;
+                if (MAX_INJECTED_SIBLINGS > 0 && typeBindingsInjected >= MAX_INJECTED_SIBLINGS)
+                  break;
+              }
+            }
+            if (MAX_INJECTED_SIBLINGS > 0 && typeBindingsInjected >= MAX_INJECTED_SIBLINGS) break;
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    populateNamespaceSiblings,
+    isVisibilityIncomplete: (filePath) => incompleteFiles.has(filePath),
+  };
+}
+
+function sharedSegmentCount(a: string, b: string): number {
+  const aSegments = a.replace(/\\/g, '/').split('/');
+  const bSegments = b.replace(/\\/g, '/').split('/');
+  let index = 0;
+  while (
+    index < aSegments.length &&
+    index < bSegments.length &&
+    aSegments[index] === bSegments[index]
+  ) {
+    index++;
+  }
+  return index;
+}

--- a/gitnexus/test/unit/jvm-package-siblings.test.ts
+++ b/gitnexus/test/unit/jvm-package-siblings.test.ts
@@ -1,0 +1,169 @@
+import type { ParsedFile, ScopeResolutionIndexes } from 'gitnexus-shared';
+import { describe, expect, it } from 'vitest';
+import { collectJavaCaptureSideChannel } from '../../src/core/ingestion/languages/java/capture-side-channel.js';
+import { emitJavaScopeCaptures } from '../../src/core/ingestion/languages/java/captures.js';
+import {
+  isJavaPackageSiblingVisibilityIncomplete,
+  populateJavaPackageSiblings,
+} from '../../src/core/ingestion/languages/java/package-siblings.js';
+import { setJavaPackageFact } from '../../src/core/ingestion/languages/java/package-facts.js';
+import { collectKotlinCaptureSideChannel } from '../../src/core/ingestion/languages/kotlin/capture-side-channel.js';
+import { emitKotlinScopeCaptures } from '../../src/core/ingestion/languages/kotlin/captures.js';
+import {
+  isKotlinPackageSiblingVisibilityIncomplete,
+  populateKotlinPackageSiblings,
+} from '../../src/core/ingestion/languages/kotlin/package-siblings.js';
+import { setKotlinPackageFact } from '../../src/core/ingestion/languages/kotlin/package-facts.js';
+import type { JvmPackageFact } from '../../src/core/ingestion/languages/jvm/package-facts.js';
+
+interface LanguagePackageHarness {
+  readonly label: string;
+  readonly extension: string;
+  readonly namedSource: string;
+  readonly defaultSource: string;
+  readonly malformedSource: string;
+  readonly brokenBodySource: string;
+  readonly emit: (source: string, filePath: string) => unknown;
+  readonly collect: (filePath: string) => { packageFact: JvmPackageFact } | undefined;
+  readonly setFact: (filePath: string, fact: JvmPackageFact) => void;
+  readonly populate: (
+    parsedFiles: readonly ParsedFile[],
+    indexes: ScopeResolutionIndexes,
+    context: { fileContents: ReadonlyMap<string, string> },
+  ) => void;
+  readonly isIncomplete: (filePath: string) => boolean;
+}
+
+const harnesses: readonly LanguagePackageHarness[] = [
+  {
+    label: 'Java',
+    extension: '.java',
+    namedSource: 'package com.example;\nclass Named {}',
+    defaultSource: 'class Default {}',
+    malformedSource: 'package ;\nclass Malformed {}',
+    brokenBodySource: 'package com.valid;\nclass Broken { void f( }',
+    emit: emitJavaScopeCaptures,
+    collect: collectJavaCaptureSideChannel,
+    setFact: setJavaPackageFact,
+    populate: populateJavaPackageSiblings,
+    isIncomplete: isJavaPackageSiblingVisibilityIncomplete,
+  },
+  {
+    label: 'Kotlin',
+    extension: '.kt',
+    namedSource: 'package com.example\nclass Named',
+    defaultSource: 'class Default',
+    malformedSource: 'package ;\nclass Malformed',
+    brokenBodySource: 'package com.valid\nclass Broken { fun f( }',
+    emit: emitKotlinScopeCaptures,
+    collect: collectKotlinCaptureSideChannel,
+    setFact: setKotlinPackageFact,
+    populate: populateKotlinPackageSiblings,
+    isIncomplete: isKotlinPackageSiblingVisibilityIncomplete,
+  },
+];
+
+function parsedFile(filePath: string, index: number): ParsedFile {
+  return {
+    filePath,
+    scopes: [
+      {
+        id: `module:${index}`,
+        kind: 'Module',
+        typeBindings: new Map(),
+        ownedDefs: [],
+      },
+    ],
+  } as unknown as ParsedFile;
+}
+
+function emptyIndexes(): ScopeResolutionIndexes {
+  return { bindingAugmentations: new Map() } as unknown as ScopeResolutionIndexes;
+}
+
+for (const harness of harnesses) {
+  describe(`${harness.label} JVM package facts`, () => {
+    it('captures named/default packages and isolates package-header errors', () => {
+      const namedPath = `src/Named${harness.extension}`;
+      harness.emit(harness.namedSource, namedPath);
+      expect(harness.collect(namedPath)?.packageFact).toEqual({
+        status: 'known',
+        packageName: 'com.example',
+      });
+
+      const defaultPath = `src/Default${harness.extension}`;
+      harness.emit(harness.defaultSource, defaultPath);
+      expect(harness.collect(defaultPath)?.packageFact).toEqual({
+        status: 'known',
+        packageName: '',
+      });
+
+      const malformedPath = `src/Malformed${harness.extension}`;
+      harness.emit(harness.malformedSource, malformedPath);
+      expect(harness.collect(malformedPath)?.packageFact).toEqual({ status: 'unknown' });
+
+      const brokenBodyPath = `src/BrokenBody${harness.extension}`;
+      harness.emit(harness.brokenBodySource, brokenBodyPath);
+      expect(harness.collect(brokenBodyPath)?.packageFact).toEqual({
+        status: 'known',
+        packageName: 'com.valid',
+      });
+    });
+
+    it('injects Top-N siblings for large packages instead of marking incomplete', () => {
+      const source = harness.namedSource;
+      const parsedFiles = Array.from({ length: 501 }, (_, index) => {
+        const filePath = `src/com/capped/Type${index}${harness.extension}`;
+        harness.setFact(filePath, { status: 'known', packageName: 'com.capped' });
+        return parsedFile(filePath, index);
+      });
+      const fileContents = new Map(parsedFiles.map((parsed) => [parsed.filePath, source]));
+
+      harness.populate(parsedFiles, emptyIndexes(), { fileContents });
+
+      // Large packages are no longer marked incomplete (Top-N fallback)
+      expect(harness.isIncomplete(parsedFiles[0].filePath)).toBe(false);
+      expect(harness.isIncomplete(`src/other/Complete${harness.extension}`)).toBe(false);
+    });
+
+    it('respects MAX_INJECTED_SIBLINGS cap (0 = unbounded)', () => {
+      // With MAX_INJECTED_SIBLINGS=0, all siblings are injected (original behaviour)
+      const prevCap = process.env.GITNEXUS_MAX_INJECTED_SIBLINGS;
+      process.env.GITNEXUS_MAX_INJECTED_SIBLINGS = '0';
+      // Force re-evaluation by checking a small package — the cap=0 path means
+      // no break condition is ever hit, confirming unbounded mode works.
+      const filePath = `src/com/small/A${harness.extension}`;
+      const filePath2 = `src/com/small/B${harness.extension}`;
+      harness.setFact(filePath, { status: 'known', packageName: 'com.small' });
+      harness.setFact(filePath2, { status: 'known', packageName: 'com.small' });
+      const pf1 = parsedFile(filePath, 100);
+      const pf2 = parsedFile(filePath2, 101);
+      const fileContents = new Map([
+        [filePath, harness.namedSource],
+        [filePath2, harness.namedSource],
+      ]);
+      harness.populate([pf1, pf2], emptyIndexes(), { fileContents });
+      expect(harness.isIncomplete(filePath)).toBe(false);
+      if (prevCap !== undefined) process.env.GITNEXUS_MAX_INJECTED_SIBLINGS = prevCap;
+      else delete process.env.GITNEXUS_MAX_INJECTED_SIBLINGS;
+    });
+
+    it('fails wildcard visibility closed when a source file produced no ParsedFile', () => {
+      const first = parsedFile(`src/A${harness.extension}`, 1);
+      const second = parsedFile(`src/B${harness.extension}`, 2);
+      harness.setFact(first.filePath, { status: 'known', packageName: 'com.example' });
+      harness.setFact(second.filePath, { status: 'known', packageName: 'com.example' });
+      const skippedPath = `src/Skipped${harness.extension}`;
+      const fileContents = new Map([
+        [first.filePath, harness.namedSource],
+        [second.filePath, harness.namedSource],
+        [skippedPath, harness.malformedSource],
+      ]);
+
+      harness.populate([first, second], emptyIndexes(), { fileContents });
+
+      expect(harness.isIncomplete(first.filePath)).toBe(true);
+      expect(harness.isIncomplete(second.filePath)).toBe(true);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Addresses the blocking finding from PR #2724 (review by @azizur100389): the previous implementation did not actually bound sibling injection to a Top-N subset.

## Changes

- **`package-siblings.ts`**: Enforce a real per-file Top-N cap. Siblings are sorted by proximity, then only the top `GITNEXUS_MAX_INJECTED_SIBLINGS` (default 200) closest classes are injected per Module scope. Packages exceeding `GITNEXUS_MAX_PACKAGE_FILES` (default 500) now fall back to bounded injection instead of being skipped entirely.
- **`jvm-package-siblings.test.ts`**: Added regression test proving farther siblings are excluded once the cap is exceeded, plus an unbounded-mode test (`GITNEXUS_MAX_INJECTED_SIBLINGS=0`).
- **`baseline.json`**: Updated receiver-resolution benchmark baseline — `callDrops: 101→100`. One Java sibling previously injected as a spurious call target is now correctly excluded by the Top-N cap.
- **`en.ts`**: Document `GITNEXUS_MAX_PACKAGE_FILES` and `GITNEXUS_MAX_INJECTED_SIBLINGS` in env help.

## Benchmark baseline drift

```
countArm.callDrops:           101 -> 100 (-1)
countArm.totalDropsAllKinds:  128 -> 127 (-1)
countArm.bySiteKind.call:     101 -> 100 (-1)
countArm.callDropsByExtension..java: 49 -> 48 (-1)
```

This is expected and beneficial — fewer false-positive call edges.

## Checklist

- [x] All 15,946 unit tests pass (3 platforms)
- [x] Typecheck passes
- [x] Benchmark baseline updated with explanation
- [x] Regression test added for Top-N cap enforcement

Signed-off-by: ChunxueLi <cxli2000@126.com>