### PR TITLE
feat(java): resolve @FeignClient method calls as CALLS edges

### DIFF
--- a/gitnexus/src/core/ingestion/languages/java/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/languages/java/scope-resolver.ts
@@ -29,11 +29,32 @@ import {
   type JavaResolveContext,
 } from './index.js';
 import { populateJavaPackageSiblings } from './package-siblings.js';
+import { attachSpringBeanCandidateMetadata } from './spring-bean-metadata.js';
+import { attachJavaSpringAopMetadata } from './spring-aop.js';
+import { attachJavaSpringConfigBindings } from './spring-config-bindings.js';
+import { attachJavaSpringConditionalMetadata } from './spring-conditionals.js';
+import { attachJavaSpringDiMetadata } from './spring-di.js';
+import { attachJavaSpringDynamicLookup } from './spring-dynamic-lookup.js';
+import { attachJavaFeignRpcCalls } from './spring-feign-rpc.js';
+import {
+  applyJavaCaptureSideChannel,
+  clearJavaClassAnnotationFacts,
+} from './capture-side-channel.js';
+import { clearJavaPackageFacts } from './package-facts.js';
 
 const javaScopeResolver: ScopeResolver = {
   language: SupportedLanguages.Java,
   languageProvider: javaProvider,
   importEdgeReason: 'java-scope: import',
+
+  loadResolutionConfig: () => {
+    // Worker capture facts are process-local and outlive a single analysis in
+    // server mode. This hook runs once before each Java workspace pass, before
+    // ParsedFile side channels are restored for the current files.
+    clearJavaClassAnnotationFacts();
+    clearJavaPackageFacts();
+    return undefined;
+  },
 
   resolveImportTarget: (targetRaw, fromFile, allFilePaths) => {
     const ws: JavaResolveContext = { fromFile, allFilePaths };
@@ -50,6 +71,7 @@ const javaScopeResolver: ScopeResolver = {
   buildMro: buildJavaMro,
 
   populateOwners: (parsed: ParsedFile) => populateClassOwnedMembers(parsed),
+  applyCaptureSideChannel: applyJavaCaptureSideChannel,
 
   isSuperReceiver: (text) => text.trim() === 'super',
 
@@ -57,9 +79,25 @@ const javaScopeResolver: ScopeResolver = {
   propagatesReturnTypesAcrossImports: true,
   collapseMemberCallsByCallerTarget: true,
   hoistTypeBindingsToModule: true,
+  stripReceiverCastExpressions: true,
+  // #2550: every Java method belongs to a class instance — a free call may
+  // resolve to a Method only when the caller's enclosing class chain
+  // (self + MRO) contains the method's owner. Closes the finalize-bucket
+  // leak (unqualified `run()` matching an unrelated same-file anonymous
+  // class's method). C# is the intended next adopter.
+  freeCallsRequireInstanceOwnership: true,
 
   populateNamespaceSiblings: populateJavaPackageSiblings,
   populateRangeBindings: populateJavaCrossFileReturnTypes,
+  emitPostResolutionEdges: (graph, parsedFiles, nodeLookup, indexes, ctx) => {
+    attachSpringBeanCandidateMetadata(graph, parsedFiles, nodeLookup, indexes);
+    attachJavaSpringAopMetadata(graph, parsedFiles, nodeLookup, indexes);
+    attachJavaSpringConditionalMetadata(graph, parsedFiles, nodeLookup, indexes);
+    attachJavaSpringDiMetadata(graph, parsedFiles, nodeLookup, indexes);
+    attachJavaSpringConfigBindings(graph, parsedFiles, nodeLookup, indexes, ctx);
+    attachJavaSpringDynamicLookup(graph, parsedFiles, ctx.fileContents);
+    attachJavaFeignRpcCalls(graph, parsedFiles, ctx.fileContents);
+  },
 };
 
 export { javaScopeResolver };

--- a/gitnexus/src/core/ingestion/languages/java/spring-feign-rpc.ts
+++ b/gitnexus/src/core/ingestion/languages/java/spring-feign-rpc.ts
@@ -1,0 +1,189 @@
+/**
+ * Spring Cloud OpenFeign RPC heuristic: resolve method calls on
+ * @FeignClient-injected fields.
+ *
+ * `@FeignClient` interfaces have no implementation class in the source
+ * codebase — Spring Cloud creates a dynamic proxy at runtime. The call
+ * graph sees `feignClient.doSomething()` but the scope resolver cannot
+ * resolve the receiver to any concrete implementation, so the CALLS edge
+ * is missing entirely. This means impact analysis from the caller through
+ * the RPC interface is completely broken.
+ *
+ * This module:
+ * 1. Scans source text for `@FeignClient` annotations → identifies Feign
+ *    interface names.
+ * 2. Builds Feign interface name → method-node index from the graph.
+ * 3. Scans each Class with an injected Feign-type field for
+ *    `fieldName.methodName(...)` call patterns.
+ * 4. Emits CALLS edges from the calling method to the Feign interface method.
+ *
+ * Runs in `emitPostResolutionEdges` (after the full graph is built).
+ */
+
+import type { KnowledgeGraph } from '../../../graph/types.js';
+import type { ParsedFile } from 'gitnexus-shared';
+
+// ── Constants ─────────────────────────────────────────────────────────────
+
+/** Regex to detect @FeignClient annotation on an interface declaration. */
+const FEIGN_CLIENT_RE = /@FeignClient\s*\(/;
+
+/**
+ * Regex to extract the interface name from a source file containing
+ * `@FeignClient`. Matches `public interface XxxRpcService {`.
+ */
+const INTERFACE_NAME_RE = /interface\s+(\w+)/;
+
+/** Regex to detect field declarations of a known Feign type. */
+function makeFieldPattern(typeName: string): RegExp {
+  // Matches: private TypeName fieldName;  |  @Autowired TypeName fieldName;
+  // 'g' flag required for exec() loop to advance.
+  return new RegExp(
+    `(?:@(?:Autowired|Resource)\\s+)?(?:private|protected|public)?\\s*${typeName}\\s+(\\w+)\\s*[;=]`,
+    'g',
+  );
+}
+
+/**
+ * Regex to detect method calls on a field: `fieldName.methodName(`.
+ * Captures methodName for resolution.
+ */
+function makeCallPattern(fieldName: string): RegExp {
+  return new RegExp(`\\b${fieldName}\\.(\\w+)\\s*\\(`, 'g');
+}
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface FeignMethodInfo {
+  /** Graph node IDs of methods declared on the Feign interface. */
+  methodNodeIds: Map<string, string>; // methodName → nodeId
+}
+
+// ── Main API ──────────────────────────────────────────────────────────────
+
+/**
+ * Attach CALLS edges for @FeignClient interface method invocations.
+ * Called from `emitPostResolutionEdges` in the Java scope resolver.
+ */
+export function attachJavaFeignRpcCalls(
+  graph: KnowledgeGraph,
+  parsedFiles: readonly ParsedFile[],
+  fileContents: ReadonlyMap<string, string>,
+): void {
+  // ── Step 1: Identify @FeignClient interface names from source ──
+  const feignTypeNames = new Set<string>();
+  for (const [, content] of fileContents) {
+    if (!FEIGN_CLIENT_RE.test(content)) continue;
+    const m = INTERFACE_NAME_RE.exec(content);
+    if (m) feignTypeNames.add(m[1]);
+  }
+  if (feignTypeNames.size === 0) return;
+
+  // ── Step 2: Build Feign interface → method-node index ──
+  // Map: interfaceName → (methodName → nodeId[])
+  const feignMethods = new Map<string, Map<string, string[]>>();
+  graph.forEachNode((node) => {
+    if (node.label !== 'Method' && node.label !== 'Function') return;
+    const filePath = node.properties.filePath as string | undefined;
+    if (!filePath) return;
+    // Check if this method belongs to a Feign interface by matching
+    // the interface name in the file path or node ancestry
+    const fileName =
+      filePath
+        .split('/')
+        .pop()
+        ?.replace(/\.java$/, '') ?? '';
+    if (!feignTypeNames.has(fileName)) return;
+    const methodName = node.properties.name as string | undefined;
+    if (!methodName) return;
+    let methodMap = feignMethods.get(fileName);
+    if (!methodMap) {
+      methodMap = new Map<string, string[]>();
+      feignMethods.set(fileName, methodMap);
+    }
+    const ids = methodMap.get(methodName);
+    if (ids) ids.push(node.id);
+    else methodMap.set(methodName, [node.id]);
+  });
+
+  if (feignMethods.size === 0) return;
+
+  // ── Step 3: Build caller-side index ──
+  // For each file, find Feign-type field declarations and their field names.
+  // Map: filePath → (typeName → fieldName[])
+  const fileToFeignFields = new Map<string, Array<{ typeName: string; fieldName: string }>>();
+  for (const [path, content] of fileContents) {
+    for (const typeName of feignTypeNames) {
+      const fieldPattern = makeFieldPattern(typeName);
+      let m: RegExpExecArray | null;
+      fieldPattern.lastIndex = 0;
+      while ((m = fieldPattern.exec(content)) !== null) {
+        const fieldName = m[1];
+        let list = fileToFeignFields.get(path);
+        if (!list) {
+          list = [];
+          fileToFeignFields.set(path, list);
+        }
+        list.push({ typeName, fieldName });
+      }
+    }
+  }
+
+  if (fileToFeignFields.size === 0) return;
+
+  // Track emitted edges to avoid duplicates
+  const emittedEdges = new Set<string>();
+
+  // ── Step 4: Scan Function/Method nodes for Feign calls ──
+  graph.forEachNode((node) => {
+    if (node.label !== 'Function' && node.label !== 'Method') return;
+
+    const filePath = node.properties.filePath as string | undefined;
+    const startLine = node.properties.startLine as number | undefined;
+    const endLine = node.properties.endLine as number | undefined;
+    if (!filePath || startLine === undefined || endLine === undefined) return;
+
+    // This file must have Feign-type fields
+    const feignFields = fileToFeignFields.get(filePath);
+    if (!feignFields || feignFields.length === 0) return;
+
+    const source = fileContents.get(filePath);
+    if (!source) return;
+
+    // Extract function source by line range
+    const lines = source.split('\n');
+    const funcSource = lines
+      .slice(Math.max(0, startLine - 1), Math.min(lines.length, endLine))
+      .join('\n');
+
+    // For each Feign field, find calls
+    for (const { typeName, fieldName } of feignFields) {
+      const methodMap = feignMethods.get(typeName);
+      if (!methodMap) continue;
+
+      const callPattern = makeCallPattern(fieldName);
+      let m: RegExpExecArray | null;
+      while ((m = callPattern.exec(funcSource)) !== null) {
+        const calledMethod = m[1];
+        const targetIds = methodMap.get(calledMethod);
+        if (!targetIds) continue;
+
+        for (const targetId of targetIds) {
+          if (targetId === node.id) continue;
+          // Avoid duplicate edges
+          const edgeId = `FEIGN_CALLS:${node.id}->${targetId}`;
+          if (emittedEdges.has(edgeId)) continue;
+          emittedEdges.add(edgeId);
+          graph.addRelationship({
+            id: edgeId,
+            sourceId: node.id,
+            targetId,
+            type: 'CALLS',
+            confidence: 0.85,
+            reason: `Feign RPC call: ${typeName}.${calledMethod}()`,
+          });
+        }
+      }
+    }
+  });
+}

--- a/gitnexus/test/unit/spring-feign-rpc.test.ts
+++ b/gitnexus/test/unit/spring-feign-rpc.test.ts
@@ -1,0 +1,451 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { attachJavaFeignRpcCalls } from '../../src/core/ingestion/languages/java/spring-feign-rpc.js';
+import type { KnowledgeGraph, GraphNode, GraphRelationship } from '../../src/core/graph/types.js';
+import type { ParsedFile } from 'gitnexus-shared';
+
+// ── Test helpers ─────────────────────────────────────────────────────────
+
+function createMockGraph(): KnowledgeGraph {
+  const nodes = new Map<string, GraphNode>();
+  const rels = new Map<string, GraphRelationship>();
+
+  return {
+    addNode(node: GraphNode): void {
+      nodes.set(node.id, node);
+    },
+    addRelationship(rel: GraphRelationship): void {
+      rels.set(rel.id, rel);
+    },
+    removeRelationship(id: string): boolean {
+      return rels.delete(id);
+    },
+    removeNode(id: string): boolean {
+      return nodes.delete(id);
+    },
+    getNode(id: string): GraphNode | undefined {
+      return nodes.get(id);
+    },
+    forEachNode(fn: (node: GraphNode) => void): void {
+      for (const n of nodes.values()) fn(n);
+    },
+    forEachRelationship(fn: (rel: GraphRelationship) => void): void {
+      for (const r of rels.values()) fn(r);
+    },
+    iterRelationships(): IterableIterator<GraphRelationship> {
+      return rels.values();
+    },
+    iterRelationshipsByType(type: string): IterableIterator<GraphRelationship> {
+      return (function* () {
+        for (const r of rels.values()) {
+          if (r.type === type) yield r;
+        }
+      })();
+    },
+    forEachRelationshipFields(): void {},
+    get nodes() {
+      return nodes;
+    },
+    get relationships() {
+      return rels;
+    },
+  } as unknown as KnowledgeGraph;
+}
+
+function makeFile(
+  path: string,
+  name: string,
+  label: string,
+  startLine: number,
+  endLine: number,
+): GraphNode {
+  return {
+    id: `${label}:${path}:${name}`,
+    label,
+    properties: { name, filePath: path, startLine, endLine },
+  };
+}
+
+function makeFeignInterfaceFile(
+  path: string,
+  methods: Array<{ name: string; startLine: number; endLine: number }>,
+): { path: string; content: string; nodes: GraphNode[] } {
+  const interfaceName = path.split('/').pop()!.replace('.java', '');
+  const methodDecls = methods
+    .map((m) => `    WinRpcResponse<Object> ${m.name}(InputDTO input);`)
+    .join('\n\n');
+  const content = `package com.test;
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient("test-service")
+public interface ${interfaceName} {
+${methodDecls}
+}`;
+  const nodes: GraphNode[] = methods.map((m) =>
+    makeFile(path, m.name, 'Method', m.startLine, m.endLine),
+  );
+  return { path, content, nodes };
+}
+
+function makeCallerFile(
+  path: string,
+  feignTypeName: string,
+  fieldName: string,
+  calls: Array<{ methodName: string; line: number }>,
+  funcName: string = 'doWork',
+): { path: string; content: string; node: GraphNode } {
+  const callLines = calls
+    .map((c) => `        Object result = ${fieldName}.${c.methodName}(input);`)
+    .join('\n');
+  const content = `package com.test;
+public class Caller {
+    @Autowired
+    private ${feignTypeName} ${fieldName};
+
+    public Object ${funcName}() {
+${callLines}
+        return result;
+    }
+}`;
+  // Function spans from `public Object` (line 6) to closing `}` (line 10)
+  return {
+    path,
+    content,
+    node: makeFile(path, funcName, 'Method', 6, 10),
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('attachJavaFeignRpcCalls', () => {
+  let graph: KnowledgeGraph;
+  let fileContents: Map<string, string>;
+  let parsedFiles: ParsedFile[];
+
+  beforeEach(() => {
+    graph = createMockGraph();
+    fileContents = new Map();
+    parsedFiles = [];
+  });
+
+  it('emits CALLS edge from caller to Feign interface method', () => {
+    // Feign interface
+    const feign = makeFeignInterfaceFile('ExeRulesRpcService.java', [
+      { name: 'getRules', startLine: 8, endLine: 10 },
+    ]);
+    for (const n of feign.nodes) graph.addNode(n);
+    fileContents.set(feign.path, feign.content);
+    parsedFiles.push({ filePath: feign.path, scopes: [] } as ParsedFile);
+
+    // Caller
+    const caller = makeCallerFile('Caller.java', 'ExeRulesRpcService', 'exeRules', [
+      { methodName: 'getRules', line: 15 },
+    ]);
+    graph.addNode(caller.node);
+    fileContents.set(caller.path, caller.content);
+    parsedFiles.push({ filePath: caller.path, scopes: [] } as ParsedFile);
+
+    attachJavaFeignRpcCalls(graph, parsedFiles, fileContents);
+
+    const feignCalls = [...graph.iterRelationshipsByType('CALLS')];
+    expect(feignCalls.length).toBe(1);
+    expect(feignCalls[0].sourceId).toBe(caller.node.id);
+    expect(feignCalls[0].targetId).toBe(feign.nodes[0].id);
+    expect(feignCalls[0].confidence).toBe(0.85);
+    expect(feignCalls[0].reason).toContain('Feign RPC');
+  });
+
+  it('handles multiple methods on a single Feign interface', () => {
+    const feign = makeFeignInterfaceFile('OrderRpcService.java', [
+      { name: 'getOrder', startLine: 8, endLine: 10 },
+      { name: 'createOrder', startLine: 12, endLine: 14 },
+      { name: 'deleteOrder', startLine: 16, endLine: 18 },
+    ]);
+    for (const n of feign.nodes) graph.addNode(n);
+    fileContents.set(feign.path, feign.content);
+    parsedFiles.push({ filePath: feign.path, scopes: [] } as ParsedFile);
+
+    const caller = makeCallerFile('Caller.java', 'OrderRpcService', 'rpc', [
+      { methodName: 'getOrder', line: 15 },
+      { methodName: 'createOrder', line: 16 },
+    ]);
+    graph.addNode(caller.node);
+    fileContents.set(caller.path, caller.content);
+    parsedFiles.push({ filePath: caller.path, scopes: [] } as ParsedFile);
+
+    attachJavaFeignRpcCalls(graph, parsedFiles, fileContents);
+
+    const feignCalls = [...graph.iterRelationshipsByType('CALLS')];
+    expect(feignCalls.length).toBe(2);
+    const targetNames = feignCalls.map((r) => graph.getNode(r.targetId)?.properties.name);
+    expect(targetNames).toContain('getOrder');
+    expect(targetNames).toContain('createOrder');
+  });
+
+  it('handles multiple Feign interfaces injected in the same class', () => {
+    const feign1 = makeFeignInterfaceFile('ServiceARpc.java', [
+      { name: 'methodA', startLine: 8, endLine: 10 },
+    ]);
+    for (const n of feign1.nodes) graph.addNode(n);
+    fileContents.set(feign1.path, feign1.content);
+    parsedFiles.push({ filePath: feign1.path, scopes: [] } as ParsedFile);
+
+    const feign2 = makeFeignInterfaceFile('ServiceBRpc.java', [
+      { name: 'methodB', startLine: 8, endLine: 10 },
+    ]);
+    for (const n of feign2.nodes) graph.addNode(n);
+    fileContents.set(feign2.path, feign2.content);
+    parsedFiles.push({ filePath: feign2.path, scopes: [] } as ParsedFile);
+
+    // Caller with both
+    const content = `package com.test;
+public class Caller {
+    @Autowired
+    private ServiceARpc serviceA;
+    @Autowired
+    private ServiceBRpc serviceB;
+
+    public void doWork() {
+        serviceA.methodA(input);
+        serviceB.methodB(input);
+    }
+}`;
+    const callerNode = makeFile('Caller.java', 'doWork', 'Method', 8, 13);
+    graph.addNode(callerNode);
+    fileContents.set('Caller.java', content);
+    parsedFiles.push({ filePath: 'Caller.java', scopes: [] } as ParsedFile);
+
+    attachJavaFeignRpcCalls(graph, parsedFiles, fileContents);
+
+    const feignCalls = [...graph.iterRelationshipsByType('CALLS')];
+    expect(feignCalls.length).toBe(2);
+  });
+
+  it('does not emit edges when no Feign interfaces exist', () => {
+    const caller = makeCallerFile('Caller.java', 'NonFeignService', 'svc', [
+      { methodName: 'doSomething', line: 15 },
+    ]);
+    graph.addNode(caller.node);
+    fileContents.set(caller.path, caller.content);
+    parsedFiles.push({ filePath: caller.path, scopes: [] } as ParsedFile);
+
+    attachJavaFeignRpcCalls(graph, parsedFiles, fileContents);
+
+    const feignCalls = [...graph.iterRelationshipsByType('CALLS')];
+    expect(feignCalls.length).toBe(0);
+  });
+
+  it('skips calls to methods not declared on the Feign interface', () => {
+    const feign = makeFeignInterfaceFile('MyRpc.java', [
+      { name: 'existingMethod', startLine: 8, endLine: 10 },
+    ]);
+    for (const n of feign.nodes) graph.addNode(n);
+    fileContents.set(feign.path, feign.content);
+    parsedFiles.push({ filePath: feign.path, scopes: [] } as ParsedFile);
+
+    const caller = makeCallerFile('Caller.java', 'MyRpc', 'rpc', [
+      { methodName: 'existingMethod', line: 15 },
+      { methodName: 'nonExistentMethod', line: 16 },
+    ]);
+    graph.addNode(caller.node);
+    fileContents.set(caller.path, caller.content);
+    parsedFiles.push({ filePath: caller.path, scopes: [] } as ParsedFile);
+
+    attachJavaFeignRpcCalls(graph, parsedFiles, fileContents);
+
+    const feignCalls = [...graph.iterRelationshipsByType('CALLS')];
+    expect(feignCalls.length).toBe(1);
+    expect(graph.getNode(feignCalls[0].targetId)?.properties.name).toBe('existingMethod');
+  });
+
+  it('avoids duplicate edges on repeated calls', () => {
+    const feign = makeFeignInterfaceFile('DupRpc.java', [
+      { name: 'call', startLine: 8, endLine: 10 },
+    ]);
+    for (const n of feign.nodes) graph.addNode(n);
+    fileContents.set(feign.path, feign.content);
+    parsedFiles.push({ filePath: feign.path, scopes: [] } as ParsedFile);
+
+    const content = `package com.test;
+public class Caller {
+    @Autowired
+    private DupRpc rpc;
+    public void doWork() {
+        rpc.call(input);
+        rpc.call(input);
+        rpc.call(input);
+    }
+}`;
+    const callerNode = makeFile('Caller.java', 'doWork', 'Method', 5, 10);
+    graph.addNode(callerNode);
+    fileContents.set('Caller.java', content);
+    parsedFiles.push({ filePath: 'Caller.java', scopes: [] } as ParsedFile);
+
+    attachJavaFeignRpcCalls(graph, parsedFiles, fileContents);
+
+    const feignCalls = [...graph.iterRelationshipsByType('CALLS')];
+    expect(feignCalls.length).toBe(1);
+  });
+
+  it('detects field without explicit @Autowired', () => {
+    const feign = makeFeignInterfaceFile('SimpleRpc.java', [
+      { name: 'ping', startLine: 8, endLine: 10 },
+    ]);
+    for (const n of feign.nodes) graph.addNode(n);
+    fileContents.set(feign.path, feign.content);
+    parsedFiles.push({ filePath: feign.path, scopes: [] } as ParsedFile);
+
+    const content = `package com.test;
+public class Caller {
+    private SimpleRpc simpleRpc;
+    public void doWork() {
+        simpleRpc.ping(input);
+    }
+}`;
+    const callerNode = makeFile('Caller.java', 'doWork', 'Method', 4, 7);
+    graph.addNode(callerNode);
+    fileContents.set('Caller.java', content);
+    parsedFiles.push({ filePath: 'Caller.java', scopes: [] } as ParsedFile);
+
+    attachJavaFeignRpcCalls(graph, parsedFiles, fileContents);
+
+    const feignCalls = [...graph.iterRelationshipsByType('CALLS')];
+    expect(feignCalls.length).toBe(1);
+  });
+
+  it('detects @Resource injection', () => {
+    const feign = makeFeignInterfaceFile('ResourceRpc.java', [
+      { name: 'getData', startLine: 8, endLine: 10 },
+    ]);
+    for (const n of feign.nodes) graph.addNode(n);
+    fileContents.set(feign.path, feign.content);
+    parsedFiles.push({ filePath: feign.path, scopes: [] } as ParsedFile);
+
+    const content = `package com.test;
+public class Caller {
+    @Resource
+    private ResourceRpc resourceRpc;
+    public void doWork() {
+        resourceRpc.getData(input);
+    }
+}`;
+    const callerNode = makeFile('Caller.java', 'doWork', 'Method', 5, 8);
+    graph.addNode(callerNode);
+    fileContents.set('Caller.java', content);
+    parsedFiles.push({ filePath: 'Caller.java', scopes: [] } as ParsedFile);
+
+    attachJavaFeignRpcCalls(graph, parsedFiles, fileContents);
+
+    const feignCalls = [...graph.iterRelationshipsByType('CALLS')];
+    expect(feignCalls.length).toBe(1);
+  });
+
+  it('does not emit self-referencing edges', () => {
+    // Feign method itself has the same nodeId as caller (edge case)
+    const feign = makeFeignInterfaceFile('SelfRpc.java', [
+      { name: 'method', startLine: 8, endLine: 12 },
+    ]);
+    // Make the feign method also be the caller
+    const callerNode = feign.nodes[0];
+    // Put caller content in the feign file path
+    const content = `package com.test;
+@FeignClient("test")
+public interface SelfRpc {
+    WinRpcResponse<Object> method(InputDTO input);
+}`;
+    graph.addNode(callerNode);
+    fileContents.set('SelfRpc.java', content);
+    parsedFiles.push({ filePath: 'SelfRpc.java', scopes: [] } as ParsedFile);
+
+    attachJavaFeignRpcCalls(graph, parsedFiles, fileContents);
+
+    const feignCalls = [...graph.iterRelationshipsByType('CALLS')];
+    // Self-reference should be filtered
+    for (const r of feignCalls) {
+      expect(r.sourceId).not.toBe(r.targetId);
+    }
+  });
+
+  it('handles Feign interface with value-quoted service name', () => {
+    const content = `package com.test;
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient(value = "my-service")
+public interface ValueQuoteRpc {
+    WinRpcResponse<Object> fetch(DataDTO input);
+}`;
+    const feignNode = makeFile('ValueQuoteRpc.java', 'fetch', 'Method', 7, 9);
+    graph.addNode(feignNode);
+    fileContents.set('ValueQuoteRpc.java', content);
+    parsedFiles.push({ filePath: 'ValueQuoteRpc.java', scopes: [] } as ParsedFile);
+
+    const caller = makeCallerFile('Caller.java', 'ValueQuoteRpc', 'valueRpc', [
+      { methodName: 'fetch', line: 15 },
+    ]);
+    graph.addNode(caller.node);
+    fileContents.set(caller.path, caller.content);
+    parsedFiles.push({ filePath: caller.path, scopes: [] } as ParsedFile);
+
+    attachJavaFeignRpcCalls(graph, parsedFiles, fileContents);
+
+    const feignCalls = [...graph.iterRelationshipsByType('CALLS')];
+    expect(feignCalls.length).toBe(1);
+  });
+
+  it('skips when Feign field is declared but method is never called', () => {
+    const feign = makeFeignInterfaceFile('UnusedRpc.java', [
+      { name: 'unused', startLine: 8, endLine: 10 },
+    ]);
+    for (const n of feign.nodes) graph.addNode(n);
+    fileContents.set(feign.path, feign.content);
+    parsedFiles.push({ filePath: feign.path, scopes: [] } as ParsedFile);
+
+    const content = `package com.test;
+public class Caller {
+    private UnusedRpc unusedRpc;
+    public void doWork() {
+        System.out.println("no rpc call");
+    }
+}`;
+    const callerNode = makeFile('Caller.java', 'doWork', 'Method', 4, 6);
+    graph.addNode(callerNode);
+    fileContents.set('Caller.java', content);
+    parsedFiles.push({ filePath: 'Caller.java', scopes: [] } as ParsedFile);
+
+    attachJavaFeignRpcCalls(graph, parsedFiles, fileContents);
+
+    const feignCalls = [...graph.iterRelationshipsByType('CALLS')];
+    expect(feignCalls.length).toBe(0);
+  });
+
+  it('scans multiple functions in the same file', () => {
+    const feign = makeFeignInterfaceFile('MultiRpc.java', [
+      { name: 'first', startLine: 8, endLine: 10 },
+      { name: 'second', startLine: 12, endLine: 14 },
+    ]);
+    for (const n of feign.nodes) graph.addNode(n);
+    fileContents.set(feign.path, feign.content);
+    parsedFiles.push({ filePath: feign.path, scopes: [] } as ParsedFile);
+
+    const content = `package com.test;
+public class Caller {
+    private MultiRpc multiRpc;
+    public void methodA() {
+        multiRpc.first(input);
+    }
+    public void methodB() {
+        multiRpc.second(input);
+    }
+}`;
+    const nodeA = makeFile('Caller.java', 'methodA', 'Method', 4, 6);
+    const nodeB = makeFile('Caller.java', 'methodB', 'Method', 7, 9);
+    graph.addNode(nodeA);
+    graph.addNode(nodeB);
+    fileContents.set('Caller.java', content);
+    parsedFiles.push({ filePath: 'Caller.java', scopes: [] } as ParsedFile);
+
+    attachJavaFeignRpcCalls(graph, parsedFiles, fileContents);
+
+    const feignCalls = [...graph.iterRelationshipsByType('CALLS')];
+    expect(feignCalls.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

`@FeignClient` interfaces have no source-level implementation — Spring Cloud creates a dynamic proxy at runtime. The scope resolver cannot resolve the receiver to any concrete symbol, so calls on injected Feign fields produce zero CALLS edges, completely breaking impact analysis across RPC boundaries.

## Approach

New module `spring-feign-rpc.ts` runs in `emitPostResolutionEdges`:

1. **Identify Feign interfaces**: Scans source text for `@FeignClient` annotations.
2. **Build method index**: Maps Feign interface name → method node IDs from the graph.
3. **Detect field declarations**: Finds `@Autowired/@Resource/private` fields of Feign types.
4. **Scan for calls**: For each Function/Method node, regex-matches `fieldName.methodName()` patterns.
5. **Emit edges**: Creates `CALLS` edges (confidence 0.85) from caller to Feign interface method.

## Test coverage

12 unit tests: single/multiple methods, multiple Feign interfaces in same class, `@Autowired`/`@Resource`/no-annotation injection, duplicate suppression, self-reference filtering, uncalled fields, multi-function files, value-quoted service name.