### PR TITLE
fix(ingestion): treat an empty constant fold as a resolved route path, not a skip

### DIFF
--- a/gitnexus/src/core/ingestion/route-extractors/java-const-resolver.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/java-const-resolver.ts
@@ -619,12 +619,20 @@ function foldOperands(
 /**
  * Fold an inline operand list (e.g. `API_CIS_V1 + "summary/save"`) against
  * `fileKey`, or null when any piece is unresolvable (skip floor).
+ *
+ * An empty result is a SUCCESS, not a skip. `static final String ROOT = "";`
+ * folds to `""`, which `joinPath` then resolves against the type-level prefix
+ * exactly as it resolves the literal `@GetMapping("")`. Collapsing it into
+ * `null` would make a resolved-empty path indistinguishable from an
+ * unresolvable one — the skip floor is reserved for "could not fold", and
+ * nothing else in the resolver conflates the two: `resolveOperands` in the
+ * shared core returns `foldExpr` unfiltered, and `resolveJavaConstant` returns
+ * `""` for an empty constant.
  */
 export function foldJavaOperands(
   fileKey: string,
   operands: readonly Operand[],
   repo: RepoConstants,
 ): string | null {
-  const out = foldOperands(fileKey, operands, newFoldState(repo), 0);
-  return out === '' ? null : out;
+  return foldOperands(fileKey, operands, newFoldState(repo), 0);
 }

--- a/gitnexus/test/unit/group/java-const-route-parity.test.ts
+++ b/gitnexus/test/unit/group/java-const-route-parity.test.ts
@@ -211,3 +211,46 @@ public class OrderController {
     expect(ingestionRoutes(files)).toEqual(['POST /api/v1/orders']);
   });
 });
+
+describe('an empty-valued constant route matches its literal spelling', () => {
+  // Before this fix the two spellings diverged: `@GetMapping("")` was kept and
+  // `@GetMapping(ApiPaths.ROOT)` with `ROOT = ""` was dropped, because the fold
+  // collapsed a resolved-empty result into the skip floor. The class-level
+  // prefix is what makes an empty method path meaningful, so the parity is
+  // asserted with one present.
+  const ROOT_CONSTS = `package com.example;
+public class ApiPaths {
+  public static final String ROOT = "";
+}`;
+
+  const controller = (mapping: string): string => `package com.example;
+import com.example.ApiPaths;
+@RequestMapping("/api/v1")
+public class RootController {
+  @GetMapping(${mapping})
+  public void root() {}
+}`;
+
+  it('resolves the constant spelling to the same path as the literal one', () => {
+    const literal = { [CTL]: controller('""') };
+    const constant = { [CONSTS]: ROOT_CONSTS, [CTL]: controller('ApiPaths.ROOT') };
+
+    expect(groupProviders(constant)).toEqual(groupProviders(literal));
+    expect(ingestionRoutes(constant)).toEqual(ingestionRoutes(literal));
+  });
+
+  it('emits the route on both sides rather than dropping it', () => {
+    // Deliberately NOT asserting the two sides produce the same string here.
+    // They do not, and they did not before this change either: measured on the
+    // LITERAL spelling, which no part of this change touches, the group side
+    // emits `/api/v1/` (`joinPath` appends `/` before an empty method path)
+    // while ingestion emits `/api/v1`. That trailing-slash divergence is a
+    // separate pre-existing defect; the fix here only makes the constant
+    // spelling reach it too, instead of silently dropping the route. The test
+    // above is what pins the parity that this change is responsible for —
+    // constant behaves as literal, on each side.
+    const files = { [CONSTS]: ROOT_CONSTS, [CTL]: controller('ApiPaths.ROOT') };
+    expect(groupProviders(files)).toEqual(['GET /api/v1/']);
+    expect(ingestionRoutes(files)).toEqual(['GET /api/v1']);
+  });
+});

--- a/gitnexus/test/unit/java-route-const-resolver.test.ts
+++ b/gitnexus/test/unit/java-route-const-resolver.test.ts
@@ -792,3 +792,66 @@ describe('text blocks keep the skip floor', () => {
     expect(extractJavaModuleConstants(parse(src)).literals.has('X')).toBe(false);
   });
 });
+
+describe('an empty fold is a success, not a skip', () => {
+  // `null` from this fold is the SKIP FLOOR: it means "a piece was
+  // unresolvable", and every caller acts on it by dropping the route. An
+  // empty-valued constant is not that case — it resolved, to the empty string.
+  // Spring reads `@GetMapping(ROOT)` with `ROOT = ""` exactly as it reads
+  // `@GetMapping("")`, and the group extractor's literal branch already keeps
+  // the latter. Collapsing the two silently lost the route for the constant
+  // spelling alone.
+  const EMPTY = 'src/main/java/com/example/Paths.java';
+
+  it('folds a constant whose value is the empty string', () => {
+    const repo = repoOf({
+      [EMPTY]: `package com.example;
+public class Paths { public static final String ROOT = ""; }`,
+    });
+    expect(foldJavaOperands(EMPTY, [{ kind: 'ref', name: 'ROOT' }], repo)).toBe('');
+  });
+
+  it('concatenating empty constants folds to the empty string', () => {
+    const repo = repoOf({
+      [EMPTY]: `package com.example;
+public class Paths {
+  public static final String A = "";
+  public static final String B = "";
+}`,
+    });
+    expect(
+      foldJavaOperands(
+        EMPTY,
+        [
+          { kind: 'ref', name: 'A' },
+          { kind: 'ref', name: 'B' },
+        ],
+        repo,
+      ),
+    ).toBe('');
+  });
+
+  it('still floors to skip when a piece is genuinely unresolvable', () => {
+    // The control: the two outcomes have to stay distinguishable, or the fix
+    // would trade one conflation for another.
+    const repo = repoOf({
+      [EMPTY]: `package com.example;
+public class Paths { public static final String ROOT = compute(); }`,
+    });
+    expect(foldJavaOperands(EMPTY, [{ kind: 'ref', name: 'ROOT' }], repo)).toBeNull();
+  });
+
+  it('agrees with resolveJavaConstant, which never collapsed empty to null', () => {
+    // The binding used to disagree with itself: the single-constant resolver
+    // returns `""` (pinned by the 30-level DAG case above, whose every
+    // intermediate value is empty), and `resolveOperands` in the shared
+    // language-agnostic core returns `foldExpr` unfiltered. Only this fold
+    // collapsed.
+    const repo = repoOf({
+      [EMPTY]: `package com.example;
+public class Paths { public static final String ROOT = ""; }`,
+    });
+    expect(resolveJavaConstant(EMPTY, 'ROOT', repo)).toBe('');
+    expect(foldJavaOperands(EMPTY, [{ kind: 'ref', name: 'ROOT' }], repo)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

`foldJavaOperands` returned `null` for a constant that folds to the empty string, so `@GetMapping(ROOT)` with `static final String ROOT = "";` produced no route while the literal `@GetMapping("")` on the same controller produced one. `null` from that function is the skip floor — "a piece was unresolvable" — and an empty result is not that case.

## Motivation / context

Found by the review bot on #3059 (which adds the Kotlin binding). Investigating it showed the collapse is an anomaly in one function rather than a deliberate rule, on four independent counts:

1. **The shared core does not collapse.** `resolveOperands` in `constant-resolver.ts` returns `foldExpr(...)` unfiltered, so every language that reaches the fold through the language-agnostic path — JavaScript, Python, anything without a provider hook — already treats `""` as a result.
2. **The sibling function does not collapse.** `resolveJavaConstant` returns `""` for an empty constant, and that is already pinned by an existing test: the 30-level shared-descendant DAG case added with #2980 asserts `toBe('')`, its every intermediate value being the empty string.
3. **The literal branch does not drop it.** `java.ts:608-610` skips only when `unquoteLiteral(...) === null`, so `@GetMapping("")` is kept.
4. **The doc comment says otherwise.** It reserves `null` for "when any piece is unresolvable (skip floor)".

So the binding disagreed with the core, with its own sibling, with the literal path it is meant to mirror, and with its own documentation.

## Areas touched

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only

## Scope & constraints

**In scope**

- Drop the `out === '' ? null : out` filter in `foldJavaOperands`, and explain in the doc comment why an empty fold is a success.
- Unit coverage for the new behaviour, its multi-operand form, and — as a control — that a genuinely unresolvable operand still returns `null`, so the two outcomes stay distinguishable.
- A group ↔ ingestion parity case asserting that the constant spelling now behaves like the literal one on each side.

**Explicitly out of scope / not done here**

- **The trailing-slash divergence between the two sides.** Writing the parity test surfaced that an empty method path renders as `/api/v1/` from the group extractor (`joinPath` inserts the separator ahead of an empty path) and as `/api/v1` from ingestion. This reproduces on `main` with the **literal** spelling, with no part of this change involved — I measured it before adjusting the test. It is a separate defect, so the test pins both strings as current behaviour rather than asserting the divergence away. Happy to open it as its own issue or PR.
- **The Kotlin binding.** `foldKotlinOperands` in #3059 mirrors this function line for line, including the filter. That PR will be updated to match once the shape here is agreed, so the two bindings never diverge.

## Implementation notes

An empty method path is meaningful precisely when the type carries the prefix: `@RequestMapping("/api/v1")` on the class and an empty path on the method is how Spring spells "the collection root". Dropping the route lost a real endpoint rather than avoiding a wrong one, which inverts what the skip floor is for.

The three call sites need no change — `http-patterns/java.ts`, and the ingestion hook wired at `languages/java.ts:245` — because each already branches on `=== null` and then uses the string as-is, which is exactly how they treat a literal empty path today.

## Testing & verification

- [x] `cd gitnexus && npm test` — **18697 passed, 4 failed.** All four failures are environmental and pre-existing on my macOS machine, in `analyze-index-lock-concurrency.test.ts`, `hooks.test.ts` and `review-agent-workflow.test.ts`; none references route extraction or constant resolution. The last two reproduce on a clean checkout of the base commit.
- [ ] `cd gitnexus && npm run test:integration` — not run separately; the integration specs ran as part of the suite above, after `npm run build`.
- [x] `cd gitnexus && npx tsc --noEmit` — clean
- [x] `npx prettier --check` and `npx eslint` on the three changed files — clean (eslint reports only pre-existing non-null-assertion warnings elsewhere in the file)
- [ ] `cd gitnexus-web && …` — web untouched

## Risk & rollout

**This changes the graph Java emits**, which is why it is not folded into #3059. Re-indexing a Spring service that uses an empty-valued constant as a method path will now emit a route where it previously emitted none. The added route is one the application genuinely serves; no previously emitted route changes or disappears.

Rollback is a one-line revert.

## Checklist

- [x] PR body meets repo minimum length
- [x] `AGENTS.md` / overlays unchanged, so no header or changelog update is due
- [x] No secrets, tokens, or machine-specific paths committed

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*A narrowly scoped Java ingestion change with critical blast posture, centered on route extraction and backed by focused resolver parity tests. The graph shows limited direct reach, but the affected execution flows make the resolver behavior important to review closely.*

**🔴 CRITICAL blast radius. A Java constant-folding change to `foldJavaOperands` in `gitnexus/src/core/ingestion/route-extractors/java-const-resolver.ts`, reaching one direct dependent across 12 affected flows.**

The implementation change is concentrated in the `Route-extractors` module, with related impact in `Http-patterns`. The accompanying coverage is in `gitnexus/test/unit/group/java-const-route-parity.test.ts` and `gitnexus/test/unit/java-route-const-resolver.test.ts`.

Review `foldJavaOperands` first, particularly how an empty constant fold is handled as a resolved route path rather than skipped. Then verify the route parity and resolver unit tests cover that behavior across the affected flows.

_Added by GitNexus for PR #3061. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->