### PR TITLE
fix(mcp): resolve repo param pointing at a linked git worktree

### DIFF
--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -437,6 +437,11 @@ program
   .option('-b, --base-ref <ref>', 'Branch/commit for compare scope (e.g. main)')
   .option('-r, --repo <name>', 'Target repository')
   .option('--branch <name>', 'Scope to a specific branch index (multi-branch repos)')
+  .option(
+    '--worktree <path>',
+    'Absolute path to a linked git worktree. Pass this when "repo" resolves to the main ' +
+      'checkout (it never matches a worktree path) but your changes live in that worktree.',
+  )
   .option('-l, --limit <n>', 'Max changed symbols to return')
   .action(createLbugLazyAction(() => import('./tool.js'), 'detectChangesCommand'));
 

--- a/gitnexus/src/cli/tool.ts
+++ b/gitnexus/src/cli/tool.ts
@@ -346,6 +346,7 @@ export async function detectChangesCommand(options?: {
   baseRef?: string;
   repo?: string;
   branch?: string;
+  worktree?: string;
   limit?: string;
 }): Promise<void> {
   const limit = parseLimit(options?.limit);
@@ -355,6 +356,7 @@ export async function detectChangesCommand(options?: {
     base_ref: options?.baseRef,
     repo: options?.repo,
     branch: options?.branch,
+    worktree: options?.worktree,
   });
   if (limit !== undefined) {
     if (Array.isArray(result.changed_symbols))

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -1879,11 +1879,31 @@ export class LocalBackend {
 
       const resolvePathMatch = (): RepoHandle | undefined => {
         const canonicalTarget = canonicalizePath(repoParam);
-        return [...this.repos.values()].find((handle) => {
+        const exact = [...this.repos.values()].find((handle) => {
           const stored = canonicalizePath(handle.repoPath);
           return process.platform === 'win32'
             ? stored.toLowerCase() === canonicalTarget.toLowerCase()
             : stored === canonicalTarget;
+        });
+        if (exact) return exact;
+
+        // `repoParam` may be a LINKED WORKTREE rather than the registered main
+        // checkout. `gitnexus analyze` only ever registers a repo's canonical
+        // root (#1259), so a worktree path — or the common `--repo .` fallback
+        // run from inside one — never equals a registered `handle.repoPath`
+        // and used to fall straight through to "Repository not found", even
+        // though the worktree shares that exact repo's index. Resolve
+        // `repoParam`'s own canonical root (a no-op for a normal clone; the
+        // main checkout for a worktree) and match THAT against the already-
+        // canonical registered paths.
+        const paramCanonicalRoot = getCanonicalRepoRoot(repoParam);
+        if (!paramCanonicalRoot) return undefined;
+        const realParamRoot = tryRealpath(paramCanonicalRoot);
+        return [...this.repos.values()].find((handle) => {
+          const stored = canonicalizePath(handle.repoPath);
+          return process.platform === 'win32'
+            ? stored.toLowerCase() === realParamRoot.toLowerCase()
+            : stored === realParamRoot;
         });
       };
 

--- a/gitnexus/test/unit/cli-index-help.test.ts
+++ b/gitnexus/test/unit/cli-index-help.test.ts
@@ -234,6 +234,17 @@ describe('CLI help surface', () => {
     expect(result.stdout).toContain('--repo <name>');
   });
 
+  it('detect-changes help exposes the --worktree escape hatch for linked worktrees', () => {
+    // Mirrors the MCP tool's "worktree" param (#1654/#1691) — without this
+    // flag, CLI callers running from inside a linked worktree had no way to
+    // pin the git-diff cwd when `--repo .` failed to resolve or auto-detection
+    // couldn't fire (e.g. behind a wrapper that changes cwd).
+    const result = runHelp('detect-changes');
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('--worktree <path>');
+  });
+
   it('query-family commands expose the --branch scope flag (#2106)', () => {
     for (const cmd of ['query', 'context', 'impact', 'cypher', 'detect-changes']) {
       const result = runHelp(cmd);

--- a/gitnexus/test/unit/resolve-repo-worktree.test.ts
+++ b/gitnexus/test/unit/resolve-repo-worktree.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for resolving the `repo` param when it points at a LINKED GIT WORKTREE
+ * rather than the registered main checkout.
+ *
+ * `gitnexus analyze` only ever registers a repo's canonical root (main
+ * checkout) — see `getCanonicalRepoRoot` (#1259). Every MCP/CLI tool that
+ * accepts `repo` (impact, cypher, context, detect_changes, ...) resolves it
+ * through `resolveRepoFromCache`, which used to compare `repo` against each
+ * registered `handle.repoPath` by EXACT canonical path only. A linked
+ * worktree's path — or the documented CLI fallback `--repo .` run from
+ * inside one — never equals the main checkout's path, so resolution used to
+ * fail with "Repository ... not found" even though the worktree belongs to
+ * exactly the repo that IS indexed.
+ *
+ * This suite verifies `resolveRepoFromCache` (accessed via the private cast,
+ * same pattern as impact-pagination.test.ts) now falls back to comparing the
+ * PARAM's own canonical root against the registered path, so a worktree path
+ * resolves to its repo's handle instead of throwing.
+ */
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { execSync } from 'child_process';
+import path from 'path';
+import os from 'os';
+import { LocalBackend } from '../../src/mcp/local/local-backend';
+import { commitAll, initGitRepo } from '../helpers/temp-git-repo.js';
+
+function makeBackendWithRepo(repoPath: string) {
+  const backend = new LocalBackend();
+  const repoHandle = {
+    id: 'repo1',
+    name: 'repo1',
+    repoPath,
+    storagePath: path.join(repoPath, '.gitnexus'),
+    lbugPath: path.join(repoPath, '.gitnexus', 'lbug'),
+    indexedAt: 'now',
+    lastCommit: 'c',
+    stats: {},
+  } as any;
+  (backend as any).repos.set(repoHandle.id, repoHandle);
+  return { backend, repoHandle };
+}
+
+describe('resolveRepoFromCache — linked worktree path', () => {
+  it('resolves a linked worktree path to the repo registered at the main checkout', () => {
+    const repoDir = mkdtempSync(path.join(os.tmpdir(), 'gitnexus-resolve-wt-'));
+    try {
+      initGitRepo(repoDir);
+      writeFileSync(path.join(repoDir, 'x.ts'), 'export const x = 1;\n');
+      commitAll(repoDir, 'initial');
+
+      const worktreeDir = path.join(repoDir, 'wt-feature');
+      execSync(`git worktree add -q -b feature "${worktreeDir}"`, {
+        cwd: repoDir,
+        stdio: 'ignore',
+      });
+
+      const { backend, repoHandle } = makeBackendWithRepo(repoDir);
+
+      // Before the fix this returned null (exact-path match only), and
+      // resolveRepo() would ultimately throw `Repository "<worktreeDir>" not found`.
+      const resolved = (backend as any).resolveRepoFromCache(worktreeDir);
+      expect(resolved).toBe(repoHandle);
+    } finally {
+      try {
+        execSync('git worktree remove -f wt-feature', { cwd: repoDir, stdio: 'ignore' });
+      } catch {
+        // ignore
+      }
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('still returns null for a worktree belonging to an unrelated repo', () => {
+    const repoDir = mkdtempSync(path.join(os.tmpdir(), 'gitnexus-resolve-wt-a-'));
+    const otherRepoDir = mkdtempSync(path.join(os.tmpdir(), 'gitnexus-resolve-wt-b-'));
+    try {
+      initGitRepo(repoDir);
+      writeFileSync(path.join(repoDir, 'x.ts'), 'export const x = 1;\n');
+      commitAll(repoDir, 'initial');
+
+      initGitRepo(otherRepoDir);
+      writeFileSync(path.join(otherRepoDir, 'y.ts'), 'export const y = 1;\n');
+      commitAll(otherRepoDir, 'initial');
+
+      const worktreeDir = path.join(otherRepoDir, 'wt-unrelated');
+      execSync(`git worktree add -q -b unrelated "${worktreeDir}"`, {
+        cwd: otherRepoDir,
+        stdio: 'ignore',
+      });
+
+      // Only repoDir is registered — a worktree of the unrelated otherRepoDir
+      // must not resolve to it.
+      const { backend } = makeBackendWithRepo(repoDir);
+      const resolved = (backend as any).resolveRepoFromCache(worktreeDir);
+      expect(resolved).toBeNull();
+    } finally {
+      try {
+        execSync('git worktree remove -f wt-unrelated', { cwd: otherRepoDir, stdio: 'ignore' });
+      } catch {
+        // ignore
+      }
+      rmSync(repoDir, { recursive: true, force: true });
+      rmSync(otherRepoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('still resolves a normal (non-worktree) exact repo path as before', () => {
+    const repoDir = mkdtempSync(path.join(os.tmpdir(), 'gitnexus-resolve-plain-'));
+    try {
+      execSync('git init -q', { cwd: repoDir, stdio: 'ignore' });
+      const { backend, repoHandle } = makeBackendWithRepo(repoDir);
+      const resolved = (backend as any).resolveRepoFromCache(repoDir);
+      expect(resolved).toBe(repoHandle);
+    } finally {
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/gitnexus/test/unit/tool-direct-cli.test.ts
+++ b/gitnexus/test/unit/tool-direct-cli.test.ts
@@ -223,6 +223,32 @@ describe('direct CLI tool commands', () => {
     expect(writeSyncMock).toHaveBeenCalledWith(1, expect.stringContaining('Risk level: low'));
   });
 
+  it('passes --worktree through to the detect_changes tool call', async () => {
+    callToolMock.mockResolvedValue({
+      summary: {
+        changed_files: 1,
+        changed_count: 2,
+        affected_count: 1,
+        risk_level: 'low',
+      },
+    });
+    const { detectChangesCommand } = await import('../../src/cli/tool.js');
+
+    await detectChangesCommand({
+      scope: 'unstaged',
+      repo: 'gitnexus',
+      worktree: '/repo/wt-feature',
+    });
+
+    expect(callToolMock).toHaveBeenCalledWith('detect_changes', {
+      scope: 'unstaged',
+      base_ref: undefined,
+      repo: 'gitnexus',
+      branch: undefined,
+      worktree: '/repo/wt-feature',
+    });
+  });
+
   it('prints "No changes detected." when changed_count is 0', async () => {
     callToolMock.mockResolvedValue({
       summary: { changed_files: 0, changed_count: 0, affected_count: 0, risk_level: 'low' },


### PR DESCRIPTION
## Summary
- `resolveRepoFromCache` matched `repo` against each registered handle's exact canonical path only. Since `gitnexus analyze` always registers a repo's main-checkout root, a linked worktree's path never matched — including the project's own documented CLI fallback `... detect-changes --scope all --repo .` run from inside a worktree — so resolution threw `Repository "..." not found` even though the worktree belongs to the exact repo that's indexed.
- Fixed by falling back to resolving the *param's own* canonical root (a no-op for a normal clone, the main checkout for a worktree) and matching that against the registered canonical path. Fixes this for every `repo`-accepting tool (`impact`, `cypher`, `context`, `detect_changes`, etc.), not just detect-changes.
- Added the missing `--worktree <path>` CLI flag to `detect-changes`, giving one-shot CLI callers parity with the MCP tool's existing `worktree` param — needed when auto-detection via `process.cwd()` can't fire (e.g. a long-lived MCP server launched from a different directory than the worktree being edited).

## Root cause context
Traced from a real session against an indexed `~/work/apps` repo: an agent working inside a linked worktree passed the worktree path as `repo`, got `Repository "..." not found`, then had no working alternative — `repo` couldn't identify the worktree and the CLI had no `--worktree` escape hatch (only the MCP tool schema documented one). This closes the gap so the project's own `AGENTS.md`/`CLAUDE.md` rule ("`detect_changes({scope: "all"})` (MCP) or `... detect-changes --scope all --repo .` (CLI fallback)") is actually satisfiable when working from a worktree.

## Files changed
- `gitnexus/src/mcp/local/local-backend.ts` — `resolveRepoFromCache` worktree-aware fallback
- `gitnexus/src/cli/index.ts`, `gitnexus/src/cli/tool.ts` — `--worktree` flag for `detect-changes`
- `gitnexus/test/unit/resolve-repo-worktree.test.ts` (new), `tool-direct-cli.test.ts`, `cli-index-help.test.ts` — coverage

## Test plan
- [x] `npm run build` (tsc + vite) passes clean
- [x] `vitest run` on the touched suites: `resolve-repo-worktree.test.ts` (new, 3 tests using real `git worktree add`), `detect-changes-worktree.test.ts`, `tool-direct-cli.test.ts`, `cli-index-help.test.ts`, `ai-context.test.ts`, `calltool-dispatch.test.ts`, `mcp-repository-policy.test.ts`, `repo-manager.test.ts`, `git.test.ts` — all pass except pre-existing, unrelated failures in `git-utils.test.ts` caused by this machine's global `~/.gitignore_global` excluding `AGENTS.md`/`CLAUDE.md` (unrelated to this change)

## Not in scope
A related finding from the same session reported that JSX component usage (`<Foo />`) isn't modeled as a graph edge, making `impact`/`context` report zero dependents for React components. That's **already fixed on `main`** (`feat: close reported graph blind spots...` (#2856), JSX-as-CALLS via `TSX_JSX_QUERY_SUFFIX`) but unreleased to npm — the published `gitnexus@latest` (1.6.9, July 4) predates it. No source change needed here; re-analyzing with a current build (or once 1.6.10 ships) resolves it.

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*A broad MCP and CLI repository resolution change centered on linked Git worktrees. Its file-level risk is low, but the graph shows critical reach through repository selection and dependent execution flows.*

**🔴 CRITICAL blast radius. An MCP and CLI change for resolving repository parameters from linked Git worktrees, centered on `gitnexus/src/mcp/local/local-backend.ts`, reaches callers across the repository.**

The main implementation is concentrated in `LocalBackend` and its methods `pickRepoHandleForCwd`, `handleToRegistryEntry`, and `resolveWorktreeCwd`, alongside the supporting functions `tryRealpath`, `attachToolStaleness`, `canCarryStaleness`, `requireInt`, `parseListReposPagination`, and `buildDetectChangesDiffArgs`. The CLI side also changes `checkCommand` in `gitnexus/src/cli/tool.ts` and `gitnexus/src/cli/index.ts`.

The impact spans the `Local`, `Cli`, `Mcp`, `Integration`, `Server`, and `Group` modules, with 33 graph dependents and 31 affected flows. Review the worktree path resolution and repository handle selection first, then the related CLI behavior and tests in `gitnexus/test/unit/resolve-repo-worktree.test.ts`, `gitnexus/test/unit/cli-index-help.test.ts`, and `gitnexus/test/unit/tool-direct-cli.test.ts`.

_Added by GitNexus for PR #2996. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->