### PR TITLE
feat(graph): expose isTestCode on definition nodes

### DIFF
--- a/gitnexus/src/core/ingestion/entry-point-scoring.ts
+++ b/gitnexus/src/core/ingestion/entry-point-scoring.ts
@@ -13,6 +13,7 @@
 import { detectFrameworkFromPath } from './framework-detection.js';
 import { SupportedLanguages } from 'gitnexus-shared';
 import { providers } from './languages/index.js';
+import { isTestFilePath } from './utils/test-file-path.js';
 
 // ============================================================================
 // NAME PATTERNS
@@ -164,54 +165,15 @@ export function calculateEntryPointScore(
 // ============================================================================
 
 /**
- * Check if a file path is a test file (should be excluded from entry points)
- * Covers common test file patterns across all supported languages
+ * Check if a file path is a test file (should be excluded from entry points).
+ *
+ * Delegates to the shared predicate in `utils/test-file-path.ts`. This used to be
+ * a second, hand-maintained copy that had drifted from the one backing the MCP
+ * `includeTests` flag — see that module's header. Re-exported under this name so
+ * existing importers are unaffected.
  */
 export function isTestFile(filePath: string): boolean {
-  const p = filePath.toLowerCase().replace(/\\/g, '/');
-
-  return (
-    // JavaScript/TypeScript test patterns
-    p.includes('.test.') ||
-    p.includes('.spec.') ||
-    p.includes('__tests__/') ||
-    p.includes('__mocks__/') ||
-    // Generic test folders
-    p.includes('/test/') ||
-    p.includes('/tests/') ||
-    p.includes('/testing/') ||
-    // Python test patterns
-    p.endsWith('_test.py') ||
-    p.includes('/test_') ||
-    // Go test patterns
-    p.endsWith('_test.go') ||
-    // Java test patterns
-    p.includes('/src/test/') ||
-    // Rust test patterns (inline tests are different, but test files)
-    p.includes('/tests/') ||
-    // Swift/iOS test patterns
-    p.endsWith('tests.swift') ||
-    p.endsWith('test.swift') ||
-    p.includes('uitests/') ||
-    // C# test patterns
-    p.endsWith('tests.cs') ||
-    p.endsWith('test.cs') ||
-    p.includes('.tests/') ||
-    p.includes('.test/') ||
-    p.includes('.integrationtests/') ||
-    p.includes('.unittests/') ||
-    p.includes('/testproject/') ||
-    // PHP/Laravel test patterns
-    p.endsWith('test.php') ||
-    p.endsWith('spec.php') ||
-    p.includes('/tests/feature/') ||
-    p.includes('/tests/unit/') ||
-    // Ruby test patterns
-    p.endsWith('_spec.rb') ||
-    p.endsWith('_test.rb') ||
-    p.includes('/spec/') ||
-    p.includes('/test/fixtures/')
-  );
+  return isTestFilePath(filePath);
 }
 
 /**

--- a/gitnexus/src/core/ingestion/utils/test-file-path.ts
+++ b/gitnexus/src/core/ingestion/utils/test-file-path.ts
@@ -1,0 +1,101 @@
+/**
+ * Test-file path classification — the single source of truth.
+ *
+ * WHY THIS MODULE EXISTS
+ *
+ * Two independent copies of this predicate existed and had drifted apart:
+ *
+ *   - `core/ingestion/entry-point-scoring.ts` `isTestFile`  — excludes test
+ *     files from process entry-point detection.
+ *   - `mcp/local/local-backend.ts` `isTestFilePath`         — backs the
+ *     `includeTests` flag on `impact` / `trace` / `context`.
+ *
+ * They answered "is this a test file?" differently, so the same path could be a
+ * test in one code path and not the other. The MCP copy recognized no C#, Java,
+ * or Swift test convention at all, meaning `includeTests: false` silently failed
+ * to filter them; the scoring copy missed `/fixtures/` and `/conftest.`.
+ *
+ * The duplication was not gratuitous: `entry-point-scoring.ts` imports the
+ * language-provider registry, and #2802 deliberately cut that closure out of MCP
+ * server startup. Importing it back into `local-backend.ts` would reintroduce
+ * that cost. So the shared predicate lives here instead, with NO imports — pure
+ * string matching — and both callers delegate to it.
+ *
+ * Keep it dependency-free. Anything imported here lands in MCP startup.
+ */
+
+/**
+ * Patterns that mark a path as test code, as lowercase forward-slash
+ * substrings/suffixes. The union of both former implementations.
+ *
+ * Ordered by language for review; matching is order-independent.
+ */
+const TEST_PATH_SUBSTRINGS: readonly string[] = [
+  // JavaScript / TypeScript
+  '.test.',
+  '.spec.',
+  '__tests__/',
+  '__mocks__/',
+  // Generic test/fixture folders
+  '/test/',
+  '/tests/',
+  '/testing/',
+  '/fixtures/',
+  '/test/fixtures/',
+  '/spec/',
+  // Python
+  '/test_',
+  '/conftest.',
+  // Java / Kotlin (Maven + Gradle layout)
+  '/src/test/',
+  // Swift
+  'uitests/',
+  // C#
+  '.tests/',
+  '.test/',
+  '.integrationtests/',
+  '.unittests/',
+  '/testproject/',
+  // PHP / Laravel
+  '/tests/feature/',
+  '/tests/unit/',
+];
+
+/** Patterns that mark a path as test code by filename suffix. */
+const TEST_PATH_SUFFIXES: readonly string[] = [
+  // Python
+  '_test.py',
+  // Go
+  '_test.go',
+  // Ruby
+  '_spec.rb',
+  '_test.rb',
+  // Swift
+  'tests.swift',
+  'test.swift',
+  // C#
+  'tests.cs',
+  'test.cs',
+  // PHP
+  'test.php',
+  'spec.php',
+];
+
+/**
+ * Is this path test code?
+ *
+ * Callers use it for two purposes that must agree: excluding tests from
+ * entry-point detection, and honoring `includeTests: false` on the read tools.
+ * A path classified differently by the two produces results that contradict
+ * each other, which is why there is exactly one implementation.
+ *
+ * Accepts nullish input so call sites reading an optional `filePath` do not each
+ * need their own guard; absent paths are not test paths.
+ */
+export function isTestFilePath(filePath: string | null | undefined): boolean {
+  if (!filePath) return false;
+  const p = filePath.toLowerCase().replace(/\\/g, '/');
+  for (const needle of TEST_PATH_SUBSTRINGS) if (p.includes(needle)) return true;
+  for (const suffix of TEST_PATH_SUFFIXES) if (p.endsWith(suffix)) return true;
+  return false;
+}

--- a/gitnexus/src/core/lbug/csv-generator.ts
+++ b/gitnexus/src/core/lbug/csv-generator.ts
@@ -18,6 +18,7 @@ import path from 'path';
 import type { GraphNode, GraphRelationship } from 'gitnexus-shared';
 import { KnowledgeGraph } from '../graph/types.js';
 import { NodeTableName, RELATION_SCHEMA } from './schema.js';
+import { isTestFilePath } from '../ingestion/utils/test-file-path.js';
 import { VALID_NODE_TABLES, parseRelationSchemaPairs, RelPairRouter } from './rel-pair-routing.js';
 import { parseTruthyEnv } from '../ingestion/utils/env.js';
 import { SYMBOL_NODE_LABELS } from '../ingestion/utils/symbol-labels.js';
@@ -439,7 +440,8 @@ export const streamAllCSVsToDisk = async (
       'id,name,filePath,content',
     );
     const folderWriter = new BufferedCSVWriter(path.join(csvDir, 'folder.csv'), 'id,name,filePath');
-    const codeElementHeader = 'id,name,filePath,startLine,endLine,isExported,content,description';
+    const codeElementHeader =
+      'id,name,filePath,startLine,endLine,isExported,isTestCode,content,description';
     const functionWriter = new BufferedCSVWriter(
       path.join(csvDir, 'function.csv'),
       codeElementHeader,
@@ -453,7 +455,7 @@ export const streamAllCSVsToDisk = async (
       codeElementHeader,
     );
     const methodHeader =
-      'id,name,filePath,startLine,endLine,isExported,content,description,parameterCount,returnType';
+      'id,name,filePath,startLine,endLine,isExported,isTestCode,content,description,parameterCount,returnType';
     const methodWriter = new BufferedCSVWriter(path.join(csvDir, 'method.csv'), methodHeader);
     const codeElemWriter = new BufferedCSVWriter(
       path.join(csvDir, 'codeelement.csv'),
@@ -615,6 +617,7 @@ export const streamAllCSVsToDisk = async (
               escapeCSVNumber(node.properties.startLine, -1),
               escapeCSVNumber(node.properties.endLine, -1),
               node.properties.isExported ? 'true' : 'false',
+              isTestFilePath(node.properties.filePath) ? 'true' : 'false',
               escapeCSVField(content),
               escapeCSVField(formatFtsDescription(node.properties.description || '')),
               escapeCSVNumber(node.properties.parameterCount, 0),
@@ -687,6 +690,7 @@ export const streamAllCSVsToDisk = async (
               escapeCSVNumber(node.properties.startLine, -1),
               escapeCSVNumber(node.properties.endLine, -1),
               node.properties.isExported ? 'true' : 'false',
+              isTestFilePath(node.properties.filePath) ? 'true' : 'false',
               escapeCSVField(content),
               escapeCSVField(formatFtsDescription(node.properties.description || '')),
             ];

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -1478,17 +1478,17 @@ export const getCopyQuery = (table: NodeTableName, filePath: string): string => 
     return `COPY ${t}(id, filePath, startLine, endLine, text, callees, calleeIds) FROM "${filePath}" ${COPY_CSV_OPTS}`;
   }
   if (table === 'Class') {
-    return `COPY ${t}(id, name, filePath, startLine, endLine, isExported, content, description, frameworkAnnotations) FROM "${filePath}" ${COPY_CSV_OPTS}`;
+    return `COPY ${t}(id, name, filePath, startLine, endLine, isExported, isTestCode, content, description, frameworkAnnotations) FROM "${filePath}" ${COPY_CSV_OPTS}`;
   }
   if (table === 'Method') {
-    return `COPY ${t}(id, name, filePath, startLine, endLine, isExported, content, description, parameterCount, returnType) FROM "${filePath}" ${COPY_CSV_OPTS}`;
+    return `COPY ${t}(id, name, filePath, startLine, endLine, isExported, isTestCode, content, description, parameterCount, returnType) FROM "${filePath}" ${COPY_CSV_OPTS}`;
   }
   if (table === 'Property') {
     return `COPY ${t}(id, name, filePath, startLine, endLine, content, description, declaredType) FROM "${filePath}" ${COPY_CSV_OPTS}`;
   }
   // TypeScript/JS code element tables have isExported; multi-language tables do not
   if (TABLES_WITH_EXPORTED.has(table)) {
-    return `COPY ${t}(id, name, filePath, startLine, endLine, isExported, content, description) FROM "${filePath}" ${COPY_CSV_OPTS}`;
+    return `COPY ${t}(id, name, filePath, startLine, endLine, isExported, isTestCode, content, description) FROM "${filePath}" ${COPY_CSV_OPTS}`;
   }
   // Multi-language tables (Struct, Impl, Trait, Macro, etc.)
   return `COPY ${t}(id, name, filePath, startLine, endLine, content, description) FROM "${filePath}" ${COPY_CSV_OPTS}`;

--- a/gitnexus/src/core/lbug/schema.ts
+++ b/gitnexus/src/core/lbug/schema.ts
@@ -49,6 +49,7 @@ CREATE NODE TABLE Function (
   startLine INT64,
   endLine INT64,
   isExported BOOLEAN,
+  isTestCode BOOLEAN,
   content STRING,
   description STRING,
   PRIMARY KEY (id)
@@ -62,6 +63,7 @@ CREATE NODE TABLE Class (
   startLine INT64,
   endLine INT64,
   isExported BOOLEAN,
+  isTestCode BOOLEAN,
   content STRING,
   description STRING,
   frameworkAnnotations STRING[],
@@ -76,6 +78,7 @@ CREATE NODE TABLE Interface (
   startLine INT64,
   endLine INT64,
   isExported BOOLEAN,
+  isTestCode BOOLEAN,
   content STRING,
   description STRING,
   PRIMARY KEY (id)
@@ -89,6 +92,7 @@ CREATE NODE TABLE Method (
   startLine INT64,
   endLine INT64,
   isExported BOOLEAN,
+  isTestCode BOOLEAN,
   content STRING,
   description STRING,
   parameterCount INT32,
@@ -104,6 +108,7 @@ CREATE NODE TABLE CodeElement (
   startLine INT64,
   endLine INT64,
   isExported BOOLEAN,
+  isTestCode BOOLEAN,
   content STRING,
   description STRING,
   PRIMARY KEY (id)

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -297,29 +297,18 @@ function normalizeToolParams(
 
 /**
  * Quick test-file detection for filtering impact results.
- * Matches common test file patterns across all supported languages.
+ *
+ * Re-exported from the shared predicate in
+ * `core/ingestion/utils/test-file-path.ts`, which is deliberately
+ * dependency-free: importing `entry-point-scoring.ts` (the other former home of
+ * this logic) would pull the language-provider registry back into MCP startup,
+ * the closure #2802 removed.
+ *
+ * The two copies had drifted — this one recognized no C#, Java or Swift test
+ * convention, so `includeTests: false` silently failed to filter them.
  */
-export function isTestFilePath(filePath: string | null | undefined): boolean {
-  if (!filePath) return false;
-  const p = filePath.toLowerCase().replace(/\\/g, '/');
-  return (
-    p.includes('.test.') ||
-    p.includes('.spec.') ||
-    p.includes('__tests__/') ||
-    p.includes('__mocks__/') ||
-    p.includes('/test/') ||
-    p.includes('/tests/') ||
-    p.includes('/testing/') ||
-    p.includes('/fixtures/') ||
-    p.endsWith('_test.go') ||
-    p.endsWith('_test.py') ||
-    p.endsWith('_spec.rb') ||
-    p.endsWith('_test.rb') ||
-    p.includes('/spec/') ||
-    p.includes('/test_') ||
-    p.includes('/conftest.')
-  );
-}
+import { isTestFilePath } from '../../core/ingestion/utils/test-file-path.js';
+export { isTestFilePath };
 
 /** Valid LadybugDB node labels for safe Cypher query construction */
 export const VALID_NODE_LABELS = new Set([

--- a/gitnexus/test/unit/node-column-parity.test.ts
+++ b/gitnexus/test/unit/node-column-parity.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { NODE_SCHEMA_QUERIES } from '../../src/core/lbug/schema.js';
+import { getCopyQuery } from '../../src/core/lbug/lbug-adapter.js';
+import type { NodeTableName } from '../../src/core/lbug/schema.js';
+
+/**
+ * A node column lives in THREE places that must agree:
+ *
+ *   1. the `CREATE NODE TABLE` DDL          (`lbug/schema.ts`)
+ *   2. the CSV header + row builder         (`lbug/csv-generator.ts`)
+ *   3. the explicit COPY column list        (`lbug/lbug-adapter.ts` getCopyQuery)
+ *
+ * Adding `isTestCode` to only (1) and (2) produced
+ *   `COPY failed for Function: Number of columns mismatch. Expected 8 but got 9`
+ * at load time, AFTER a full parse — the whole analyze wasted before the failure
+ * surfaced. The DDL and the COPY list are the pair that can disagree silently,
+ * so pin them to each other here.
+ */
+
+/** Parse column names out of a `CREATE NODE TABLE X (...)` statement. */
+function ddlColumns(stmt: string): { table: string; columns: string[] } | null {
+  const m = /CREATE NODE TABLE (\w+) \(([\s\S]*)\)/.exec(stmt);
+  if (!m) return null;
+  const [, table, body] = m;
+  const columns = body
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !l.startsWith('PRIMARY KEY'))
+    .map((l) => l.replace(/,$/, '').split(/\s+/)[0])
+    .filter((c): c is string => Boolean(c));
+  return { table: table!, columns };
+}
+
+/** Parse column names out of a `COPY X(a, b, c) FROM ...` statement. */
+function copyColumns(query: string): string[] | null {
+  const m = /COPY\s+`?\w+`?\(([^)]*)\)/.exec(query);
+  if (!m) return null;
+  return m[1]!.split(',').map((c) => c.trim());
+}
+
+const ddl = NODE_SCHEMA_QUERIES.map(ddlColumns).filter(
+  (d): d is { table: string; columns: string[] } => d !== null,
+);
+
+describe('node DDL and COPY column lists agree', () => {
+  it('parsed the DDL at all (guard against a regex that silently matches nothing)', () => {
+    expect(ddl.length).toBeGreaterThan(5);
+    const fn = ddl.find((d) => d.table === 'Function');
+    expect(fn?.columns).toContain('id');
+    expect(fn?.columns).toContain('isTestCode');
+  });
+
+  for (const { table, columns } of ddl) {
+    it(`${table}: COPY column list matches its DDL, in order`, () => {
+      const query = getCopyQuery(table as NodeTableName, '/tmp/x.csv');
+      const copied = copyColumns(query);
+      // A table whose COPY omits an explicit list is out of scope — the
+      // positional form cannot drift from the DDL.
+      if (copied === null) return;
+      expect(copied).toEqual(columns);
+    });
+  }
+});
+
+describe('isTestCode is declared everywhere a definition table needs it', () => {
+  // The five tables carrying `isExported` are the definition-bearing ones; a
+  // symbol in any of them can live in test code, so all five need the flag for
+  // the reachability query to be answerable without path heuristics.
+  const EXPECTED = ['Function', 'Class', 'Interface', 'Method', 'CodeElement'];
+
+  for (const table of EXPECTED) {
+    it(`${table} declares isTestCode in its DDL`, () => {
+      const entry = ddl.find((d) => d.table === table);
+      expect(entry, `${table} not found in NODE_SCHEMA_QUERIES`).toBeDefined();
+      expect(entry!.columns).toContain('isTestCode');
+    });
+
+    it(`${table} COPY includes isTestCode`, () => {
+      const copied = copyColumns(getCopyQuery(table as NodeTableName, '/tmp/x.csv'));
+      expect(copied).toContain('isTestCode');
+    });
+  }
+});

--- a/gitnexus/test/unit/spring-bean-schema.test.ts
+++ b/gitnexus/test/unit/spring-bean-schema.test.ts
@@ -15,7 +15,7 @@ describe('Spring Bean Class persistence schema', () => {
     expect(CLASS_SCHEMA).toContain('frameworkAnnotations STRING[]');
 
     expect(getCopyQuery('Class', '/tmp/class.csv')).toContain(
-      '(id, name, filePath, startLine, endLine, isExported, content, description, frameworkAnnotations)',
+      '(id, name, filePath, startLine, endLine, isExported, isTestCode, content, description, frameworkAnnotations)',
     );
   });
 

--- a/gitnexus/test/unit/test-file-path.test.ts
+++ b/gitnexus/test/unit/test-file-path.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { isTestFilePath } from '../../src/core/ingestion/utils/test-file-path.js';
+import { isTestFile } from '../../src/core/ingestion/entry-point-scoring.js';
+import { isTestFilePath as backendIsTestFilePath } from '../../src/mcp/local/local-backend.js';
+
+describe('isTestFilePath — shared predicate', () => {
+  it('returns false for nullish input rather than throwing', () => {
+    expect(isTestFilePath(undefined)).toBe(false);
+    expect(isTestFilePath(null)).toBe(false);
+    expect(isTestFilePath('')).toBe(false);
+  });
+
+  it('normalizes Windows separators and casing', () => {
+    expect(isTestFilePath('SRC\\Test\\FooTests.cs')).toBe(true);
+    expect(isTestFilePath('pkg\\thing_test.go')).toBe(true);
+  });
+
+  // These were recognized by entry-point scoring but NOT by the MCP copy, so
+  // `includeTests: false` silently failed to filter them.
+  for (const p of [
+    'app/src/test/java/com/x/FooTest.java',
+    'ios/MyAppTests/LoginTests.swift',
+    'ios/MyAppUITests/FlowTest.swift',
+    'src/Widgets.Tests/WidgetTests.cs',
+    'src/Widgets.UnitTests/Thing.cs',
+    'src/Widgets.IntegrationTests/Thing.cs',
+    'tests/Feature/LoginTest.php',
+    'tests/Unit/ThingSpec.php',
+  ]) {
+    it(`detects a test path the MCP copy used to miss: ${p}`, () => {
+      expect(isTestFilePath(p)).toBe(true);
+    });
+  }
+
+  // These were recognized by the MCP copy but NOT by entry-point scoring, so
+  // they could be selected as process entry points.
+  for (const p of ['pkg/fixtures/sample.py', 'tests/conftest.py']) {
+    it(`detects a test path entry-point scoring used to miss: ${p}`, () => {
+      expect(isTestFilePath(p)).toBe(true);
+    });
+  }
+
+  for (const p of [
+    'src/app/widgets.ts',
+    'src/core/ingestion/utils/test-file-path.ts',
+    'pkg/service/handler.go',
+    'app/models/user.rb',
+  ]) {
+    it(`does not classify production code as test: ${p}`, () => {
+      expect(isTestFilePath(p)).toBe(false);
+    });
+  }
+});
+
+describe('test-file classification has exactly one implementation', () => {
+  // Regression guard: two hand-maintained copies drifted apart once already.
+  // Both public names must delegate to the same predicate.
+  const paths = [
+    'src/app/widgets.ts',
+    'app/src/test/java/com/x/FooTest.java',
+    'ios/MyAppTests/LoginTests.swift',
+    'src/Widgets.Tests/WidgetTests.cs',
+    'tests/conftest.py',
+    'pkg/fixtures/sample.py',
+    'spec/models/user_spec.rb',
+    'pkg/thing_test.go',
+    'tests/Feature/LoginTest.php',
+  ];
+
+  it('entry-point-scoring isTestFile agrees with the shared predicate', () => {
+    for (const p of paths) expect(isTestFile(p)).toBe(isTestFilePath(p));
+  });
+
+  it('local-backend isTestFilePath agrees with the shared predicate', () => {
+    for (const p of paths) expect(backendIsTestFilePath(p)).toBe(isTestFilePath(p));
+  });
+});
+
+describe('shared predicate stays dependency-free', () => {
+  // Poka-yoke for #2802: `local-backend.ts` imports this module, so anything
+  // imported here lands in MCP server startup. The duplication this module
+  // replaced existed precisely because `entry-point-scoring.ts` pulls in the
+  // language-provider registry. An import added here would silently reintroduce
+  // that startup cost.
+  it('declares no imports', () => {
+    const src = readFileSync(
+      new URL('../../src/core/ingestion/utils/test-file-path.ts', import.meta.url),
+      'utf8',
+    );
+    const imports = src
+      .split('\n')
+      .filter((l) => /^\s*(import|export)\s.*\sfrom\s/.test(l) || /^\s*import\s*\(/.test(l));
+    expect(imports).toEqual([]);
+  });
+});


### PR DESCRIPTION
> **Depends on #2866** — the shared predicate this derives from is created there. This branch contains that commit; review #2866 first and this diff shrinks to one commit.
>
> **This changes the graph DDL**, so `SCHEMA_FINGERPRINT` changes and every existing index rebuilds once. Flagging that up front since it's the main thing to weigh — see Risks.

## Why

Test-file classification is only reachable from inside the codebase. A Cypher consumer — the `cypher` MCP tool, or an agent reasoning over the graph — has no way to ask "is this test code?", so it ends up reimplementing the path heuristic inside the query.

That reimplementation is fragile in exactly the way the duplicated predicate in #2866 was: it drifts from the real definition, silently, with nothing covering it. I know because I wrote one, in Cypher, and got a materially wrong answer from it before noticing.

Concretely, this is what makes the reachability question unanswerable from outside. "Does this function have a caller, or is it a framework entry point, or is it test code, or is it genuinely unreferenced?" is the question you actually want, and only the graph can answer it cheaply.

## What Changed

`isTestCode BOOLEAN` on the five definition-bearing node tables (Function, Class, Interface, Method, CodeElement — the ones already carrying `isExported`), derived centrally in the CSV writer from each node's `filePath` so it can't be forgotten at an emit site.

**On the name:** `isTestCode`, not `isTestEntryPoint`. The predicate classifies the *file*, so it's true for a helper inside a test file as well as for the case the framework invokes. Telling those apart needs name patterns (`test_*`, `Test*`) and is a separate question — calling this "entry point" would overstate what the value means.

## How To Review

1. `lbug/schema.ts` — the DDL columns
2. `lbug/csv-generator.ts` — header and the central derivation
3. `lbug/lbug-adapter.ts` — the COPY column lists (see below)
4. `test/unit/node-column-parity.test.ts` — the guard

## Verification

The whole reachability picture, in Cypher, with no path heuristics, on a 12.4k-file repo:

```
lang    bucket                  n
go      has_caller           1231
go      framework_entrypoint    5
go      test_code            2965
go      UNEXPLAINED            38   (0.9%)
python  has_caller           4495
python  framework_entrypoint  183
python  test_code            6477
python  UNEXPLAINED           398   (3.4%)
```

The residual is what *should* stay non-zero — genuinely unreferenced code plus dynamic dispatch static resolution can't see. That's the dead-code signal, and driving it to zero would destroy it.

`npx tsc --noEmit` clean; 27 tests across the two schema-parity suites, 417 across schema/lbug/csv.

## Risks

**One-time reindex for every user.** The DDL change bumps `SCHEMA_FINGERPRINT`. Verified that the existing guard detects it and forces the re-analyze automatically — no user action, no stale column — but it is a rebuild, and it's the reason this is a separate PR from #2866 rather than folded into it. #2866 is a behavior-neutral bug fix that should be able to land without waiting on this decision.

**A note on the third column list.** A node column lives in three places that must agree: the DDL, the CSV header/row builder, and the explicit `COPY` list in `getCopyQuery`. I updated the first two and got:

```
COPY failed for Function: Number of columns mismatch. Expected 8 but got 9
```

thrown at load time, *after* a full parse had already run. So `node-column-parity.test.ts` now pins every table's COPY list to its DDL, in order, and asserts the DDL parse is non-vacuous so a broken regex can't make it pass silently. `spring-bean-schema.test.ts` already guarded this for `Class` alone — its expectation is updated and the new test generalizes it.

Happy to drop this PR if the classification is considered a query-side concern rather than something the graph should carry. The argument for carrying it is that every external consumer otherwise reinvents a heuristic that has already drifted once inside the codebase.