### PR TITLE
feat(web): add OrcaRouter as a named LLM provider

### DIFF
--- a/gitnexus-web/src/components/SettingsPanel.tsx
+++ b/gitnexus-web/src/components/SettingsPanel.tsx
@@ -371,6 +371,7 @@ export const SettingsPanel = ({
     'minimax',
     'glm',
     'deepseek',
+    'orcarouter',
   ];
 
   return (
@@ -484,7 +485,9 @@ export const SettingsPanel = ({
                                   ? '🔮'
                                   : provider === 'deepseek'
                                     ? '🐋'
-                                    : '☁️'}
+                                    : provider === 'orcarouter'
+                                      ? '🐳'
+                                      : '☁️'}
                   </div>
                   <span className="font-medium">{getProviderDisplayName(provider)}</span>
                 </button>
@@ -1003,6 +1006,50 @@ export const SettingsPanel = ({
               <p className="text-xs text-text-muted">
                 Compatible via OpenAI API format. The deepseek-reasoner model uses thinking mode and
                 requires round-tripping reasoning content.
+              </p>
+            </ProviderConfigCard>
+          )}
+
+          {/* OrcaRouter Settings */}
+          {settings.activeProvider === 'orcarouter' && (
+            <ProviderConfigCard
+              title="OrcaRouter"
+              apiKey={{
+                value: settings.orcarouter?.apiKey ?? '',
+                placeholder: t('settings:providers.orcarouter.apiKeyPlaceholder'),
+                helperText: t('settings:providers.openrouter.helperText'),
+                helperLink: 'https://www.orcarouter.ai',
+                helperLinkLabel: t('settings:providers.orcarouter.helperLinkLabel'),
+                isVisible: !!showApiKey['orcarouter'],
+                onChange: (value) =>
+                  setSettings((prev) => ({
+                    ...prev,
+                    orcarouter: { ...prev.orcarouter!, apiKey: value },
+                  })),
+                onToggleVisibility: () => toggleApiKeyVisibility('orcarouter'),
+              }}
+              model={{
+                value: settings.orcarouter?.model ?? 'orcarouter/auto',
+                placeholder: t('settings:providers.orcarouter.modelPlaceholder'),
+                onChange: (value) =>
+                  setSettings((prev) => ({
+                    ...prev,
+                    orcarouter: { ...prev.orcarouter!, model: value },
+                  })),
+                helperText: 'orcarouter/auto (default) — or any model id exposed by the gateway',
+              }}
+            >
+              <p className="text-xs text-text-muted">
+                OpenAI-compatible gateway. Get your API key from{' '}
+                <a
+                  href="https://www.orcarouter.ai"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-accent hover:underline"
+                >
+                  orcarouter.ai
+                </a>
+                .
               </p>
             </ProviderConfigCard>
           )}

--- a/gitnexus-web/src/config/ui-constants.ts
+++ b/gitnexus-web/src/config/ui-constants.ts
@@ -7,6 +7,8 @@ export const DEFAULT_BACKEND_URL =
   'http://localhost:4747';
 export const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
 export const DEFAULT_OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+export const DEFAULT_ORCAROUTER_BASE_URL = 'https://api.orcarouter.ai/v1';
+export const DEFAULT_ORCAROUTER_MODEL = 'orcarouter/auto';
 
 /**
  * sessionStorage key for the deploy access token sent as

--- a/gitnexus-web/src/core/llm/agent.ts
+++ b/gitnexus-web/src/core/llm/agent.ts
@@ -31,6 +31,7 @@ import type {
   MiniMaxConfig,
   GLMConfig,
   DeepSeekConfig,
+  OrcaRouterConfig,
   AgentStreamChunk,
   AgentHistoryMessage,
   MiniMaxThinkingMode,
@@ -41,7 +42,11 @@ import {
   buildDynamicSystemPrompt,
   CHAT_ONLY_PROMPT_NOTE,
 } from './context-builder';
-import { DEFAULT_OLLAMA_BASE_URL, DEFAULT_OPENROUTER_BASE_URL } from '../../config/ui-constants';
+import {
+  DEFAULT_OLLAMA_BASE_URL,
+  DEFAULT_OPENROUTER_BASE_URL,
+  DEFAULT_ORCAROUTER_BASE_URL,
+} from '../../config/ui-constants';
 import {
   DeepSeekChatOpenAI,
   normalizeMessageContent,
@@ -266,6 +271,36 @@ export const createChatModel = (config: ProviderConfig): BaseChatModel => {
         configuration: {
           apiKey: openRouterConfig.apiKey, // Ensure client receives it
           baseURL: openRouterConfig.baseUrl ?? DEFAULT_OPENROUTER_BASE_URL,
+        },
+        streaming: true,
+      });
+    }
+
+    case 'orcarouter': {
+      const orcaRouterConfig = config as OrcaRouterConfig;
+
+      // Debug logging
+      if (import.meta.env.DEV) {
+        console.log('🐋 OrcaRouter config:', {
+          hasApiKey: !!orcaRouterConfig.apiKey,
+          model: orcaRouterConfig.model,
+          baseUrl: orcaRouterConfig.baseUrl,
+        });
+      }
+
+      if (!orcaRouterConfig.apiKey || orcaRouterConfig.apiKey.trim() === '') {
+        throw new Error('OrcaRouter API key is required but was not provided');
+      }
+
+      return new ChatOpenAI({
+        openAIApiKey: orcaRouterConfig.apiKey,
+        apiKey: orcaRouterConfig.apiKey, // Fallback for some versions
+        modelName: orcaRouterConfig.model,
+        temperature: orcaRouterConfig.temperature ?? 0.1,
+        maxTokens: orcaRouterConfig.maxTokens,
+        configuration: {
+          apiKey: orcaRouterConfig.apiKey, // Ensure client receives it
+          baseURL: orcaRouterConfig.baseUrl ?? DEFAULT_ORCAROUTER_BASE_URL,
         },
         streaming: true,
       });

--- a/gitnexus-web/src/core/llm/settings-service.ts
+++ b/gitnexus-web/src/core/llm/settings-service.ts
@@ -18,10 +18,15 @@ import {
   MiniMaxConfig,
   GLMConfig,
   DeepSeekConfig,
+  OrcaRouterConfig,
   ProviderConfig,
   MINIMAX_MODEL_IDS,
 } from './types';
-import { DEFAULT_OPENROUTER_BASE_URL, DEFAULT_OLLAMA_BASE_URL } from '../../config/ui-constants';
+import {
+  DEFAULT_OPENROUTER_BASE_URL,
+  DEFAULT_OLLAMA_BASE_URL,
+  DEFAULT_ORCAROUTER_BASE_URL,
+} from '../../config/ui-constants';
 import { resilientFetch } from 'gitnexus-shared';
 
 const STORAGE_KEY = 'gitnexus-llm-settings';
@@ -80,6 +85,10 @@ const mergeWithDefaults = (parsed?: Partial<LLMSettings> | null): LLMSettings =>
   deepseek: {
     ...DEFAULT_LLM_SETTINGS.deepseek,
     ...parsed?.deepseek,
+  },
+  orcarouter: {
+    ...DEFAULT_LLM_SETTINGS.orcarouter,
+    ...parsed?.orcarouter,
   },
 });
 
@@ -168,7 +177,9 @@ export const updateProviderSettings = <T extends LLMProvider>(
                     ? Partial<Omit<GLMConfig, 'provider'>>
                     : T extends 'deepseek'
                       ? Partial<Omit<DeepSeekConfig, 'provider'>>
-                      : never
+                      : T extends 'orcarouter'
+                        ? Partial<Omit<OrcaRouterConfig, 'provider'>>
+                        : never
   >,
 ): LLMSettings => {
   const current = loadSettings();
@@ -274,6 +285,17 @@ export const updateProviderSettings = <T extends LLMProvider>(
       saveSettings(updated);
       return updated;
     }
+    case 'orcarouter': {
+      const updated: LLMSettings = {
+        ...current,
+        orcarouter: {
+          ...(current.orcarouter ?? {}),
+          ...(updates as Partial<Omit<OrcaRouterConfig, 'provider'>>),
+        },
+      };
+      saveSettings(updated);
+      return updated;
+    }
     default: {
       // Should be unreachable due to T extends LLMProvider, but keep a safe fallback
       const updated: LLMSettings = { ...current };
@@ -355,6 +377,17 @@ const providerBuilders: Record<LLMProvider, ProviderBuilder> = {
     if (!settings.deepseek?.apiKey) return null;
     return { provider: 'deepseek', ...settings.deepseek } as DeepSeekConfig;
   },
+  orcarouter: (settings) => {
+    if (!settings.orcarouter?.apiKey || settings.orcarouter.apiKey.trim() === '') return null;
+    return {
+      provider: 'orcarouter',
+      apiKey: settings.orcarouter.apiKey,
+      model: settings.orcarouter.model || 'orcarouter/auto',
+      baseUrl: settings.orcarouter.baseUrl || DEFAULT_ORCAROUTER_BASE_URL,
+      temperature: settings.orcarouter.temperature,
+      maxTokens: settings.orcarouter.maxTokens,
+    } as OrcaRouterConfig;
+  },
 };
 
 export const getActiveProviderConfig = (): ProviderConfig | null => {
@@ -427,6 +460,8 @@ export const getProviderDisplayName = (provider: LLMProvider): string => {
       return 'GLM (Z.AI)';
     case 'deepseek':
       return 'DeepSeek';
+    case 'orcarouter':
+      return 'OrcaRouter';
     default:
       return provider;
   }
@@ -459,6 +494,8 @@ export const getAvailableModels = (provider: LLMProvider): string[] => {
       return ['GLM-5', 'GLM-5-Turbo', 'GLM-4.7', 'GLM-4.5'];
     case 'deepseek':
       return ['deepseek-v4-flash', 'deepseek-v4-pro', 'deepseek-chat', 'deepseek-reasoner'];
+    case 'orcarouter':
+      return ['orcarouter/auto'];
     default:
       return [];
   }

--- a/gitnexus-web/src/core/llm/types.ts
+++ b/gitnexus-web/src/core/llm/types.ts
@@ -2,13 +2,18 @@
  * LLM Provider Types
  *
  * Type definitions for multi-provider LLM support.
- * Supports OpenAI, Azure OpenAI, Gemini, Anthropic, Ollama, OpenRouter, MiniMax, GLM, and DeepSeek.
+ * Supports OpenAI, Azure OpenAI, Gemini, Anthropic, Ollama, OpenRouter, MiniMax, GLM, DeepSeek, and OrcaRouter.
  */
 
 /**
  * Supported LLM providers
  */
-import { DEFAULT_OLLAMA_BASE_URL, DEFAULT_OPENROUTER_BASE_URL } from '../../config/ui-constants';
+import {
+  DEFAULT_OLLAMA_BASE_URL,
+  DEFAULT_OPENROUTER_BASE_URL,
+  DEFAULT_ORCAROUTER_BASE_URL,
+  DEFAULT_ORCAROUTER_MODEL,
+} from '../../config/ui-constants';
 export type LLMProvider =
   | 'openai'
   | 'azure-openai'
@@ -18,7 +23,8 @@ export type LLMProvider =
   | 'openrouter'
   | 'minimax'
   | 'glm'
-  | 'deepseek';
+  | 'deepseek'
+  | 'orcarouter';
 
 export const MINIMAX_ANTHROPIC_BASE_URLS = {
   global_en: 'https://api.minimax.io/anthropic',
@@ -184,6 +190,16 @@ export interface DeepSeekConfig extends BaseProviderConfig {
 }
 
 /**
+ * OrcaRouter configuration — OpenAI-compatible gateway
+ */
+export interface OrcaRouterConfig extends BaseProviderConfig {
+  provider: 'orcarouter';
+  apiKey: string;
+  model: string; // e.g., 'orcarouter/auto'
+  baseUrl?: string; // defaults to https://api.orcarouter.ai/v1
+}
+
+/**
  * Union type for all provider configurations
  */
 export type ProviderConfig =
@@ -195,7 +211,8 @@ export type ProviderConfig =
   | OpenRouterConfig
   | MiniMaxConfig
   | GLMConfig
-  | DeepSeekConfig;
+  | DeepSeekConfig
+  | OrcaRouterConfig;
 
 /**
  * Stored settings (what goes to localStorage)
@@ -215,6 +232,7 @@ export interface LLMSettings {
   minimax?: Partial<Omit<MiniMaxConfig, 'provider'>>;
   glm?: Partial<Omit<GLMConfig, 'provider'>>;
   deepseek?: Partial<Omit<DeepSeekConfig, 'provider'>>;
+  orcarouter?: Partial<Omit<OrcaRouterConfig, 'provider'>>;
 
   // Intelligent Clustering Settings
   intelligentClustering: boolean;
@@ -281,6 +299,12 @@ export const DEFAULT_LLM_SETTINGS: LLMSettings = {
   deepseek: {
     apiKey: '',
     model: 'deepseek-v4-flash',
+    temperature: 0.1,
+  },
+  orcarouter: {
+    apiKey: '',
+    model: DEFAULT_ORCAROUTER_MODEL,
+    baseUrl: DEFAULT_ORCAROUTER_BASE_URL,
     temperature: 0.1,
   },
 };

--- a/gitnexus-web/src/locales/en/settings.json
+++ b/gitnexus-web/src/locales/en/settings.json
@@ -93,6 +93,10 @@
     },
     "glm": {
       "apiKeyPlaceholder": "Enter your Z.AI API key"
+    },
+    "orcarouter": {
+      "apiKeyPlaceholder": "Enter your OrcaRouter API key",
+      "helperLinkLabel": "OrcaRouter"
     }
   },
   "loadingModels": "Loading models...",

--- a/gitnexus-web/src/locales/zh-CN/settings.json
+++ b/gitnexus-web/src/locales/zh-CN/settings.json
@@ -93,6 +93,10 @@
     },
     "glm": {
       "apiKeyPlaceholder": "输入 Z.AI API Key"
+    },
+    "orcarouter": {
+      "apiKeyPlaceholder": "输入 OrcaRouter API Key",
+      "helperLinkLabel": "OrcaRouter"
     }
   },
   "loadingModels": "正在加载模型...",

--- a/gitnexus-web/test/unit/settings-service.test.ts
+++ b/gitnexus-web/test/unit/settings-service.test.ts
@@ -151,6 +151,19 @@ describe('getActiveProviderConfig', () => {
     expect(config!.provider).toBe('deepseek');
   });
 
+  it('returns config for orcarouter when API key is set', () => {
+    const settings = loadSettings();
+    settings.activeProvider = 'orcarouter';
+    settings.orcarouter = { ...settings.orcarouter, apiKey: 'sk-orca-123' };
+    saveSettings(settings);
+
+    const config = getActiveProviderConfig();
+    expect(config).not.toBeNull();
+    expect(config!.provider).toBe('orcarouter');
+    expect(config!.baseUrl).toBe('https://api.orcarouter.ai/v1');
+    expect(config!.model).toBe('orcarouter/auto');
+  });
+
   it('returns the regional endpoint and thinking mode for MiniMax', () => {
     const settings = loadSettings();
     settings.activeProvider = 'minimax';
@@ -175,6 +188,15 @@ describe('getActiveProviderConfig', () => {
     const settings = loadSettings();
     settings.activeProvider = 'openrouter';
     settings.openrouter = { ...settings.openrouter, apiKey: '  ' };
+    saveSettings(settings);
+
+    expect(getActiveProviderConfig()).toBeNull();
+  });
+
+  it('returns null for orcarouter with empty API key', () => {
+    const settings = loadSettings();
+    settings.activeProvider = 'orcarouter';
+    settings.orcarouter = { ...settings.orcarouter, apiKey: '  ' };
     saveSettings(settings);
 
     expect(getActiveProviderConfig()).toBeNull();
@@ -207,6 +229,7 @@ describe('getProviderDisplayName', () => {
     expect(getProviderDisplayName('ollama')).toBe('Ollama (Local)');
     expect(getProviderDisplayName('openrouter')).toBe('OpenRouter');
     expect(getProviderDisplayName('deepseek')).toBe('DeepSeek');
+    expect(getProviderDisplayName('orcarouter')).toBe('OrcaRouter');
   });
 });
 
@@ -217,6 +240,7 @@ describe('getAvailableModels', () => {
     expect(getAvailableModels('anthropic')).toContain('claude-sonnet-4-20250514');
     expect(getAvailableModels('deepseek')).toContain('deepseek-v4-flash');
     expect(getAvailableModels('minimax')).toEqual([...MINIMAX_MODEL_IDS]);
+    expect(getAvailableModels('orcarouter')).toContain('orcarouter/auto');
   });
 
   it('describes MiniMax model input and thinking capabilities', () => {


### PR DESCRIPTION
## What

Adds **OrcaRouter** as a first-class, named LLM provider in the WebUI, mirroring the existing OpenRouter wiring.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model gateway that routes a single API key across 160+ models. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `gitnexus-web/src/core/llm/types.ts` — new `orcarouter` entry in the `LLMProvider` union, an `OrcaRouterConfig` interface, `ProviderConfig` / `LLMSettings` union members, and default settings (`baseUrl: https://api.orcarouter.ai/v1`, default model `orcarouter/auto`).
- `gitnexus-web/src/core/llm/agent.ts` — new `createChatModel` case that builds a `ChatOpenAI` client pointed at the OrcaRouter base URL (same pattern as OpenRouter).
- `gitnexus-web/src/core/llm/settings-service.ts` — persistence/validation in `mergeWithDefaults`, `updateProviderSettings`, `providerBuilders`, plus display name and default model list.
- `gitnexus-web/src/components/SettingsPanel.tsx` — OrcaRouter appears in the provider pick list (🐳) with its own config card and key/model fields.
- i18n for `en` and `zh-CN`.
- Unit tests for config resolution, empty-key validation, display name, and available models.

## How to verify

- `cd gitnexus-web && npx tsc -b` — passes
- `npx vitest run` — 421 passed (including new `orcarouter` cases)
- `npx prettier --check` on changed files — clean
- `npx eslint` on changed files — 0 errors
- Live check against the gateway: a chat completion via `ChatOpenAI(baseURL: https://api.orcarouter.ai/v1, model: orcarouter/auto)` returned `ORCA-LIVE-OK`.

Disclosure: I'm an engineer on the OrcaRouter team.

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*A provider addition that spans the web UI, LLM configuration, persistence, localization, and tests. The blast is broad across the settings path, although the affected execution-flow count is empty and no individual file is marked high risk.*

**🔴 CRITICAL blast radius. A web frontend and LLM provider configuration change adding OrcaRouter, with impact reaching callers across the `gitnexus-web` LLM settings path.**

The change is concentrated in `gitnexus-web/src/core/llm/settings-service.ts`, where `mergeMiniMaxSettings`, `readSettings`, `updateProviderSettings`, `setActiveProvider`, `clearSettings`, `getAvailableModels`, `STORAGE_KEY`, and `ProviderCapabilities` are affected. Review this file first, then trace how `createChatModel`, `thinkingMode`, and `temperature` in `gitnexus-web/src/core/llm/agent.ts` connect to `SettingsPanel` in `gitnexus-web/src/components/SettingsPanel.tsx`.

The broader surface includes `LLMSettings`, `ChatMessage`, `MINIMAX_DOCS_ROOTS`, and `DEFAULT_LLM_SETTINGS` in `gitnexus-web/src/core/llm/types.ts`, plus UI constants, English and Chinese settings locales, and `gitnexus-web/test/unit/settings-service.test.ts`. The architecture impact spans `Llm`, `Hooks`, `Components`, `Services`, `Graph`, and `App-state`; 0 affected flows were found. Individual file risk is LOW, with no HIGH or CRITICAL risk files identified.

_Added by GitNexus for PR #2997. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->