### PR TITLE
fix(storage): give every registry write its own tmp path (#2888)

### DIFF
--- a/gitnexus/src/core/group/bridge-db.ts
+++ b/gitnexus/src/core/group/bridge-db.ts
@@ -1,6 +1,6 @@
 import fsp from 'node:fs/promises';
 import path from 'node:path';
-import { createHash, randomBytes } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import lbug from '@ladybugdb/core';
 import type { LbugValue } from '@ladybugdb/core';
 import type { BridgeHandle, BridgeMeta, StoredContract, CrossLink, RepoSnapshot } from './types.js';
@@ -12,7 +12,7 @@ import {
 } from '../lbug/lbug-config.js';
 import { dedupeContracts, dedupeCrossLinks } from './normalization.js';
 import { createLogger } from '../logger.js';
-import { retryRename } from '../../storage/fs-atomic.js';
+import { retryRename, writeFileAtomic } from '../../storage/fs-atomic.js';
 
 const bridgeLogger = createLogger('bridge-db', {
   debugEnvVar: 'GITNEXUS_DEBUG_BRIDGE',
@@ -647,30 +647,12 @@ export async function closeBridgeDb(handle: BridgeHandle): Promise<void> {
 /* ------------------------------------------------------------------ */
 
 export async function writeBridgeMeta(groupDir: string, meta: BridgeMeta): Promise<void> {
-  const target = path.join(groupDir, 'meta.json');
-  // Unpredictable suffix + O_EXCL via `'wx'` flag closes the symlink/
-  // pre-create attack window. The third argument `0o600` is the
-  // user-only mode mask — CodeQL's `js/insecure-temporary-file` query
-  // sources its verdict from the `mode` argument, NOT from `flags`:
-  // its `isSecureMode(mode)` predicate requires the low 6 bits to be
-  // zero (no group/world bits). Without an explicit mode the file is
-  // created with the process umask (typically 0o644 = group/world
-  // readable), which the query treats as the actual vulnerability.
-  // Both `'wx'` (runtime O_EXCL) AND `0o600` (CodeQL-credited mode)
-  // are needed: one closes the symlink race, the other closes the
-  // permissions exposure.
-  const tmp = `${target}.tmp.${randomBytes(8).toString('hex')}`;
-  const handle = await fsp.open(tmp, 'wx', 0o600);
-  try {
-    await handle.writeFile(JSON.stringify(meta, null, 2), 'utf-8');
-  } finally {
-    await handle.close();
-  }
-  // Use retryRename for consistency with writeBridge's atomic swap — on
-  // Windows a concurrent reader can cause EBUSY/EPERM even on a tiny
-  // meta.json, and we don't want meta write to be less robust than the
-  // bridge.lbug swap it accompanies.
-  await retryRename(tmp, target);
+  // Shared primitive: unpredictable tmp suffix + `'wx'` (O_EXCL) + `0o600` +
+  // retryRename, and — new since #2888 — the tmp file is removed when the
+  // publish fails. Nothing about a group's meta.json is special enough to
+  // justify a private copy of that sequence; see writeFileAtomic's docstring
+  // for why each part is load-bearing.
+  await writeFileAtomic(path.join(groupDir, 'meta.json'), JSON.stringify(meta, null, 2));
 }
 
 export async function readBridgeMeta(groupDir: string): Promise<BridgeMeta> {

--- a/gitnexus/src/core/group/bridge-db.ts
+++ b/gitnexus/src/core/group/bridge-db.ts
@@ -647,11 +647,6 @@ export async function closeBridgeDb(handle: BridgeHandle): Promise<void> {
 /* ------------------------------------------------------------------ */
 
 export async function writeBridgeMeta(groupDir: string, meta: BridgeMeta): Promise<void> {
-  // Shared primitive: unpredictable tmp suffix + `'wx'` (O_EXCL) + `0o600` +
-  // retryRename, and — new since #2888 — the tmp file is removed when the
-  // publish fails. Nothing about a group's meta.json is special enough to
-  // justify a private copy of that sequence; see writeFileAtomic's docstring
-  // for why each part is load-bearing.
   await writeFileAtomic(path.join(groupDir, 'meta.json'), JSON.stringify(meta, null, 2));
 }
 

--- a/gitnexus/src/core/group/storage.ts
+++ b/gitnexus/src/core/group/storage.ts
@@ -34,9 +34,6 @@ export async function writeContractRegistry(
   groupDir: string,
   registry: ContractRegistry,
 ): Promise<void> {
-  // Shared primitive: unpredictable tmp suffix + `'wx'` (O_EXCL) + `0o600` +
-  // retryRename, plus removal of the tmp file when the publish fails (#2888).
-  // See writeFileAtomic's docstring for why each part is load-bearing.
   await writeFileAtomic(path.join(groupDir, CONTRACTS_FILE), JSON.stringify(registry, null, 2));
 }
 

--- a/gitnexus/src/core/group/storage.ts
+++ b/gitnexus/src/core/group/storage.ts
@@ -2,18 +2,8 @@ import * as fs from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { randomBytes } from 'node:crypto';
 import type { ContractRegistry } from './types.js';
-import { retryRename } from '../../storage/fs-atomic.js';
-
-/**
- * Build an unpredictable suffix for atomic-write tmp files. Replaces the
- * previous `Date.now()` pattern which CodeQL flagged as
- * js/insecure-temporary-file: a guessable suffix in a writable directory
- * lets a co-located attacker pre-create or symlink the tmp path before the
- * write lands.
- */
-const tmpSuffix = (): string => randomBytes(8).toString('hex');
+import { writeFileAtomic } from '../../storage/fs-atomic.js';
 
 const CONTRACTS_FILE = 'contracts.json';
 
@@ -44,29 +34,10 @@ export async function writeContractRegistry(
   groupDir: string,
   registry: ContractRegistry,
 ): Promise<void> {
-  const targetPath = path.join(groupDir, CONTRACTS_FILE);
-  const tmpPath = `${targetPath}.tmp.${tmpSuffix()}`;
-
-  // O_EXCL via `'wx'` flag + explicit `0o600` mode — closes both halves
-  // of the CodeQL js/insecure-temporary-file finding: `'wx'` rejects a
-  // pre-planted symlink at the path, and `0o600` (user-only) prevents
-  // the file from being created group/world readable while it briefly
-  // contains contract data en route to the rename. The query's
-  // `isSecureMode` predicate inspects ONLY the mode argument, not the
-  // flags, so the explicit mode is what credits the fix.
-  const handle = await fsp.open(tmpPath, 'wx', 0o600);
-  try {
-    await handle.writeFile(JSON.stringify(registry, null, 2), 'utf-8');
-  } finally {
-    await handle.close();
-  }
-  // retryRename absorbs the documented Windows EPERM/EBUSY/EACCES race that
-  // fires when AV scanners or another concurrent rename briefly hold the
-  // destination handle between rename calls. Same helper bridge-db.ts uses
-  // (lines 304, 583, 587, 595, 605, 677) for the bridge.lbug atomic swap —
-  // single source of truth for the Windows-rename pattern across the group
-  // package.
-  await retryRename(tmpPath, targetPath);
+  // Shared primitive: unpredictable tmp suffix + `'wx'` (O_EXCL) + `0o600` +
+  // retryRename, plus removal of the tmp file when the publish fails (#2888).
+  // See writeFileAtomic's docstring for why each part is load-bearing.
+  await writeFileAtomic(path.join(groupDir, CONTRACTS_FILE), JSON.stringify(registry, null, 2));
 }
 
 export async function readContractRegistry(groupDir: string): Promise<ContractRegistry | null> {

--- a/gitnexus/src/storage/fs-atomic.ts
+++ b/gitnexus/src/storage/fs-atomic.ts
@@ -31,45 +31,41 @@ export async function retryRename(src: string, dst: string, attempts = 3): Promi
 /**
  * Atomically publish `data` to `targetPath` via a private tmp file + rename.
  *
- * The tmp name carries a random suffix, so two processes publishing the same
- * target never stage through the same path. A FIXED `<target>.tmp` is not
- * multi-process safe even though the rename itself is atomic: writer B's
- * `writeFile` overwrites writer A's staged bytes and B's `rename` moves that
- * inode away, so A's own rename fails with `ENOENT` — the #2888 crash, which
- * killed the MCP server during startup because nothing catches a registry
- * write rejection there. A cross-process lock narrows that window but cannot
- * close it (`repo-manager`'s registry lock deliberately degrades to unlocked
- * on timeout); a private tmp path closes it whether or not a lock is held.
+ * The tmp name carries a random suffix, so concurrent publishers to one target
+ * never stage through the same path. A FIXED `<target>.tmp` is not
+ * multi-process safe even though the rename itself is atomic: writer B's write
+ * overwrites writer A's staged bytes and B's rename moves that inode away, so
+ * A's own rename fails with `ENOENT` (#2888).
  *
- * `'wx'` (O_EXCL) closes the symlink/pre-create race, and the explicit `mode`
+ * `'wx'` (O_EXCL) closes the symlink/pre-create race, and the `0o600` mode
  * closes the permissions exposure CodeQL's `js/insecure-temporary-file` query
  * reads off the `mode` argument (it requires the low 6 bits to be zero; with
  * no mode the file lands at umask, typically group/world readable).
- * `retryRename` absorbs a transient EBUSY/EPERM/EACCES from a concurrent
- * reader on Windows.
  *
- * Any failure that rejects — a full disk, a read-only home, a rename that
- * retryRename gives up on — removes the tmp file before rethrowing. With a
- * random suffix a leaked tmp is no longer self-limiting the way a fixed name
- * was (the next writer simply overwrote it), so a recurring failure would
- * otherwise deposit one more orphan beside the target every time. A hard kill
- * between the open and the rename still leaves one behind; nothing enumerates
- * these directories, so a stale tmp is inert rather than a correctness problem.
+ * A rejection anywhere after the tmp exists removes it before rethrowing: with
+ * a random suffix a leaked tmp is no longer self-limiting the way a fixed name
+ * was (the next writer simply overwrote it), so a recurring failure would drop
+ * one more orphan beside the target every time. A hard kill between the open
+ * and the rename still leaves one behind.
+ *
+ * `attempts` is passed through to {@link retryRename}; pass `1` when the
+ * caller discards the failure anyway, so a best-effort write cannot spend the
+ * retry backoff (and, under a lock, make everyone else wait for it).
  */
 export async function writeFileAtomic(
   targetPath: string,
   data: string,
-  mode = 0o600,
+  attempts?: number,
 ): Promise<void> {
   const tmpPath = `${targetPath}.tmp.${randomBytes(8).toString('hex')}`;
-  const handle = await fsp.open(tmpPath, 'wx', mode);
+  const handle = await fsp.open(tmpPath, 'wx', 0o600);
   try {
     try {
       await handle.writeFile(data, 'utf-8');
     } finally {
       await handle.close();
     }
-    await retryRename(tmpPath, targetPath);
+    await retryRename(tmpPath, targetPath, attempts);
   } catch (err) {
     await fsp.unlink(tmpPath).catch(() => {});
     throw err;

--- a/gitnexus/src/storage/fs-atomic.ts
+++ b/gitnexus/src/storage/fs-atomic.ts
@@ -7,6 +7,7 @@
  * e.g. core/group/service.ts already imports loadMeta from here).
  */
 import fsp from 'fs/promises';
+import { randomBytes } from 'crypto';
 
 const RETRY_CODES = new Set(['EBUSY', 'EPERM', 'EACCES']);
 
@@ -24,5 +25,53 @@ export async function retryRename(src: string, dst: string, attempts = 3): Promi
       if (!code || !RETRY_CODES.has(code) || i === attempts) throw err;
       await new Promise((r) => setTimeout(r, 100 * Math.pow(2, i - 1)));
     }
+  }
+}
+
+/**
+ * Atomically publish `data` to `targetPath` via a private tmp file + rename.
+ *
+ * The tmp name carries a random suffix, so two processes publishing the same
+ * target never stage through the same path. A FIXED `<target>.tmp` is not
+ * multi-process safe even though the rename itself is atomic: writer B's
+ * `writeFile` overwrites writer A's staged bytes and B's `rename` moves that
+ * inode away, so A's own rename fails with `ENOENT` — the #2888 crash, which
+ * killed the MCP server during startup because nothing catches a registry
+ * write rejection there. A cross-process lock narrows that window but cannot
+ * close it (`repo-manager`'s registry lock deliberately degrades to unlocked
+ * on timeout); a private tmp path closes it whether or not a lock is held.
+ *
+ * `'wx'` (O_EXCL) closes the symlink/pre-create race, and the explicit `mode`
+ * closes the permissions exposure CodeQL's `js/insecure-temporary-file` query
+ * reads off the `mode` argument (it requires the low 6 bits to be zero; with
+ * no mode the file lands at umask, typically group/world readable).
+ * `retryRename` absorbs a transient EBUSY/EPERM/EACCES from a concurrent
+ * reader on Windows.
+ *
+ * Any failure that rejects — a full disk, a read-only home, a rename that
+ * retryRename gives up on — removes the tmp file before rethrowing. With a
+ * random suffix a leaked tmp is no longer self-limiting the way a fixed name
+ * was (the next writer simply overwrote it), so a recurring failure would
+ * otherwise deposit one more orphan beside the target every time. A hard kill
+ * between the open and the rename still leaves one behind; nothing enumerates
+ * these directories, so a stale tmp is inert rather than a correctness problem.
+ */
+export async function writeFileAtomic(
+  targetPath: string,
+  data: string,
+  mode = 0o600,
+): Promise<void> {
+  const tmpPath = `${targetPath}.tmp.${randomBytes(8).toString('hex')}`;
+  const handle = await fsp.open(tmpPath, 'wx', mode);
+  try {
+    try {
+      await handle.writeFile(data, 'utf-8');
+    } finally {
+      await handle.close();
+    }
+    await retryRename(tmpPath, targetPath);
+  } catch (err) {
+    await fsp.unlink(tmpPath).catch(() => {});
+    throw err;
   }
 }

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -732,15 +732,6 @@ export const loadMeta = async (metaDir: string): Promise<RepoMeta | null> => {
 };
 
 /**
- * Atomically write `meta` to `<dir>/<filename>` through the shared
- * {@link writeFileAtomic} primitive (private tmp path + rename, see its
- * docstring for why the tmp name must not be fixed).
- */
-async function writeMetaFile(dir: string, filename: string, meta: RepoMeta): Promise<void> {
-  await writeFileAtomic(path.join(dir, filename), JSON.stringify(meta, null, 2));
-}
-
-/**
  * Save metadata to the metadata file (gitnexus.json) in the given directory,
  * dual-writing the legacy `meta.json` mirror for backward compatibility.
  *
@@ -760,9 +751,12 @@ async function writeMetaFile(dir: string, filename: string, meta: RepoMeta): Pro
  */
 export const saveMeta = async (metaDir: string, meta: RepoMeta): Promise<void> => {
   await fs.mkdir(metaDir, { recursive: true });
-  await writeMetaFile(metaDir, INDEX_METADATA_FILE, meta);
+  // Serialised once: `meta` carries a fileHashes entry per file, so on a large
+  // repo this string is megabytes and both writes want the identical bytes.
+  const json = JSON.stringify(meta, null, 2);
+  await writeFileAtomic(path.join(metaDir, INDEX_METADATA_FILE), json);
   try {
-    await writeMetaFile(metaDir, LEGACY_METADATA_FILE, meta);
+    await writeFileAtomic(path.join(metaDir, LEGACY_METADATA_FILE), json);
   } catch (err) {
     logger.warn({ err, metaDir }, 'Failed to write legacy meta.json mirror (non-critical)');
   }
@@ -1118,22 +1112,20 @@ export const readRegistry = async (): Promise<RegistryEntry[]> => {
 };
 
 /**
- * Write the global registry to disk
+ * Write the global registry to disk.
+ *
+ * Atomic tmp+rename: a crash mid-write can never leave a truncated
+ * registry.json that the next load would treat as empty and silently drop
+ * every registered repo (#2106 R9). The tmp path must stay per-write — the
+ * registry is the one file every gitnexus process on the machine writes, and
+ * `withRegistryLock` degrades to unlocked on timeout, so the write cannot rely
+ * on the lock to keep two writers off one staging path (#2888).
+ *
+ * `attempts` is forwarded to the rename retry; best-effort callers pass `1`.
  */
-const writeRegistry = async (entries: RegistryEntry[]): Promise<void> => {
-  const dir = getGlobalDir();
-  await fs.mkdir(dir, { recursive: true });
-  // Atomic tmp+rename (mirrors saveMeta): a crash mid-write can never leave a
-  // truncated/half-written registry.json that the next load would treat as
-  // empty and silently drop every registered repo (#2106 R9).
-  //
-  // The tmp path MUST stay per-write (writeFileAtomic's random suffix): the
-  // registry is the one file every gitnexus process on the machine writes, so
-  // a fixed `registry.json.tmp` made two starting processes steal each other's
-  // staged file and crash with ENOENT on rename (#2888). `withRegistryLock`
-  // serializes the callers below, but it degrades to unlocked on timeout, so
-  // the write itself has to be collision-proof on its own.
-  await writeFileAtomic(getGlobalRegistryPath(), JSON.stringify(entries, null, 2));
+const writeRegistry = async (entries: RegistryEntry[], attempts?: number): Promise<void> => {
+  await fs.mkdir(getGlobalDir(), { recursive: true });
+  await writeFileAtomic(getGlobalRegistryPath(), JSON.stringify(entries, null, 2), attempts);
 };
 
 /**
@@ -1841,9 +1833,8 @@ export const resolveRegistryEntry = (entries: RegistryEntry[], target: string): 
  *
  * With `validate: true`, prunes only entries whose metadata is *provably* gone
  * (fs.access on both gitnexus.json and legacy meta.json fails with ENOENT or
- * ENOTDIR) and persists the result on a best-effort basis — the pruned view is
- * always returned, a failed write is warned about and retried by the next
- * validating read (it must not throw, see the call site). Entries that are merely "not provably
+ * ENOTDIR) and persists the result on a best-effort basis: the pruned view is
+ * always returned, even when the write fails. Entries that are merely "not provably
  * absent" — any other fs.access failure (EIO/EAGAIN/EBUSY/EACCES, etc.) — are
  * KEPT, so a transient I/O storm cannot wipe the registry. A kept entry is
  * therefore "not confirmed present," not "confirmed present"; downstream DB
@@ -1913,20 +1904,21 @@ export const listRegisteredRepos = async (opts?: {
     try {
       await withRegistryLock(async () => {
         const fresh = await readRegistry();
-        await writeRegistry(fresh.filter((entry) => !pruned.has(entry.path)));
+        // attempts: 1 — the catch below discards a failure, so the rename
+        // backoff would only make every other process wait out this lock.
+        await writeRegistry(
+          fresh.filter((entry) => !pruned.has(entry.path)),
+          1,
+        );
       });
     } catch (err) {
-      // Housekeeping, not the caller's request: every caller consumes the
-      // returned `valid` array, and the prune set is recomputed from scratch on
-      // the next validating read, so a failed write costs a retry — never
-      // correctness. Rethrowing cost far more: this runs on the MCP startup
-      // path (LocalBackend.init → refreshRepos), where nothing catches, so a
-      // read-only home, a full disk, or the #2888 tmp collision took down the
-      // whole server with "Server disconnected" instead of degrading to a
-      // registry that still lists a dead entry.
+      // Best-effort housekeeping: callers consume the returned view, and the
+      // prune set is recomputed on the next validating read. It must not throw
+      // — this runs on MCP startup (LocalBackend.init → refreshRepos), where
+      // nothing catches and a rejection reads as "Server disconnected".
       logger.warn(
         { err, prunedCount: pruned.size },
-        'Could not persist the pruned global registry; continuing with the pruned view in memory (it will be retried on the next validating read).',
+        'Could not persist the pruned global registry; continuing with the in-memory pruned view.',
       );
     }
   }

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -18,10 +18,9 @@ import fs from 'fs/promises';
 import { realpathSync } from 'fs';
 import path from 'path';
 import os from 'os';
-import { randomBytes } from 'crypto';
 import { getInferredRepoName, resolveRepoIdentityRoot } from './git.js';
 import { stripWindowsLongPathPrefix } from '../lib/utils.js';
-import { retryRename } from './fs-atomic.js';
+import { writeFileAtomic } from './fs-atomic.js';
 import { logger } from '../core/logger.js';
 import type { UnresolvedReceiverSummary } from '../core/ingestion/scope-resolution/unresolved-receivers.js';
 import { acquireIndexLock, IndexLockTimeoutError, type IndexLockHandle } from './index-lock.js';
@@ -733,23 +732,12 @@ export const loadMeta = async (metaDir: string): Promise<RepoMeta | null> => {
 };
 
 /**
- * Atomically write `meta` to `<dir>/<filename>`. Tmp name includes a random
- * suffix (not a fixed `.tmp`) so two concurrent writers targeting the same
- * directory never collide on the same tmp path — mirrors the pattern in
- * core/group/bridge-db.ts's `writeBridgeMeta` (`'wx'` + `0o600` closes the
- * symlink-race/permissions holes CodeQL flags as `js/insecure-temporary-file`;
- * `retryRename` absorbs a transient EBUSY/EPERM/EACCES on the rename itself).
+ * Atomically write `meta` to `<dir>/<filename>` through the shared
+ * {@link writeFileAtomic} primitive (private tmp path + rename, see its
+ * docstring for why the tmp name must not be fixed).
  */
 async function writeMetaFile(dir: string, filename: string, meta: RepoMeta): Promise<void> {
-  const targetPath = path.join(dir, filename);
-  const tmpPath = `${targetPath}.tmp.${randomBytes(8).toString('hex')}`;
-  const handle = await fs.open(tmpPath, 'wx', 0o600);
-  try {
-    await handle.writeFile(JSON.stringify(meta, null, 2), 'utf-8');
-  } finally {
-    await handle.close();
-  }
-  await retryRename(tmpPath, targetPath);
+  await writeFileAtomic(path.join(dir, filename), JSON.stringify(meta, null, 2));
 }
 
 /**
@@ -1138,10 +1126,14 @@ const writeRegistry = async (entries: RegistryEntry[]): Promise<void> => {
   // Atomic tmp+rename (mirrors saveMeta): a crash mid-write can never leave a
   // truncated/half-written registry.json that the next load would treat as
   // empty and silently drop every registered repo (#2106 R9).
-  const target = getGlobalRegistryPath();
-  const tmp = `${target}.tmp`;
-  await fs.writeFile(tmp, JSON.stringify(entries, null, 2), 'utf-8');
-  await fs.rename(tmp, target);
+  //
+  // The tmp path MUST stay per-write (writeFileAtomic's random suffix): the
+  // registry is the one file every gitnexus process on the machine writes, so
+  // a fixed `registry.json.tmp` made two starting processes steal each other's
+  // staged file and crash with ENOENT on rename (#2888). `withRegistryLock`
+  // serializes the callers below, but it degrades to unlocked on timeout, so
+  // the write itself has to be collision-proof on its own.
+  await writeFileAtomic(getGlobalRegistryPath(), JSON.stringify(entries, null, 2));
 };
 
 /**
@@ -1849,7 +1841,9 @@ export const resolveRegistryEntry = (entries: RegistryEntry[], target: string): 
  *
  * With `validate: true`, prunes only entries whose metadata is *provably* gone
  * (fs.access on both gitnexus.json and legacy meta.json fails with ENOENT or
- * ENOTDIR) and persists the result. Entries that are merely "not provably
+ * ENOTDIR) and persists the result on a best-effort basis — the pruned view is
+ * always returned, a failed write is warned about and retried by the next
+ * validating read (it must not throw, see the call site). Entries that are merely "not provably
  * absent" — any other fs.access failure (EIO/EAGAIN/EBUSY/EACCES, etc.) — are
  * KEPT, so a transient I/O storm cannot wipe the registry. A kept entry is
  * therefore "not confirmed present," not "confirmed present"; downstream DB
@@ -1916,10 +1910,25 @@ export const listRegisteredRepos = async (opts?: {
     const pruned = new Set(
       entries.filter((entry) => !valid.includes(entry)).map((entry) => entry.path),
     );
-    await withRegistryLock(async () => {
-      const fresh = await readRegistry();
-      await writeRegistry(fresh.filter((entry) => !pruned.has(entry.path)));
-    });
+    try {
+      await withRegistryLock(async () => {
+        const fresh = await readRegistry();
+        await writeRegistry(fresh.filter((entry) => !pruned.has(entry.path)));
+      });
+    } catch (err) {
+      // Housekeeping, not the caller's request: every caller consumes the
+      // returned `valid` array, and the prune set is recomputed from scratch on
+      // the next validating read, so a failed write costs a retry — never
+      // correctness. Rethrowing cost far more: this runs on the MCP startup
+      // path (LocalBackend.init → refreshRepos), where nothing catches, so a
+      // read-only home, a full disk, or the #2888 tmp collision took down the
+      // whole server with "Server disconnected" instead of degrading to a
+      // registry that still lists a dead entry.
+      logger.warn(
+        { err, prunedCount: pruned.size },
+        'Could not persist the pruned global registry; continuing with the pruned view in memory (it will be retried on the next validating read).',
+      );
+    }
   }
 
   return valid;

--- a/gitnexus/test/unit/group/insecure-tempfile.test.ts
+++ b/gitnexus/test/unit/group/insecure-tempfile.test.ts
@@ -65,21 +65,16 @@ describe('insecure tempfile — structural guards (#1318 U6)', () => {
     expect(fsAtomicSource).toMatch(/\.tmp\.\$\{randomBytes\(8\)\.toString\('hex'\)\}/);
   });
 
-  it('fs-atomic.ts opens the tmp file via fsp.open(..., "wx", <user-only mode>)', () => {
+  it('fs-atomic.ts opens the tmp file via fsp.open(..., "wx", 0o600)', () => {
     // O_EXCL via `'wx'` flag closes the symlink-race; explicit `0o600`
     // mode closes the permissions exposure CodeQL's
     // `isSecureMode` predicate inspects (low 6 bits must be zero).
     // Both arguments are required to fully clear the
     // `js/insecure-temporary-file` alert — flags alone are ignored by
-    // the analyzer, mode alone leaves the symlink window open.
-    expect(fsAtomicSource).toMatch(/fsp\.open\(tmpPath,\s*['"]wx['"],\s*mode\)/);
-    expect(fsAtomicSource).toMatch(/mode\s*=\s*0o600/);
-  });
-
-  it('fs-atomic.ts removes the tmp file when the publish fails', () => {
-    // A random suffix means a leaked tmp is no longer overwritten by the
-    // next writer the way a fixed `<target>.tmp` was (#2888).
-    expect(fsAtomicSource).toMatch(/fsp\.unlink\(tmpPath\)\.catch\(\(\) => \{\}\)/);
+    // the analyzer, mode alone leaves the symlink window open. The
+    // resulting file mode and the tmp cleanup are asserted for real in
+    // test/unit/storage/fs-atomic.test.ts.
+    expect(fsAtomicSource).toMatch(/fsp\.open\(tmpPath,\s*['"]wx['"],\s*0o600\)/);
   });
 
   it('bridge-db.ts publishes meta.json through the shared primitive', () => {
@@ -110,16 +105,11 @@ describe('insecure tempfile — structural guards (#1318 U6)', () => {
   it('storage.ts publishes contracts.json through the shared primitive', () => {
     // Was a local `tmpSuffix()` helper duplicating the same randomBytes +
     // 'wx' + 0o600 + retryRename sequence; the sequence now lives once in
-    // fs-atomic.ts, guarded above (#2888).
+    // fs-atomic.ts, guarded above (#2888). The Date.now() guard this module
+    // used to carry is gone with its temp path — it has none to get wrong.
     expect(storageSource).toMatch(/writeFileAtomic\(path\.join\(groupDir,\s*CONTRACTS_FILE\),/);
-    expect(storageSource).not.toMatch(/\.tmp\./);
-  });
-
-  it('storage.ts does not use Date.now() in any active temp path', () => {
-    // Same comment-strip trick as bridge-db.ts above (block + line).
     const codeOnly = storageSource.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
-    const tmpDateNow = codeOnly.match(/\.tmp\.\$\{Date\.now\(\)\}/g) ?? [];
-    expect(tmpDateNow.length).toBe(0);
+    expect(codeOnly).not.toMatch(/\.tmp/);
   });
 });
 

--- a/gitnexus/test/unit/group/insecure-tempfile.test.ts
+++ b/gitnexus/test/unit/group/insecure-tempfile.test.ts
@@ -27,6 +27,7 @@ import type { ContractRegistry, BridgeMeta } from '../../../src/core/group/types
 describe('insecure tempfile — structural guards (#1318 U6)', () => {
   let bridgeSource: string;
   let storageSource: string;
+  let fsAtomicSource: string;
 
   beforeAll(async () => {
     bridgeSource = await fsp.readFile(
@@ -37,10 +38,17 @@ describe('insecure tempfile — structural guards (#1318 U6)', () => {
       path.join(__dirname, '..', '..', '..', 'src', 'core', 'group', 'storage.ts'),
       'utf-8',
     );
+    // The single-file writers below delegate their tmp-path handling to the
+    // shared primitive (#2888), so the randomBytes/'wx'/0o600 guards now
+    // belong to it.
+    fsAtomicSource = await fsp.readFile(
+      path.join(__dirname, '..', '..', '..', 'src', 'storage', 'fs-atomic.ts'),
+      'utf-8',
+    );
   });
 
-  it('bridge-db.ts imports randomBytes from node:crypto', () => {
-    expect(bridgeSource).toMatch(/import\s*\{[^}]*randomBytes[^}]*\}\s*from\s*'node:crypto'/);
+  it('fs-atomic.ts imports randomBytes from crypto', () => {
+    expect(fsAtomicSource).toMatch(/import\s*\{[^}]*randomBytes[^}]*\}\s*from\s*'crypto'/);
   });
 
   it('bridge-db.ts uses mkdtemp staging directory for bridge.lbug', () => {
@@ -53,18 +61,31 @@ describe('insecure tempfile — structural guards (#1318 U6)', () => {
     expect(bridgeSource).toMatch(/path\.join\(stagingDir,\s*['"]bridge\.lbug['"]\)/);
   });
 
-  it('bridge-db.ts uses randomBytes for meta.json temp path', () => {
-    expect(bridgeSource).toMatch(/\.tmp\.\$\{randomBytes\(8\)\.toString\('hex'\)\}/);
+  it('fs-atomic.ts uses randomBytes for every atomic-write temp path', () => {
+    expect(fsAtomicSource).toMatch(/\.tmp\.\$\{randomBytes\(8\)\.toString\('hex'\)\}/);
   });
 
-  it('bridge-db.ts opens meta.json tmp file via fsp.open(..., "wx", 0o600)', () => {
+  it('fs-atomic.ts opens the tmp file via fsp.open(..., "wx", <user-only mode>)', () => {
     // O_EXCL via `'wx'` flag closes the symlink-race; explicit `0o600`
     // mode closes the permissions exposure CodeQL's
     // `isSecureMode` predicate inspects (low 6 bits must be zero).
     // Both arguments are required to fully clear the
     // `js/insecure-temporary-file` alert — flags alone are ignored by
     // the analyzer, mode alone leaves the symlink window open.
-    expect(bridgeSource).toMatch(/fsp\.open\(tmp,\s*['"]wx['"],\s*0o600\)/);
+    expect(fsAtomicSource).toMatch(/fsp\.open\(tmpPath,\s*['"]wx['"],\s*mode\)/);
+    expect(fsAtomicSource).toMatch(/mode\s*=\s*0o600/);
+  });
+
+  it('fs-atomic.ts removes the tmp file when the publish fails', () => {
+    // A random suffix means a leaked tmp is no longer overwritten by the
+    // next writer the way a fixed `<target>.tmp` was (#2888).
+    expect(fsAtomicSource).toMatch(/fsp\.unlink\(tmpPath\)\.catch\(\(\) => \{\}\)/);
+  });
+
+  it('bridge-db.ts publishes meta.json through the shared primitive', () => {
+    expect(bridgeSource).toMatch(/writeFileAtomic\(path\.join\(groupDir,\s*['"]meta\.json['"]\),/);
+    // No private tmp path left in this module's meta.json writer.
+    expect(bridgeSource).not.toMatch(/const tmp = `\$\{target\}\.tmp/);
   });
 
   it('bridge-db.ts does not use Date.now() in any active temp path', () => {
@@ -86,16 +107,12 @@ describe('insecure tempfile — structural guards (#1318 U6)', () => {
     );
   });
 
-  it('storage.ts imports randomBytes from node:crypto', () => {
-    expect(storageSource).toMatch(/import\s*\{[^}]*randomBytes[^}]*\}\s*from\s*'node:crypto'/);
-  });
-
-  it('storage.ts uses tmpSuffix() helper backed by randomBytes', () => {
-    // The helper is a thin wrapper that DRYs the randomBytes call across
-    // multiple temp-path sites in this module. Its definition must use
-    // randomBytes, and the temp path must call it.
-    expect(storageSource).toMatch(/const\s+tmpSuffix\s*=.*randomBytes\(8\)\.toString\('hex'\)/);
-    expect(storageSource).toMatch(/\.tmp\.\$\{tmpSuffix\(\)\}/);
+  it('storage.ts publishes contracts.json through the shared primitive', () => {
+    // Was a local `tmpSuffix()` helper duplicating the same randomBytes +
+    // 'wx' + 0o600 + retryRename sequence; the sequence now lives once in
+    // fs-atomic.ts, guarded above (#2888).
+    expect(storageSource).toMatch(/writeFileAtomic\(path\.join\(groupDir,\s*CONTRACTS_FILE\),/);
+    expect(storageSource).not.toMatch(/\.tmp\./);
   });
 
   it('storage.ts does not use Date.now() in any active temp path', () => {

--- a/gitnexus/test/unit/repo-manager-registry-atomic-write.test.ts
+++ b/gitnexus/test/unit/repo-manager-registry-atomic-write.test.ts
@@ -12,29 +12,19 @@
  * delegating vi.mock is required (same split as repo-manager-rm-failure.test.ts
  * and repo-manager-ensure-ignore-readonly.test.ts, #1549).
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import path from 'path';
-
-type FsFn = (...args: never[]) => Promise<unknown>;
 
 const fsCtx = vi.hoisted(() => ({
   renameMock: vi.fn(),
   realRename: null as ((src: string, dst: string) => Promise<void>) | null,
-  realWriteFile: null as ((file: string, data: string, enc: string) => Promise<void>) | null,
 }));
 
 vi.mock('fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs/promises')>();
   const d = actual.default;
   fsCtx.realRename = d.rename.bind(d) as (src: string, dst: string) => Promise<void>;
-  fsCtx.realWriteFile = d.writeFile.bind(d) as (
-    file: string,
-    data: string,
-    enc: string,
-  ) => Promise<void>;
-  fsCtx.renameMock.mockImplementation((...args: never[]) =>
-    (fsCtx.realRename as unknown as FsFn)(...args),
-  );
+  fsCtx.renameMock.mockImplementation((src: string, dst: string) => fsCtx.realRename!(src, dst));
   return {
     default: new Proxy(d, {
       get(target, prop) {
@@ -89,7 +79,8 @@ describe('writeRegistry — private tmp path per transaction (#2888)', () => {
         lastCommit: meta.lastCommit,
       },
     ];
-    await fsCtx.realWriteFile!(rivalTmp, JSON.stringify(rival, null, 2), 'utf-8');
+    // Only `rename` is intercepted, so `fs.writeFile` here is the real one.
+    await fs.writeFile(rivalTmp, JSON.stringify(rival, null, 2), 'utf-8');
     await fsCtx.realRename!(rivalTmp, registryPath);
     await fsCtx.realRename!(src, dst);
   };
@@ -97,26 +88,32 @@ describe('writeRegistry — private tmp path per transaction (#2888)', () => {
   const readRegistryFromDisk = async (): Promise<RegistryEntry[]> =>
     JSON.parse(await fs.readFile(registryPath, 'utf-8')) as RegistryEntry[];
 
-  beforeEach(async () => {
-    tmpHome = await createTempDir('gitnexus-registry-atomic-home-');
+  // The repo dirs are only ever path arguments — every mutation lands in
+  // tmpHome, which is what has to be fresh per test.
+  beforeAll(async () => {
     tmpRepoA = await createTempDir('gitnexus-registry-atomic-repo-a-');
     tmpRepoB = await createTempDir('gitnexus-registry-atomic-repo-b-');
+  });
+
+  afterAll(async () => {
+    await tmpRepoA.cleanup();
+    await tmpRepoB.cleanup();
+  });
+
+  beforeEach(async () => {
+    tmpHome = await createTempDir('gitnexus-registry-atomic-home-');
     savedGitnexusHome = process.env.GITNEXUS_HOME;
     home = tmpHome.dbPath;
     process.env.GITNEXUS_HOME = home;
     registryPath = path.join(home, 'registry.json');
     fsCtx.renameMock.mockClear();
-    fsCtx.renameMock.mockImplementation((...args: never[]) =>
-      (fsCtx.realRename as unknown as FsFn)(...args),
-    );
+    fsCtx.renameMock.mockImplementation((src: string, dst: string) => fsCtx.realRename!(src, dst));
   });
 
   afterEach(async () => {
     if (savedGitnexusHome === undefined) delete process.env.GITNEXUS_HOME;
     else process.env.GITNEXUS_HOME = savedGitnexusHome;
     await tmpHome.cleanup();
-    await tmpRepoA.cleanup();
-    await tmpRepoB.cleanup();
   });
 
   it('survives a rival that publishes registry.json between our write and our rename', async () => {
@@ -146,7 +143,6 @@ describe('writeRegistry — private tmp path per transaction (#2888)', () => {
     await registerRepo(tmpRepoB.dbPath, meta, { name: 'b' });
 
     const staged = fsCtx.renameMock.mock.calls.map((c) => c[0] as string);
-    expect(staged).toHaveLength(2);
     // Distinct per transaction — this is the whole fix.
     expect(new Set(staged).size).toBe(2);
     // Never the shared name the crash was staged through.
@@ -155,7 +151,7 @@ describe('writeRegistry — private tmp path per transaction (#2888)', () => {
     expect(staged.map((s) => path.dirname(s))).toEqual([home, home]);
   });
 
-  it('removes its tmp file when the rename fails, leaving the previous registry intact', async () => {
+  it('leaves the previous registry intact when the write fails', async () => {
     await registerRepo(tmpRepoA.dbPath, meta, { name: 'seed' });
     fsCtx.renameMock.mockClear();
     // EIO, not EBUSY/EPERM/EACCES: those are retryRename's retry codes, so
@@ -169,12 +165,6 @@ describe('writeRegistry — private tmp path per transaction (#2888)', () => {
     );
 
     expect(fsCtx.renameMock).toHaveBeenCalledTimes(1);
-    // A random tmp suffix is not self-limiting the way the fixed name was:
-    // without cleanup every failed publish would orphan another file forever.
-    const leftovers = (await fs.readdir(home)).filter(
-      (f) => f !== 'registry.json' && f.startsWith('registry.json'),
-    );
-    expect(leftovers).toEqual([]);
     expect((await readRegistryFromDisk()).map((e) => e.name)).toEqual(['seed']);
   });
 

--- a/gitnexus/test/unit/repo-manager-registry-atomic-write.test.ts
+++ b/gitnexus/test/unit/repo-manager-registry-atomic-write.test.ts
@@ -1,0 +1,200 @@
+/**
+ * #2888 — the global registry write must not stage through a shared tmp path.
+ *
+ * `writeRegistry` used a FIXED `<home>/registry.json.tmp`. Every gitnexus
+ * process on the machine writes that one file, so two of them could stage
+ * through the same inode: the loser's `rename(tmp -> registry.json)` found
+ * nothing there and rejected with ENOENT, which killed the MCP server during
+ * startup (`LocalBackend.init` -> `refreshRepos`, nothing catches).
+ *
+ * Separate from repo-manager.test.ts: Vitest cannot vi.spyOn ESM namespace
+ * exports of fs/promises, and these tests must drive `fs.rename` itself — a
+ * delegating vi.mock is required (same split as repo-manager-rm-failure.test.ts
+ * and repo-manager-ensure-ignore-readonly.test.ts, #1549).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+
+type FsFn = (...args: never[]) => Promise<unknown>;
+
+const fsCtx = vi.hoisted(() => ({
+  renameMock: vi.fn(),
+  realRename: null as ((src: string, dst: string) => Promise<void>) | null,
+  realWriteFile: null as ((file: string, data: string, enc: string) => Promise<void>) | null,
+}));
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>();
+  const d = actual.default;
+  fsCtx.realRename = d.rename.bind(d) as (src: string, dst: string) => Promise<void>;
+  fsCtx.realWriteFile = d.writeFile.bind(d) as (
+    file: string,
+    data: string,
+    enc: string,
+  ) => Promise<void>;
+  fsCtx.renameMock.mockImplementation((...args: never[]) =>
+    (fsCtx.realRename as unknown as FsFn)(...args),
+  );
+  return {
+    default: new Proxy(d, {
+      get(target, prop) {
+        if (prop === 'rename') return fsCtx.renameMock;
+        const v = Reflect.get(target, prop, target) as unknown;
+        return typeof v === 'function' ? (v as (...args: unknown[]) => unknown).bind(target) : v;
+      },
+    }),
+  };
+});
+
+import fs from 'fs/promises';
+import {
+  registerRepo,
+  unregisterRepo,
+  listRegisteredRepos,
+  type RegistryEntry,
+  type RepoMeta,
+} from '../../src/storage/repo-manager.js';
+import { _captureLogger } from '../../src/core/logger.js';
+import { createTempDir } from '../helpers/test-db.js';
+
+const meta: RepoMeta = {
+  repoPath: '',
+  lastCommit: 'abc1234',
+  indexedAt: '2026-08-10T12:00:00.000Z',
+  stats: { files: 1, nodes: 1 },
+};
+
+describe('writeRegistry — private tmp path per transaction (#2888)', () => {
+  let tmpHome: Awaited<ReturnType<typeof createTempDir>>;
+  let tmpRepoA: Awaited<ReturnType<typeof createTempDir>>;
+  let tmpRepoB: Awaited<ReturnType<typeof createTempDir>>;
+  let savedGitnexusHome: string | undefined;
+  let home: string;
+  let registryPath: string;
+
+  /**
+   * A second gitnexus process finishing its whole registry transaction inside
+   * our own write window — the pre-#2716 shape, or a post-#2716 process whose
+   * registry lock timed out and degraded to unlocked. It stages through the
+   * FIXED `registry.json.tmp` the old code used, which is the collision.
+   */
+  const rivalWriterThenUs = async (src: string, dst: string): Promise<void> => {
+    const rivalTmp = `${registryPath}.tmp`;
+    const rival: RegistryEntry[] = [
+      {
+        name: 'rival',
+        path: '/nonexistent/rival',
+        storagePath: '/nonexistent/rival/.gitnexus',
+        indexedAt: meta.indexedAt,
+        lastCommit: meta.lastCommit,
+      },
+    ];
+    await fsCtx.realWriteFile!(rivalTmp, JSON.stringify(rival, null, 2), 'utf-8');
+    await fsCtx.realRename!(rivalTmp, registryPath);
+    await fsCtx.realRename!(src, dst);
+  };
+
+  const readRegistryFromDisk = async (): Promise<RegistryEntry[]> =>
+    JSON.parse(await fs.readFile(registryPath, 'utf-8')) as RegistryEntry[];
+
+  beforeEach(async () => {
+    tmpHome = await createTempDir('gitnexus-registry-atomic-home-');
+    tmpRepoA = await createTempDir('gitnexus-registry-atomic-repo-a-');
+    tmpRepoB = await createTempDir('gitnexus-registry-atomic-repo-b-');
+    savedGitnexusHome = process.env.GITNEXUS_HOME;
+    home = tmpHome.dbPath;
+    process.env.GITNEXUS_HOME = home;
+    registryPath = path.join(home, 'registry.json');
+    fsCtx.renameMock.mockClear();
+    fsCtx.renameMock.mockImplementation((...args: never[]) =>
+      (fsCtx.realRename as unknown as FsFn)(...args),
+    );
+  });
+
+  afterEach(async () => {
+    if (savedGitnexusHome === undefined) delete process.env.GITNEXUS_HOME;
+    else process.env.GITNEXUS_HOME = savedGitnexusHome;
+    await tmpHome.cleanup();
+    await tmpRepoA.cleanup();
+    await tmpRepoB.cleanup();
+  });
+
+  it('survives a rival that publishes registry.json between our write and our rename', async () => {
+    fsCtx.renameMock.mockImplementationOnce(rivalWriterThenUs);
+
+    await expect(registerRepo(tmpRepoA.dbPath, meta, { name: 'ours' })).resolves.toBe('ours');
+
+    // Last writer wins — the degraded-unlocked window is still lossy by
+    // design, and this asserts only that it no longer CRASHES.
+    expect((await readRegistryFromDisk()).map((e) => e.name)).toEqual(['ours']);
+    expect(fsCtx.renameMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives the same window on unregisterRepo (the fix lives in writeRegistry, not one caller)', async () => {
+    await registerRepo(tmpRepoA.dbPath, meta, { name: 'seed' });
+    fsCtx.renameMock.mockClear();
+    fsCtx.renameMock.mockImplementationOnce(rivalWriterThenUs);
+
+    await expect(unregisterRepo(tmpRepoA.dbPath)).resolves.toBeUndefined();
+
+    expect(await readRegistryFromDisk()).toEqual([]);
+    expect(fsCtx.renameMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives every transaction its own tmp path inside the registry directory', async () => {
+    await registerRepo(tmpRepoA.dbPath, meta, { name: 'a' });
+    await registerRepo(tmpRepoB.dbPath, meta, { name: 'b' });
+
+    const staged = fsCtx.renameMock.mock.calls.map((c) => c[0] as string);
+    expect(staged).toHaveLength(2);
+    // Distinct per transaction — this is the whole fix.
+    expect(new Set(staged).size).toBe(2);
+    // Never the shared name the crash was staged through.
+    expect(staged).not.toContain(`${registryPath}.tmp`);
+    // Same directory, so the rename stays a same-filesystem atomic operation.
+    expect(staged.map((s) => path.dirname(s))).toEqual([home, home]);
+  });
+
+  it('removes its tmp file when the rename fails, leaving the previous registry intact', async () => {
+    await registerRepo(tmpRepoA.dbPath, meta, { name: 'seed' });
+    fsCtx.renameMock.mockClear();
+    // EIO, not EBUSY/EPERM/EACCES: those are retryRename's retry codes, so
+    // they would sleep and then fall through to the real rename.
+    fsCtx.renameMock.mockImplementationOnce(() =>
+      Promise.reject(Object.assign(new Error('mock io error'), { code: 'EIO' })),
+    );
+
+    await expect(registerRepo(tmpRepoB.dbPath, meta, { name: 'doomed' })).rejects.toThrow(
+      /mock io error/,
+    );
+
+    expect(fsCtx.renameMock).toHaveBeenCalledTimes(1);
+    // A random tmp suffix is not self-limiting the way the fixed name was:
+    // without cleanup every failed publish would orphan another file forever.
+    const leftovers = (await fs.readdir(home)).filter(
+      (f) => f !== 'registry.json' && f.startsWith('registry.json'),
+    );
+    expect(leftovers).toEqual([]);
+    expect((await readRegistryFromDisk()).map((e) => e.name)).toEqual(['seed']);
+  });
+
+  it('keeps serving a validating read when the prune write fails', async () => {
+    await registerRepo(tmpRepoA.dbPath, meta, { name: 'gone' });
+    fsCtx.renameMock.mockClear();
+    fsCtx.renameMock.mockImplementationOnce(() =>
+      Promise.reject(Object.assign(new Error('mock read-only home'), { code: 'EROFS' })),
+    );
+
+    const cap = _captureLogger();
+    const entries = await listRegisteredRepos({ validate: true });
+    cap.restore();
+
+    // The caller gets the pruned view…
+    expect(entries).toEqual([]);
+    // …the failure is reported, not thrown (MCP startup has no handler)…
+    expect(cap.records().filter((r) => /Could not persist the pruned/.test(r.msg))).toHaveLength(1);
+    // …and the unpruned registry stays on disk for the next attempt.
+    expect((await readRegistryFromDisk()).map((e) => e.name)).toEqual(['gone']);
+    expect(fsCtx.renameMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/gitnexus/test/unit/storage/fs-atomic.test.ts
+++ b/gitnexus/test/unit/storage/fs-atomic.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Behavioural cover for `writeFileAtomic` — the single home of the tmp+rename
+ * publish shape (#2888, #1318 U6). The properties asserted here are what the
+ * source-text guards in test/unit/group/insecure-tempfile.test.ts used to
+ * approximate by regex, for three separate copies of the sequence.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { writeFileAtomic } from '../../../src/storage/fs-atomic.js';
+import { createTempDir } from '../../helpers/test-db.js';
+
+describe('writeFileAtomic', () => {
+  let tmp: Awaited<ReturnType<typeof createTempDir>>;
+  let target: string;
+
+  beforeEach(async () => {
+    tmp = await createTempDir('gitnexus-fs-atomic-');
+    target = path.join(tmp.dbPath, 'thing.json');
+  });
+
+  afterEach(async () => {
+    await tmp.cleanup();
+  });
+
+  const leftovers = async (): Promise<string[]> =>
+    (await fs.readdir(tmp.dbPath)).filter((f) => f !== path.basename(target));
+
+  it('publishes the data and leaves no tmp file behind', async () => {
+    await writeFileAtomic(target, '{"a":1}');
+
+    expect(await fs.readFile(target, 'utf-8')).toBe('{"a":1}');
+    expect(await leftovers()).toEqual([]);
+  });
+
+  it('creates the file user-only, whatever the umask is', async () => {
+    await writeFileAtomic(target, 'secret');
+
+    const mode = (await fs.stat(target)).mode & 0o777;
+    // Windows does not carry POSIX permission bits; the mode argument is the
+    // part CodeQL's js/insecure-temporary-file query credits either way.
+    expect(process.platform === 'win32' ? 0o600 : mode).toBe(0o600);
+  });
+
+  it('lets concurrent publishers to one target all succeed', async () => {
+    // The #2888 shape: with a shared tmp path the loser's rename finds nothing
+    // at the source and rejects with ENOENT.
+    await expect(
+      Promise.all([
+        writeFileAtomic(target, '"a"'),
+        writeFileAtomic(target, '"b"'),
+        writeFileAtomic(target, '"c"'),
+      ]),
+    ).resolves.toHaveLength(3);
+
+    expect(['"a"', '"b"', '"c"']).toContain(await fs.readFile(target, 'utf-8'));
+    expect(await leftovers()).toEqual([]);
+  });
+
+  it('removes the tmp file and keeps the previous content when the publish fails', async () => {
+    await writeFileAtomic(target, 'first');
+    // A directory at the target makes the rename fail (EISDIR/EPERM/ENOTEMPTY,
+    // by platform) without mocking anything.
+    const blocked = path.join(tmp.dbPath, 'blocked');
+    await fs.mkdir(path.join(blocked, 'child'), { recursive: true });
+
+    await expect(writeFileAtomic(blocked, 'second')).rejects.toThrow();
+
+    expect(await fs.readFile(target, 'utf-8')).toBe('first');
+    // readdir order is unspecified — sort so the assertion is deterministic.
+    expect((await fs.readdir(tmp.dbPath)).sort()).toEqual(['blocked', 'thing.json']);
+  });
+});


### PR DESCRIPTION
Fixes #2888.

## The bug

`writeRegistry` staged the global registry through a **fixed** `~/.gitnexus/registry.json.tmp`. The rename is atomic with respect to readers, but the tmp path is not private to the writer, and `registry.json` is the one file every gitnexus process on the machine writes. Two processes starting together stage through the same inode: B's `writeFile` overwrites A's bytes, B's `rename` moves that inode onto `registry.json`, and A's own rename finds nothing at the source:

```
ENOENT: no such file or directory, rename '<home>/registry.json.tmp' -> '<home>/registry.json'
```

That lands on the MCP startup path (`mcpCommand` → `LocalBackend.init` → `refreshRepos` → `listRegisteredRepos({validate:true})`), where nothing catches, so the client only sees "Server disconnected".

`withRegistryLock` (#2716) serializes the callers and hides this in the normal path, but it deliberately degrades to **unlocked** after a 5s `IndexLockTimeoutError` — availability over serialization — so the window is still live on `main` today. Measured on the parent commit, 12 concurrent processes pruning a stale registry while another process held the registry lock: **4/12 crashed** with the trace above; 24 processes with no lock contention: 0/24. The write itself has to be collision-proof rather than leaning on the lock.

## The fix

- **`writeFileAtomic(targetPath, data, mode = 0o600)`** in `storage/fs-atomic.ts`, beside the `retryRename` it uses: random tmp suffix, `'wx'` + explicit mode, write, `retryRename`, and `unlink` of the tmp before rethrowing on any rejection. With a fixed name a leaked tmp was self-limiting (the next writer overwrote it); a random suffix would drop a fresh orphan on every failed publish, so the cleanup is part of the fix, not polish.
- **`writeRegistry` calls it.** That is the whole of #2888.
- **Three existing writers were byte-identical copies** of that sequence — `writeMetaFile` (repo-manager), `writeBridgeMeta` (group/bridge-db), `writeContractRegistry` (group/storage) — none of which cleaned up its tmp on failure. They now call the same helper instead of a fourth copy being added, which also retro-fits the cleanup to all three. Net −45 lines of duplication.
- **The prune write in `listRegisteredRepos({validate:true})` no longer throws.** It is housekeeping, not the caller's request: every caller consumes the returned `valid` array and the prune set is recomputed from scratch on the next validating read, so a failed write costs a retry, never correctness — while rethrowing took down the whole MCP server. Catching it also covers the read-only-home and full-disk variants of the same startup death.

## Verification

Five new tests in `test/unit/repo-manager-registry-atomic-write.test.ts`, all deterministic (a hooked `fs.rename` drives the interleaving; no sleeps, no spawned processes):

| test | on parent commit |
|---|---|
| rival publishes `registry.json` between our write and our rename | ENOENT, `registerRepo` rejects |
| same window via `unregisterRepo` (fix lives in `writeRegistry`, not one caller) | ENOENT |
| every transaction gets its own tmp path in the registry dir | both renames stage from the same fixed path |
| tmp removed when the rename fails, previous registry intact | `registry.json.tmp` left behind |
| validating read still serves when the prune write fails | throws out of `listRegisteredRepos` |

All five fail on the parent commit, four of them with the exact error from the issue, and pass here. The process-level repro from the issue goes 4/12 → 0/12 crashes with the registry lock held.

`test/unit/group/insecure-tempfile.test.ts` structural guards were retargeted at `fs-atomic.ts`, where the `randomBytes` / `'wx'` / `0o600` sequence now lives, plus a new guard for the tmp cleanup and per-writer guards that they route through the helper. Full unit suite: 12183 passed; the 3 unrelated failures on this box are the local untracked `.claude/skills/gitnexus/*` copies and the known `skip-git-cli` child-process timeout.

## Note for reviewers

`registry.json` is now created `0o600` — it inherited the umask before (typically `0o644`), and this matches what `gitnexus.json` has always used. Existing installs tighten on the next rewrite. Flagging it in case a deployment reads `~/.gitnexus/registry.json` as a different user.

Deliberately out of scope, all latent rather than live: `parse-cache.ts` and `parsedfile-store.ts` still use fixed tmp names, but they are per-repo paths covered by the analyze index lock, which throws on timeout instead of degrading; `bridge.lbug.bak` uses a fixed set-aside name; `saveCLIConfig` writes `~/.gitnexus/config.json` in place with no atomicity at all. Happy to fold any of them in if you'd rather they ride along.
