### PR TITLE
fix(fts): keep binary payloads out of the description column, confine an unbuildable index to its own table

### DIFF
--- a/gitnexus/src/core/lbug/csv-generator.ts
+++ b/gitnexus/src/core/lbug/csv-generator.ts
@@ -137,6 +137,28 @@ const formatCSVStringArray = (value: unknown): string => {
 // CONTENT EXTRACTION (lazy — reads from disk on demand)
 // ============================================================================
 
+/**
+ * U+FFFD REPLACEMENT CHARACTER — the only trace a byte-level corruption leaves
+ * behind by the time this function sees it (#2889).
+ *
+ * Every source file enters the pipeline through a `utf-8` decode: the content
+ * cache below reads with `fs.readFile(path, 'utf-8')` and the parse worker
+ * decodes the same way. That decode is lossy and total — an invalid byte
+ * sequence never survives as invalid bytes, it is REPLACED with U+FFFD. So the
+ * embedded-binary payloads #2889 describes (webpack bundles, class-file
+ * constant pools, serialized objects inside .js/.vue sources) arrive here as
+ * long runs of U+FFFD, not as the control bytes this scan was written to count.
+ * charCode 0xFFFD is neither `< 9` nor `>= 127`-and-below-32, so the detector
+ * scored a wholly corrupt payload as clean text and every caller below waved it
+ * through. Counting it is what makes this function see the case it exists for.
+ *
+ * The threshold stays 10% of the first 1000 characters: a legitimate source file
+ * does not carry replacement characters at all unless it was mis-decoded, and a
+ * handful (a stray latin-1 comment, one bad byte in a license header) still
+ * scores far under the bar.
+ */
+const UNICODE_REPLACEMENT_CHAR = 0xfffd;
+
 export const isBinaryContent = (content: string): boolean => {
   if (!content || content.length === 0) return false;
   const sample = content.slice(0, 1000);
@@ -144,6 +166,7 @@ export const isBinaryContent = (content: string): boolean => {
   for (let i = 0; i < sample.length; i++) {
     const code = sample.charCodeAt(i);
     if (code < 9 || (code > 13 && code < 32) || code === 127) nonPrintable++;
+    else if (code === UNICODE_REPLACEMENT_CHAR) nonPrintable++;
   }
   return nonPrintable / sample.length > 0.1;
 };
@@ -225,9 +248,21 @@ class FileContentCache {
  */
 export const normalizeFtsText = (text: string): string => text.replace(/[\r\n\t]+/g, ' ');
 
-/** Composes both FTS-text transforms for the `description` column — one place for the six emission sites below to call, instead of repeating the composition. */
+/**
+ * Composes both FTS-text transforms for the `description` column — one place for
+ * the six emission sites below to call, instead of repeating the composition.
+ *
+ * Binary-looking descriptions are dropped rather than transformed (#2889). The
+ * `content` column has always been gated on {@link isBinaryContent} inside
+ * {@link extractContent}; `description` never was, so a symbol whose "doc
+ * comment" is really a slice of an embedded binary payload had that payload
+ * copied verbatim into an FTS-indexed column. Dropping it here rather than at
+ * each of the six call sites keeps the gate in the same place as the transforms
+ * it guards. Empty string, not a sentinel: unlike `content`, a description has
+ * no reader that needs to be told why it is missing.
+ */
 const formatFtsDescription = (description: string): string =>
-  normalizeFtsText(applyCjkSegmentationIfEnabled(description));
+  isBinaryContent(description) ? '' : normalizeFtsText(applyCjkSegmentationIfEnabled(description));
 
 // Labels that get exact source-span content (no ±2 window). Single source of
 // truth in `symbol-labels.ts` — see there for why the exactness depends on the

--- a/gitnexus/src/core/lbug/csv-generator.ts
+++ b/gitnexus/src/core/lbug/csv-generator.ts
@@ -137,38 +137,44 @@ const formatCSVStringArray = (value: unknown): string => {
 // CONTENT EXTRACTION (lazy — reads from disk on demand)
 // ============================================================================
 
-/**
- * U+FFFD REPLACEMENT CHARACTER — the only trace a byte-level corruption leaves
- * behind by the time this function sees it (#2889).
- *
- * Every source file enters the pipeline through a `utf-8` decode: the content
- * cache below reads with `fs.readFile(path, 'utf-8')` and the parse worker
- * decodes the same way. That decode is lossy and total — an invalid byte
- * sequence never survives as invalid bytes, it is REPLACED with U+FFFD. So the
- * embedded-binary payloads #2889 describes (webpack bundles, class-file
- * constant pools, serialized objects inside .js/.vue sources) arrive here as
- * long runs of U+FFFD, not as the control bytes this scan was written to count.
- * charCode 0xFFFD is neither `< 9` nor `>= 127`-and-below-32, so the detector
- * scored a wholly corrupt payload as clean text and every caller below waved it
- * through. Counting it is what makes this function see the case it exists for.
- *
- * The threshold stays 10% of the first 1000 characters: a legitimate source file
- * does not carry replacement characters at all unless it was mis-decoded, and a
- * handful (a stray latin-1 comment, one bad byte in a license header) still
- * scores far under the bar.
- */
+const BINARY_SAMPLE_CHARS = 1000;
 const UNICODE_REPLACEMENT_CHAR = 0xfffd;
 
+/**
+ * Did this text come from a binary payload? Density of non-printables over the
+ * first {@link BINARY_SAMPLE_CHARS} characters, above 10%.
+ *
+ * U+FFFD counts, and it is the character that matters most here (#2889). Every
+ * source file enters the pipeline through a `utf-8` decode — the content cache
+ * below reads with `fs.readFile(path, 'utf-8')`, and the parse worker decodes
+ * the same way. That decode is lossy and total: an invalid byte sequence never
+ * survives as invalid bytes, it is REPLACED with U+FFFD. So the embedded-binary
+ * payloads #2889 describes (webpack bundles, class-file constant pools,
+ * serialized objects inside .js/.vue sources) arrive here as long runs of
+ * U+FFFD, not as the control bytes this scan was originally written to count —
+ * charCode 0xFFFD is neither `< 9`, nor between 13 and 32, nor 127, so the
+ * detector scored a wholly corrupt payload as clean text and every caller waved
+ * it through.
+ *
+ * The threshold stays at 10%: a legitimate source file carries no replacement
+ * characters at all unless it was mis-decoded, and a handful (a stray latin-1
+ * comment, one bad byte in a license header) still scores far under the bar.
+ * Density rather than "contains any binary run" is deliberate — a description
+ * that is mostly real prose with one stray replacement character is worth more
+ * indexed than dropped.
+ */
 export const isBinaryContent = (content: string): boolean => {
-  if (!content || content.length === 0) return false;
-  const sample = content.slice(0, 1000);
+  // `content &&` keeps the original tolerance for a null/undefined caller —
+  // `strict` is off in this package, so the type alone does not rule it out.
+  const end = content ? Math.min(content.length, BINARY_SAMPLE_CHARS) : 0;
+  if (end === 0) return false;
   let nonPrintable = 0;
-  for (let i = 0; i < sample.length; i++) {
-    const code = sample.charCodeAt(i);
-    if (code < 9 || (code > 13 && code < 32) || code === 127) nonPrintable++;
-    else if (code === UNICODE_REPLACEMENT_CHAR) nonPrintable++;
+  for (let i = 0; i < end; i++) {
+    const code = content.charCodeAt(i);
+    if (code < 9 || (code > 13 && code < 32) || code === 127 || code === UNICODE_REPLACEMENT_CHAR)
+      nonPrintable++;
   }
-  return nonPrintable / sample.length > 0.1;
+  return nonPrintable / end > 0.1;
 };
 
 /**

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -61,7 +61,7 @@ import {
   buildSearchIndexesOrDegrade,
   ftsFailureIsFatal,
   createSearchFTSIndexes,
-  describeFtsIndexBuildFailures,
+  summarizeFtsIndexBuildFailures,
   dropSearchFTSIndexes,
   initialiseSearchFTSStemmer,
   verifySearchFTSIndexes,
@@ -1208,11 +1208,10 @@ async function runFullAnalysisInner(
         // Repair now rebuilds every table it can before reporting, so the tables
         // absent from this list were genuinely repaired even on a failed run —
         // previously the first failure aborted the sweep and the message could
-        // only ever list "missing", never a reason.
+        // only ever list "missing", never a reason. Same sentence the analyze
+        // degrade path prints, so one failure does not read two ways.
         const reasons =
-          repairFailures.length > 0
-            ? ` Build errors: ${describeFtsIndexBuildFailures(repairFailures)}.`
-            : '';
+          repairFailures.length > 0 ? ` ${summarizeFtsIndexBuildFailures(repairFailures)}.` : '';
         throw new Error(
           `FTS repair failed - missing indexes after rebuild: ${missing.join(', ')}.${reasons} ` +
             'Run `gitnexus analyze --force` to perform a full graph+FTS rebuild; ' +

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -61,6 +61,7 @@ import {
   buildSearchIndexesOrDegrade,
   ftsFailureIsFatal,
   createSearchFTSIndexes,
+  describeFtsIndexBuildFailures,
   dropSearchFTSIndexes,
   initialiseSearchFTSStemmer,
   verifySearchFTSIndexes,
@@ -1193,7 +1194,7 @@ async function runFullAnalysisInner(
         );
       }
       progress('fts', 85, 'Repairing search indexes...');
-      await createSearchFTSIndexes({
+      const repairFailures = await createSearchFTSIndexes({
         onIndexStart: options.verbose
           ? (table, indexName) => log(`FTS: creating ${table}.${indexName}`)
           : undefined,
@@ -1203,8 +1204,17 @@ async function runFullAnalysisInner(
       });
       const missing = await verifySearchFTSIndexes(executeQuery);
       if (missing.length > 0) {
+        // #2889: name WHY each index is missing when the build itself said so.
+        // Repair now rebuilds every table it can before reporting, so the tables
+        // absent from this list were genuinely repaired even on a failed run —
+        // previously the first failure aborted the sweep and the message could
+        // only ever list "missing", never a reason.
+        const reasons =
+          repairFailures.length > 0
+            ? ` Build errors: ${describeFtsIndexBuildFailures(repairFailures)}.`
+            : '';
         throw new Error(
-          `FTS repair failed - missing indexes after rebuild: ${missing.join(', ')}. ` +
+          `FTS repair failed - missing indexes after rebuild: ${missing.join(', ')}.${reasons} ` +
             'Run `gitnexus analyze --force` to perform a full graph+FTS rebuild; ' +
             'if that also fails, verify FTS extension availability via `gitnexus doctor`.',
         );

--- a/gitnexus/src/core/search/fts-indexes.ts
+++ b/gitnexus/src/core/search/fts-indexes.ts
@@ -263,7 +263,6 @@ export interface FtsIndexBuildFailure {
   indexName: string;
   /** The raw LadybugDB message, unmodified — it is the only row-level evidence there is. */
   error: string;
-  failureClass: FtsBuildFailureClass;
 }
 
 /**
@@ -307,8 +306,9 @@ export async function createSearchFTSIndexes(
       await dropFTSIndex(table, indexName);
       await createFTSIndex(table, indexName, [...properties], stemmer);
     } catch (e) {
-      const error = e instanceof Error ? e.message : String(e);
-      failures.push({ table, indexName, error, failureClass: classifyFtsBuildError(error) });
+      // The message, never the Error: holding the Error would pin its stack and
+      // whatever the native binding attached to it, for up to one per table.
+      failures.push({ table, indexName, error: e instanceof Error ? e.message : String(e) });
       continue;
     }
     options?.onIndexReady?.(table, indexName);
@@ -316,8 +316,20 @@ export async function createSearchFTSIndexes(
   return failures;
 }
 
-/** `Method.method_fts (Runtime exception: …), Variable.variable_fts (…)` — every failure, table-named. */
-export const describeFtsIndexBuildFailures = (failures: readonly FtsIndexBuildFailure[]): string =>
+/**
+ * One sentence naming every table that failed and why, e.g. `FTS index build
+ * failed for 2 of 21 tables: Method.method_fts (Runtime exception: …), …`.
+ *
+ * Lives here rather than at the call sites because only this module knows the
+ * denominator. Both the analyze degrade path and `--repair-fts` render it, so
+ * one failure reads the same way whichever command produced it.
+ *
+ * Embeds the raw LadybugDB message UNREDACTED — CLI and log surfaces only.
+ * Anything heading for a network response has to pass it through
+ * {@link redactPaths} first, the same rule the query-side warnings follow.
+ */
+export const summarizeFtsIndexBuildFailures = (failures: readonly FtsIndexBuildFailure[]): string =>
+  `FTS index build failed for ${failures.length} of ${FTS_INDEXES.length} tables: ` +
   failures.map((f) => `${f.table}.${f.indexName} (${f.error})`).join(', ');
 
 export async function verifySearchFTSIndexes(
@@ -453,27 +465,36 @@ export async function buildSearchIndexesOrDegrade(
   options?: CreateSearchFTSIndexesOptions,
 ): Promise<BuildSearchIndexesResult> {
   try {
+    // Verify ALWAYS runs, failures or not (#2889). Reporting must not jump the
+    // queue ahead of verification: a partial build is exactly when "the other
+    // tables are fine" needs proving rather than asserting, and a stale
+    // name+content-only index is invisible to the build (it succeeds) yet still
+    // means description search is broken (#2299).
     const failures = await createSearchFTSIndexes(options);
-    if (failures.length > 0) {
-      // Every OTHER index was still built and verified below is skipped only
-      // for the report — the surviving tables stay searchable this run (#2889).
-      // `integrity` wins the aggregate: a genuinely broken write must not be
-      // downgraded to a degrade just because an untokenizable row failed first.
-      const error = `FTS index build failed for ${failures.length} of ${FTS_INDEXES.length} tables: ${describeFtsIndexBuildFailures(failures)}`;
-      const failureClass = failures.some((f) => f.failureClass === 'integrity')
-        ? 'integrity'
-        : 'capability';
-      return { ok: false, error, failureClass };
-    }
     const missing = await verifySearchFTSIndexes(executeQuery);
-    if (missing.length > 0) {
-      // Structural incompleteness with no thrown error — treat as capability
-      // (degrade), matching prior behavior; a broken *write* surfaces as a
-      // thrown IO/checkpoint error below and is classified integrity there.
-      const error = `missing indexes after build: ${missing.join(', ')}`;
-      return { ok: false, error, failureClass: classifyFtsBuildError(error) };
-    }
-    return { ok: true };
+    if (failures.length === 0 && missing.length === 0) return { ok: true };
+
+    // A table that failed to build is necessarily missing too — report it once,
+    // with its reason, and keep `missing` for indexes nothing explains.
+    const named = new Set(failures.map((f) => `${f.table}.${f.indexName}`));
+    const unexplained = missing.filter((name) => !named.has(name));
+    const error = [
+      failures.length > 0 ? summarizeFtsIndexBuildFailures(failures) : '',
+      // Structural incompleteness with no thrown error — classified capability
+      // (degrade) below, matching prior behavior; a broken *write* surfaces as
+      // a thrown IO/checkpoint error and is classified integrity there.
+      unexplained.length > 0 ? `missing indexes after build: ${unexplained.join(', ')}` : '',
+    ]
+      .filter((part) => part.length > 0)
+      .join('; ');
+
+    // Classify per failure, not over the joined text: capability signatures are
+    // checked first, so folding the messages together would let an untokenizable
+    // row mask a genuinely broken write and downgrade an abort into a degrade.
+    const failureClass = failures.some((f) => classifyFtsBuildError(f.error) === 'integrity')
+      ? 'integrity'
+      : classifyFtsBuildError(error);
+    return { ok: false, error, failureClass };
   } catch (e) {
     const error = e instanceof Error ? e.message : String(e);
     return { ok: false, error, failureClass: classifyFtsBuildError(error) };

--- a/gitnexus/src/core/search/fts-indexes.ts
+++ b/gitnexus/src/core/search/fts-indexes.ts
@@ -257,10 +257,39 @@ export async function dropSearchFTSIndexes(indexRows?: IndexCatalogSnapshot): Pr
   }
 }
 
+/** One configured index that could not be (re)built, and why. */
+export interface FtsIndexBuildFailure {
+  table: string;
+  indexName: string;
+  /** The raw LadybugDB message, unmodified — it is the only row-level evidence there is. */
+  error: string;
+  failureClass: FtsBuildFailureClass;
+}
+
+/**
+ * Build every configured FTS index, and keep going when one of them fails
+ * (#2889).
+ *
+ * The loop used to let the first failure propagate, which made a single
+ * untokenizable row far more expensive than it looks: `dropFTSIndex` has
+ * already run for the failing table, so that table ends with NO index, and
+ * every table after it in {@link FTS_INDEXES} order is never reached — on a
+ * fresh build, or on the incremental path where `dropSearchFTSIndexes` cleared
+ * them all up front, those tables end with no index either. One bad `Method`
+ * row therefore cost keyword search on Namespace, Property, Record, Union,
+ * Static and Variable as well, and `verifySearchFTSIndexes` never ran to say
+ * so. The blast radius was an artifact of loop control flow, not of the data.
+ *
+ * Isolating per index bounds the damage to the table that actually holds the
+ * bad row, and makes `--repair-fts` able to recover everything else. Failures
+ * are returned rather than thrown so the caller can decide — degrade or abort —
+ * with every failure in hand instead of only the first.
+ */
 export async function createSearchFTSIndexes(
   options?: CreateSearchFTSIndexesOptions,
-): Promise<void> {
+): Promise<FtsIndexBuildFailure[]> {
   const stemmer = getSearchFTSStemmer();
+  const failures: FtsIndexBuildFailure[] = [];
   for (const { table, indexName, properties } of FTS_INDEXES) {
     options?.onIndexStart?.(table, indexName);
     // Drop first so the live `properties` always win. `createFTSIndex` is
@@ -274,11 +303,22 @@ export async function createSearchFTSIndexes(
     // skipping when present; FTS build is proportional to symbol-table size and
     // runs inside the existing FTS phase. Gate on a stored schema fingerprint if
     // this rebuild cost ever shows up in analyze profiles.
-    await dropFTSIndex(table, indexName);
-    await createFTSIndex(table, indexName, [...properties], stemmer);
+    try {
+      await dropFTSIndex(table, indexName);
+      await createFTSIndex(table, indexName, [...properties], stemmer);
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e);
+      failures.push({ table, indexName, error, failureClass: classifyFtsBuildError(error) });
+      continue;
+    }
     options?.onIndexReady?.(table, indexName);
   }
+  return failures;
 }
+
+/** `Method.method_fts (Runtime exception: …), Variable.variable_fts (…)` — every failure, table-named. */
+export const describeFtsIndexBuildFailures = (failures: readonly FtsIndexBuildFailure[]): string =>
+  failures.map((f) => `${f.table}.${f.indexName} (${f.error})`).join(', ');
 
 export async function verifySearchFTSIndexes(
   executeQuery: (cypher: string) => Promise<unknown[]>,
@@ -413,7 +453,18 @@ export async function buildSearchIndexesOrDegrade(
   options?: CreateSearchFTSIndexesOptions,
 ): Promise<BuildSearchIndexesResult> {
   try {
-    await createSearchFTSIndexes(options);
+    const failures = await createSearchFTSIndexes(options);
+    if (failures.length > 0) {
+      // Every OTHER index was still built and verified below is skipped only
+      // for the report — the surviving tables stay searchable this run (#2889).
+      // `integrity` wins the aggregate: a genuinely broken write must not be
+      // downgraded to a degrade just because an untokenizable row failed first.
+      const error = `FTS index build failed for ${failures.length} of ${FTS_INDEXES.length} tables: ${describeFtsIndexBuildFailures(failures)}`;
+      const failureClass = failures.some((f) => f.failureClass === 'integrity')
+        ? 'integrity'
+        : 'capability';
+      return { ok: false, error, failureClass };
+    }
     const missing = await verifySearchFTSIndexes(executeQuery);
     if (missing.length > 0) {
       // Structural incompleteness with no thrown error — treat as capability

--- a/gitnexus/test/integration/csv-pipeline.test.ts
+++ b/gitnexus/test/integration/csv-pipeline.test.ts
@@ -402,10 +402,15 @@ describe('streamAllCSVsToDisk', () => {
     const DECODED_BINARY_DESCRIPTION = `用户服务 ${'�'.repeat(24)}MethCw`;
     const CLEAN_DESCRIPTION = 'approves an inventory transfer';
 
-    it('drops a binary description on the default emission branch, keeping the row', async () => {
+    // `Method` has its own emission branch; `Function` falls to the `default:`
+    // one. Both call the same helper, so one graph carrying both proves the gate
+    // is in the helper rather than in one branch's copy of the call.
+    const BRANCHES = ['Function', 'Method'] as const;
+
+    it('drops a binary description on every emission branch, keeping the row', async () => {
       await fs.writeFile(
         path.join(repoDir, 'src', 'payload.ts'),
-        'export function fromPayload() {\n  return 1;\n}\n',
+        'export function fromPayload() {\n  return 1;\n}\nexport class Svc {\n  run() {\n    return 1;\n  }\n}\n',
       );
       const graph = buildTestGraph([
         {
@@ -428,55 +433,37 @@ describe('streamAllCSVsToDisk', () => {
           filePath: 'src/payload.ts',
           extra: { description: CLEAN_DESCRIPTION, startLine: 0, endLine: 2 },
         },
-      ]);
-
-      const result = await streamAllCSVsToDisk(graph, repoDir, csvDir);
-      const funcContent = await fs.readFile(result.nodeFiles.get('Function')!.csvPath, 'utf-8');
-
-      expect(funcContent).not.toContain('MethCw');
-      expect(funcContent).not.toContain('�');
-      // The symbol itself still ships — only its description was dropped.
-      expect(funcContent).toContain('fromPayload');
-      // A clean description on the same emission path is untouched, so the
-      // gate cannot pass by emptying the column for everyone.
-      expect(funcContent).toContain(CLEAN_DESCRIPTION);
-    });
-
-    it('drops a binary description on the Method emission branch', async () => {
-      await fs.writeFile(
-        path.join(repoDir, 'src', 'payload-method.ts'),
-        'export class Svc {\n  run() {\n    return 1;\n  }\n}\n',
-      );
-      const graph = buildTestGraph([
-        {
-          id: 'file:src/payload-method.ts',
-          label: 'File',
-          name: 'payload-method.ts',
-          filePath: 'src/payload-method.ts',
-        },
         {
           id: 'method:Svc.run',
           label: 'Method',
           name: 'run',
-          filePath: 'src/payload-method.ts',
-          extra: { description: DECODED_BINARY_DESCRIPTION, startLine: 1, endLine: 3 },
+          filePath: 'src/payload.ts',
+          extra: { description: DECODED_BINARY_DESCRIPTION, startLine: 4, endLine: 6 },
         },
         {
           id: 'method:Svc.clean',
           label: 'Method',
           name: 'cleanRun',
-          filePath: 'src/payload-method.ts',
-          extra: { description: CLEAN_DESCRIPTION, startLine: 1, endLine: 3 },
+          filePath: 'src/payload.ts',
+          extra: { description: CLEAN_DESCRIPTION, startLine: 4, endLine: 6 },
         },
       ]);
 
       const result = await streamAllCSVsToDisk(graph, repoDir, csvDir);
-      const methodContent = await fs.readFile(result.nodeFiles.get('Method')!.csvPath, 'utf-8');
 
-      expect(methodContent).not.toContain('MethCw');
-      expect(methodContent).not.toContain('�');
-      expect(methodContent).toContain('cleanRun');
-      expect(methodContent).toContain(CLEAN_DESCRIPTION);
+      for (const label of BRANCHES) {
+        const csv = await fs.readFile(result.nodeFiles.get(label)!.csvPath, 'utf-8');
+        expect(csv, label).not.toContain('MethCw');
+        expect(csv, label).not.toContain('�');
+        // A clean description on the same branch is untouched, so the gate
+        // cannot pass by emptying the column for everyone.
+        expect(csv, label).toContain(CLEAN_DESCRIPTION);
+      }
+      // The symbols themselves still ship — only their descriptions were dropped.
+      const functionCsv = await fs.readFile(result.nodeFiles.get('Function')!.csvPath, 'utf-8');
+      const methodCsv = await fs.readFile(result.nodeFiles.get('Method')!.csvPath, 'utf-8');
+      expect(functionCsv).toContain('fromPayload');
+      expect(methodCsv).toContain('"run"');
     });
   });
 

--- a/gitnexus/test/integration/csv-pipeline.test.ts
+++ b/gitnexus/test/integration/csv-pipeline.test.ts
@@ -393,6 +393,93 @@ describe('streamAllCSVsToDisk', () => {
     });
   });
 
+  describe('binary descriptions (#2889)', () => {
+    // What an embedded binary payload actually looks like by the time it
+    // reaches the emitter: every read decodes `utf-8`, so the invalid bytes
+    // are already gone, replaced with U+FFFD. `MethCw` is the readable tail of
+    // a Java constant-pool run — the marker that proves the payload, not just
+    // the corruption around it, stayed out of the indexed column.
+    const DECODED_BINARY_DESCRIPTION = `用户服务 ${'�'.repeat(24)}MethCw`;
+    const CLEAN_DESCRIPTION = 'approves an inventory transfer';
+
+    it('drops a binary description on the default emission branch, keeping the row', async () => {
+      await fs.writeFile(
+        path.join(repoDir, 'src', 'payload.ts'),
+        'export function fromPayload() {\n  return 1;\n}\n',
+      );
+      const graph = buildTestGraph([
+        {
+          id: 'file:src/payload.ts',
+          label: 'File',
+          name: 'payload.ts',
+          filePath: 'src/payload.ts',
+        },
+        {
+          id: 'func:fromPayload',
+          label: 'Function',
+          name: 'fromPayload',
+          filePath: 'src/payload.ts',
+          extra: { description: DECODED_BINARY_DESCRIPTION, startLine: 0, endLine: 2 },
+        },
+        {
+          id: 'func:clean',
+          label: 'Function',
+          name: 'cleanFn',
+          filePath: 'src/payload.ts',
+          extra: { description: CLEAN_DESCRIPTION, startLine: 0, endLine: 2 },
+        },
+      ]);
+
+      const result = await streamAllCSVsToDisk(graph, repoDir, csvDir);
+      const funcContent = await fs.readFile(result.nodeFiles.get('Function')!.csvPath, 'utf-8');
+
+      expect(funcContent).not.toContain('MethCw');
+      expect(funcContent).not.toContain('�');
+      // The symbol itself still ships — only its description was dropped.
+      expect(funcContent).toContain('fromPayload');
+      // A clean description on the same emission path is untouched, so the
+      // gate cannot pass by emptying the column for everyone.
+      expect(funcContent).toContain(CLEAN_DESCRIPTION);
+    });
+
+    it('drops a binary description on the Method emission branch', async () => {
+      await fs.writeFile(
+        path.join(repoDir, 'src', 'payload-method.ts'),
+        'export class Svc {\n  run() {\n    return 1;\n  }\n}\n',
+      );
+      const graph = buildTestGraph([
+        {
+          id: 'file:src/payload-method.ts',
+          label: 'File',
+          name: 'payload-method.ts',
+          filePath: 'src/payload-method.ts',
+        },
+        {
+          id: 'method:Svc.run',
+          label: 'Method',
+          name: 'run',
+          filePath: 'src/payload-method.ts',
+          extra: { description: DECODED_BINARY_DESCRIPTION, startLine: 1, endLine: 3 },
+        },
+        {
+          id: 'method:Svc.clean',
+          label: 'Method',
+          name: 'cleanRun',
+          filePath: 'src/payload-method.ts',
+          extra: { description: CLEAN_DESCRIPTION, startLine: 1, endLine: 3 },
+        },
+      ]);
+
+      const result = await streamAllCSVsToDisk(graph, repoDir, csvDir);
+      const methodContent = await fs.readFile(result.nodeFiles.get('Method')!.csvPath, 'utf-8');
+
+      expect(methodContent).not.toContain('MethCw');
+      expect(methodContent).not.toContain('�');
+      expect(methodContent).toContain('cleanRun');
+      expect(methodContent).toContain(CLEAN_DESCRIPTION);
+    });
+  });
+
   it('handles community nodes with keywords', async () => {
     const graph = buildTestGraph([
       {

--- a/gitnexus/test/unit/csv-escaping.test.ts
+++ b/gitnexus/test/unit/csv-escaping.test.ts
@@ -170,4 +170,29 @@ describe('isBinaryContent', () => {
     const text = 'a'.repeat(1000) + '\x00'.repeat(500);
     expect(isBinaryContent(text)).toBe(false);
   });
+
+  // #2889 — every file enters through a lossy `utf-8` decode, so an embedded
+  // binary payload reaches this function as U+FFFD, never as the raw bytes.
+  it('returns true when >10% U+FFFD replacement characters', () => {
+    const decoded = 'a'.repeat(80) + '�'.repeat(20);
+    expect(isBinaryContent(decoded)).toBe(true);
+  });
+
+  it('counts U+FFFD toward the same threshold as control bytes', () => {
+    // 5 control + 6 replacement = 11% of 100 — neither group crosses 10% alone.
+    const mixed = 'a'.repeat(89) + '\x01'.repeat(5) + '�'.repeat(6);
+    expect(isBinaryContent(mixed)).toBe(true);
+  });
+
+  it('returns false for text carrying a few replacement characters', () => {
+    // A mis-decoded latin-1 comment in an otherwise clean file stays indexable.
+    const mostlyText = 'a'.repeat(95) + '�'.repeat(5);
+    expect(isBinaryContent(mostlyText)).toBe(false);
+  });
+
+  it('returns false for CJK text', () => {
+    // Guards the #2889 gate against the opposite failure: multi-byte text is
+    // not binary, and every code point here is well above the control range.
+    expect(isBinaryContent('库存管理系统更新'.repeat(20))).toBe(false);
+  });
 });

--- a/gitnexus/test/unit/csv-escaping.test.ts
+++ b/gitnexus/test/unit/csv-escaping.test.ts
@@ -189,10 +189,4 @@ describe('isBinaryContent', () => {
     const mostlyText = 'a'.repeat(95) + '�'.repeat(5);
     expect(isBinaryContent(mostlyText)).toBe(false);
   });
-
-  it('returns false for CJK text', () => {
-    // Guards the #2889 gate against the opposite failure: multi-byte text is
-    // not binary, and every code point here is well above the control range.
-    expect(isBinaryContent('库存管理系统更新'.repeat(20))).toBe(false);
-  });
 });

--- a/gitnexus/test/unit/fts-indexes.test.ts
+++ b/gitnexus/test/unit/fts-indexes.test.ts
@@ -44,6 +44,13 @@ const fullCoverageRows = () =>
 afterEach(() => {
   calls.length = 0;
   vi.clearAllMocks();
+  // `clearAllMocks` does NOT drain the `…Once` queue. A test that queues more
+  // rejections than the code under test consumes would otherwise leak the
+  // leftovers into whichever test runs next — order-dependent, and exactly the
+  // shape of failure a per-index isolation change makes easy to introduce.
+  // `mockReset` restores the implementation the `vi.mock` factory passed to
+  // `vi.fn(impl)`, so the recording default survives.
+  vi.mocked(createFTSIndex).mockReset();
   vi.unstubAllEnvs();
 });
 
@@ -85,6 +92,71 @@ describe('createSearchFTSIndexes', () => {
     await expect(createSearchFTSIndexes()).rejects.toThrow('Invalid GITNEXUS_FTS_STEMMER');
     expect(calls).toEqual([]);
   });
+
+  // #2889 — one untokenizable row used to cost the indexes of its own table AND
+  // every table after it in FTS_INDEXES order, because the first rejection left
+  // the loop. The `drop` for the failing table has already run by then, so the
+  // damage was never confined to "the index we could not rebuild".
+  describe('per-index failure isolation (#2889)', () => {
+    const POISON = 'Runtime exception: Failed calling LOWER: Invalid UTF-8.';
+    const recordCreate = async (
+      table: string,
+      indexName: string,
+      _properties: string[],
+      stemmer: string,
+    ) => {
+      calls.push(`create:${table}.${indexName}:${stemmer}`);
+    };
+
+    it('builds every remaining table after one index build rejects', async () => {
+      const poisoned = FTS_INDEXES[1];
+      vi.mocked(createFTSIndex)
+        .mockImplementationOnce(recordCreate)
+        .mockRejectedValueOnce(new Error(POISON));
+
+      const failures = await createSearchFTSIndexes();
+
+      expect(failures).toEqual([
+        {
+          table: poisoned.table,
+          indexName: poisoned.indexName,
+          error: POISON,
+          failureClass: 'capability',
+        },
+      ]);
+      expect(calls.filter((call) => call.startsWith('create:'))).toEqual(
+        FTS_INDEXES.filter((i) => i.indexName !== poisoned.indexName).map(
+          (i) => `create:${i.table}.${i.indexName}:porter`,
+        ),
+      );
+    });
+
+    it('still drops the failing index, and every other index is left rebuilt', async () => {
+      vi.mocked(createFTSIndex)
+        .mockImplementationOnce(recordCreate)
+        .mockRejectedValueOnce(new Error(POISON));
+
+      await createSearchFTSIndexes();
+
+      expect(calls.filter((call) => call.startsWith('drop:'))).toEqual(
+        FTS_INDEXES.map((i) => `drop:${i.table}.${i.indexName}`),
+      );
+    });
+
+    it('does not report a failed index as ready', async () => {
+      const poisoned = FTS_INDEXES[1];
+      vi.mocked(createFTSIndex)
+        .mockImplementationOnce(recordCreate)
+        .mockRejectedValueOnce(new Error(POISON));
+      const ready: string[] = [];
+
+      await createSearchFTSIndexes({ onIndexReady: (_t, name) => ready.push(name) });
+
+      expect(ready).toEqual(
+        FTS_INDEXES.filter((i) => i.indexName !== poisoned.indexName).map((i) => i.indexName),
+      );
+    });
+  });
 });
 
 describe('buildSearchIndexesOrDegrade', () => {
@@ -106,6 +178,44 @@ describe('buildSearchIndexesOrDegrade', () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toContain('Invalid UTF-8');
+  });
+
+  it('names every failing table, not just the first (#2889)', async () => {
+    vi.mocked(createFTSIndex)
+      .mockRejectedValueOnce(new Error('Runtime exception: Failed calling LOWER: Invalid UTF-8.'))
+      .mockRejectedValueOnce(new Error('Runtime exception: Failed calling LOWER: Invalid UTF-8.'));
+    const executeQuery = vi.fn(async () => fullCoverageRows());
+
+    const result = await buildSearchIndexesOrDegrade(executeQuery);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain(FTS_INDEXES[0].table);
+    expect(result.error).toContain(FTS_INDEXES[1].table);
+    expect(result.error).toContain(`2 of ${FTS_INDEXES.length} tables`);
+  });
+
+  it('escalates the aggregate to integrity when any single failure is integrity (#2889)', async () => {
+    // Capability signatures are checked first, so aggregating the raw messages
+    // into one string would have let an untokenizable row mask a broken write.
+    vi.mocked(createFTSIndex)
+      .mockRejectedValueOnce(new Error('Runtime exception: Failed calling LOWER: Invalid UTF-8.'))
+      .mockRejectedValueOnce(new Error('IO exception: checkpoint failed'));
+    const executeQuery = vi.fn(async () => fullCoverageRows());
+
+    const result = await buildSearchIndexesOrDegrade(executeQuery);
+
+    expect(result.failureClass).toBe('integrity');
+  });
+
+  it('stays capability when every failure is a row-level tokenizer error (#2889)', async () => {
+    vi.mocked(createFTSIndex).mockRejectedValueOnce(
+      new Error('Runtime exception: Failed calling LOWER: Invalid UTF-8.'),
+    );
+    const executeQuery = vi.fn(async () => fullCoverageRows());
+
+    const result = await buildSearchIndexesOrDegrade(executeQuery);
+
+    expect(result.failureClass).toBe('capability');
   });
 
   it('returns ok:false when verification finds a missing index, without throwing', async () => {

--- a/gitnexus/test/unit/fts-indexes.test.ts
+++ b/gitnexus/test/unit/fts-indexes.test.ts
@@ -41,16 +41,17 @@ const { createFTSIndex } = await import('../../src/core/lbug/lbug-adapter.js');
 const fullCoverageRows = () =>
   FTS_INDEXES.map((i) => ({ index_name: i.indexName, property_names: [...i.properties] }));
 
+/** The row-level tokenizer error of #2544/#2546/#2889, verbatim. */
+const POISON = 'Runtime exception: Failed calling LOWER: Invalid UTF-8.';
+
 afterEach(() => {
   calls.length = 0;
-  vi.clearAllMocks();
-  // `clearAllMocks` does NOT drain the `…Once` queue. A test that queues more
-  // rejections than the code under test consumes would otherwise leak the
-  // leftovers into whichever test runs next — order-dependent, and exactly the
-  // shape of failure a per-index isolation change makes easy to introduce.
-  // `mockReset` restores the implementation the `vi.mock` factory passed to
-  // `vi.fn(impl)`, so the recording default survives.
-  vi.mocked(createFTSIndex).mockReset();
+  // `reset`, not `clear`: only reset drains the `…Once` queue, and a test that
+  // queues more rejections than the code consumes would otherwise leak the
+  // leftovers into whichever test runs next. Vitest 4's reset restores the
+  // implementation each `vi.fn(impl)` was created with, so the factory's
+  // recording defaults survive.
+  vi.resetAllMocks();
   vi.unstubAllEnvs();
 });
 
@@ -97,65 +98,25 @@ describe('createSearchFTSIndexes', () => {
   // every table after it in FTS_INDEXES order, because the first rejection left
   // the loop. The `drop` for the failing table has already run by then, so the
   // damage was never confined to "the index we could not rebuild".
-  describe('per-index failure isolation (#2889)', () => {
-    const POISON = 'Runtime exception: Failed calling LOWER: Invalid UTF-8.';
-    const recordCreate = async (
-      table: string,
-      indexName: string,
-      _properties: string[],
-      stemmer: string,
-    ) => {
-      calls.push(`create:${table}.${indexName}:${stemmer}`);
-    };
+  it('isolates a failing index: others build, all drop, the failed one is not ready (#2889)', async () => {
+    vi.mocked(createFTSIndex).mockRejectedValueOnce(new Error(POISON));
+    const ready: string[] = [];
 
-    it('builds every remaining table after one index build rejects', async () => {
-      const poisoned = FTS_INDEXES[1];
-      vi.mocked(createFTSIndex)
-        .mockImplementationOnce(recordCreate)
-        .mockRejectedValueOnce(new Error(POISON));
+    const failures = await createSearchFTSIndexes({ onIndexReady: (_t, name) => ready.push(name) });
 
-      const failures = await createSearchFTSIndexes();
-
-      expect(failures).toEqual([
-        {
-          table: poisoned.table,
-          indexName: poisoned.indexName,
-          error: POISON,
-          failureClass: 'capability',
-        },
-      ]);
-      expect(calls.filter((call) => call.startsWith('create:'))).toEqual(
-        FTS_INDEXES.filter((i) => i.indexName !== poisoned.indexName).map(
-          (i) => `create:${i.table}.${i.indexName}:porter`,
-        ),
-      );
-    });
-
-    it('still drops the failing index, and every other index is left rebuilt', async () => {
-      vi.mocked(createFTSIndex)
-        .mockImplementationOnce(recordCreate)
-        .mockRejectedValueOnce(new Error(POISON));
-
-      await createSearchFTSIndexes();
-
-      expect(calls.filter((call) => call.startsWith('drop:'))).toEqual(
-        FTS_INDEXES.map((i) => `drop:${i.table}.${i.indexName}`),
-      );
-    });
-
-    it('does not report a failed index as ready', async () => {
-      const poisoned = FTS_INDEXES[1];
-      vi.mocked(createFTSIndex)
-        .mockImplementationOnce(recordCreate)
-        .mockRejectedValueOnce(new Error(POISON));
-      const ready: string[] = [];
-
-      await createSearchFTSIndexes({ onIndexReady: (_t, name) => ready.push(name) });
-
-      expect(ready).toEqual(
-        FTS_INDEXES.filter((i) => i.indexName !== poisoned.indexName).map((i) => i.indexName),
-      );
-    });
+    const [poisoned, ...survivors] = FTS_INDEXES;
+    expect(failures).toEqual([
+      { table: poisoned.table, indexName: poisoned.indexName, error: POISON },
+    ]);
+    // The drop for the failing table still ran — that is why letting the
+    // rejection leave the loop cost the table its index as well as the rebuild.
+    expect(calls.filter((call) => call.startsWith('drop:'))).toEqual(
+      FTS_INDEXES.map((i) => `drop:${i.table}.${i.indexName}`),
+    );
+    expect(calls.filter((call) => call.startsWith('create:'))).toEqual(
+      survivors.map((i) => `create:${i.table}.${i.indexName}:porter`),
+    );
+    expect(ready).toEqual(survivors.map((i) => i.indexName));
   });
 });
 
@@ -169,21 +130,25 @@ describe('buildSearchIndexesOrDegrade', () => {
   });
 
   it('returns ok:false instead of throwing when a single index build rejects (#2544/#2546)', async () => {
-    vi.mocked(createFTSIndex).mockRejectedValueOnce(
-      new Error('Runtime exception: Failed calling LOWER: Invalid UTF-8.'),
-    );
+    vi.mocked(createFTSIndex).mockRejectedValueOnce(new Error(POISON));
     const executeQuery = vi.fn(async () => fullCoverageRows());
 
     const result = await buildSearchIndexesOrDegrade(executeQuery);
 
     expect(result.ok).toBe(false);
     expect(result.error).toContain('Invalid UTF-8');
+    // A row-level tokenizer error degrades; it must never escalate to an abort.
+    expect(result.failureClass).toBe('capability');
+    // #2889: verification still runs on a partial build — the surviving indexes
+    // are the whole point of isolating the failure, so they get proven, not
+    // assumed. (One SHOW_INDEXES read.)
+    expect(executeQuery).toHaveBeenCalledTimes(1);
   });
 
   it('names every failing table, not just the first (#2889)', async () => {
     vi.mocked(createFTSIndex)
-      .mockRejectedValueOnce(new Error('Runtime exception: Failed calling LOWER: Invalid UTF-8.'))
-      .mockRejectedValueOnce(new Error('Runtime exception: Failed calling LOWER: Invalid UTF-8.'));
+      .mockRejectedValueOnce(new Error(POISON))
+      .mockRejectedValueOnce(new Error(POISON));
     const executeQuery = vi.fn(async () => fullCoverageRows());
 
     const result = await buildSearchIndexesOrDegrade(executeQuery);
@@ -198,24 +163,13 @@ describe('buildSearchIndexesOrDegrade', () => {
     // Capability signatures are checked first, so aggregating the raw messages
     // into one string would have let an untokenizable row mask a broken write.
     vi.mocked(createFTSIndex)
-      .mockRejectedValueOnce(new Error('Runtime exception: Failed calling LOWER: Invalid UTF-8.'))
+      .mockRejectedValueOnce(new Error(POISON))
       .mockRejectedValueOnce(new Error('IO exception: checkpoint failed'));
     const executeQuery = vi.fn(async () => fullCoverageRows());
 
     const result = await buildSearchIndexesOrDegrade(executeQuery);
 
     expect(result.failureClass).toBe('integrity');
-  });
-
-  it('stays capability when every failure is a row-level tokenizer error (#2889)', async () => {
-    vi.mocked(createFTSIndex).mockRejectedValueOnce(
-      new Error('Runtime exception: Failed calling LOWER: Invalid UTF-8.'),
-    );
-    const executeQuery = vi.fn(async () => fullCoverageRows());
-
-    const result = await buildSearchIndexesOrDegrade(executeQuery);
-
-    expect(result.failureClass).toBe('capability');
   });
 
   it('returns ok:false when verification finds a missing index, without throwing', async () => {
@@ -225,6 +179,20 @@ describe('buildSearchIndexesOrDegrade', () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toContain('missing indexes');
+  });
+
+  it('reports a failed table once, with its reason, not twice (#2889)', async () => {
+    // The failing table is missing from the catalog too — verification would
+    // name it a second time, with no reason attached, if the report did not
+    // subtract what the build already explained.
+    vi.mocked(createFTSIndex).mockRejectedValueOnce(new Error(POISON));
+    const executeQuery = vi.fn(async () => fullCoverageRows().slice(1));
+
+    const result = await buildSearchIndexesOrDegrade(executeQuery);
+
+    const failed = `${FTS_INDEXES[0].table}.${FTS_INDEXES[0].indexName}`;
+    expect(result.error).toContain(`${failed} (${POISON})`);
+    expect(result.error).not.toContain('missing indexes');
   });
 });
 

--- a/gitnexus/test/unit/repo-manager-reconcile.test.ts
+++ b/gitnexus/test/unit/repo-manager-reconcile.test.ts
@@ -258,7 +258,7 @@ describe('runFullAnalysis metadata reconciliation (mocked pipeline)', () => {
     }));
     vi.doMock('../../src/core/search/fts-indexes.js', () => ({
       initialiseSearchFTSStemmer: vi.fn(() => 'porter'),
-      createSearchFTSIndexes: vi.fn(async () => undefined),
+      createSearchFTSIndexes: vi.fn(async () => []),
       verifySearchFTSIndexes: vi.fn(async () => []),
     }));
     vi.doMock('../../src/core/ingestion/pipeline.js', () => ({

--- a/gitnexus/test/unit/run-analyze-fts-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-fts-repair.test.ts
@@ -237,7 +237,7 @@ describe('runFullAnalysis FTS repair and verification failure paths', () => {
     }));
     vi.doMock('../../src/core/search/fts-indexes.js', () => ({
       initialiseSearchFTSStemmer: vi.fn(() => 'porter'),
-      createSearchFTSIndexes: vi.fn(async () => undefined),
+      createSearchFTSIndexes: vi.fn(async () => []),
       verifySearchFTSIndexes: vi.fn(async () => [SIMULATED_MISSING_FTS_INDEX_NAME]),
     }));
 
@@ -292,7 +292,7 @@ describe('runFullAnalysis FTS repair and verification failure paths', () => {
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => mockRepairSuccessLbugAdapter());
     vi.doMock('../../src/core/search/fts-indexes.js', () => ({
       initialiseSearchFTSStemmer: vi.fn(() => 'porter'),
-      createSearchFTSIndexes: vi.fn(async () => undefined),
+      createSearchFTSIndexes: vi.fn(async () => []),
       verifySearchFTSIndexes: vi.fn(async () => []),
     }));
     vi.doMock('../../src/storage/repo-manager.js', async (importActual) => ({
@@ -363,7 +363,7 @@ describe('runFullAnalysis FTS repair and verification failure paths', () => {
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => mockRepairSuccessLbugAdapter());
     vi.doMock('../../src/core/search/fts-indexes.js', () => ({
       initialiseSearchFTSStemmer: vi.fn(() => 'porter'),
-      createSearchFTSIndexes: vi.fn(async () => undefined),
+      createSearchFTSIndexes: vi.fn(async () => []),
       verifySearchFTSIndexes: vi.fn(async () => []),
     }));
     vi.doMock('../../src/storage/repo-manager.js', async (importActual) => ({
@@ -410,7 +410,7 @@ describe('runFullAnalysis FTS repair and verification failure paths', () => {
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => mockRepairSuccessLbugAdapter());
     vi.doMock('../../src/core/search/fts-indexes.js', () => ({
       initialiseSearchFTSStemmer: vi.fn(() => 'porter'),
-      createSearchFTSIndexes: vi.fn(async () => undefined),
+      createSearchFTSIndexes: vi.fn(async () => []),
       verifySearchFTSIndexes: vi.fn(async () => []),
     }));
     vi.doMock('../../src/storage/repo-manager.js', async (importActual) => ({
@@ -470,6 +470,7 @@ describe('runFullAnalysis FTS repair and verification failure paths', () => {
           indexedAt: new Date().toISOString(),
           stats: { files: 999 },
         });
+        return [];
       }),
       verifySearchFTSIndexes: vi.fn(async () => []),
     }));
@@ -1086,7 +1087,7 @@ describe('runFullAnalysis wipe-and-restore vector-index stamp (tri-review 466951
     }));
     vi.doMock('../../src/core/search/fts-indexes.js', () => ({
       initialiseSearchFTSStemmer: vi.fn(() => 'porter'),
-      createSearchFTSIndexes: vi.fn(async () => undefined),
+      createSearchFTSIndexes: vi.fn(async () => []),
       verifySearchFTSIndexes: vi.fn(async () => []),
     }));
     // The stub graph must CONTAIN the cached row's node: Phase 3.5's
@@ -1227,7 +1228,7 @@ describe('runFullAnalysis dirty-recovery parking failure fails fast (this shippi
     }));
     vi.doMock('../../src/core/search/fts-indexes.js', () => ({
       initialiseSearchFTSStemmer: vi.fn(() => 'porter'),
-      createSearchFTSIndexes: vi.fn(async () => undefined),
+      createSearchFTSIndexes: vi.fn(async () => []),
       verifySearchFTSIndexes: vi.fn(async () => []),
     }));
     vi.doMock('../../src/core/ingestion/pipeline.js', () => ({
@@ -1508,7 +1509,7 @@ describe('runFullAnalysis Phase 5 embedding gate (#2790)', () => {
     }));
     vi.doMock('../../src/core/search/fts-indexes.js', () => ({
       initialiseSearchFTSStemmer: vi.fn(() => 'porter'),
-      createSearchFTSIndexes: vi.fn(async () => undefined),
+      createSearchFTSIndexes: vi.fn(async () => []),
       verifySearchFTSIndexes: vi.fn(async () => []),
     }));
     vi.doMock('../../src/core/ingestion/pipeline.js', () => ({
@@ -1867,7 +1868,7 @@ describe('runFullAnalysis embedding-checkpoint meta write (#2790)', () => {
     }));
     vi.doMock('../../src/core/search/fts-indexes.js', () => ({
       initialiseSearchFTSStemmer: vi.fn(() => 'porter'),
-      createSearchFTSIndexes: vi.fn(async () => undefined),
+      createSearchFTSIndexes: vi.fn(async () => []),
       verifySearchFTSIndexes: vi.fn(async () => []),
     }));
     // No File nodes → this run's computed fileHashes are EMPTY, so a save that
@@ -2114,7 +2115,7 @@ describe('runFullAnalysis embedding-checkpoint resilience (#2790 review)', () =>
     }));
     vi.doMock('../../src/core/search/fts-indexes.js', () => ({
       initialiseSearchFTSStemmer: vi.fn(() => 'porter'),
-      createSearchFTSIndexes: vi.fn(async () => undefined),
+      createSearchFTSIndexes: vi.fn(async () => []),
       verifySearchFTSIndexes: vi.fn(async () => []),
     }));
     vi.doMock('../../src/core/ingestion/pipeline.js', () => ({

--- a/gitnexus/test/unit/run-analyze-fts-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-fts-repair.test.ts
@@ -576,7 +576,7 @@ describe('runFullAnalysis FTS repair and verification failure paths', () => {
     // before recreating it. If the extension is unavailable, the repair path must
     // bail before any drop runs — otherwise it would destroy the existing indexes
     // and then fail to recreate them, leaving the DB worse off.
-    const createSearchFTSIndexes = vi.fn(async () => undefined);
+    const createSearchFTSIndexes = vi.fn(async () => []);
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
       initLbug: vi.fn(async () => undefined),
       loadGraphToLbug: vi.fn(async () => undefined),
@@ -644,7 +644,7 @@ describe('runFullAnalysis FTS repair and verification failure paths', () => {
   });
 
   it('repair error carries the runtime-dependency remedy, not "retry the network install" (#2383 F6a)', async () => {
-    const createSearchFTSIndexes = vi.fn(async () => undefined);
+    const createSearchFTSIndexes = vi.fn(async () => []);
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
       initLbug: vi.fn(async () => undefined),
       loadGraphToLbug: vi.fn(async () => undefined),
@@ -855,7 +855,7 @@ describe('runFullAnalysis FTS repair and verification failure paths', () => {
     // Offline-first degradation: when loadFTSExtension() returns false, the
     // analyze path must NOT call createSearchFTSIndexes / verifySearchFTSIndexes
     // and must NOT throw — it logs a warning and completes (#1161).
-    const createSearchFTSIndexes = vi.fn(async () => undefined);
+    const createSearchFTSIndexes = vi.fn(async () => []);
     const verifySearchFTSIndexes = vi.fn(async () => []);
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
       initLbug: vi.fn(async () => undefined),
@@ -928,7 +928,7 @@ describe('runFullAnalysis FTS repair and verification failure paths', () => {
   });
 
   it('degrade log for a missing runtime dependency omits the contradictory reinstall guidance (#2383 F2)', async () => {
-    const createSearchFTSIndexes = vi.fn(async () => undefined);
+    const createSearchFTSIndexes = vi.fn(async () => []);
     const verifySearchFTSIndexes = vi.fn(async () => []);
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
       initLbug: vi.fn(async () => undefined),


### PR DESCRIPTION
Fixes #2889.

## What the investigation found

I could not reproduce the reported failure from the mechanism the issue describes, and two of its three gaps do not hold. The third is real, worse than described, and there is a separate defect that explains the multi-table degradation. This PR fixes what is actually broken and documents the rest.

**Repro attempt on main.** A fixture repo of `.js` / `.vue` / `.class` files carrying raw invalid UTF-8 bytes (`80`, truncated `e4 b8`, overlong `c0 af`, `ff fe`), NUL runs, Java constant pool bytes and CJK text, analyzed end to end. Analyze succeeded, all 20 FTS indexes built, keyword search worked. The dirty text did reach the column:

```
| Function | dirtyDoc | 用户服务 handles 数据 �������MethCw  @returns {string} 中文说明 , |
| Method   | run      | 方法 MethCw                                                      |
```

Dirty data in, `LOWER` still fine. So the data path is a real problem and the `Invalid UTF-8` failure is a separate question.

**Gap 1 does not hold.** `Buffer.from(jsString, 'utf-8')` always produces well formed UTF-8. Lone surrogates encode to `EF BF BD`. I probed lone high and low surrogates, a surrogate pair split by `slice`, embedded NUL, CJK mixed with control bytes and U+FFFE/FFFF: every one decodes cleanly under `TextDecoder(..., { fatal: true })`. The proposed round trip can never throw, so it would add cost and catch nothing. Nothing in the JS layer can put invalid UTF-8 into the database: every value is a JS string by construction (`filesystem-walker.ts:143`, `csv-generator.ts:181`, `parse-worker.ts:3053`), and both writers encode a JS string (`csv-generator.ts:279`, `sync-csv-writer.ts:83`).

**Gap 2 targets dead code.** `insertNodeToLbug` and `batchInsertNodesToLbug` have zero production call sites. A repo wide search finds the two definitions plus three test files. Every node write, full and incremental, goes `loadGraphToLbug` → CSV COPY → `escapeCSVField` → `sanitizeUTF8` (`run-analyze.ts:2558`, `:2661`, `:2680`). `escapeCypherString` only ever handles ids, file paths and patterns, never `description` or `content`. Adding sanitization there would also be actively wrong for ids and paths, since it would silently rewrite the value a later lookup compares against.

**Gap 3 is real, and the detector was blind to the exact case.** `formatFtsDescription` never gated on `isBinaryContent`, so binary payloads landed in an FTS indexed column. But `isBinaryContent` could not have caught them anyway: files are read with `fs.readFile(path, 'utf-8')`, so invalid bytes are already replaced with U+FFFD by the time the scan runs, and the scan counted only control bytes and DEL. charCode 0xFFFD is neither, so a wholly corrupt payload scored as clean text. That is why the repro description above survived with seven replacement characters in it.

## What this PR changes

**1. `isBinaryContent` counts U+FFFD** toward the same 10% threshold over the same 1000 character sample. No new tuning constant. A legitimate source file carries no replacement characters unless it was mis-decoded, and a handful still score far under the bar. This also improves the `content` column, which already used this gate.

**2. `formatFtsDescription` drops a binary looking description.** Empty string rather than a sentinel, because unlike `content` a description has no reader that needs to be told why it is missing. The gate lives beside the transforms it guards, not at the six emission sites.

**3. `createSearchFTSIndexes` isolates a failure to its own table.** This is the part that explains the report's blast radius. The loop used to let the first rejection propagate, and `dropFTSIndex` has already run for the failing table by then, so that table ended with no index and every table after it in `FTS_INDEXES` order was never reached. On a fresh build, or on the incremental path where `dropSearchFTSIndexes` clears all of them up front, those later tables ended with no index either, and `verifySearchFTSIndexes` never ran to say so. The issue lists Function, Method, Property and Variable failing together, which is loop control flow rather than four independent bad rows.

It also explains why `--repair-fts` looked useless. Repair runs the same loop, so it stopped at the same table, left everything after it unbuilt, and failed with a list of missing indexes and no reason attached. Repair now rebuilds every table it can and appends the raw LadybugDB message for each one it could not.

Failures are returned rather than thrown so the caller sees all of them. `buildSearchIndexesOrDegrade` names every failing table with its error and reports `N of M tables`. The aggregate failure class is computed per failure with integrity winning, because classification checks capability signatures first and folding the messages into one string would have let an untokenizable row mask a genuinely broken write and downgrade an abort into a degrade.

## What this PR does not change

The `Failed calling LOWER: Invalid UTF-8` error itself. It cannot originate in this layer, for the reason under Gap 1. If it is real for the reporter it comes from below the JS boundary, which is where #2546 was already looking. What this PR does is stop feeding junk into the indexed column, and make one poisoned row cost one table instead of every table after it.

## Tests

Nine new tests, each verified red against main before the fix and green after.

* `test/unit/csv-escaping.test.ts` — U+FFFD over the threshold, U+FFFD counting toward the same budget as control bytes, a few replacement characters staying indexable, CJK never classified as binary.
* `test/integration/csv-pipeline.test.ts` — a decoded binary payload dropped from `description` on the default emission branch and on the Method branch, with the symbol row itself and a clean sibling description untouched. Reached through `streamAllCSVsToDisk` and the emitted CSV, which is how this file already tests the other private helpers.
* `test/unit/fts-indexes.test.ts` — later tables still built after one index rejects, the failing index still dropped, no `onIndexReady` for a failed index, every failing table named in the degrade error, and integrity winning the aggregate class.

`afterEach` in `fts-indexes.test.ts` now also drains the `...Once` mock queue. `clearAllMocks` does not, so a test that queues more rejections than the code consumes leaks the leftovers into whichever test runs next, which is exactly the failure mode a per index isolation change makes easy to introduce.

Full unit suite green locally: 602 files, 12195 passed, 45 skipped.

## Separate finding, not fixed here

`Community.keywords` (`csv-generator.ts:611-618`) is the one CSV cell that never reaches `escapeCSVField`, so it gets neither `sanitizeUTF8` nor CSV quoting. It builds its own list literal with bespoke escaping instead. It is not FTS indexed, so it is not related to this failure, but a newline or control character in an LLM generated keyword would corrupt the row. Worth its own issue rather than widening this diff, since the obvious fix routes it through `formatCSVStringArray`, which throws on unsafe items and would newly fail an analyze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oEY2i74d1HLa5FuGVuPiT
