### PR TITLE
fix: honor nested gitignore files and repository boundaries

### DIFF
--- a/gitnexus/src/config/ignore-service.ts
+++ b/gitnexus/src/config/ignore-service.ts
@@ -1,5 +1,6 @@
 import ignore, { type Ignore } from 'ignore';
 import { existsSync } from 'fs';
+import { glob } from 'glob';
 import fs from 'fs/promises';
 import nodePath from 'path';
 import type { Path } from 'path-scurry';
@@ -406,6 +407,39 @@ export interface IgnoreOptions {
   strictRepoControlFiles?: boolean;
 }
 
+const addNestedIgnoreRules = async (repoPath: string, ig: Ignore): Promise<boolean> => {
+  let hasRules = false;
+  const controlFiles = await glob('**/.gitignore', { cwd: repoPath, dot: true, nodir: true });
+  for (const relativeFile of controlFiles) {
+    if (relativeFile === '.gitignore') continue;
+    const directory = nodePath.dirname(relativeFile).replace(/\\/g, '/');
+    // Nested repositories are separate projects. Their control files must not
+    // affect the parent scan; the boundary itself is pruned below.
+    if (directory.split('/').some((segment, index, parts) =>
+      existsSync(nodePath.join(repoPath, ...parts.slice(0, index + 1), '.git')),
+    )) continue;
+    try {
+      const content = await fs.readFile(nodePath.join(repoPath, relativeFile), 'utf-8');
+      const transformed = content.split(/\\r?\\n/).map((line) => {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) return line;
+        const negated = trimmed.startsWith('!');
+        const pattern = negated ? trimmed.slice(1) : trimmed;
+        if (pattern.startsWith('#') || !pattern) return line;
+        const anchored = pattern.startsWith('/');
+        const body = anchored ? pattern.slice(1) : pattern;
+        const scoped = body.includes('/') ? `${directory}/${body}` : `${directory}/**/${body}`;
+        return `${negated ? '!' : ''}${scoped}`;
+      }).join('\n');
+      ig.add(transformed);
+      hasRules = true;
+    } catch (err) {
+      logger.warn(`  Warning: could not read nested ${relativeFile}: ${(err as Error).message}`);
+    }
+  }
+  return hasRules;
+};
+
 export const loadIgnoreRules = async (
   repoPath: string,
   options?: IgnoreOptions,
@@ -458,6 +492,8 @@ export const loadIgnoreRules = async (
       logger.warn(`  Warning: could not read ${filename}: ${(err as Error).message}`);
     }
   }
+
+  if (!skipGitignore) hasRules = (await addNestedIgnoreRules(repoPath, ig)) || hasRules;
 
   return hasRules ? ig : null;
 };
@@ -583,6 +619,9 @@ export const createIgnoreFilter = async (repoPath: string, options?: IgnoreOptio
       // last-match-wins: `!__tests__/` + `__tests__/generated/` still
       // blocks descent into `__tests__/generated/`.
       if (ig && rel && hasExplicitUnignore(ig, rel) && !ig.ignores(rel + '/')) return false;
+      // A nested Git checkout is a separate repository. Stop at its root so
+      // the parent analysis never indexes submodule/vendor working trees (#2675).
+      if (rel && existsSync(nodePath.join(repoPath, rel, '.git'))) return true;
       // Hardcoded and path-aware rules prune whole trees before glob walks them.
       if (rel && isHardcodedIgnoredDirectoryAtPath(repoPath, nodePath.join(repoPath, rel))) {
         return true;

--- a/gitnexus/test/unit/nested-ignore.test.ts
+++ b/gitnexus/test/unit/nested-ignore.test.ts
@@ -1,0 +1,24 @@
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { walkRepositoryPaths } from '../../src/core/ingestion/filesystem-walker.js';
+
+describe('nested repository boundaries and ignore files', () => {
+  it('honors nested .gitignore rules and does not enter nested Git checkouts', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'gitnexus-nested-ignore-'));
+    await mkdir(path.join(root, 'service'), { recursive: true });
+    await writeFile(path.join(root, 'service', '.gitignore'), '*.generated.ts\n');
+    await writeFile(path.join(root, 'service', 'keep.ts'), 'export const keep = 1;');
+    await writeFile(path.join(root, 'service', 'skip.generated.ts'), 'generated');
+    await mkdir(path.join(root, 'vendor', '.git'), { recursive: true });
+    await writeFile(path.join(root, 'vendor', 'foreign.ts'), 'foreign');
+
+    const entries = await walkRepositoryPaths(root);
+    const paths = entries.map(({ path: filePath }) => filePath);
+
+    expect(paths).toContain('service/keep.ts');
+    expect(paths).not.toContain('service/skip.generated.ts');
+    expect(paths).not.toContain('vendor/foreign.ts');
+  });
+});


### PR DESCRIPTION
## Summary
- honor nested .gitignore rules during repository scans
- stop traversal at nested Git checkout boundaries to avoid indexing embedded repositories
- add regression coverage for both behaviors

Fixes #2675

## Validation
- npx vitest run test/unit/nested-ignore.test.ts — passed
- Typecheck attempted; current cloud checkout lacks the built gitnexus-shared package and reports unrelated baseline module-resolution errors.

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a configuration and test change for nested ignore handling and repository boundaries. The file footprint is small, but the graph shows broad transitive reach and a critical blast posture.*

**🔴 CRITICAL blast radius. A configuration change in `gitnexus/src/config/ignore-service.ts`, alongside `gitnexus/test/unit/nested-ignore.test.ts`, reaches broadly through the repository’s dependent graph.**

The implementation changes the `code` constant and `loadIgnoreRules` function in `gitnexus/src/config/ignore-service.ts`. The graph identifies 40 dependents and 6 affected flows, with impact concentrated in `Extractors` and extending into `Group`, `Storage`, `Cli`, and `Config`.

Review `loadIgnoreRules` first, then its callers in the affected extraction and grouping paths, with particular attention to how nested ignore files and repository boundaries are handled. The report marks the file risk level LOW and identifies no HIGH or CRITICAL risk files, so the critical posture comes from the breadth of the dependency reach rather than from a flagged individual file.

_Added by GitNexus for PR #3103. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->