### PR TITLE
fix(ingestion): index JavaScript module extensions

### DIFF
--- a/gitnexus/src/core/ingestion/languages/typescript.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript.ts
@@ -469,7 +469,7 @@ export const typescriptProvider = defineLanguage({
 
 export const javascriptProvider = defineLanguage({
   id: SupportedLanguages.JavaScript,
-  extensions: ['.js', '.jsx'],
+  extensions: ['.js', '.jsx', '.mjs', '.cjs'],
   entryPointPatterns: [/^use[A-Z]/],
   astFrameworkPatterns: [
     {

--- a/gitnexus/test/unit/ingestion-utils.test.ts
+++ b/gitnexus/test/unit/ingestion-utils.test.ts
@@ -40,12 +40,9 @@ describe('getLanguageFromFilename', () => {
   });
 
   describe('JavaScript', () => {
-    it('detects .js files', () => {
-      expect(getLanguageFromFilename('index.js')).toBe(SupportedLanguages.JavaScript);
-    });
-
-    it('detects .jsx files', () => {
-      expect(getLanguageFromFilename('App.jsx')).toBe(SupportedLanguages.JavaScript);
+    it.each(['.js', '.jsx', '.mjs', '.cjs'])('detects %s files', (ext) => {
+      expect(getLanguageFromFilename(`module${ext}`)).toBe(SupportedLanguages.JavaScript);
+      expect(getProviderForFile(`src/module${ext}`)?.id).toBe(SupportedLanguages.JavaScript);
     });
   });
 


### PR DESCRIPTION
## Summary

- register `.mjs` and `.cjs` with the JavaScript ingestion provider
- cover both shared language detection and provider lookup for all JavaScript extensions

## Why

The shared detector and import resolver already recognize `.mjs` and `.cjs`, but the ingestion provider only registered `.js` and `.jsx`. As a result, module-format JavaScript files were discovered but never assigned a parser provider.

Closes #3033.

## Verification

- `npm test -- --run test/unit/ingestion-utils.test.ts` (109 passed)
- `npx tsc --noEmit`

## Risk

Low. The change routes two existing JavaScript extensions through the same provider and grammar already used for `.js` and `.jsx`.

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*A small, self-contained ingestion change with low blast radius. The implementation and its unit coverage are concentrated in the JavaScript and TypeScript indexing path.*

**🟢 LOW blast radius. A JavaScript module extension indexing change in `gitnexus/src/core/ingestion/languages/typescript.ts`, covered by `gitnexus/test/unit/ingestion-utils.test.ts`, with no graph-discovered dependents.**

The implementation is centered on the `javascriptProvider` constant in `gitnexus/src/core/ingestion/languages/typescript.ts`, with corresponding coverage in `gitnexus/test/unit/ingestion-utils.test.ts`. Review the provider logic and the ingestion utility test first.

The graph identifies no affected flows and no cross-repo consumers. There are no HIGH or CRITICAL risk files.

_Added by GitNexus for PR #3034. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->