### PR TITLE
docs(pdg): replace unbounded guard query with bounded example

### DIFF
--- a/.claude/skills/gitnexus/gitnexus-pdg-query/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-pdg-query/SKILL.md
@@ -36,7 +36,7 @@ All three are `BasicBlock → BasicBlock` edges in the single `CodeRelation` tab
 
 - `pdg_query({ mode: 'controls', target })` — CDG. For the anchored function,
   each edge: controlling predicate block → dependent block + branch sense in
-  `label` (`'T'` = predicate's true/taken arm, `'F'` = false/fall-through). An
+  `reason` (`'T'` = predicate's true/taken arm, `'F'` = false/fall-through). An
   edge into an early-return/throw block is flagged `guard: true`.
 - `pdg_query({ mode: 'flows', target, variable? })` — REACHING_DEF def→use
   edges; `variable` filters to one binding.
@@ -44,16 +44,37 @@ All three are `BasicBlock → BasicBlock` edges in the single `CodeRelation` tab
 `target` is **required** — a file path or a symbol/function name (resolved like
 `context()`). There is no anchorless mode (see below).
 
-## The corrected guard-clause Cypher
+## Guard-clause queries
 
-The RFC #567 §2 form (`[:CDG {label:'F'}]`) does **not** run as written. Edges
-are values of the single `CodeRelation` table's `type` property, and the branch
-sense is in `reason`, NOT a `label` column:
+Prefer the dedicated, bounded `pdg_query` surface for guard discovery:
+
+```text
+pdg_query({ mode: 'controls', target: '<function-or-file>' })
+```
+
+Filter the returned rows for `guard: true` when you only need early-return or
+throw guards. The tool requires an explicit target and applies its own bounded
+result limit, so it cannot accidentally turn a local guard lookup into a
+repository-wide CDG scan.
+
+If you are debugging the graph and truly need raw Cypher, keep the same two
+constraints explicit: anchor the blocks to one known function/file span **and**
+add a deterministic `LIMIT`. CDG edges are values of the single `CodeRelation`
+table's `type` property, and the branch sense is in `reason`, not a `label`
+column. For example, after resolving a function to its file and line span:
 
 ```cypher
 MATCH (pred:BasicBlock)-[r:CodeRelation {type: 'CDG'}]->(dep:BasicBlock)
-WHERE dep.text STARTS WITH 'return' OR dep.text STARTS WITH 'throw'
+WHERE pred.filePath = $filePath
+  AND dep.filePath = $filePath
+  AND pred.startLine >= $startLine
+  AND pred.startLine <= $endLine
+  AND dep.startLine >= $startLine
+  AND dep.startLine <= $endLine
+  AND (dep.text STARTS WITH 'return' OR dep.text STARTS WITH 'throw')
 RETURN pred.startLine, r.reason AS branch, dep.startLine, dep.text
+ORDER BY dep.startLine, pred.startLine
+LIMIT 100
 ```
 
 `r.reason` is the sense the predicate took to reach the early exit. For
@@ -66,7 +87,7 @@ so don't hard-code one sense.
 - **Always anchored + LIMIT-bounded.** LadybugDB has no rel-property index, so
   an unanchored `[:CDG*]`/`[:REACHING_DEF*]` path scan is unbounded. `pdg_query`
   requires `target` and bounds the page; raw `cypher` callers must anchor on a
-  file id-prefix or symbol span themselves.
+  file id-prefix or symbol span themselves and include a deterministic `LIMIT`.
 - **BasicBlock↔symbol join is reconstructed.** No `Function→BasicBlock` edge:
   the block is matched by its id-prefix (`BasicBlock:<file>:<fnStartLine>:…`)
   plus `startLine` within the symbol's span. BasicBlock `startLine` is **1-based**

--- a/gitnexus-claude-plugin/skills/gitnexus-pdg-query/SKILL.md
+++ b/gitnexus-claude-plugin/skills/gitnexus-pdg-query/SKILL.md
@@ -44,16 +44,37 @@ All three are `BasicBlock → BasicBlock` edges in the single `CodeRelation` tab
 `target` is **required** — a file path or a symbol/function name (resolved like
 `context()`). There is no anchorless mode (see below).
 
-## The corrected guard-clause Cypher
+## Guard-clause queries
 
-The RFC #567 §2 form (`[:CDG {label:'F'}]`) does **not** run as written. Edges
-are values of the single `CodeRelation` table's `type` property, and the branch
-sense is in `reason`, NOT a `label` column:
+Prefer the dedicated, bounded `pdg_query` surface for guard discovery:
+
+```text
+pdg_query({ mode: 'controls', target: '<function-or-file>' })
+```
+
+Filter the returned rows for `guard: true` when you only need early-return or
+throw guards. The tool requires an explicit target and applies its own bounded
+result limit, so it cannot accidentally turn a local guard lookup into a
+repository-wide CDG scan.
+
+If you are debugging the graph and truly need raw Cypher, keep the same two
+constraints explicit: anchor the blocks to one known function/file span **and**
+add a deterministic `LIMIT`. CDG edges are values of the single `CodeRelation`
+table's `type` property, and the branch sense is in `reason`, not a `label`
+column. For example, after resolving a function to its file and line span:
 
 ```cypher
 MATCH (pred:BasicBlock)-[r:CodeRelation {type: 'CDG'}]->(dep:BasicBlock)
-WHERE dep.text STARTS WITH 'return' OR dep.text STARTS WITH 'throw'
+WHERE pred.filePath = $filePath
+  AND dep.filePath = $filePath
+  AND pred.startLine >= $startLine
+  AND pred.startLine <= $endLine
+  AND dep.startLine >= $startLine
+  AND dep.startLine <= $endLine
+  AND (dep.text STARTS WITH 'return' OR dep.text STARTS WITH 'throw')
 RETURN pred.startLine, r.reason AS branch, dep.startLine, dep.text
+ORDER BY dep.startLine, pred.startLine
+LIMIT 100
 ```
 
 `r.reason` is the sense the predicate took to reach the early exit. For
@@ -66,7 +87,7 @@ so don't hard-code one sense.
 - **Always anchored + LIMIT-bounded.** LadybugDB has no rel-property index, so
   an unanchored `[:CDG*]`/`[:REACHING_DEF*]` path scan is unbounded. `pdg_query`
   requires `target` and bounds the page; raw `cypher` callers must anchor on a
-  file id-prefix or symbol span themselves.
+  file id-prefix or symbol span themselves and include a deterministic `LIMIT`.
 - **BasicBlock↔symbol join is reconstructed.** No `Function→BasicBlock` edge:
   the block is matched by its id-prefix (`BasicBlock:<file>:<fnStartLine>:…`)
   plus `startLine` within the symbol's span. BasicBlock `startLine` is **1-based**

--- a/gitnexus/skills/gitnexus-pdg-query.md
+++ b/gitnexus/skills/gitnexus-pdg-query.md
@@ -44,16 +44,37 @@ All three are `BasicBlock → BasicBlock` edges in the single `CodeRelation` tab
 `target` is **required** — a file path or a symbol/function name (resolved like
 `context()`). There is no anchorless mode (see below).
 
-## The corrected guard-clause Cypher
+## Guard-clause queries
 
-The RFC #567 §2 form (`[:CDG {label:'F'}]`) does **not** run as written. Edges
-are values of the single `CodeRelation` table's `type` property, and the branch
-sense is in `reason`, NOT a `label` column:
+Prefer the dedicated, bounded `pdg_query` surface for guard discovery:
+
+```text
+pdg_query({ mode: 'controls', target: '<function-or-file>' })
+```
+
+Filter the returned rows for `guard: true` when you only need early-return or
+throw guards. The tool requires an explicit target and applies its own bounded
+result limit, so it cannot accidentally turn a local guard lookup into a
+repository-wide CDG scan.
+
+If you are debugging the graph and truly need raw Cypher, keep the same two
+constraints explicit: anchor the blocks to one known function/file span **and**
+add a deterministic `LIMIT`. CDG edges are values of the single `CodeRelation`
+table's `type` property, and the branch sense is in `reason`, not a `label`
+column. For example, after resolving a function to its file and line span:
 
 ```cypher
 MATCH (pred:BasicBlock)-[r:CodeRelation {type: 'CDG'}]->(dep:BasicBlock)
-WHERE dep.text STARTS WITH 'return' OR dep.text STARTS WITH 'throw'
+WHERE pred.filePath = $filePath
+  AND dep.filePath = $filePath
+  AND pred.startLine >= $startLine
+  AND pred.startLine <= $endLine
+  AND dep.startLine >= $startLine
+  AND dep.startLine <= $endLine
+  AND (dep.text STARTS WITH 'return' OR dep.text STARTS WITH 'throw')
 RETURN pred.startLine, r.reason AS branch, dep.startLine, dep.text
+ORDER BY dep.startLine, pred.startLine
+LIMIT 100
 ```
 
 `r.reason` is the sense the predicate took to reach the early exit. For
@@ -66,7 +87,7 @@ so don't hard-code one sense.
 - **Always anchored + LIMIT-bounded.** LadybugDB has no rel-property index, so
   an unanchored `[:CDG*]`/`[:REACHING_DEF*]` path scan is unbounded. `pdg_query`
   requires `target` and bounds the page; raw `cypher` callers must anchor on a
-  file id-prefix or symbol span themselves.
+  file id-prefix or symbol span themselves and include a deterministic `LIMIT`.
 - **BasicBlock↔symbol join is reconstructed.** No `Function→BasicBlock` edge:
   the block is matched by its id-prefix (`BasicBlock:<file>:<fnStartLine>:…`)
   plus `startLine` within the symbol's span. BasicBlock `startLine` is **1-based**


### PR DESCRIPTION
## Summary

<!-- One or two sentences: what does this PR change? -->

## Motivation / context

<!-- Why is this change needed? Link issues, ADRs, or prior discussion. -->

## Areas touched

<!-- Check all that apply -->

- [ ] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- <!-- bullets -->

**Explicitly out of scope / not done here**

- <!-- bullets — prevents reviewers assuming missing work is an oversight -->

## Implementation notes

<!-- Optional: design choices, tradeoffs, follow-ups -->

## Testing & verification

<!-- What you ran; paste commands. Omit sections that do not apply. -->

- [ ] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [ ] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(if web changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

## Risk & rollout

<!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->

## Checklist

- [ ] PR body meets repo minimum length (workflow may label short descriptions)
- [ ] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [ ] No secrets, tokens, or machine-specific paths committed

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*A small, self-contained documentation update that tightens PDG query guidance while keeping the change isolated from runtime code and execution flows.*

**🟢 LOW blast radius. A documentation and skill guidance change replacing an unbounded guard query with a bounded example across three skill documentation files, with no graph dependents.**

The change is concentrated in `gitnexus-claude-plugin/skills/gitnexus-pdg-query/SKILL.md`, which has the highest concentration of changed symbols. Review the updated `PDG query surface with GitNexus`, `The corrected guard-clause Cypher`, `Gotchas (the load-bearing ones)`, and `Mirror, don't fork` sections first.

The same guidance is mirrored in `.claude/skills/gitnexus/gitnexus-pdg-query/SKILL.md` and `gitnexus/skills/gitnexus-pdg-query.md`. Check that the corrected guard-clause Cypher and the surrounding guidance remain consistent across all three files.

_Added by GitNexus for PR #3042. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->