### PR TITLE
ci: fail a PR whose SCHEMA_BUMP collides with the base branch

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -22,6 +22,30 @@ jobs:
       - run: npm ci
       - run: npx prettier --check .
 
+  parse-cache-version:
+    # Guards a collision no single-branch test can see: two PRs claiming the
+    # same SCHEMA_BUMP both pass their own `toBe(N)` pin, then share one
+    # PARSE_CACHE_VERSION after merge and one side's parse-time capture change
+    # silently replays pre-change ParsedFiles forever. Ten ledger entries, four
+    # exact clashes, every one caught by hand at merge time until now.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history: the check reads the BASE branch's value, which a
+          # shallow clone does not contain. The script exits 2 (distinct from a
+          # real conflict) if the ref is unreachable, so a misconfiguration here
+          # cannot masquerade as a pass.
+          fetch-depth: 0
+      - name: Fetch base branch
+        run: git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF:-main}:refs/remotes/origin/${GITHUB_BASE_REF:-main}" || git fetch --no-tags origin "${GITHUB_BASE_REF:-main}"
+      - name: Compare SCHEMA_BUMP against the base branch
+        env:
+          GITNEXUS_BASE_REF: origin/${{ github.base_ref || 'main' }}
+        run: node scripts/check-parse-cache-version.mjs
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/gitnexus/test/unit/parse-cache-version-check.test.ts
+++ b/gitnexus/test/unit/parse-cache-version-check.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The CI guard for concurrent `SCHEMA_BUMP` claims.
+ *
+ * The in-repo pin (`expect(...).toBe(N)`) cannot catch this and the ledger says
+ * so four separate times: both branches assert the same number, so both are
+ * green while they collide. The conflict exists only in the RELATION between
+ * two branches, so the check has to compare against the base — and therefore
+ * has to be tested against real git state rather than mocked.
+ *
+ * Failure here is silent in production, which is why it kept recurring:
+ * `PARSE_CACHE_VERSION` is the only invalidator for the durable ParsedFile
+ * store, so a shared version means one side's parse-time change replays
+ * pre-change ParsedFiles on every incremental analyze, and the graph is simply
+ * missing edges.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const SCRIPT = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'scripts',
+  'check-parse-cache-version.mjs',
+);
+const CACHE_REL = path.join('gitnexus', 'src', 'storage', 'parse-cache.ts');
+
+let repo: string;
+
+const git = (...args: string[]): void => {
+  execFileSync('git', args, { cwd: repo, stdio: 'ignore' });
+};
+
+const writeBump = (n: number): void => {
+  const file = path.join(repo, CACHE_REL);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `// fixture\nconst SCHEMA_BUMP = ${n};\nexport {};\n`, 'utf8');
+};
+
+/** Run the check against `baseRef`, returning its exit code and stderr. */
+const runCheck = (baseRef: string): { code: number; out: string } => {
+  const res = spawnSync(process.execPath, [SCRIPT], {
+    cwd: repo,
+    encoding: 'utf8',
+    env: { ...process.env, GITNEXUS_BASE_REF: baseRef },
+  });
+  return { code: res.status ?? -1, out: `${res.stdout}${res.stderr}` };
+};
+
+beforeAll(() => {
+  repo = fs.mkdtempSync(path.join(os.tmpdir(), 'gn-cachever-'));
+  git('init', '-q', '--initial-branch=main');
+  git('config', 'user.email', 't@t');
+  git('config', 'user.name', 't');
+  writeBump(45);
+  git('add', '-A');
+  git('commit', '-qm', 'base at 45');
+});
+
+afterAll(() => {
+  fs.rmSync(repo, { recursive: true, force: true });
+});
+
+describe('check-parse-cache-version', () => {
+  // The case that matters most in practice, because it is the case for almost
+  // every PR — and the one this check got wrong first. Requiring a strict
+  // increase unconditionally would have failed every branch that does not touch
+  // the parse cache, including the branch that introduced the check.
+  it('passes a branch that does not touch the parse cache at all', () => {
+    // Byte-identical to base: no claim on any version, nothing to collide with.
+    const { code, out } = runCheck('main');
+    expect(code).toBe(0);
+    expect(out).toContain('claims no version');
+  });
+
+  it('passes when the branch raises the version', () => {
+    writeBump(46);
+    const { code, out } = runCheck('main');
+    expect(code).toBe(0);
+    expect(out).toContain('OK');
+  });
+
+  // The case the pin test is blind to, and the one that has actually happened
+  // four times.
+  it('fails when both sides claim the same number', () => {
+    // Same NUMBER but the file is modified, which is what makes it a claim.
+    // (A comment change is enough — the point is that this branch is editing
+    // the parse cache while leaving the version alone.)
+    fs.writeFileSync(
+      path.join(repo, CACHE_REL),
+      `// fixture, edited\nconst SCHEMA_BUMP = 45;\nexport {};\n`,
+      'utf8',
+    );
+    const { code, out } = runCheck('main');
+    expect(code).toBe(1);
+    expect(out).toContain('on BOTH this branch');
+    // The message must say what to do, not just that something is wrong.
+    expect(out).toContain('46 or higher');
+  });
+
+  it('fails when the version goes backwards', () => {
+    writeBump(44);
+    const { code, out } = runCheck('main');
+    expect(code).toBe(1);
+    expect(out).toMatch(/BACKWARDS/);
+  });
+
+  // A misconfigured CI checkout must not look like a pass. Exit 2 is distinct
+  // from both success and a real conflict so the two cannot be confused.
+  it('exits 2 — not 0 — when the base ref is unreachable', () => {
+    writeBump(46);
+    const { code, out } = runCheck('origin/nope');
+    expect(code).toBe(2);
+    expect(out).toContain('fetch-depth');
+  });
+
+  it('fails loudly if the declaration it parses ever moves', () => {
+    fs.writeFileSync(
+      path.join(repo, CACHE_REL),
+      '// renamed away\nconst SOMETHING_ELSE = 46;\nexport {};\n',
+      'utf8',
+    );
+    const { code, out } = runCheck('main');
+    expect(code).not.toBe(0);
+    expect(out).toContain('do not delete the check');
+  });
+});

--- a/scripts/check-parse-cache-version.mjs
+++ b/scripts/check-parse-cache-version.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Fail a PR whose `SCHEMA_BUMP` is not STRICTLY GREATER than the base branch's.
+ *
+ * The in-repo pin test cannot catch this, and its ledger says so in four
+ * separate entries: both branches assert `toBe(N)`, so the assertion is green on
+ * each side while they claim the same number. The collision only exists in the
+ * relationship BETWEEN the two branches, which no single-branch test can see.
+ *
+ * The consequence is silent, which is why it keeps recurring. `PARSE_CACHE_VERSION`
+ * is the only invalidator for the durable ParsedFile store — byte-unchanged files
+ * skip tree-sitter entirely — so two divergent capture schemas sharing one version
+ * string means one side's parse-time change replays pre-change ParsedFiles forever.
+ * Nothing throws; the graph is simply missing edges, which is the confident-empty
+ * answer this repo has spent several PRs removing.
+ *
+ * Ten ledger entries, four of them exact clashes, every one caught by hand at
+ * merge time. This is that manual step, run on every PR instead of remembered.
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const BASE_REF = process.env.GITNEXUS_BASE_REF ?? 'origin/main';
+const CACHE_FILE = 'gitnexus/src/storage/parse-cache.ts';
+const PATTERN = /^const SCHEMA_BUMP = (\d+);/m;
+
+/** Parse `SCHEMA_BUMP` out of a parse-cache source string. */
+function readBump(source, origin) {
+  const match = PATTERN.exec(source);
+  if (match === null) {
+    throw new Error(
+      `Could not find \`const SCHEMA_BUMP = <n>;\` in ${origin}. If the declaration ` +
+        `moved or was renamed, update scripts/check-parse-cache-version.mjs to match — ` +
+        `do not delete the check.`,
+    );
+  }
+  return Number(match[1]);
+}
+
+function readBaseSource() {
+  try {
+    return execFileSync('git', ['show', `${BASE_REF}:${CACHE_FILE}`], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch {
+    return null;
+  }
+}
+
+const baseSource = readBaseSource();
+if (baseSource === null) {
+  // A shallow clone or a missing base ref is a CI-configuration problem, not a
+  // version conflict. Say so plainly rather than passing quietly (which would
+  // make the check look green while testing nothing) or failing the PR for it.
+  console.error(
+    `parse-cache version check: could not read ${CACHE_FILE} at ${BASE_REF}.\n` +
+      `Fetch the base branch before running this (actions/checkout needs ` +
+      `fetch-depth: 0, or an explicit \`git fetch origin main\`).`,
+  );
+  process.exit(2);
+}
+
+const headSource = readFileSync(CACHE_FILE, 'utf8');
+const base = readBump(baseSource, BASE_REF);
+const head = readBump(headSource, 'the working tree');
+
+// A branch that does not touch this file cannot collide with anything, and
+// must not be asked to bump a version it has no reason to change. Only a branch
+// that MODIFIES the parse cache is claiming a version, so only it has to prove
+// the claim is unique.
+//
+// This is also why the check stays useful after both PRs are open: while base
+// is still 45 two branches can both claim 46 and both pass, exactly as the
+// ledger describes. What catches it is CI re-running once the first one merges
+// and base becomes 46 — which is the "RE-CHECK AGAINST origin/main IMMEDIATELY
+// BEFORE MERGING" step, now automatic instead of remembered.
+if (headSource === baseSource) {
+  console.log(
+    `parse-cache version check: OK — ${CACHE_FILE} is unchanged from ${BASE_REF} ` +
+      `(SCHEMA_BUMP ${head}), so this branch claims no version.`,
+  );
+  process.exit(0);
+}
+
+if (head > base) {
+  console.log(`parse-cache version check: OK — SCHEMA_BUMP ${head} > ${BASE_REF} ${base}.`);
+  process.exit(0);
+}
+
+const verdict =
+  head === base
+    ? `${CACHE_FILE} changed on this branch, but SCHEMA_BUMP is ${head} on BOTH this ` +
+      `branch and ${BASE_REF}.`
+    : `SCHEMA_BUMP is ${head} here but ${base} on ${BASE_REF} — it has gone BACKWARDS.`;
+
+console.error(
+  `parse-cache version check: FAILED\n\n` +
+    `  ${verdict}\n\n` +
+    `  Two divergent capture schemas would share one PARSE_CACHE_VERSION. The durable\n` +
+    `  ParsedFile store treats that string as its only invalidator, so one side's\n` +
+    `  parse-time change would replay pre-change ParsedFiles on every incremental\n` +
+    `  analyze. Nothing fails; the graph is just missing edges.\n\n` +
+    `  Fix: raise SCHEMA_BUMP in ${CACHE_FILE} to ${base + 1} or higher, move the pin in\n` +
+    `  gitnexus/test/unit/incremental-parse-cache.test.ts to match, and add a ledger\n` +
+    `  entry above the constant recording BOTH claimants.\n\n` +
+    `  The pin test cannot catch this on its own: both branches assert the same\n` +
+    `  number and both pass. That is why this check compares against ${BASE_REF}.`,
+);
+process.exit(1);


### PR DESCRIPTION
## Summary

Fails a PR whose `SCHEMA_BUMP` collides with the base branch's. This is the follow-up called out as deliberately deferred in #2856, where the reviewer's framing is the whole argument for it:

> a CI check that compares against `origin/main`'s value at merge time, rather than a literal pin, is the only thing that structurally closes it.

**Independent of #2856** — this branch is cut from `main` and touches no runtime code, so it can be reviewed and merged in any order. (Its sibling follow-up, #2859, is *not* independent; see below.)

## Motivation / context

`parse-cache.ts` carries a ledger of **ten** prior version collisions, **four of them exact**. Every one was caught by hand at merge time, and one only after it had already shipped. The ledger itself explains why the existing test cannot help:

> the pin test cannot catch it — both PRs asserted `toBe(44)`, which passes even when main is already 44 […] Only comparing against origin/main at MERGE time surfaces it.

Both branches are green. The conflict exists only in the *relation* between them, and no single-branch assertion can see a relation.

The consequence is silent, which is why it keeps recurring. `PARSE_CACHE_VERSION` is the only invalidator for the durable ParsedFile store — byte-unchanged files skip tree-sitter entirely — so two divergent capture schemas sharing one version string means one side's parse-time change replays pre-change ParsedFiles on every incremental analyze. Nothing throws. The graph is simply missing edges, which is the confident-empty answer #2856 spent thirty-odd commits removing.

## Areas touched

- [ ] `gitnexus/` (CLI / core / MCP server) — *test only*
- [ ] `gitnexus-web/` (Vite / React UI)
- [x] `.github/` (workflows, actions)
- [x] `eval/` or other tooling (`scripts/`)
- [ ] Docs / agent config only

## Scope & constraints

**In scope**

- `scripts/check-parse-cache-version.mjs` — compares `SCHEMA_BUMP` against the PR's base branch.
- A `parse-cache-version` job in `ci-quality.yml`, with the `fetch-depth: 0` and base-branch fetch it needs.

**Explicitly out of scope**

- Changing `SCHEMA_BUMP` itself, or anything about how the parse cache works. This branch adds no runtime code.
- Blocking two PRs that are merely *open* at the same time — see below; that is not the collision, and treating it as one would fail honest work.

## Implementation notes

**Only a branch that modifies the parse cache is claiming a version**, so only that branch has to prove the claim is unique. Everything else passes untouched.

That rule is not cosmetic, and the first version of this check got it wrong: it required a strict increase unconditionally, which fails every PR that does not touch the file — including this one. **It failed on its own branch, which is how it was caught.** A check that cannot pass its own PR would have been noticed by CI, but the fix belongs in the design, not in an exemption.

**Being open at the same time is not the collision.** While base is still 45, two branches can both claim 46 and both pass — exactly the scenario the ledger describes. What catches it is CI re-running once the first one merges and base becomes 46. That is precisely the *"RE-CHECK AGAINST origin/main IMMEDIATELY BEFORE MERGING"* step the ledger already demands in capital letters, now automatic instead of remembered.

**Three outcomes, deliberately distinct.** Pass; conflict (exit 1, naming the number to move to and the two other files that must move with it); and unreachable base ref (exit **2**), so a shallow checkout or a missing fetch reads as a configuration error rather than a pass. That last one is the failure mode a naive version of this check would have — quietly green while testing nothing.

## Testing & verification

- [x] `cd gitnexus && npm test` — the new suite passes; full pack green on the sibling branch that carries this commit (**16,436 passed, 0 failed**)
- [x] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(untouched)*
- [ ] Manual / Playwright E2E *(n/a)*

Six tests, driven against **real git state rather than mocks**, because the thing under test *is* a comparison between branches: a temp repo with a base at 45, then a branch that is untouched (passes — the common case), at 46 (passes), at 45 with the file edited (the clash that has actually happened four times), at 44 (backwards), an unreachable base ref (must exit 2, not 0), and one where the declaration has been renamed — which must fail loudly rather than silently matching nothing and reporting success.

## Risk & rollout

- **No re-index, no graph change, no runtime code.** `SCHEMA_BUMP` is not touched by this branch.
- **A new CI job that can fail PRs.** By design. It only fires on branches that modify `parse-cache.ts`, and the failure message names the exact remedy: the number to raise to, the pin test to move, and the ledger entry to add recording both claimants.
- **Requires full history.** `fetch-depth: 0` plus a base-branch fetch are wired in the job. If either is missing the script exits 2 rather than passing.
- No breaking API changes, no migrations.

## Related

- #2856 — the PR this follow-up came out of. **Independent of this one**; merge order does not matter.
- #2859 — the sibling follow-up (share the property-name index across language passes). That one **is stacked on #2856** and cannot merge before it.

## Checklist

- [x] PR body meets repo minimum length
- [x] `AGENTS.md` / overlays unchanged
- [x] No secrets, tokens, or machine-specific paths committed
