### PR TITLE
chore: release v1.6.10

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.9",
+      "version": "1.6.10",
       "source": {
         "source": "local",
         "path": "./gitnexus-claude-plugin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.9",
+      "version": "1.6.10",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/eval/workflow_bench/runtime_mounts.py
+++ b/eval/workflow_bench/runtime_mounts.py
@@ -28,8 +28,10 @@ from .proposer_sandbox import (
     SandboxError,
 )
 
-PINNED_GITNEXUS_VERSION = "1.6.9"
 HARNESS_ROOT = Path(__file__).resolve().parents[2]
+# The mounted runtime is built from this checkout, so the pin tracks the harness'
+# own package version. A hardcoded copy only drifts on release day (#3064).
+PINNED_GITNEXUS_VERSION = json.loads((HARNESS_ROOT / "gitnexus" / "package.json").read_text())["version"]
 
 CE_ARMS = frozenset({"ce_workflow", "ce_workflow_direct", "ce_review"})
 SANDBOX_CE_PLUGIN = "/opt/compound-engineering-plugin"

--- a/gitnexus-claude-plugin/.claude-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "author": {
     "name": "GitNexus"
   },

--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "skills": "./skills",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",

--- a/gitnexus-claude-plugin/skills/gitnexus-cli/mcp.json
+++ b/gitnexus-claude-plugin/skills/gitnexus-cli/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "gitnexus": {
       "command": "npx",
-      "args": ["-y", "gitnexus@1.6.9", "mcp"]
+      "args": ["-y", "gitnexus@1.6.10", "mcp"]
     }
   }
 }

--- a/gitnexus-claude-plugin/skills/gitnexus-debugging/mcp.json
+++ b/gitnexus-claude-plugin/skills/gitnexus-debugging/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "gitnexus": {
       "command": "npx",
-      "args": ["-y", "gitnexus@1.6.9", "mcp"]
+      "args": ["-y", "gitnexus@1.6.10", "mcp"]
     }
   }
 }

--- a/gitnexus-claude-plugin/skills/gitnexus-exploring/mcp.json
+++ b/gitnexus-claude-plugin/skills/gitnexus-exploring/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "gitnexus": {
       "command": "npx",
-      "args": ["-y", "gitnexus@1.6.9", "mcp"]
+      "args": ["-y", "gitnexus@1.6.10", "mcp"]
     }
   }
 }

--- a/gitnexus-claude-plugin/skills/gitnexus-guide/mcp.json
+++ b/gitnexus-claude-plugin/skills/gitnexus-guide/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "gitnexus": {
       "command": "npx",
-      "args": ["-y", "gitnexus@1.6.9", "mcp"]
+      "args": ["-y", "gitnexus@1.6.10", "mcp"]
     }
   }
 }

--- a/gitnexus-claude-plugin/skills/gitnexus-impact-analysis/mcp.json
+++ b/gitnexus-claude-plugin/skills/gitnexus-impact-analysis/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "gitnexus": {
       "command": "npx",
-      "args": ["-y", "gitnexus@1.6.9", "mcp"]
+      "args": ["-y", "gitnexus@1.6.10", "mcp"]
     }
   }
 }

--- a/gitnexus-claude-plugin/skills/gitnexus-lfg/mcp.json
+++ b/gitnexus-claude-plugin/skills/gitnexus-lfg/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "gitnexus": {
       "command": "npx",
-      "args": ["-y", "gitnexus@1.6.9", "mcp"]
+      "args": ["-y", "gitnexus@1.6.10", "mcp"]
     }
   }
 }

--- a/gitnexus-claude-plugin/skills/gitnexus-plan/mcp.json
+++ b/gitnexus-claude-plugin/skills/gitnexus-plan/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "gitnexus": {
       "command": "npx",
-      "args": ["-y", "gitnexus@1.6.9", "mcp"]
+      "args": ["-y", "gitnexus@1.6.10", "mcp"]
     }
   }
 }

--- a/gitnexus-claude-plugin/skills/gitnexus-refactoring/mcp.json
+++ b/gitnexus-claude-plugin/skills/gitnexus-refactoring/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "gitnexus": {
       "command": "npx",
-      "args": ["-y", "gitnexus@1.6.9", "mcp"]
+      "args": ["-y", "gitnexus@1.6.10", "mcp"]
     }
   }
 }

--- a/gitnexus-claude-plugin/skills/gitnexus-review/mcp.json
+++ b/gitnexus-claude-plugin/skills/gitnexus-review/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "gitnexus": {
       "command": "npx",
-      "args": ["-y", "gitnexus@1.6.9", "mcp"]
+      "args": ["-y", "gitnexus@1.6.10", "mcp"]
     }
   }
 }

--- a/gitnexus-claude-plugin/skills/gitnexus-work/mcp.json
+++ b/gitnexus-claude-plugin/skills/gitnexus-work/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "gitnexus": {
       "command": "npx",
-      "args": ["-y", "gitnexus@1.6.9", "mcp"]
+      "args": ["-y", "gitnexus@1.6.10", "mcp"]
     }
   }
 }

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,97 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.10] - 2026-08-27
+
+### Added
+
+- **Spring framework modeling expanded end to end** — AOP transactions, caching and security (#2783), `@Bean` factories and `@Resource` injection (#2740), profiles/conditions/auto-configuration (#2678), constructor and standard injection (#2632), bean candidate inventory (#2494), configuration-property consumers, and non-HTTP handler entry points (#2891)
+- **Receiver chains typed from AST structure across all 14 languages**, with an explicit epistemic lower bound on what the graph can claim (#2708, #2744, #2747)
+- **Java enum constant bodies modeled as first-class instances**, with JLS 13.1 anonymous-class naming (#2558)
+- **More route surfaces indexed** — Java constant-based route paths such as `@PostMapping(ApiPathConstants.X)` (#2980) and JavaScript data route tables (#2972)
+- **MCP server hardening** — repository allowlist, fail-closed read-only mode, deterministic output budgets, and normalized `impact`/`context` aliases
+- **`bunx` lane so bun-only machines can run GitNexus** (#2765)
+- **Codex support** — hooks, plugin marketplace and setup (#2328, #2369) — plus CodeBuddy and Qoder coding-agent integrations (#2368)
+- **Skills mirrored to `.agents/skills/`** when an `.agents/` directory exists
+- **One-click Render deploy** (#2804)
+- **`serve` origin/proxy configuration is validated and port-scoped** (#2820)
+- **Expanded TypeScript/JavaScript taint sink model** (#2490)
+- **Wiki generation accepts explicit HTTP LLM hosts** (#2491)
+- **Embedding request-body dimensions configurable** via `GITNEXUS_EMBEDDING_REQUEST_DIMS` (#2574)
+- **Refreshed MiniMax model and endpoint configuration** (#2780)
+- **`MAX_CALLABLE_VALUE_TARGETS` and `MAX_PROPERTY_DISPATCH_FANOUT` configurable via env** (#2725, #2726)
+- **Opt-in `analyze --self-commit`** for AGENTS.md/CLAUDE.md churn (#2640)
+- **Buffer pool sized to the graph before the database opens**, with an adaptive size hint
+- **CI review agent runs as a coordinated reviewer swarm** on Sonnet 5 with structured, linked reviews (#2570, #2572), alongside the GitNexus Engineering Tool Kit skills (#2566) and an online skill-evolution loop (#2571)
+- **Icebug community-engine prototype behind a gate** (#2376)
+
+### Fixed
+
+- **`group sync` stops claiming matching it never did** — the advertised BM25/embedding cascade was config, help text and MCP schema with no matcher behind it; the unread `matching.bm25_threshold`, `matching.embedding_threshold`, `detect.embedding_fallback` and `--skip-embeddings` surfaces are removed (#3020)
+- **Emitted Next.js build output is ignored during ingestion**, and the inert `public/build` entry is deleted (#3018)
+- **NestJS decorator routes are indexed** so `api_impact` and `route_map` stop reporting live endpoints as non-existent (#3017)
+- **Import resolution gated by real module configuration** instead of path-suffix guessing — TypeScript config (#2953, #2956), Java and Kotlin declared packages (#2955, #2990), Go module paths (#2984), PHP Composer autoload maps (#2987), Python `__init__.py` re-exports (#2864) and unaliased dotted namespace imports (#2826, #2828), and JavaScript module extensions (#3034)
+- **Interface dispatch is generic-instantiation aware** (#2912, #2939), fans out from Case 3b receivers (#2832, #2842) and from C# record interface calls (#2904), and resolves through generic-typed field receivers in every language (#2833, #2855)
+- **Go method sets modeled exactly** so interface satisfaction is decidable (#2813, #2829), out-of-repo package qualifiers resolve, and an undecided interface check is no longer reported as a decided negative (#2873, #2921)
+- **Go pointer-receiver calls resolve**, reporting the program boundary instead of hedging (#2766, #2782)
+- **Java record support** — graph nodes for `record_declaration`, component accessors, enum and record interface heritage (#2564, #2916, #2935, #2936), plus `E.CONST.method()` enum-constant receiver dispatch (#2561) and JLS binary-name identities for local classes, enums, records and interfaces (#2562, #2653)
+- **Rust module-qualified calls resolve against the module tree** (#2730, #2741), items are qualified by their enclosing `mod` chain (#2742, #2745), duplicate type names stay ambiguous in range binding (#2514, #2652), and `Box<dyn Trait>` names normalize
+- **Closure bindings are call sources in every language**, and function-local values carry their own identity (#2693, #2695, #2699, #2718)
+- **A named receiver's member never resolves lexically** (#2714), platform builtins stop resolving to unrelated same-file symbols (#2549), and inline constructor receivers are typed in every spelling (#2708, #2737)
+- **Python calls resolve through constructor-injected fields** (#2628) and module-imported classes (#2770)
+- **Package directories that repeat higher in the path resolve correctly** (#2881, #2929)
+- **`check` stops reporting erased and deferred imports as initialization cycles** (#2934)
+- **`detect_changes` no longer scales its query with the diff's hunk count** (#2915, #2930), and CR-only line-ending diffs are ignored (#2839)
+- **`group` stops reporting what could not be measured as a measurement of zero** (#3012), resolves HTTP consumers through configured clients and constant route tables (#3008), and preserves manifest-only impact crossings (#2784)
+- **`impact` and `context` are reproducible** — deterministic ordering on every capped query (#2787, #2796) — and Convex caller results are marked incomplete rather than empty (#3044)
+- **Object handler identity is preserved** during ingestion (#3046), nested source directories are discovered (#3043), and parse-node insertion is canonicalized
+- **Large-repo analyze OOM and the false worker-timeout cascade are fixed** (#2649, #2679)
+- **Single-writer lock on the index write path** (#2658, #2677), atomic index swap with read-pool staleness invalidation (#2614), and reliable large incremental writeback commits (#2409, #2425)
+- **Remote URLs are stripped of credentials before they are persisted** (#2914, #2928), and every registry write gets its own tmp path (#2888, #2920)
+- **Schema version derived from a DDL fingerprint** instead of a hand-incremented constant (#2798, #2808), and the scope-resolution relation cross product is fully declared (#2792, #2793)
+- **FTS reliability** — binary payloads stay out of the description column and an unbuildable index is confined to its own table (#2919), FTS-indexed DML is gated before the incremental writeback (#2841, #2854), analyze degrades instead of aborting on index-build failure (#2548), real LOAD errors surface and broken extension files self-heal (#2374, #2375), and Windows missing-dependency load failures are diagnosed (#2383)
+- **`VECTOR` is loaded only when needed** (#3045) and before the incremental writeback touches embedding rows (#2623, #2624)
+- **Buffer pool bounded instead of taking the native 80%-of-RAM default** (#2560), scaled by the OS page-size granule ratio (#2631, #2636), with a COPY-safe floor and actionable diagnostics for non-4K page sizes (#2424)
+- **`Napi::Error` SIGABRT on analyze eliminated** — C++ type lookups are indexed and workers terminate only at JS-safe points (#2432, #2436)
+- **Native-load failures fail closed**, including truncated-binary SIGBUS (#2441, #2651), and glibc-too-old loads are no longer misdiagnosed (#2672, #2689)
+- **Index staleness reporting fixed** — no false-stale status after analyze, with inline staleness in `query`/`context`/`impact`/`cypher` (#2655, #2668, #2683)
+- **Windows path handling** — the `\\?\` long-path prefix no longer breaks repo path matching (#2667, #2700), `parts` negation is honored (#2720), and missing-shadow errors let `serve` repo-switch recover (#2382, #2387)
+- **Embeddings survive partial failures** — unparseable 200 responses are retried (#2790, #2795), batch inserts are retry-safe (#2453), HTTP generation is resumable, resume checkpoints bind to their provider, and proxy-blocked installs self-heal (#2370, #2372)
+- **Custom HTTP embedding endpoint failures are reported as themselves**, not as Hugging Face download errors (#2385, #2386)
+- **Exact symbol content with 0-based line storage and 1-based MCP display** (#2377, #2379, #2380)
+- **`rename` reports every edit that apply writes** and reconciles its report on partial failure (#2605)
+- **Global registry transactions serialized across processes** (#2716)
+- **Swift indented conditional directives are preprocessed** so class bodies survive parsing (#2771), and Swift member-containment pairs are declared in the `CONTAINS` DDL (#2769)
+- **JavaScript `exports.foo = function () {}` CommonJS exports are indexed** (#2723, #2729), and `const X = () => {}` is no longer double-indexed as a Function plus an edgeless Const twin (#2687, #2691)
+- **JVM sibling injection is proximity-bounded** (#2732), and C#/Kotlin free calls are gated by instance ownership (#2563, #2654)
+- **Dart extension type symbols are extracted** (#2539), and declarations recover after embedded NUL bytes (#2430)
+- **CLI and hooks fail loudly on backend error payloads**, with an MCP query hint when the server owns the DB lock (#2396, #2397)
+- **Committed agent guides stop churning**, with an `--index-only` nudge (#2907, #2927), and `gitnexus-plan` artifacts publish on macOS without an interpreter (#2905, #2922)
+- **The 300-flows cap is removed for large repositories** (#2198)
+
+### Changed
+
+- **BREAKING: Node `^22.18.0 || >=24.11.0` is now the supported floor**; the `@types/uuid` stub is dropped
+- **BREAKING: the non-functional `group` matching knobs are gone** — `matching.bm25_threshold`, `matching.embedding_threshold`, `detect.embedding_fallback` in `group.yaml`, the `gitnexus group sync --skip-embeddings` flag, and the MCP `group_sync` `skipEmbeddings` argument (#3020)
+- **Structural relationships are held out of the JS heap by default** during analyze (#2680, #2685)
+- **Global ignore support** — `core.excludesFile`, `.git/info/exclude`, and a user-level global ignore file are honored (#2606)
+- **Plugin manifests sync on every version bump** (#2445), and planning output under `docs/plans` is no longer tracked
+
+### Performance
+
+- **Import resolution indexed instead of scanned** — every scanning resolver with a consolidated memo (#2911), a per-run workspace index for Go/C#/Dart/Ruby (#2898), and Kotlin import resolution (#2872)
+- **MCP server startup drops the analyze-only language-provider closure** (#2802, #2806)
+- **C++ qualified namespace members indexed once per pipeline run** (#2788, #2794)
+- **Vendored Leiden O(communities × N) copy removed**, with Icebug wired to its real API (#2337, #2692)
+- **`core.excludesFile` / `info/exclude` resolution memoized** (#2606)
+
+### Chore / Dependencies
+
+- **`@ladybugdb/core` bumped to ^0.18.3** for the rel-property IN-predicate fix (#2508, #2634)
+- **Security overrides** — `sharp` >=0.35.0 for libvips vulnerabilities (#2993) and `adm-zip` >=0.6.0 for a memory-allocation vulnerability (#2992)
+- **~130 dependency bumps** across the CLI, web app and GitHub Actions, including `@modelcontextprotocol/sdk`, LangChain, Vite, Vitest, TypeScript, React and the Docker/CodeQL action suite
+- **CI hardening** — Windows shard watchdog widened with exit diagnostics (#2449), platform-sensitive matrix sharded to fix the Windows cross-platform timeout (#2394), and CI Report no longer dies silently when the tests job fails (#2728)
+
 ## [1.6.9] - 2026-07-04
 
 ### Added

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.9",
+      "version": "1.6.10",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Release prep for **v1.6.10**.

## What's in the commit

Single `chore: release v1.6.10` commit, 17 files:

- `gitnexus/package.json` + `gitnexus/package-lock.json` — `1.6.9` → `1.6.10` (via `npm version --no-git-tag-version`)
- `gitnexus/CHANGELOG.md` — new `## [1.6.10] - 2026-08-27` section
- 15 plugin manifest surfaces auto-stamped by `scripts/sync-plugin-manifests.mjs` (the `version` lifecycle hook): both marketplaces, both plugin manifests, and the 10 skill `mcp.json` launch args

## Release contents

396 non-merge commits since `v1.6.9` (2026-07-04): 37 features, 178 fixes, 8 performance changes, 132 dependency bumps.

Highlights:

- **Spring modeling** — AOP/transactions/caching/security, `@Bean` factories, `@Resource` injection, profiles/conditions/auto-configuration, constructor injection, bean inventory
- **Receiver-chain typing from AST structure across all 14 languages**, plus interface dispatch that is generic-instantiation aware and exact Go method sets
- **Import resolution gated by real module configuration** (tsconfig, Java/Kotlin packages, Go module paths, Composer autoload) instead of path-suffix guessing
- **Storage and analyze reliability** — single-writer lock, atomic index swap, bounded buffer pool, DDL-fingerprint schema versions, large-repo OOM fix
- **MCP hardening** — repository allowlist, fail-closed read-only mode, deterministic ordering on capped queries, output budgets
- **Codex + CodeBuddy + Qoder integrations, `bunx` lane, one-click Render deploy**

Two breaking changes are called out in the `### Changed` section: the Node floor moves to `^22.18.0 || >=24.11.0`, and the non-functional `group` matching knobs are removed (#3020).

## Verification

- `node gitnexus/scripts/sync-plugin-manifests.mjs --check` — all surfaces at 1.6.10
- `npx prettier --check` on all 16 changed JSON files — clean
- `test/unit/cli-commands.test.ts` + `test/unit/sync-plugin-manifests.test.ts` — 27 passed
- CI's release-notes extraction (`awk "/^## \[1.6.10\]/…"`) returns the full 90-line section
- `git grep '"version": "1.6.9"'` — no hits outside `.github/gitnexus-review-runtime/`, which pins the *published* npm version and is intentionally left at 1.6.9 until 1.6.10 is on the registry

Rebased onto `origin/main` at `0f793558a`.

## After merge

Push the `v1.6.10` tag to trigger the stable npm publish and GitHub Release.

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a release-oriented metadata and configuration update, broad in file count but shallow in graph reach. The change is concentrated in plugin and package descriptors, the changelog, and runtime mount definitions rather than traced execution flows.*

**🟢 LOW blast radius. This appears to be a release update spanning plugin and package metadata, `gitnexus/CHANGELOG.md`, and runtime mount variables in `eval/workflow_bench/runtime_mounts.py`, with no graph dependents.**

The hottest file is `eval/workflow_bench/runtime_mounts.py`, where the changed symbols are `CE_ARMS` and `SANDBOX_CE_PLUGIN`. The remaining changes are concentrated in marketplace and plugin manifests, MCP configuration files under `gitnexus-claude-plugin/skills/`, and `gitnexus/package.json` with `gitnexus/package-lock.json`.

Review the runtime mount definitions first, then verify that the release metadata stays consistent across `.agents/plugins/marketplace.json`, `.claude-plugin/marketplace.json`, `gitnexus-claude-plugin/.claude-plugin/plugin.json`, `gitnexus-claude-plugin/.codex-plugin/plugin.json`, and the package files. The graph reports no affected flows and no dependent callers.

_Added by GitNexus for PR #3064. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->