### PR TITLE
fix(storage): strip credentials from remote URLs before they are persisted (#2914)

### DIFF
--- a/gitnexus/src/server/git-clone.ts
+++ b/gitnexus/src/server/git-clone.ts
@@ -10,7 +10,7 @@ import path from 'path';
 import fs from 'fs/promises';
 import { isIP } from 'net';
 import { logger } from '../core/logger.js';
-import { parseRepoNameFromUrl } from '../storage/git.js';
+import { parseRepoNameFromUrl, stripUrlCredentials } from '../storage/git.js';
 import { getGlobalDir } from '../storage/repo-manager.js';
 
 /**
@@ -410,7 +410,10 @@ export async function assertRemoteMatchesRequestedUrl(
   }
   if (normalizeGitUrlForCompare(remoteUrl) !== normalizeGitUrlForCompare(requestedUrl)) {
     throw new Error(
-      `Existing clone at ${targetDir} has remote ${remoteUrl}, not the requested URL ${requestedUrl}`,
+      // Both URLs are echoed to the API caller and the server log, and either
+      // can carry `https://user:token@` userinfo — strip it here too (#2914).
+      `Existing clone at ${targetDir} has remote ${stripUrlCredentials(remoteUrl)}, ` +
+        `not the requested URL ${stripUrlCredentials(requestedUrl)}`,
     );
   }
 }

--- a/gitnexus/src/storage/git.ts
+++ b/gitnexus/src/storage/git.ts
@@ -202,6 +202,28 @@ export const getCurrentCommit = (repoPath: string): string => {
 };
 
 /**
+ * Remove `user[:password]@` userinfo from an http(s) URL.
+ *
+ * `git config remote.origin.url` returns whatever was configured, and the
+ * HTTPS token form `https://x-access-token:<token>@host/owner/repo` is how
+ * CI checkouts and credential helpers routinely authenticate. That string
+ * reached `registry.json`, the per-repo meta and the MCP `list_repos`
+ * payload verbatim, which turned repository discovery into credential
+ * disclosure (#2914).
+ *
+ * Only `http`/`https` are rewritten. `ssh://git@host/…` and the SCP-like
+ * `git@host:owner/repo` carry an SSH *user name*, not a secret, and are part
+ * of the remote's identity — dropping it would repoint the sibling-clone
+ * fingerprint (#2054) for every already-registered repo.
+ *
+ * The match is bounded by the authority (`[^/]*` cannot cross the first `/`
+ * after the scheme) and greedy to the last `@` in it, so a password
+ * containing `@` is removed whole rather than leaving its tail behind.
+ */
+export const stripUrlCredentials = (url: string): string =>
+  url.replace(/^(https?:\/\/)[^/]*@/i, '$1');
+
+/**
  * Get a stable canonical identifier for the repo's `origin` remote, if any.
  *
  * Used to fingerprint two on-disk clones as the same logical repository
@@ -212,6 +234,10 @@ export const getCurrentCommit = (repoPath: string): string => {
  * survives those conventions.
  *
  * Normalisation strategy:
+ *   - Strip http(s) userinfo credentials (see {@link stripUrlCredentials}).
+ *     Done FIRST, before the host lower-casing below — that regex treats the
+ *     whole `user:pass@host` span as the host and would mangle the secret's
+ *     case on its way into the registry (#2914).
  *   - Strip a trailing `.git` so `https://x/y` and `https://x/y.git` collapse.
  *   - Strip a trailing `/` for the same reason.
  *   - `git@github.com:foo/bar` and `https://github.com/foo/bar` are
@@ -239,7 +265,9 @@ export const getRemoteUrl = (repoPath: string): string | undefined => {
   }
   if (!raw) return undefined;
 
-  let normalised = raw.replace(/\/$/, '').replace(/\.git$/, '');
+  let normalised = stripUrlCredentials(raw)
+    .replace(/\/$/, '')
+    .replace(/\.git$/, '');
 
   // Lower-case the host segment of `scheme://[user@]host[:port]/...`
   // and the host segment of `git@host:owner/repo` SCP form.

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -18,7 +18,7 @@ import fs from 'fs/promises';
 import { realpathSync } from 'fs';
 import path from 'path';
 import os from 'os';
-import { getInferredRepoName, resolveRepoIdentityRoot } from './git.js';
+import { getInferredRepoName, resolveRepoIdentityRoot, stripUrlCredentials } from './git.js';
 import { stripWindowsLongPathPrefix } from '../lib/utils.js';
 import { writeFileAtomic } from './fs-atomic.js';
 import { logger } from '../core/logger.js';
@@ -1116,13 +1116,34 @@ const withRegistryLock = async <T>(operation: () => Promise<T>): Promise<T> => {
 };
 
 /**
+ * Drop credentials from every entry's `remoteUrl` (#2914).
+ *
+ * Applied on BOTH registry edges. Capture-time stripping in `getRemoteUrl`
+ * only covers values this version writes; a `registry.json` (or a per-repo
+ * meta that a re-register copies forward) written by an older version still
+ * holds the credential. Reading through here keeps it out of every consumer —
+ * `listRegisteredRepos`, MCP `list_repos`, `gitnexus list`, group sync — and
+ * writing through here means the next registry write drops it at rest instead
+ * of round-tripping it back to disk.
+ *
+ * Sanitised values compare equal to a freshly captured `getRemoteUrl`, so
+ * sibling-clone matching (#2054) is unaffected: both sides lose the same span.
+ */
+const sanitizeEntries = (entries: RegistryEntry[]): RegistryEntry[] =>
+  entries.map((e) => {
+    if (!e.remoteUrl) return e;
+    const cleaned = stripUrlCredentials(e.remoteUrl);
+    return cleaned === e.remoteUrl ? e : { ...e, remoteUrl: cleaned };
+  });
+
+/**
  * Read the global registry. Returns empty array if not found.
  */
 export const readRegistry = async (): Promise<RegistryEntry[]> => {
   try {
     const raw = await fs.readFile(getGlobalRegistryPath(), 'utf-8');
     const data = JSON.parse(raw);
-    return Array.isArray(data) ? data : [];
+    return Array.isArray(data) ? sanitizeEntries(data) : [];
   } catch {
     return [];
   }
@@ -1142,7 +1163,11 @@ export const readRegistry = async (): Promise<RegistryEntry[]> => {
  */
 const writeRegistry = async (entries: RegistryEntry[], attempts?: number): Promise<void> => {
   await fs.mkdir(getGlobalDir(), { recursive: true });
-  await writeFileAtomic(getGlobalRegistryPath(), JSON.stringify(entries, null, 2), attempts);
+  await writeFileAtomic(
+    getGlobalRegistryPath(),
+    JSON.stringify(sanitizeEntries(entries), null, 2),
+    attempts,
+  );
 };
 
 /**

--- a/gitnexus/test/unit/git-utils.test.ts
+++ b/gitnexus/test/unit/git-utils.test.ts
@@ -189,17 +189,17 @@ describe('getGitRoot', () => {
 
 // ─── getRemoteUrl ─────────────────────────────────────────────────────────
 
-describe('getRemoteUrl', () => {
-  const setupRepoWithRemote = (remoteUrl: string): string => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-remote-'));
-    // Use real fs paths and shellouts — the helper itself shells out to
-    // `git config`, so we need a real git repo for the assertion to be
-    // meaningful.
-    execSync('git init -q', { cwd: tmpDir });
-    execSync(`git remote add origin ${remoteUrl}`, { cwd: tmpDir });
-    return tmpDir;
-  };
+const setupRepoWithRemote = (remoteUrl: string): string => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-remote-'));
+  // Use real fs paths and shellouts — the helper itself shells out to
+  // `git config`, so we need a real git repo for the assertion to be
+  // meaningful.
+  execSync('git init -q', { cwd: tmpDir });
+  execSync(`git remote add origin ${remoteUrl}`, { cwd: tmpDir });
+  return tmpDir;
+};
 
+describe('getRemoteUrl', () => {
   it('returns undefined for a non-git directory', async () => {
     const { getRemoteUrl } = await import('../../src/storage/git.js');
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-test-'));
@@ -251,6 +251,80 @@ describe('getRemoteUrl', () => {
     } finally {
       fs.rmSync(a, { recursive: true, force: true });
       fs.rmSync(b, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── credentials in remote URLs (#2914) ──────────────────────────────────
+//
+// `git config remote.origin.url` hands back whatever CI or a credential
+// helper configured, including `https://x-access-token:<token>@host/…`.
+// That value is persisted (registry.json, the per-repo meta) and echoed by
+// MCP `list_repos`, so it must lose its userinfo at capture time. Every
+// credential below is an obviously fake constant.
+
+describe('remote URL credentials (#2914)', () => {
+  const FAKE_TOKEN = 'ExAmPle-FAKE-SECRET';
+
+  it('strips userinfo from an HTTPS remote before it can be persisted', async () => {
+    const { getRemoteUrl } = await import('../../src/storage/git.js');
+    const tmpDir = setupRepoWithRemote(
+      `https://x-access-token:${FAKE_TOKEN}@github.com/example/project.git`,
+    );
+    try {
+      expect(getRemoteUrl(tmpDir)).toBe('https://github.com/example/project');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('strips a username-only HTTPS remote (the PAT-as-username form)', async () => {
+    const { getRemoteUrl } = await import('../../src/storage/git.js');
+    const tmpDir = setupRepoWithRemote(`https://${FAKE_TOKEN}@github.com/example/project.git`);
+    try {
+      expect(getRemoteUrl(tmpDir)).toBe('https://github.com/example/project');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves plain HTTPS, SSH-URL and SCP-like remotes untouched', async () => {
+    const { stripUrlCredentials } = await import('../../src/storage/git.js');
+    // The SSH forms carry a user NAME, not a secret, and are part of the
+    // remote's identity — rewriting them would repoint the #2054 fingerprint.
+    expect(stripUrlCredentials('https://github.com/example/project.git')).toBe(
+      'https://github.com/example/project.git',
+    );
+    expect(stripUrlCredentials('ssh://git@github.com/example/project.git')).toBe(
+      'ssh://git@github.com/example/project.git',
+    );
+    expect(stripUrlCredentials('git@github.com:example/project.git')).toBe(
+      'git@github.com:example/project.git',
+    );
+    // An `@` in the PATH is not userinfo — the authority ends at the first `/`.
+    expect(stripUrlCredentials('https://github.com/example/pro@ject')).toBe(
+      'https://github.com/example/pro@ject',
+    );
+  });
+
+  it('removes a password containing @ whole, leaving no tail behind', async () => {
+    const { stripUrlCredentials } = await import('../../src/storage/git.js');
+    expect(stripUrlCredentials(`https://user:pa@ss-${FAKE_TOKEN}@host.example/o/r`)).toBe(
+      'https://host.example/o/r',
+    );
+  });
+
+  it('keeps the same fingerprint for credentialed and clean clones of one repo', async () => {
+    const { getRemoteUrl } = await import('../../src/storage/git.js');
+    const withCreds = setupRepoWithRemote(
+      `https://x-access-token:${FAKE_TOKEN}@example.com/foo/bar.git`,
+    );
+    const clean = setupRepoWithRemote('https://example.com/foo/bar');
+    try {
+      expect(getRemoteUrl(withCreds)).toBe(getRemoteUrl(clean));
+    } finally {
+      fs.rmSync(withCreds, { recursive: true, force: true });
+      fs.rmSync(clean, { recursive: true, force: true });
     }
   });
 });

--- a/gitnexus/test/unit/repo-manager.test.ts
+++ b/gitnexus/test/unit/repo-manager.test.ts
@@ -975,6 +975,112 @@ describe('registerRepo name override + collision guard (#829)', () => {
 
 // ─── registerRepo branch nesting (#2106) ─────────────────────────────
 
+// ─── remoteUrl credentials (#2914) ───────────────────────────────────
+//
+// The registry is the surface `list_repos` (MCP), `gitnexus list` and group
+// sync read from, so a `remoteUrl` carrying `https://user:token@` turns repo
+// discovery into credential disclosure. Capture-time stripping in
+// `getRemoteUrl` only covers what THIS version writes — a registry.json (or a
+// per-repo meta a re-register copies forward) written by an older version
+// still holds one, so both registry edges sanitize. Fake credential only.
+
+describe('registry never emits or persists remoteUrl credentials (#2914)', () => {
+  const FAKE_TOKEN = 'ExAmPle-FAKE-SECRET';
+  const CREDENTIALED = `https://x-access-token:${FAKE_TOKEN}@github.com/example/project`;
+  const CLEAN = 'https://github.com/example/project';
+
+  let tmpHome: Awaited<ReturnType<typeof createTempDir>>;
+  let tmpRepo: Awaited<ReturnType<typeof createTempDir>>;
+  let savedGitnexusHome: string | undefined;
+  let registryPath: string;
+
+  const meta: RepoMeta = {
+    repoPath: '',
+    lastCommit: 'abc1234',
+    indexedAt: '2026-08-11T12:00:00.000Z',
+    stats: { files: 1, nodes: 1 },
+  };
+
+  beforeEach(async () => {
+    tmpHome = await createTempDir('gitnexus-2914-home-');
+    tmpRepo = await createTempDir('gitnexus-2914-repo-');
+    savedGitnexusHome = process.env.GITNEXUS_HOME;
+    process.env.GITNEXUS_HOME = tmpHome.dbPath;
+    registryPath = path.join(tmpHome.dbPath, 'registry.json');
+  });
+
+  afterEach(async () => {
+    if (savedGitnexusHome === undefined) delete process.env.GITNEXUS_HOME;
+    else process.env.GITNEXUS_HOME = savedGitnexusHome;
+    await tmpHome.cleanup();
+    await tmpRepo.cleanup();
+  });
+
+  /** A registry.json as an older version would have left it. */
+  const seedLegacyRegistry = async (entryPath: string): Promise<void> => {
+    const legacy: RegistryEntry[] = [
+      {
+        name: 'legacy',
+        path: entryPath,
+        storagePath: path.join(entryPath, '.gitnexus'),
+        indexedAt: meta.indexedAt,
+        lastCommit: meta.lastCommit,
+        remoteUrl: CREDENTIALED,
+      },
+    ];
+    await fs.writeFile(registryPath, JSON.stringify(legacy, null, 2), 'utf-8');
+  };
+
+  it('sanitizes a legacy on-disk entry before listRegisteredRepos returns it', async () => {
+    await seedLegacyRegistry(tmpRepo.dbPath);
+
+    const entries = await listRegisteredRepos();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].remoteUrl).toBe(CLEAN);
+    expect(JSON.stringify(entries)).not.toContain(FAKE_TOKEN);
+  });
+
+  it('never writes a credentialed remoteUrl to registry.json', async () => {
+    // meta.remoteUrl bypasses getRemoteUrl entirely — this is the legacy
+    // per-repo gitnexus.json being copied forward into a fresh registry.
+    await registerRepo(tmpRepo.dbPath, { ...meta, remoteUrl: CREDENTIALED }, { name: 'repro' });
+
+    const raw = await fs.readFile(registryPath, 'utf-8');
+    expect(raw).not.toContain(FAKE_TOKEN);
+    expect((JSON.parse(raw) as RegistryEntry[])[0].remoteUrl).toBe(CLEAN);
+  });
+
+  it('scrubs an untouched legacy entry when some other repo is registered', async () => {
+    const other = await createTempDir('gitnexus-2914-other-');
+    try {
+      await seedLegacyRegistry(other.dbPath);
+      await registerRepo(tmpRepo.dbPath, meta, { name: 'fresh' });
+
+      const raw = await fs.readFile(registryPath, 'utf-8');
+      expect(raw).not.toContain(FAKE_TOKEN);
+      // The legacy entry survives — it is scrubbed, not dropped.
+      expect(JSON.parse(raw)).toHaveLength(2);
+    } finally {
+      await other.cleanup();
+    }
+  });
+
+  it('still matches sibling clones after sanitization (#2054 fingerprint)', async () => {
+    await registerRepo(tmpRepo.dbPath, { ...meta, remoteUrl: CREDENTIALED }, { name: 'with-cred' });
+    const other = await createTempDir('gitnexus-2914-sibling-');
+    try {
+      await registerRepo(other.dbPath, { ...meta, remoteUrl: CLEAN }, { name: 'clean' });
+
+      const entries = await listRegisteredRepos();
+      const remotes = entries.map((e) => e.remoteUrl);
+      expect(remotes).toEqual([CLEAN, CLEAN]);
+    } finally {
+      await other.cleanup();
+    }
+  });
+});
+
 describe('registerRepo branch nesting (#2106)', () => {
   let tmpHome: Awaited<ReturnType<typeof createTempDir>>;
   let tmpRepo: Awaited<ReturnType<typeof createTempDir>>;


### PR DESCRIPTION
Fixes #2914.

## Problem

`getRemoteUrl` returns `git config --get remote.origin.url` verbatim. When the checkout was configured with an HTTPS token remote (`https://x-access-token:<token>@github.com/owner/repo`, the shape CI checkouts and credential helpers produce), that string is written to `~/.gitnexus/registry.json` and to the per-repo meta, and MCP `list_repos` returns it unchanged. Repository discovery doubles as credential disclosure.

Reproduced on `main` (`d3687259d`) with a fake credential:

```
getRemoteUrl        = https://x-access-token:example-secret@github.com/example/project
registry.json       contains the secret
listRegisteredRepos = {"remoteUrl":"https://x-access-token:example-secret@github.com/..."}
```

A second, smaller bug fell out of the same path: the existing host lower-casing regex treats `user:pass@host` as one host span, so a mixed case token was persisted lower cased (`ExAmPle-SECRET` became `example-secret`).

## Fix

One helper, applied at three edges:

* `stripUrlCredentials(url)` removes `user[:password]@` userinfo from http(s) URLs. `ssh://git@host/...` and SCP like `git@host:owner/repo` are deliberately untouched, that is an SSH user name rather than a secret, and rewriting it would repoint the sibling clone fingerprint (#2054) for every already registered repo. The match is bounded by the authority and greedy to the last `@` in it, so a password containing `@` is removed whole.
* `getRemoteUrl` strips at capture, before the host lower-casing, so nothing credentialed is ever written and the token case is no longer mangled.
* The registry sanitizes on read and on write. Capture time stripping only covers what this version writes, so a `registry.json` written by an older version, or a legacy per-repo meta that a re-register copies forward, is neither emitted by `list_repos` nor rewritten back to disk with the credential still in it.

Also stripped from the mismatch error in `assertRemoteMatchesRequestedUrl`, which is echoed to API callers and to the server log.

Sanitized values compare equal to a freshly captured remote on both sides, so sibling matching, drift checks, `--name` inference and group sync behave exactly as before.

## Acceptance criteria

* Sanitize HTTPS remote URLs before registry persistence: yes, at capture and at the write edge.
* Sanitize legacy registry values before any API or MCP output: yes, at the read edge.
* Preserve normal HTTPS, SSH and SCP like remote URL behaviour: yes, covered by tests.
* Regression coverage with an obviously fake credential: 9 new tests, all use `ExAmPle-FAKE-SECRET`.
* Focused unit tests and TypeScript compilation verified.

## Tests

`gitnexus/test/unit/git-utils.test.ts` (5 new)
* HTTPS userinfo and username only forms are stripped at capture.
* Plain HTTPS, `ssh://git@...`, SCP like and an `@` inside the path are untouched.
* A password containing `@` is removed whole, no tail left behind.
* A credentialed clone and a clean clone of the same repo still fingerprint identically.

`gitnexus/test/unit/repo-manager.test.ts` (4 new)
* A legacy on-disk entry is sanitized before `listRegisteredRepos` returns it.
* A credentialed `meta.remoteUrl` never reaches `registry.json`.
* A legacy entry that this run does not touch is scrubbed, not dropped, when another repo registers.
* Sibling matching still holds after sanitization.

All 9 fail on `main` and pass here. `npx tsc --noEmit` is clean, and the surrounding registry, git util, git clone, remove and skip-git suites pass (252 tests).

## Note

The credential also sits in the repo's own `.git/config`, which is where it came from, and a legacy `.gitnexus/gitnexus.json` written before this change keeps its copy until the next analyze. Neither is a new exposure and neither is read back out to an API or MCP surface, so this PR does not rewrite them. The propagation path into the global registry and `list_repos` is what is closed here.