### PR TITLE
fix: bind Razor ViewComponent names to in-repo classes

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -711,16 +711,17 @@ jobs:
 
       - name: Cross-language pipeline benchmarks (GITNEXUS_BENCH, serial)
         if: ${{ !cancelled() }}
-        # cpp-adl-benchmark.test.ts is not a `*-pipeline-benchmark.test.ts` but
-        # belongs here for the same reason: it is skipIf-gated on GITNEXUS_BENCH,
-        # so it had never run in CI and the PR #1990 ADL emit-scaling guard it
-        # holds was dead. ~45s of test time.
+        # cpp-adl-benchmark.test.ts and csharp-razor-view-components-benchmark.test.ts
+        # are not `*-pipeline-benchmark.test.ts` files but belong here for the
+        # same reason: they are skipIf-gated on GITNEXUS_BENCH, so the scaling
+        # guards they hold never run in the main coverage job.
         env:
           GITNEXUS_BENCH: '1'
         run: >-
           npx vitest run --no-file-parallelism
           test/integration/cobol-pipeline-benchmark.test.ts
           test/integration/csharp-pipeline-benchmark.test.ts
+          test/integration/csharp-razor-view-components-benchmark.test.ts
           test/integration/cpp-adl-benchmark.test.ts
           test/integration/data-route-table-benchmark.test.ts
           test/integration/instance-ownership-pipeline-benchmark.test.ts

--- a/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
+++ b/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
@@ -409,16 +409,6 @@ function componentNameFromLiteral(value: string | undefined): string | undefined
   return value;
 }
 
-function catalogNamesFromAlias(alias: string): string[] {
-  const names = [alias];
-  const dotted = alias.lastIndexOf('.');
-  if (dotted >= 0) {
-    const shortName = alias.slice(dotted + 1);
-    if (COMPONENT_NAME_RE.test(shortName)) names.push(shortName);
-  }
-  return names;
-}
-
 function isViewComponentAttributeName(name: string): boolean {
   return name === 'ViewComponent' || name === 'ViewComponentAttribute';
 }
@@ -592,7 +582,7 @@ export function extractViewComponentAliasBinds(source: string): ViewComponentAli
       className,
       startLine: start?.startLine ?? startLine,
       startCol: start?.startCol ?? startCol,
-      aliases: [...new Set(aliases.flatMap(catalogNamesFromAlias))],
+      aliases: [...new Set(aliases)],
     });
     pending.length = 0;
   };

--- a/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
+++ b/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
@@ -1,0 +1,218 @@
+/**
+ * ASP.NET Core ViewComponent convention support.
+ *
+ * Same bound as Spring Boot DI in Java/Kotlin: do not resolve into the SDK
+ * (`Microsoft.AspNetCore.Mvc.ViewComponent`, `IViewComponentHelper`,
+ * `Component.InvokeAsync` itself). Those types live outside the workspace.
+ * The only hop worth taking is the framework convention that lands on an
+ * **in-repo** class — `InvokeAsync("Foo")` → workspace `FooViewComponent`,
+ * just as a Spring `@Autowired IFoo` fans out to an in-repo `@Service`,
+ * not to `ApplicationContext`.
+ *
+ * Razor templates are not parsed as C# (markup + code would poison
+ * tree-sitter-c-sharp). Literal name extraction is enough because the
+ * target catalog is already built from parsed `.cs` classes in this repo.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { glob } from 'glob';
+import type { ParsedFile } from 'gitnexus-shared';
+import type { KnowledgeGraph } from '../../../graph/types.js';
+import { createIgnoreFilter } from '../../../../config/ignore-service.js';
+import { generateId } from '../../../../lib/utils.js';
+import { getMaxFileSizeBytes } from '../../utils/max-file-size.js';
+import type { GraphNodeLookup } from '../../scope-resolution/graph-bridge/node-lookup.js';
+import { resolveDefGraphId } from '../../scope-resolution/graph-bridge/ids.js';
+
+const VIEW_COMPONENT_SUFFIX = 'ViewComponent';
+const RAZOR_INVOKE_RE =
+  /@\s*\(?\s*(?:await\s+)?Component\s*\.\s*InvokeAsync\s*\(\s*@?"([A-Za-z_][A-Za-z0-9_.-]*)"/g;
+const VIEW_COMPONENT_TAG_RE = /<\s*vc:([a-z][a-z0-9-]*)\b/gi;
+/** In-repo C# helper calls; `Component.` / `ViewComponent(` keep this off SDK `Task.InvokeAsync`. */
+const CSHARP_INVOKE_RE =
+  /(?:^|[^\w.])(?:await\s+)?(?:Component\s*\.\s*InvokeAsync|ViewComponent)\s*\(\s*@?"([A-Za-z_][A-Za-z0-9_.-]*)"/g;
+const VIEW_COMPONENT_ALIAS_RE =
+  /\[\s*(?:[A-Za-z_][A-Za-z0-9_.]*\.)?ViewComponent(?:Attribute)?\s*\(\s*(?:Name\s*=\s*)?@?"([A-Za-z_][A-Za-z0-9_.-]*)"[^)]*\)\s*\]\s*(?:\[[^\]]+\]\s*)*(?:(?:public|internal|protected|private|abstract|sealed|partial|static|new)\s+)*class\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+
+export interface RazorViewComponentConfig {
+  readonly views: ReadonlyMap<string, string>;
+}
+
+function withoutRazorComments(source: string): string {
+  return source
+    .replace(/@\*[\s\S]*?\*@/g, '')
+    .replace(/<!--[\s\S]*?-->/g, '');
+}
+
+function withoutCsharpComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+function tagNameToComponentName(tagName: string): string {
+  return tagName
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join('');
+}
+
+/** Extract statically resolvable ViewComponent names from one Razor template. */
+export function extractRazorViewComponentInvocations(source: string): string[] {
+  const visible = withoutRazorComments(source);
+  const names = new Set<string>();
+
+  for (const match of visible.matchAll(RAZOR_INVOKE_RE)) {
+    names.add(match[1]!);
+  }
+  for (const match of visible.matchAll(VIEW_COMPONENT_TAG_RE)) {
+    names.add(tagNameToComponentName(match[1]!));
+  }
+
+  return [...names];
+}
+
+/** In-repo C# `Component.InvokeAsync("X")` / `ViewComponent("X")` literals. */
+export function extractCsharpViewComponentInvocations(source: string): string[] {
+  const names = new Set<string>();
+  for (const match of withoutCsharpComments(source).matchAll(CSHARP_INVOKE_RE)) {
+    names.add(match[1]!);
+  }
+  return [...names];
+}
+
+/** Extract explicit `[ViewComponent(Name = "...")]` aliases by class name. */
+export function extractViewComponentAliases(source: string): ReadonlyMap<string, readonly string[]> {
+  const aliases = new Map<string, string[]>();
+  for (const match of withoutCsharpComments(source).matchAll(VIEW_COMPONENT_ALIAS_RE)) {
+    const alias = match[1]!;
+    const className = match[2]!;
+    const existing = aliases.get(className);
+    if (existing) {
+      if (!existing.includes(alias)) existing.push(alias);
+    } else {
+      aliases.set(className, [alias]);
+    }
+  }
+  return aliases;
+}
+
+/**
+ * Read Razor views once per C# resolution pass. The same ignore rules and file
+ * size ceiling as repository scanning are applied, and edge emission later
+ * additionally requires a live File node. This prevents ignored, oversized,
+ * or concurrently removed templates from entering the graph.
+ */
+export async function loadRazorViewComponentConfig(
+  repoRoot: string,
+): Promise<RazorViewComponentConfig> {
+  const ignore = await createIgnoreFilter(repoRoot);
+  const paths = await glob('**/*.cshtml', {
+    cwd: repoRoot,
+    nodir: true,
+    dot: false,
+    ignore,
+  });
+  paths.sort();
+
+  const maxBytes = getMaxFileSizeBytes();
+  const views = new Map<string, string>();
+  for (const rawPath of paths) {
+    const filePath = rawPath.replace(/\\/g, '/');
+    try {
+      const fullPath = path.join(repoRoot, filePath);
+      const stat = await fs.stat(fullPath);
+      if (!stat.isFile() || stat.size > maxBytes) continue;
+      views.set(filePath, await fs.readFile(fullPath, 'utf8'));
+    } catch {
+      // A view may disappear between glob/stat/read during watch mode.
+    }
+  }
+  return { views };
+}
+
+function addCandidate(
+  candidates: Map<string, Set<string>>,
+  invocationName: string,
+  targetId: string,
+): void {
+  const key = invocationName.toLocaleLowerCase('en-US');
+  const existing = candidates.get(key);
+  if (existing) {
+    existing.add(targetId);
+  } else {
+    candidates.set(key, new Set([targetId]));
+  }
+}
+
+/**
+ * Emit workspace File → in-repo ViewComponent Class CALLS edges.
+ *
+ * Targets are only Class nodes produced from this repo's `.cs` files. There is
+ * no lookup of ASP.NET SDK types; `: ViewComponent` in source is a naming
+ * hint, not a resolved EXTENDS edge to `Microsoft.AspNetCore.Mvc.ViewComponent`.
+ *
+ * Ambiguous component names fail closed: two in-repo classes claiming the
+ * same name is not evidence for picking either one.
+ */
+export function emitRazorViewComponentEdges(
+  graph: KnowledgeGraph,
+  parsedFiles: readonly ParsedFile[],
+  nodeLookup: GraphNodeLookup,
+  config: RazorViewComponentConfig | undefined,
+  csharpSources: ReadonlyMap<string, string>,
+): void {
+  if (!config) return;
+
+  const candidates = new Map<string, Set<string>>();
+  for (const parsed of parsedFiles) {
+    if (!parsed.filePath.endsWith('.cs')) continue;
+    const aliases = extractViewComponentAliases(csharpSources.get(parsed.filePath) ?? '');
+    for (const def of parsed.localDefs) {
+      if (def.type !== 'Class') continue;
+      const className = def.qualifiedName?.split('.').pop() ?? def.nodeId.split(':').pop() ?? '';
+      const conventionalName = className.endsWith(VIEW_COMPONENT_SUFFIX)
+        ? className.slice(0, -VIEW_COMPONENT_SUFFIX.length)
+        : undefined;
+      const explicitAliases = aliases.get(className) ?? [];
+      if (!conventionalName && explicitAliases.length === 0) continue;
+
+      const targetId = resolveDefGraphId(parsed.filePath, def, nodeLookup);
+      if (!targetId || !graph.getNode(targetId)) continue;
+      // An explicit [ViewComponent(Name = "...")] replaces the suffix name,
+      // matching ASP.NET. Never register the SDK base type as a candidate.
+      if (explicitAliases.length > 0) {
+        for (const alias of explicitAliases) addCandidate(candidates, alias, targetId);
+      } else if (conventionalName) {
+        addCandidate(candidates, conventionalName, targetId);
+      }
+    }
+  }
+
+  const emitFromFile = (filePath: string, invocationNames: readonly string[]): void => {
+    const sourceId = generateId('File', filePath);
+    if (!graph.getNode(sourceId)) return;
+    for (const invocationName of invocationNames) {
+      const matches = candidates.get(invocationName.toLocaleLowerCase('en-US'));
+      if (!matches || matches.size !== 1) continue;
+      const targetId = matches.values().next().value as string;
+      if (!graph.getNode(targetId)) continue;
+      graph.addRelationship({
+        id: generateId('CALLS', `${sourceId}:razor-view-component:${targetId}`),
+        sourceId,
+        targetId,
+        type: 'CALLS',
+        confidence: 0.9,
+        reason: 'aspnet-razor-view-component',
+      });
+    }
+  };
+
+  for (const [viewPath, source] of config.views) {
+    emitFromFile(viewPath, extractRazorViewComponentInvocations(source));
+  }
+  for (const [filePath, source] of csharpSources) {
+    if (!filePath.endsWith('.cs')) continue;
+    emitFromFile(filePath, extractCsharpViewComponentInvocations(source));
+  }
+}

--- a/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
+++ b/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
@@ -771,6 +771,12 @@ function consumeRazorTransition(cur: SourceCursor, names: Set<string>): void {
 
 /** Extract statically resolvable ViewComponent names from one Razor template. */
 export function extractRazorViewComponentInvocations(source: string): string[] {
+  // Most views do not invoke a ViewComponent. Avoid the character-by-character
+  // Razor scan unless one of the two supported invocation spellings is present.
+  // This is only a coarse gate; the state machine below still decides whether a
+  // token is executable markup/C# or a comment/string/escaped transition.
+  if (!source.includes('InvokeAsync') && !/<\s*vc:/i.test(source)) return [];
+
   const names = new Set<string>();
   const cur = new SourceCursor(source);
   let markupStart = 0;

--- a/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
+++ b/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
@@ -40,9 +40,7 @@ export interface RazorViewComponentConfig {
 }
 
 function withoutRazorComments(source: string): string {
-  return source
-    .replace(/@\*[\s\S]*?\*@/g, '')
-    .replace(/<!--[\s\S]*?-->/g, '');
+  return source.replace(/@\*[\s\S]*?\*@/g, '').replace(/<!--[\s\S]*?-->/g, '');
 }
 
 function withoutCsharpComments(source: string): string {
@@ -82,7 +80,9 @@ export function extractCsharpViewComponentInvocations(source: string): string[] 
 }
 
 /** Extract explicit `[ViewComponent(Name = "...")]` aliases by class name. */
-export function extractViewComponentAliases(source: string): ReadonlyMap<string, readonly string[]> {
+export function extractViewComponentAliases(
+  source: string,
+): ReadonlyMap<string, readonly string[]> {
   const aliases = new Map<string, string[]>();
   for (const match of withoutCsharpComments(source).matchAll(VIEW_COMPONENT_ALIAS_RE)) {
     const alias = match[1]!;

--- a/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
+++ b/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
@@ -484,17 +484,19 @@ function collectInvokeAfterIdent(
   ident: string,
   cur: SourceCursor,
   previous: string | undefined,
+  memberReceiver: string | undefined,
   names: Set<string>,
 ): void {
   skipCsharpTrivia(cur);
+  const hasMvcReceiver = previous !== '.' || memberReceiver === 'this' || memberReceiver === 'base';
   if (ident === 'ViewComponent' && cur.peek() === '(') {
-    if (previous === '[' || previous === ',') return;
+    if (previous === '[' || previous === ',' || !hasMvcReceiver) return;
     cur.advance();
     const name = componentNameFromLiteral(decodeCsharpString(cur));
     if (name !== undefined) names.add(name);
     return;
   }
-  if (ident !== 'Component' || cur.peek() !== '.') return;
+  if (ident !== 'Component' || cur.peek() !== '.' || !hasMvcReceiver) return;
   const afterDot = cur.snapshot();
   cur.advance();
   skipCsharpTrivia(cur);
@@ -515,6 +517,7 @@ export function extractCsharpViewComponentInvocations(source: string): string[] 
   const names = new Set<string>();
   const cur = new SourceCursor(source);
   let previous: string | undefined;
+  let memberReceiver: string | undefined;
   let squareDepth = 0;
   while (!cur.done) {
     skipCsharpTrivia(cur);
@@ -526,13 +529,15 @@ export function extractCsharpViewComponentInvocations(source: string): string[] 
     const ident = readIdent(cur);
     if (ident !== undefined) {
       const inAttribute = squareDepth > 0;
-      collectInvokeAfterIdent(ident, cur, inAttribute ? '[' : previous, names);
+      collectInvokeAfterIdent(ident, cur, inAttribute ? '[' : previous, memberReceiver, names);
       previous = ident;
+      memberReceiver = undefined;
       continue;
     }
     const ch = cur.peek();
     if (ch === '[') squareDepth += 1;
     else if (ch === ']' && squareDepth > 0) squareDepth -= 1;
+    memberReceiver = ch === '.' ? previous : undefined;
     previous = ch;
     cur.advance();
   }
@@ -612,7 +617,10 @@ export function extractViewComponentAliasBinds(source: string): ViewComponentAli
     }
     if (TYPE_MODIFIERS.has(ident)) continue;
     if (ident === 'class' || ident === 'record') {
-      const className = tryReadIdent(cur);
+      let className = tryReadIdent(cur);
+      if (ident === 'record' && (className === 'class' || className === 'struct')) {
+        className = tryReadIdent(cur);
+      }
       if (className !== undefined && pending.some((entry) => entry.aliases.length > 0)) {
         flushPending(className, startLine, startCol);
       } else {

--- a/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
+++ b/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
@@ -829,14 +829,20 @@ export async function loadRazorViewComponentConfig(
   const views = new Map<string, readonly string[]>();
   for (const rawPath of paths) {
     const filePath = rawPath.replace(/\\/g, '/');
+    // The size gate and the read go through one handle so both observe the same
+    // inode. Re-resolving the path for the read would let a template swapped in
+    // between them be read unchecked (CodeQL js/file-system-race).
+    let handle: fs.FileHandle | undefined;
     try {
-      const fullPath = path.join(repoRoot, filePath);
-      const stat = await fs.stat(fullPath);
+      handle = await fs.open(path.join(repoRoot, filePath), 'r');
+      const stat = await handle.stat();
       if (!stat.isFile() || stat.size > maxBytes) continue;
-      const source = await fs.readFile(fullPath, 'utf8');
+      const source = await handle.readFile('utf8');
       views.set(filePath, extractRazorViewComponentInvocations(source));
     } catch {
-      // A view may disappear between glob/stat/read during watch mode.
+      // A view may disappear between glob/open/read during watch mode.
+    } finally {
+      await handle?.close().catch(() => {});
     }
   }
   return { views };

--- a/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
+++ b/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
@@ -10,8 +10,10 @@
  * not to `ApplicationContext`.
  *
  * Razor templates are not parsed as C# (markup + code would poison
- * tree-sitter-c-sharp). Literal name extraction is enough because the
- * target catalog is already built from parsed `.cs` classes in this repo.
+ * tree-sitter-c-sharp). A small Razor state machine extracts C# islands and
+ * markup tag helpers; C# files use a string/comment-aware lexer so attributes
+ * and literals are not mistaken for helper calls. Literal names are enough
+ * because the target catalog is already built from parsed `.cs` classes.
  */
 
 import fs from 'node:fs/promises';
@@ -24,27 +26,623 @@ import { generateId } from '../../../../lib/utils.js';
 import { getMaxFileSizeBytes } from '../../utils/max-file-size.js';
 import type { GraphNodeLookup } from '../../scope-resolution/graph-bridge/node-lookup.js';
 import { resolveDefGraphId } from '../../scope-resolution/graph-bridge/ids.js';
+import { definitionIdPosition } from '../../scope-resolution/utils/definition-id.js';
 
 const VIEW_COMPONENT_SUFFIX = 'ViewComponent';
-const RAZOR_INVOKE_RE =
-  /@\s*\(?\s*(?:await\s+)?Component\s*\.\s*InvokeAsync\s*\(\s*@?"([A-Za-z_][A-Za-z0-9_.-]*)"/g;
 const VIEW_COMPONENT_TAG_RE = /<\s*vc:([a-z][a-z0-9-]*)\b/gi;
-/** In-repo C# helper calls; `Component.` / `ViewComponent(` keep this off SDK `Task.InvokeAsync`. */
-const CSHARP_INVOKE_RE =
-  /(?:^|[^\w.])(?:await\s+)?(?:Component\s*\.\s*InvokeAsync|ViewComponent)\s*\(\s*@?"([A-Za-z_][A-Za-z0-9_.-]*)"/g;
-const VIEW_COMPONENT_ALIAS_RE =
-  /\[\s*(?:[A-Za-z_][A-Za-z0-9_.]*\.)?ViewComponent(?:Attribute)?\s*\(\s*(?:Name\s*=\s*)?@?"([A-Za-z_][A-Za-z0-9_.-]*)"[^)]*\)\s*\]\s*(?:\[[^\]]+\]\s*)*(?:(?:public|internal|protected|private|abstract|sealed|partial|static|new)\s+)*class\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+const COMPONENT_NAME_RE = /^[A-Za-z_][A-Za-z0-9_.-]*$/;
+const TYPE_MODIFIERS = new Set([
+  'public',
+  'internal',
+  'protected',
+  'private',
+  'abstract',
+  'sealed',
+  'partial',
+  'static',
+  'new',
+  'file',
+  'required',
+  'unsafe',
+  'readonly',
+]);
+const RAZOR_BLOCK_KEYWORDS = new Set([
+  'if',
+  'for',
+  'foreach',
+  'while',
+  'using',
+  'switch',
+  'try',
+  'lock',
+  'functions',
+  'helper',
+  'code',
+  'section',
+  'do',
+]);
 
 export interface RazorViewComponentConfig {
-  readonly views: ReadonlyMap<string, string>;
+  /** Repo-relative `.cshtml` path → extracted invocation names. */
+  readonly views: ReadonlyMap<string, readonly string[]>;
 }
 
-function withoutRazorComments(source: string): string {
-  return source.replace(/@\*[\s\S]*?\*@/g, '').replace(/<!--[\s\S]*?-->/g, '');
+export interface ViewComponentAliasBind {
+  readonly className: string;
+  /** 1-based line of the type declaration (including leading attributes). */
+  readonly startLine: number;
+  /** 0-based column of the type declaration (including leading attributes). */
+  readonly startCol: number;
+  readonly aliases: readonly string[];
 }
 
-function withoutCsharpComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/.*$/gm, '$1');
+class SourceCursor {
+  i = 0;
+  line = 1;
+  col = 0;
+
+  constructor(readonly source: string) {}
+
+  get length(): number {
+    return this.source.length;
+  }
+
+  get done(): boolean {
+    return this.i >= this.source.length;
+  }
+
+  peek(n = 0): string {
+    return this.source[this.i + n] ?? '';
+  }
+
+  startsWith(value: string): boolean {
+    return this.source.startsWith(value, this.i);
+  }
+
+  snapshot(): { i: number; line: number; col: number } {
+    return { i: this.i, line: this.line, col: this.col };
+  }
+
+  restore(pos: { i: number; line: number; col: number }): void {
+    this.i = pos.i;
+    this.line = pos.line;
+    this.col = pos.col;
+  }
+
+  advance(count = 1): void {
+    const end = Math.min(this.i + count, this.source.length);
+    while (this.i < end) {
+      const ch = this.source[this.i]!;
+      this.i += 1;
+      if (ch === '\n') {
+        this.line += 1;
+        this.col = 0;
+      } else {
+        this.col += 1;
+      }
+    }
+  }
+}
+
+function isIdentStart(ch: string): boolean {
+  return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || ch === '_' || ch === '@';
+}
+
+function isIdentPart(ch: string): boolean {
+  return isIdentStart(ch) || (ch >= '0' && ch <= '9');
+}
+
+function skipWhitespace(cur: SourceCursor): void {
+  while (!cur.done) {
+    const ch = cur.peek();
+    if (ch !== ' ' && ch !== '\t' && ch !== '\n' && ch !== '\r' && ch !== '\f' && ch !== '\v') break;
+    cur.advance();
+  }
+}
+
+/** Skip line comments and block comments. Returns true if a comment was consumed. */
+function skipCsharpComment(cur: SourceCursor): boolean {
+  if (cur.startsWith('//')) {
+    while (!cur.done && cur.peek() !== '\n') cur.advance();
+    return true;
+  }
+  if (cur.startsWith('/*')) {
+    cur.advance(2);
+    while (!cur.done && !cur.startsWith('*/')) cur.advance();
+    if (cur.startsWith('*/')) cur.advance(2);
+    return true;
+  }
+  return false;
+}
+
+function skipCsharpTrivia(cur: SourceCursor): void {
+  for (;;) {
+    skipWhitespace(cur);
+    if (!skipCsharpComment(cur)) return;
+  }
+}
+
+function skipRegularString(cur: SourceCursor, interpolated: boolean): void {
+  cur.advance(); // opening "
+  while (!cur.done) {
+    const ch = cur.peek();
+    if (ch === '\\') {
+      cur.advance(2);
+      continue;
+    }
+    if (interpolated && ch === '{') {
+      if (cur.peek(1) === '{') {
+        cur.advance(2);
+        continue;
+      }
+      skipInterpolation(cur);
+      continue;
+    }
+    cur.advance();
+    if (ch === '"') return;
+  }
+}
+
+function skipVerbatimString(cur: SourceCursor, interpolated: boolean): void {
+  cur.advance(2); // @"
+  while (!cur.done) {
+    const ch = cur.peek();
+    if (ch === '"') {
+      if (cur.peek(1) === '"') {
+        cur.advance(2);
+        continue;
+      }
+      cur.advance();
+      return;
+    }
+    if (interpolated && ch === '{') {
+      if (cur.peek(1) === '{') {
+        cur.advance(2);
+        continue;
+      }
+      skipInterpolation(cur);
+      continue;
+    }
+    cur.advance();
+  }
+}
+
+function skipRawString(cur: SourceCursor): void {
+  let quoteCount = 0;
+  while (cur.peek() === '"') {
+    quoteCount += 1;
+    cur.advance();
+  }
+  while (!cur.done) {
+    if (cur.peek() !== '"') {
+      cur.advance();
+      continue;
+    }
+    let seen = 0;
+    while (cur.peek() === '"') {
+      seen += 1;
+      cur.advance();
+    }
+    if (seen >= quoteCount) return;
+  }
+}
+
+function skipInterpolation(cur: SourceCursor): void {
+  cur.advance(); // {
+  let depth = 1;
+  while (!cur.done && depth > 0) {
+    skipCsharpTrivia(cur);
+    if (cur.done) return;
+    if (skipCsharpString(cur)) continue;
+    const ch = cur.peek();
+    if (ch === '{') depth += 1;
+    else if (ch === '}') depth -= 1;
+    cur.advance();
+  }
+}
+
+function skipCsharpString(cur: SourceCursor): boolean {
+  const ch = cur.peek();
+  if (ch === "'") {
+    cur.advance();
+    if (cur.peek() === '\\') cur.advance(2);
+    else cur.advance();
+    if (cur.peek() === "'") cur.advance();
+    return true;
+  }
+  if (ch === '"') {
+    if (cur.peek(1) === '"' && cur.peek(2) === '"') skipRawString(cur);
+    else skipRegularString(cur, false);
+    return true;
+  }
+  if (ch === '$' && cur.peek(1) === '@' && cur.peek(2) === '"') {
+    cur.advance();
+    skipVerbatimString(cur, true);
+    return true;
+  }
+  if (ch === '@' && cur.peek(1) === '$' && cur.peek(2) === '"') {
+    cur.advance(2);
+    skipVerbatimString(cur, true);
+    return true;
+  }
+  if (ch === '@' && cur.peek(1) === '"') {
+    skipVerbatimString(cur, false);
+    return true;
+  }
+  if (ch === '$' && cur.peek(1) === '"') {
+    if (cur.peek(2) === '"' && cur.peek(3) === '"') {
+      cur.advance();
+      skipRawString(cur);
+    } else {
+      cur.advance();
+      skipRegularString(cur, true);
+    }
+    return true;
+  }
+  return false;
+}
+
+function readIdent(cur: SourceCursor): string | undefined {
+  if (!isIdentStart(cur.peek())) return undefined;
+  const start = cur.i;
+  if (cur.peek() === '@') cur.advance();
+  if (!isIdentStart(cur.peek()) && !(cur.peek() >= 'A' && cur.peek() <= 'z')) {
+    cur.i = start;
+    return undefined;
+  }
+  while (isIdentPart(cur.peek()) && cur.peek() !== '@') cur.advance();
+  const raw = cur.source.slice(start, cur.i);
+  return raw.startsWith('@') ? raw.slice(1) : raw;
+}
+
+function tryReadIdent(cur: SourceCursor): string | undefined {
+  skipCsharpTrivia(cur);
+  return readIdent(cur);
+}
+
+function decodeCsharpString(cur: SourceCursor): string | undefined {
+  skipCsharpTrivia(cur);
+  const start = cur.snapshot();
+  const ch = cur.peek();
+  if (ch === '$') return undefined;
+  if (ch === '@' && cur.peek(1) === '"') {
+    cur.advance(2);
+    let value = '';
+    while (!cur.done) {
+      if (cur.peek() === '"') {
+        if (cur.peek(1) === '"') {
+          value += '"';
+          cur.advance(2);
+          continue;
+        }
+        cur.advance();
+        return value;
+      }
+      value += cur.peek();
+      cur.advance();
+    }
+    cur.restore(start);
+    return undefined;
+  }
+  if (ch === '"' && cur.peek(1) === '"' && cur.peek(2) === '"') {
+    let quoteCount = 0;
+    while (cur.peek() === '"') {
+      quoteCount += 1;
+      cur.advance();
+    }
+    const bodyStart = cur.i;
+    while (!cur.done) {
+      if (cur.peek() !== '"') {
+        cur.advance();
+        continue;
+      }
+      const closeStart = cur.i;
+      let seen = 0;
+      while (cur.peek() === '"') {
+        seen += 1;
+        cur.advance();
+      }
+      if (seen >= quoteCount) {
+        return cur.source.slice(bodyStart, closeStart);
+      }
+    }
+    cur.restore(start);
+    return undefined;
+  }
+  if (ch === '"') {
+    cur.advance();
+    let value = '';
+    while (!cur.done) {
+      const next = cur.peek();
+      if (next === '\\') {
+        cur.advance();
+        const esc = cur.peek();
+        cur.advance();
+        const map: Record<string, string> = {
+          n: '\n',
+          r: '\r',
+          t: '\t',
+          '"': '"',
+          '\\': '\\',
+          '0': '\0',
+        };
+        value += map[esc] ?? esc;
+        continue;
+      }
+      if (next === '"') {
+        cur.advance();
+        return value;
+      }
+      value += next;
+      cur.advance();
+    }
+    cur.restore(start);
+    return undefined;
+  }
+  return undefined;
+}
+
+function skipBalanced(
+  cur: SourceCursor,
+  open: string,
+  close: string,
+): boolean {
+  skipCsharpTrivia(cur);
+  if (cur.peek() !== open) return false;
+  let depth = 0;
+  while (!cur.done) {
+    skipCsharpTrivia(cur);
+    if (cur.done) return false;
+    if (skipCsharpString(cur)) continue;
+    const ch = cur.peek();
+    if (ch === open) depth += 1;
+    else if (ch === close) {
+      depth -= 1;
+      cur.advance();
+      if (depth === 0) return true;
+      continue;
+    }
+    cur.advance();
+  }
+  return false;
+}
+
+function componentNameFromLiteral(value: string | undefined): string | undefined {
+  if (value === undefined || !COMPONENT_NAME_RE.test(value)) return undefined;
+  return value;
+}
+
+function catalogNamesFromAlias(alias: string): string[] {
+  const names = [alias];
+  const dotted = alias.lastIndexOf('.');
+  if (dotted >= 0) {
+    const shortName = alias.slice(dotted + 1);
+    if (COMPONENT_NAME_RE.test(shortName)) names.push(shortName);
+  }
+  return names;
+}
+
+function isViewComponentAttributeName(name: string): boolean {
+  return name === 'ViewComponent' || name === 'ViewComponentAttribute';
+}
+
+function readQualifiedTail(cur: SourceCursor): string | undefined {
+  skipCsharpTrivia(cur);
+  let name = readIdent(cur);
+  if (name === undefined) return undefined;
+  for (;;) {
+    skipCsharpTrivia(cur);
+    if (cur.peek() === '.' || (cur.peek() === ':' && cur.peek(1) === ':')) {
+      cur.advance(cur.peek() === ':' ? 2 : 1);
+      skipCsharpTrivia(cur);
+      const next = readIdent(cur);
+      if (next === undefined) return name;
+      name = next;
+      continue;
+    }
+    return name;
+  }
+}
+
+function readViewComponentNameArgument(cur: SourceCursor): string | undefined {
+  skipCsharpTrivia(cur);
+  if (cur.peek() !== '(') return undefined;
+  cur.advance();
+  let alias: string | undefined;
+  while (!cur.done && cur.peek() !== ')') {
+    skipCsharpTrivia(cur);
+    if (cur.peek() === ')') break;
+    const beforeArg = cur.snapshot();
+    const ident = readIdent(cur);
+    skipCsharpTrivia(cur);
+    if (ident === 'Name' && cur.peek() === '=') {
+      cur.advance();
+      alias = componentNameFromLiteral(decodeCsharpString(cur));
+    } else {
+      cur.restore(beforeArg);
+      skipCsharpTrivia(cur);
+      if (cur.peek() === '"' || cur.peek() === '@') {
+        // Positional string arguments are not ViewComponentAttribute.Name.
+        skipCsharpString(cur);
+      } else if (cur.peek() === '(' || cur.peek() === '[' || cur.peek() === '{') {
+        const open = cur.peek();
+        const close = open === '(' ? ')' : open === '[' ? ']' : '}';
+        skipBalanced(cur, open, close);
+      } else {
+        while (!cur.done && cur.peek() !== ',' && cur.peek() !== ')') {
+          if (skipCsharpString(cur)) continue;
+          if (skipCsharpComment(cur)) continue;
+          cur.advance();
+        }
+      }
+    }
+    skipCsharpTrivia(cur);
+    if (cur.peek() === ',') cur.advance();
+  }
+  if (cur.peek() === ')') cur.advance();
+  return alias;
+}
+
+function collectInvokeAfterIdent(
+  ident: string,
+  cur: SourceCursor,
+  previous: string | undefined,
+  names: Set<string>,
+): void {
+  skipCsharpTrivia(cur);
+  if (ident === 'ViewComponent' && cur.peek() === '(') {
+    if (previous === '[' || previous === ',') return;
+    cur.advance();
+    const name = componentNameFromLiteral(decodeCsharpString(cur));
+    if (name !== undefined) names.add(name);
+    return;
+  }
+  if (ident !== 'Component' || cur.peek() !== '.') return;
+  const afterDot = cur.snapshot();
+  cur.advance();
+  skipCsharpTrivia(cur);
+  if (readIdent(cur) !== 'InvokeAsync') {
+    cur.restore(afterDot);
+    return;
+  }
+  skipCsharpTrivia(cur);
+  if (cur.peek() !== '(') return;
+  cur.advance();
+  const name = componentNameFromLiteral(decodeCsharpString(cur));
+  if (name !== undefined) names.add(name);
+}
+
+/** In-repo C# `Component.InvokeAsync("X")` / `ViewComponent("X")` literals. */
+export function extractCsharpViewComponentInvocations(source: string): string[] {
+  if (!source.includes('ViewComponent') && !source.includes('InvokeAsync')) return [];
+  const names = new Set<string>();
+  const cur = new SourceCursor(source);
+  let previous: string | undefined;
+  let squareDepth = 0;
+  while (!cur.done) {
+    skipCsharpTrivia(cur);
+    if (cur.done) break;
+    if (skipCsharpString(cur)) {
+      previous = 'string';
+      continue;
+    }
+    const ident = readIdent(cur);
+    if (ident !== undefined) {
+      const inAttribute = squareDepth > 0;
+      collectInvokeAfterIdent(ident, cur, inAttribute ? '[' : previous, names);
+      previous = ident;
+      continue;
+    }
+    const ch = cur.peek();
+    if (ch === '[') squareDepth += 1;
+    else if (ch === ']' && squareDepth > 0) squareDepth -= 1;
+    previous = ch;
+    cur.advance();
+  }
+  return [...names];
+}
+
+function parseAttributeListBody(cur: SourceCursor): string[] {
+  const aliases: string[] = [];
+  skipCsharpTrivia(cur);
+  const specifier = cur.snapshot();
+  const specifierName = readIdent(cur);
+  skipCsharpTrivia(cur);
+  if (specifierName !== undefined && cur.peek() === ':' && cur.peek(1) !== ':') {
+    cur.advance();
+  } else {
+    cur.restore(specifier);
+  }
+  while (!cur.done && cur.peek() !== ']') {
+    skipCsharpTrivia(cur);
+    if (cur.peek() === ']') break;
+    const tail = readQualifiedTail(cur);
+    skipCsharpTrivia(cur);
+    if (tail !== undefined && isViewComponentAttributeName(tail) && cur.peek() === '(') {
+      const alias = readViewComponentNameArgument(cur);
+      if (alias !== undefined) aliases.push(alias);
+    } else if (cur.peek() === '(') {
+      skipBalanced(cur, '(', ')');
+    }
+    skipCsharpTrivia(cur);
+    if (cur.peek() === ',') cur.advance();
+    else break;
+  }
+  if (cur.peek() === ']') cur.advance();
+  return aliases;
+}
+
+/**
+ * Explicit `[ViewComponent(Name = "...")]` aliases keyed to the following
+ * class declaration. Positional constructor arguments are ignored: the MVC
+ * attribute only exposes `Name` as a property.
+ */
+export function extractViewComponentAliasBinds(source: string): ViewComponentAliasBind[] {
+  if (!source.includes('ViewComponent')) return [];
+  const binds: ViewComponentAliasBind[] = [];
+  const cur = new SourceCursor(source);
+  const pending: { startLine: number; startCol: number; aliases: string[] }[] = [];
+
+  const flushPending = (className: string, startLine: number, startCol: number): void => {
+    const aliases = pending.flatMap((entry) => entry.aliases);
+    const start = pending[0];
+    binds.push({
+      className,
+      startLine: start?.startLine ?? startLine,
+      startCol: start?.startCol ?? startCol,
+      aliases: [...new Set(aliases.flatMap(catalogNamesFromAlias))],
+    });
+    pending.length = 0;
+  };
+
+  while (!cur.done) {
+    skipCsharpTrivia(cur);
+    if (cur.done) break;
+    if (skipCsharpString(cur)) continue;
+    const startLine = cur.line;
+    const startCol = cur.col;
+    if (cur.peek() === '[') {
+      cur.advance();
+      const aliases = parseAttributeListBody(cur);
+      pending.push({ startLine, startCol, aliases });
+      continue;
+    }
+    const ident = readIdent(cur);
+    if (ident === undefined) {
+      pending.length = 0;
+      cur.advance();
+      continue;
+    }
+    if (TYPE_MODIFIERS.has(ident)) continue;
+    if (ident === 'class' || ident === 'record') {
+      const className = tryReadIdent(cur);
+      if (className !== undefined && pending.some((entry) => entry.aliases.length > 0)) {
+        flushPending(className, startLine, startCol);
+      } else {
+        pending.length = 0;
+      }
+      continue;
+    }
+    pending.length = 0;
+  }
+  return binds;
+}
+
+/** Extract explicit `[ViewComponent(Name = "...")]` aliases by class name. */
+export function extractViewComponentAliases(source: string): ReadonlyMap<string, readonly string[]> {
+  const aliases = new Map<string, string[]>();
+  for (const bind of extractViewComponentAliasBinds(source)) {
+    if (bind.aliases.length === 0) continue;
+    const existing = aliases.get(bind.className);
+    if (existing) {
+      for (const alias of bind.aliases) {
+        if (!existing.includes(alias)) existing.push(alias);
+      }
+    } else {
+      aliases.set(bind.className, [...bind.aliases]);
+    }
+  }
+  return aliases;
 }
 
 function tagNameToComponentName(tagName: string): string {
@@ -55,46 +653,153 @@ function tagNameToComponentName(tagName: string): string {
     .join('');
 }
 
-/** Extract statically resolvable ViewComponent names from one Razor template. */
-export function extractRazorViewComponentInvocations(source: string): string[] {
-  const visible = withoutRazorComments(source);
-  const names = new Set<string>();
-
-  for (const match of visible.matchAll(RAZOR_INVOKE_RE)) {
-    names.add(match[1]!);
-  }
-  for (const match of visible.matchAll(VIEW_COMPONENT_TAG_RE)) {
+function collectVcTags(span: string, names: Set<string>): void {
+  VIEW_COMPONENT_TAG_RE.lastIndex = 0;
+  for (const match of span.matchAll(VIEW_COMPONENT_TAG_RE)) {
     names.add(tagNameToComponentName(match[1]!));
   }
-
-  return [...names];
 }
 
-/** In-repo C# `Component.InvokeAsync("X")` / `ViewComponent("X")` literals. */
-export function extractCsharpViewComponentInvocations(source: string): string[] {
-  const names = new Set<string>();
-  for (const match of withoutCsharpComments(source).matchAll(CSHARP_INVOKE_RE)) {
-    names.add(match[1]!);
+function skipRazorComment(cur: SourceCursor): boolean {
+  if (!cur.startsWith('@*')) return false;
+  cur.advance(2);
+  while (!cur.done && !cur.startsWith('*@')) cur.advance();
+  if (cur.startsWith('*@')) cur.advance(2);
+  return true;
+}
+
+function countAtRun(cur: SourceCursor): number {
+  let count = 0;
+  while (cur.peek() === '@') {
+    count += 1;
+    cur.advance();
   }
-  return [...names];
+  return count;
 }
 
-/** Extract explicit `[ViewComponent(Name = "...")]` aliases by class name. */
-export function extractViewComponentAliases(
-  source: string,
-): ReadonlyMap<string, readonly string[]> {
-  const aliases = new Map<string, string[]>();
-  for (const match of withoutCsharpComments(source).matchAll(VIEW_COMPONENT_ALIAS_RE)) {
-    const alias = match[1]!;
-    const className = match[2]!;
-    const existing = aliases.get(className);
-    if (existing) {
-      if (!existing.includes(alias)) existing.push(alias);
-    } else {
-      aliases.set(className, [alias]);
+function scanCsharpSpan(span: string, names: Set<string>): void {
+  for (const name of extractCsharpViewComponentInvocations(span)) names.add(name);
+}
+
+function skipOptionalParens(cur: SourceCursor): void {
+  skipWhitespace(cur);
+  if (cur.peek() === '(') skipBalanced(cur, '(', ')');
+}
+
+function consumeRazorCodeBlock(cur: SourceCursor, names: Set<string>): void {
+  skipCsharpTrivia(cur);
+  skipOptionalParens(cur);
+  skipCsharpTrivia(cur);
+  if (cur.peek() !== '{') {
+    const start = cur.i;
+    while (!cur.done && cur.peek() !== '\n' && cur.peek() !== '{') {
+      if (skipCsharpString(cur) || skipCsharpComment(cur)) continue;
+      cur.advance();
     }
+    scanCsharpSpan(cur.source.slice(start, cur.i), names);
+    if (cur.peek() === '{') consumeRazorCodeBlock(cur, names);
+    return;
   }
-  return aliases;
+  const bodyStart = cur.i + 1;
+  if (!skipBalanced(cur, '{', '}')) return;
+  scanCsharpSpan(cur.source.slice(bodyStart, cur.i - 1), names);
+}
+
+function consumeImplicitExpression(cur: SourceCursor, names: Set<string>): void {
+  const start = cur.i;
+  skipCsharpTrivia(cur);
+  if (cur.peek() === '(') {
+    const innerStart = cur.i + 1;
+    if (skipBalanced(cur, '(', ')')) {
+      scanCsharpSpan(cur.source.slice(innerStart, cur.i - 1), names);
+    }
+    return;
+  }
+  // Implicit expressions: `@await Component.InvokeAsync("X")` / `@Component.InvokeAsync(...)`.
+  while (!cur.done) {
+    skipCsharpTrivia(cur);
+    if (cur.done) break;
+    if (skipCsharpString(cur)) continue;
+    if (cur.peek() === '(') {
+      skipBalanced(cur, '(', ')');
+      continue;
+    }
+    if (cur.peek() === '{') {
+      skipBalanced(cur, '{', '}');
+      continue;
+    }
+    const ch = cur.peek();
+    if (ch === '<' || ch === '\n') break;
+    if (ch === '@') break;
+    if (!isIdentPart(ch) && ch !== '.' && ch !== '?') {
+      if (ch === ';') cur.advance();
+      break;
+    }
+    cur.advance();
+  }
+  scanCsharpSpan(cur.source.slice(start, cur.i), names);
+}
+
+function consumeRazorTransition(cur: SourceCursor, names: Set<string>): void {
+  skipWhitespace(cur);
+  if (cur.peek() === '{') {
+    consumeRazorCodeBlock(cur, names);
+    return;
+  }
+  if (cur.peek() === '(') {
+    consumeImplicitExpression(cur, names);
+    return;
+  }
+  const identStart = cur.snapshot();
+  const ident = readIdent(cur);
+  if (ident === undefined) {
+    consumeImplicitExpression(cur, names);
+    return;
+  }
+  if (ident === 'await' || ident === 'Component') {
+    cur.restore(identStart);
+    consumeImplicitExpression(cur, names);
+    return;
+  }
+  if (RAZOR_BLOCK_KEYWORDS.has(ident)) {
+    if (ident === 'section' || ident === 'helper') tryReadIdent(cur);
+    consumeRazorCodeBlock(cur, names);
+    return;
+  }
+  cur.restore(identStart);
+  consumeImplicitExpression(cur, names);
+}
+
+/** Extract statically resolvable ViewComponent names from one Razor template. */
+export function extractRazorViewComponentInvocations(source: string): string[] {
+  const names = new Set<string>();
+  const cur = new SourceCursor(source);
+  let markupStart = 0;
+  const flushMarkup = (): void => {
+    if (cur.i > markupStart) collectVcTags(source.slice(markupStart, cur.i), names);
+  };
+
+  while (!cur.done) {
+    if (cur.peek() !== '@') {
+      cur.advance();
+      continue;
+    }
+    flushMarkup();
+    if (skipRazorComment(cur)) {
+      markupStart = cur.i;
+      continue;
+    }
+    const atCount = countAtRun(cur);
+    const leftover = atCount % 2;
+    if (leftover === 0) {
+      markupStart = cur.i;
+      continue;
+    }
+    consumeRazorTransition(cur, names);
+    markupStart = cur.i;
+  }
+  flushMarkup();
+  return [...names];
 }
 
 /**
@@ -116,14 +821,15 @@ export async function loadRazorViewComponentConfig(
   paths.sort();
 
   const maxBytes = getMaxFileSizeBytes();
-  const views = new Map<string, string>();
+  const views = new Map<string, readonly string[]>();
   for (const rawPath of paths) {
     const filePath = rawPath.replace(/\\/g, '/');
     try {
       const fullPath = path.join(repoRoot, filePath);
       const stat = await fs.stat(fullPath);
       if (!stat.isFile() || stat.size > maxBytes) continue;
-      views.set(filePath, await fs.readFile(fullPath, 'utf8'));
+      const source = await fs.readFile(fullPath, 'utf8');
+      views.set(filePath, extractRazorViewComponentInvocations(source));
     } catch {
       // A view may disappear between glob/stat/read during watch mode.
     }
@@ -143,6 +849,24 @@ function addCandidate(
   } else {
     candidates.set(key, new Set([targetId]));
   }
+}
+
+function bindAliasesForClass(
+  binds: readonly ViewComponentAliasBind[],
+  className: string,
+  nodeId: string,
+  filePath: string,
+): readonly string[] | undefined {
+  const matches = binds.filter((bind) => bind.className === className);
+  if (matches.length === 0) return undefined;
+  if (matches.length === 1) return matches[0]!.aliases;
+  const pos = definitionIdPosition(nodeId, filePath);
+  if (pos === undefined) return undefined;
+  const atPosition = matches.filter(
+    (bind) => bind.startLine === pos.line && bind.startCol === pos.column,
+  );
+  if (atPosition.length === 1) return atPosition[0]!.aliases;
+  return undefined;
 }
 
 /**
@@ -167,21 +891,25 @@ export function emitRazorViewComponentEdges(
   const candidates = new Map<string, Set<string>>();
   for (const parsed of parsedFiles) {
     if (!parsed.filePath.endsWith('.cs')) continue;
-    const aliases = extractViewComponentAliases(csharpSources.get(parsed.filePath) ?? '');
+    const source = csharpSources.get(parsed.filePath) ?? '';
+    const binds =
+      source.includes('ViewComponent') ? extractViewComponentAliasBinds(source) : [];
     for (const def of parsed.localDefs) {
       if (def.type !== 'Class') continue;
       const className = def.qualifiedName?.split('.').pop() ?? def.nodeId.split(':').pop() ?? '';
       const conventionalName = className.endsWith(VIEW_COMPONENT_SUFFIX)
         ? className.slice(0, -VIEW_COMPONENT_SUFFIX.length)
         : undefined;
-      const explicitAliases = aliases.get(className) ?? [];
-      if (!conventionalName && explicitAliases.length === 0) continue;
+      const explicitAliases = bindAliasesForClass(binds, className, def.nodeId, parsed.filePath);
+      if (!conventionalName && (explicitAliases === undefined || explicitAliases.length === 0)) {
+        continue;
+      }
 
       const targetId = resolveDefGraphId(parsed.filePath, def, nodeLookup);
       if (!targetId || !graph.getNode(targetId)) continue;
       // An explicit [ViewComponent(Name = "...")] replaces the suffix name,
       // matching ASP.NET. Never register the SDK base type as a candidate.
-      if (explicitAliases.length > 0) {
+      if (explicitAliases !== undefined && explicitAliases.length > 0) {
         for (const alias of explicitAliases) addCandidate(candidates, alias, targetId);
       } else if (conventionalName) {
         addCandidate(candidates, conventionalName, targetId);
@@ -195,8 +923,8 @@ export function emitRazorViewComponentEdges(
     for (const invocationName of invocationNames) {
       const matches = candidates.get(invocationName.toLocaleLowerCase('en-US'));
       if (!matches || matches.size !== 1) continue;
-      const targetId = matches.values().next().value as string;
-      if (!graph.getNode(targetId)) continue;
+      const targetId = matches.values().next().value;
+      if (typeof targetId !== 'string' || !graph.getNode(targetId)) continue;
       graph.addRelationship({
         id: generateId('CALLS', `${sourceId}:razor-view-component:${targetId}`),
         sourceId,
@@ -208,11 +936,12 @@ export function emitRazorViewComponentEdges(
     }
   };
 
-  for (const [viewPath, source] of config.views) {
-    emitFromFile(viewPath, extractRazorViewComponentInvocations(source));
+  for (const [viewPath, invocationNames] of config.views) {
+    emitFromFile(viewPath, invocationNames);
   }
   for (const [filePath, source] of csharpSources) {
     if (!filePath.endsWith('.cs')) continue;
+    if (!source.includes('ViewComponent') && !source.includes('InvokeAsync')) continue;
     emitFromFile(filePath, extractCsharpViewComponentInvocations(source));
   }
 }

--- a/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
+++ b/gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts
@@ -135,7 +135,8 @@ function isIdentPart(ch: string): boolean {
 function skipWhitespace(cur: SourceCursor): void {
   while (!cur.done) {
     const ch = cur.peek();
-    if (ch !== ' ' && ch !== '\t' && ch !== '\n' && ch !== '\r' && ch !== '\f' && ch !== '\v') break;
+    if (ch !== ' ' && ch !== '\t' && ch !== '\n' && ch !== '\r' && ch !== '\f' && ch !== '\v')
+      break;
     cur.advance();
   }
 }
@@ -382,11 +383,7 @@ function decodeCsharpString(cur: SourceCursor): string | undefined {
   return undefined;
 }
 
-function skipBalanced(
-  cur: SourceCursor,
-  open: string,
-  close: string,
-): boolean {
+function skipBalanced(cur: SourceCursor, open: string, close: string): boolean {
   skipCsharpTrivia(cur);
   if (cur.peek() !== open) return false;
   let depth = 0;
@@ -629,7 +626,9 @@ export function extractViewComponentAliasBinds(source: string): ViewComponentAli
 }
 
 /** Extract explicit `[ViewComponent(Name = "...")]` aliases by class name. */
-export function extractViewComponentAliases(source: string): ReadonlyMap<string, readonly string[]> {
+export function extractViewComponentAliases(
+  source: string,
+): ReadonlyMap<string, readonly string[]> {
   const aliases = new Map<string, string[]>();
   for (const bind of extractViewComponentAliasBinds(source)) {
     if (bind.aliases.length === 0) continue;
@@ -892,8 +891,7 @@ export function emitRazorViewComponentEdges(
   for (const parsed of parsedFiles) {
     if (!parsed.filePath.endsWith('.cs')) continue;
     const source = csharpSources.get(parsed.filePath) ?? '';
-    const binds =
-      source.includes('ViewComponent') ? extractViewComponentAliasBinds(source) : [];
+    const binds = source.includes('ViewComponent') ? extractViewComponentAliasBinds(source) : [];
     for (const def of parsed.localDefs) {
       if (def.type !== 'Class') continue;
       const className = def.qualifiedName?.split('.').pop() ?? def.nodeId.split(':').pop() ?? '';

--- a/gitnexus/src/core/ingestion/languages/csharp/resolution-config.ts
+++ b/gitnexus/src/core/ingestion/languages/csharp/resolution-config.ts
@@ -12,19 +12,29 @@ import {
   type CSharpProjectConfig,
   type CSharpNamespaceEvidence,
 } from '../../language-config.js';
+import {
+  loadRazorViewComponentConfig,
+  type RazorViewComponentConfig,
+} from './razor-view-components.js';
 
 export interface CsharpResolutionConfig {
   readonly csharpConfigs: readonly CSharpProjectConfig[];
   /** In-repo declared-namespace evidence gating suffix-fallback resolution (#1881). */
   readonly namespaces?: CSharpNamespaceEvidence;
+  /** Razor views scanned for ASP.NET ViewComponent invocation conventions. */
+  readonly razorViewComponents?: RazorViewComponentConfig;
 }
 
 export async function loadCsharpResolutionConfig(
   repoRoot: string,
 ): Promise<CsharpResolutionConfig> {
-  const scan = await scanCSharpProject(repoRoot);
+  const [scan, razorViewComponents] = await Promise.all([
+    scanCSharpProject(repoRoot),
+    loadRazorViewComponentConfig(repoRoot),
+  ]);
   return {
     csharpConfigs: scan.configs,
     namespaces: csharpScanToEvidence(scan),
+    razorViewComponents,
   };
 }

--- a/gitnexus/src/core/ingestion/languages/csharp/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/languages/csharp/scope-resolver.ts
@@ -22,6 +22,7 @@ import {
 import { populateCsharpNamespaceSiblings } from './namespace-siblings.js';
 import { loadCsharpResolutionConfig, type CsharpResolutionConfig } from './resolution-config.js';
 import { unwrapCsharpElementType } from './accessor-unwrap.js';
+import { emitRazorViewComponentEdges } from './razor-view-components.js';
 
 const csharpScopeResolver: ScopeResolver = {
   // Construction is keyword-prefixed: `new Service(db).doWork()` (#2708).
@@ -106,6 +107,20 @@ const csharpScopeResolver: ScopeResolver = {
   // `IValidator<string>` and `IValidator<String>` are one instantiation, so the
   // dispatch fan-out must not read them as two (#2912). See the alias table.
   normalizeTypeArgument: normalizeCsharpTypeArgument,
+
+  // Razor views stay out of the C# parser. Bind literal ViewComponent names
+  // only onto in-repo classes (Spring-style: skip the SDK type, hop to the
+  // workspace implementor).
+  emitPostResolutionEdges: (graph, parsedFiles, nodeLookup, _indexes, ctx) => {
+    const config = ctx.resolutionConfig as CsharpResolutionConfig | undefined;
+    emitRazorViewComponentEdges(
+      graph,
+      parsedFiles,
+      nodeLookup,
+      config?.razorViewComponents,
+      ctx.fileContents,
+    );
+  },
 };
 
 /**

--- a/gitnexus/test/integration/csharp-razor-view-components-benchmark.test.ts
+++ b/gitnexus/test/integration/csharp-razor-view-components-benchmark.test.ts
@@ -1,0 +1,179 @@
+/**
+ * C# Razor ViewComponent extractor + loader scaling guards (#2991).
+ *
+ * The coverage job always runs the tripwire (direct extractors, no worker).
+ * GITNEXUS_BENCH=1 additionally checks sub-quadratic scaling and that the
+ * production loader retains invocation names instead of view source.
+ *
+ * Run: GITNEXUS_BENCH=1 npx vitest run test/integration/csharp-razor-view-components-benchmark.test.ts
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  extractCsharpViewComponentInvocations,
+  extractRazorViewComponentInvocations,
+  loadRazorViewComponentConfig,
+} from '../../src/core/ingestion/languages/csharp/razor-view-components.js';
+
+const BENCH_ENABLED = process.env.GITNEXUS_BENCH === '1';
+const PAD = 'x'.repeat(4_000);
+
+function csharpMixed(i: number): string {
+  if (i % 10 === 0) {
+    return (
+      'using Microsoft.AspNetCore.Mvc;\n' +
+      `class C${i} {\n` +
+      '  async Task T() {\n' +
+      '    await Component.InvokeAsync("Cart");\n' +
+      '  }\n' +
+      '}\n' +
+      `// ${PAD}\n`
+    );
+  }
+  if (i % 10 === 1) {
+    return `// ViewComponent decoy\nclass C${i} { string s = "InvokeAsync"; }\n// ${PAD}\n`;
+  }
+  return `class C${i} { int X => ${i}; }\n// ${PAD}\n`;
+}
+
+function razorMixed(i: number): string {
+  if (i % 10 === 0) {
+    return `@await Component.InvokeAsync("Cart")\n<!-- ${PAD} -->\n`;
+  }
+  if (i % 10 === 1) {
+    return (
+      '@* @await Component.InvokeAsync("Dead") *@\n' +
+      '@@await Component.InvokeAsync("Escaped")\n' +
+      '@* <vc:login /> *@\n' +
+      `<!-- ${PAD} -->\n`
+    );
+  }
+  return `<p>hello ${i}</p>\n<!-- ${PAD} -->\n`;
+}
+
+function expectedHits(fileCount: number): number {
+  return Math.floor((fileCount - 1) / 10) + (fileCount > 0 ? 1 : 0);
+}
+
+function scanCsharp(fileCount: number): { hits: number; elapsedMs: number } {
+  const sources = Array.from({ length: fileCount }, (_, i) => csharpMixed(i));
+  const started = performance.now();
+  let hits = 0;
+  for (const source of sources) {
+    hits += extractCsharpViewComponentInvocations(source).length;
+  }
+  return { hits, elapsedMs: performance.now() - started };
+}
+
+function scanRazor(fileCount: number): { hits: number; elapsedMs: number } {
+  const sources = Array.from({ length: fileCount }, (_, i) => razorMixed(i));
+  const started = performance.now();
+  let hits = 0;
+  for (const source of sources) {
+    hits += extractRazorViewComponentInvocations(source).length;
+  }
+  return { hits, elapsedMs: performance.now() - started };
+}
+
+/**
+ * Direct extractor tripwire for the coverage job. Coarse budget: far above the
+ * measured linear path, far below a full-corpus character-by-character scan of
+ * every padded view without the token prefilter.
+ */
+describe('C# Razor ViewComponent extractor tripwire', () => {
+  it('scans a 400-file mixed corpus well under the O(n^2) budget', () => {
+    const FILE_COUNT = 400;
+    const BUDGET_MS = 2_000;
+    scanCsharp(40);
+    scanRazor(40);
+
+    const csharp = scanCsharp(FILE_COUNT);
+    const razor = scanRazor(FILE_COUNT);
+    expect(csharp.hits).toBe(expectedHits(FILE_COUNT));
+    expect(razor.hits).toBe(expectedHits(FILE_COUNT));
+    expect(csharp.elapsedMs + razor.elapsedMs).toBeLessThan(BUDGET_MS);
+  }, 15_000);
+});
+
+describe.skipIf(!BENCH_ENABLED)('C# Razor ViewComponent extractor benchmark', () => {
+  it('scales sub-quadratically as mixed C# and Razor corpora grow', () => {
+    scanCsharp(50);
+    scanRazor(50);
+
+    const csharpSmall = scanCsharp(500);
+    const csharpLarge = scanCsharp(2_000);
+    const razorSmall = scanRazor(500);
+    const razorLarge = scanRazor(2_000);
+    const ratio = 2_000 / 500;
+
+    console.log('\nC# Razor ViewComponent extractor benchmark');
+    console.log(
+      `  csharp files=500 wall=${csharpSmall.elapsedMs.toFixed(2)}ms hits=${csharpSmall.hits}`,
+    );
+    console.log(
+      `  csharp files=2000 wall=${csharpLarge.elapsedMs.toFixed(2)}ms hits=${csharpLarge.hits}`,
+    );
+    console.log(
+      `  razor files=500 wall=${razorSmall.elapsedMs.toFixed(2)}ms hits=${razorSmall.hits}`,
+    );
+    console.log(
+      `  razor files=2000 wall=${razorLarge.elapsedMs.toFixed(2)}ms hits=${razorLarge.hits}`,
+    );
+
+    expect(csharpSmall.hits).toBe(expectedHits(500));
+    expect(csharpLarge.hits).toBe(expectedHits(2_000));
+    expect(razorSmall.hits).toBe(expectedHits(500));
+    expect(razorLarge.hits).toBe(expectedHits(2_000));
+
+    if (csharpSmall.elapsedMs >= 5) {
+      expect(csharpLarge.elapsedMs / csharpSmall.elapsedMs).toBeLessThan(Math.pow(ratio, 1.5));
+    }
+    if (razorSmall.elapsedMs >= 5) {
+      expect(razorLarge.elapsedMs / razorSmall.elapsedMs).toBeLessThan(Math.pow(ratio, 1.5));
+    }
+    expect(csharpLarge.elapsedMs).toBeLessThan(5_000);
+    expect(razorLarge.elapsedMs).toBeLessThan(5_000);
+  }, 60_000);
+
+  it('loader retains invocation names instead of view source', async () => {
+    const FILE_COUNT = 2_000;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-razor-vc-bench-'));
+    try {
+      fs.mkdirSync(path.join(dir, 'Views'), { recursive: true });
+      for (let i = 0; i < FILE_COUNT; i++) {
+        fs.writeFileSync(path.join(dir, 'Views', `v${i}.cshtml`), razorMixed(i));
+      }
+
+      await loadRazorViewComponentConfig(dir);
+
+      const started = performance.now();
+      const config = await loadRazorViewComponentConfig(dir);
+      const elapsedMs = performance.now() - started;
+
+      let sourceBytes = 0;
+      let retainedChars = 0;
+      let hits = 0;
+      for (const names of config.views.values()) {
+        hits += names.length;
+        for (const name of names) retainedChars += name.length;
+      }
+      for (let i = 0; i < FILE_COUNT; i++) {
+        sourceBytes += Buffer.byteLength(razorMixed(i));
+      }
+
+      console.log(
+        `  loader files=${FILE_COUNT} wall=${elapsedMs.toFixed(2)}ms ` +
+          `source=${(sourceBytes / 1024 / 1024).toFixed(2)}MB retainedChars=${retainedChars}`,
+      );
+
+      expect(config.views.size).toBe(FILE_COUNT);
+      expect(hits).toBe(expectedHits(FILE_COUNT));
+      expect(retainedChars).toBeLessThan(sourceBytes / 20);
+      expect(elapsedMs).toBeLessThan(15_000);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/gitnexus/test/integration/csharp-razor-view-components-benchmark.test.ts
+++ b/gitnexus/test/integration/csharp-razor-view-components-benchmark.test.ts
@@ -54,7 +54,7 @@ function razorMixed(i: number): string {
 }
 
 function expectedHits(fileCount: number): number {
-  return Math.floor((fileCount - 1) / 10) + (fileCount > 0 ? 1 : 0);
+  return fileCount > 0 ? Math.floor((fileCount - 1) / 10) + 1 : 0;
 }
 
 function scanCsharp(fileCount: number): { hits: number; elapsedMs: number } {

--- a/gitnexus/test/integration/csharp-razor-view-components.test.ts
+++ b/gitnexus/test/integration/csharp-razor-view-components.test.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  getRelationships,
+  runPipelineFromRepo,
+  writeFixtureRepo,
+  type PipelineResult,
+} from './resolvers/helpers.js';
+
+describe('C# Razor ViewComponent conventions', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-csharp-razor-vc-'));
+  let result: PipelineResult;
+
+  beforeAll(() => vi.stubEnv('GITNEXUS_WORKER_READY_TIMEOUT_MS', '60000'));
+
+  beforeAll(async () => {
+    writeFixtureRepo(root, {
+      'Components/SessionSummaryBarViewComponent.cs': `
+        namespace Demo.Components;
+        public class SessionSummaryBarViewComponent : ViewComponent
+        {
+          public object Invoke() => new object();
+        }
+      `,
+      'Components/MenuViewComponent.cs': `
+        namespace Demo.Components;
+        [ViewComponent(Name = "AccountMenu")]
+        public class MenuViewComponent : ViewComponent
+        {
+          public object Invoke() => new object();
+        }
+      `,
+      'One/DuplicateViewComponent.cs': `
+        namespace Demo.One;
+        public class DuplicateViewComponent : ViewComponent {}
+      `,
+      'Two/DuplicateViewComponent.cs': `
+        namespace Demo.Two;
+        public class DuplicateViewComponent : ViewComponent {}
+      `,
+      'Views/Home/Index.cshtml': `
+        @await Component.InvokeAsync("SessionSummaryBar", new { id = 1 })
+        <vc:account-menu />
+      `,
+      'Views/Shared/Alias.cshtml': `@await Component.InvokeAsync("AccountMenu")`,
+      'Views/Shared/Ambiguous.cshtml': `@await Component.InvokeAsync("Duplicate")`,
+      'Views/Shared/Commented.cshtml': `
+        @* @await Component.InvokeAsync("SessionSummaryBar") *@
+      `,
+      'Controllers/HomeController.cs': `
+        using Microsoft.AspNetCore.Mvc;
+        namespace Demo.Controllers;
+        public class HomeController : Controller
+        {
+          public IViewComponentResult Widget() => ViewComponent("SessionSummaryBar");
+        }
+      `,
+    });
+    result = await runPipelineFromRepo(root, () => {}, { skipGraphPhases: true });
+  }, 120000);
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('emits File-to-Class CALLS for literal and tag-helper invocations', () => {
+    const calls = getRelationships(result, 'CALLS').filter(
+      (edge) => edge.rel.reason === 'aspnet-razor-view-component',
+    );
+
+    expect(
+      calls
+        .map((edge) => ({
+          source: edge.sourceFilePath,
+          target: edge.target,
+          targetLabel: edge.targetLabel,
+        }))
+        .sort((a, b) => `${a.source}:${a.target}`.localeCompare(`${b.source}:${b.target}`)),
+    ).toEqual([
+      {
+        source: 'Controllers/HomeController.cs',
+        target: 'SessionSummaryBarViewComponent',
+        targetLabel: 'Class',
+      },
+      {
+        source: 'Views/Home/Index.cshtml',
+        target: 'MenuViewComponent',
+        targetLabel: 'Class',
+      },
+      {
+        source: 'Views/Home/Index.cshtml',
+        target: 'SessionSummaryBarViewComponent',
+        targetLabel: 'Class',
+      },
+      {
+        source: 'Views/Shared/Alias.cshtml',
+        target: 'MenuViewComponent',
+        targetLabel: 'Class',
+      },
+    ]);
+    expect(calls.some((edge) => edge.target === 'ViewComponent')).toBe(false);
+    expect(calls.some((edge) => edge.target === 'InvokeAsync')).toBe(false);
+  });
+
+  it('fails closed for ambiguous names and commented invocations', () => {
+    const razorSources = getRelationships(result, 'CALLS')
+      .filter((edge) => edge.rel.reason === 'aspnet-razor-view-component')
+      .map((edge) => edge.sourceFilePath);
+
+    expect(razorSources).not.toContain('Views/Shared/Ambiguous.cshtml');
+    expect(razorSources).not.toContain('Views/Shared/Commented.cshtml');
+  });
+});

--- a/gitnexus/test/integration/csharp-razor-view-components.test.ts
+++ b/gitnexus/test/integration/csharp-razor-view-components.test.ts
@@ -26,7 +26,7 @@ describe('C# Razor ViewComponent conventions', () => {
       `,
       'Components/MenuViewComponent.cs': `
         namespace Demo.Components;
-        [ViewComponent(Name = "AccountMenu")]
+        [ApiController, ViewComponent(Name = "AccountMenu")]
         public class MenuViewComponent : ViewComponent
         {
           public object Invoke() => new object();
@@ -43,18 +43,26 @@ describe('C# Razor ViewComponent conventions', () => {
       'Views/Home/Index.cshtml': `
         @await Component.InvokeAsync("SessionSummaryBar", new { id = 1 })
         <vc:account-menu />
+        @{
+          await Component.InvokeAsync("SessionSummaryBar");
+        }
+        @@await Component.InvokeAsync("SessionSummaryBar")
+        <!-- @await Component.InvokeAsync("AccountMenu") -->
       `,
       'Views/Shared/Alias.cshtml': `@await Component.InvokeAsync("AccountMenu")`,
       'Views/Shared/Ambiguous.cshtml': `@await Component.InvokeAsync("Duplicate")`,
       'Views/Shared/Commented.cshtml': `
         @* @await Component.InvokeAsync("SessionSummaryBar") *@
       `,
+      'Views/Shared/Suffix.cshtml': `@await Component.InvokeAsync("Menu")`,
       'Controllers/HomeController.cs': `
         using Microsoft.AspNetCore.Mvc;
         namespace Demo.Controllers;
         public class HomeController : Controller
         {
           public IViewComponentResult Widget() => ViewComponent("SessionSummaryBar");
+          public IViewComponentResult FromBase() => base.ViewComponent("SessionSummaryBar");
+          public IViewComponentResult FromThis() => this.ViewComponent("SessionSummaryBar");
         }
       `,
     });
@@ -102,14 +110,18 @@ describe('C# Razor ViewComponent conventions', () => {
     ]);
     expect(calls.some((edge) => edge.target === 'ViewComponent')).toBe(false);
     expect(calls.some((edge) => edge.target === 'InvokeAsync')).toBe(false);
+    expect(calls.some((edge) => edge.sourceFilePath === 'Components/MenuViewComponent.cs')).toBe(
+      false,
+    );
   });
 
-  it('fails closed for ambiguous names and commented invocations', () => {
+  it('fails closed for ambiguous names, Razor comments, and replaced suffixes', () => {
     const razorSources = getRelationships(result, 'CALLS')
       .filter((edge) => edge.rel.reason === 'aspnet-razor-view-component')
       .map((edge) => edge.sourceFilePath);
 
     expect(razorSources).not.toContain('Views/Shared/Ambiguous.cshtml');
     expect(razorSources).not.toContain('Views/Shared/Commented.cshtml');
+    expect(razorSources).not.toContain('Views/Shared/Suffix.cshtml');
   });
 });

--- a/gitnexus/test/unit/scope-resolution/csharp/razor-view-components.test.ts
+++ b/gitnexus/test/unit/scope-resolution/csharp/razor-view-components.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractCsharpViewComponentInvocations,
+  extractRazorViewComponentInvocations,
+  extractViewComponentAliases,
+} from '../../../../src/core/ingestion/languages/csharp/razor-view-components.js';
+
+describe('Razor ViewComponent convention extraction', () => {
+  it('extracts literal InvokeAsync calls and ViewComponent tag helpers', () => {
+    const source = `
+      @await Component.InvokeAsync("SessionSummaryBar", new { id = 1 })
+      @Component.InvokeAsync(
+        "Navigation"
+      )
+      <vc:featured-product product-id="42" />
+    `;
+
+    expect(extractRazorViewComponentInvocations(source)).toEqual([
+      'SessionSummaryBar',
+      'Navigation',
+      'FeaturedProduct',
+    ]);
+  });
+
+  it('ignores invocations inside Razor and HTML comments', () => {
+    const source = `
+      @* @await Component.InvokeAsync("RazorComment") *@
+      <!-- @await Component.InvokeAsync("HtmlComment") -->
+      @await Component.InvokeAsync("Visible")
+    `;
+
+    expect(extractRazorViewComponentInvocations(source)).toEqual(['Visible']);
+  });
+
+  it('does not treat plain markup text as an invocation', () => {
+    expect(
+      extractRazorViewComponentInvocations(
+        `<p>Component.InvokeAsync("NotCode")</p><code>@Html.Partial("Card")</code>`,
+      ),
+    ).toEqual([]);
+  });
+
+  it('extracts in-repo C# helper calls without matching SDK Task.InvokeAsync', () => {
+    const source = `
+      await Component.InvokeAsync("SessionSummaryBar");
+      return ViewComponent("AccountMenu");
+      await Task.InvokeAsync("NotAComponent");
+    `;
+    expect(extractCsharpViewComponentInvocations(source)).toEqual([
+      'SessionSummaryBar',
+      'AccountMenu',
+    ]);
+  });
+
+  it('extracts positional, named, and qualified ViewComponent aliases', () => {
+    const source = `
+      [ViewComponent(Name = "AccountMenu")]
+      public sealed class MenuViewComponent : ViewComponent {}
+
+      [Microsoft.AspNetCore.Mvc.ViewComponentAttribute("Checkout")]
+      internal class CheckoutWidget : ViewComponent {}
+    `;
+    expect(extractViewComponentAliases(source)).toEqual(
+      new Map([
+        ['MenuViewComponent', ['AccountMenu']],
+        ['CheckoutWidget', ['Checkout']],
+      ]),
+    );
+  });
+
+  it('extracts aliases when comments sit between the attribute and the class', () => {
+    const source = `
+      [ViewComponent("AccountMenu")]
+      // registered name overrides the suffix
+      public class MenuViewComponent : ViewComponent {}
+
+      [ViewComponent(Name = "Checkout")]
+      /* other attrs */
+      internal class CheckoutWidget : ViewComponent {}
+    `;
+    expect(extractViewComponentAliases(source)).toEqual(
+      new Map([
+        ['MenuViewComponent', ['AccountMenu']],
+        ['CheckoutWidget', ['Checkout']],
+      ]),
+    );
+  });
+
+  it('ignores commented-out C# helper calls', () => {
+    expect(
+      extractCsharpViewComponentInvocations(`
+        // return ViewComponent("Hidden");
+        return ViewComponent("Visible");
+      `),
+    ).toEqual(['Visible']);
+  });
+});

--- a/gitnexus/test/unit/scope-resolution/csharp/razor-view-components.test.ts
+++ b/gitnexus/test/unit/scope-resolution/csharp/razor-view-components.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   extractCsharpViewComponentInvocations,
   extractRazorViewComponentInvocations,
+  extractViewComponentAliasBinds,
   extractViewComponentAliases,
 } from '../../../../src/core/ingestion/languages/csharp/razor-view-components.js';
 
@@ -22,14 +23,19 @@ describe('Razor ViewComponent convention extraction', () => {
     ]);
   });
 
-  it('ignores invocations inside Razor and HTML comments', () => {
+  it('ignores Razor comments but keeps invocations inside HTML comments', () => {
     const source = `
       @* @await Component.InvokeAsync("RazorComment") *@
       <!-- @await Component.InvokeAsync("HtmlComment") -->
+      <!-- <vc:session-summary-bar /> -->
       @await Component.InvokeAsync("Visible")
     `;
 
-    expect(extractRazorViewComponentInvocations(source)).toEqual(['Visible']);
+    expect(extractRazorViewComponentInvocations(source)).toEqual([
+      'HtmlComment',
+      'SessionSummaryBar',
+      'Visible',
+    ]);
   });
 
   it('does not treat plain markup text as an invocation', () => {
@@ -40,24 +46,79 @@ describe('Razor ViewComponent convention extraction', () => {
     ).toEqual([]);
   });
 
+  it('treats even @ runs as literals and odd leftover @ as a transition', () => {
+    expect(
+      extractRazorViewComponentInvocations(`
+        @@await Component.InvokeAsync("Escaped")
+        @@@await Component.InvokeAsync("OddTransition")
+      `),
+    ).toEqual(['OddTransition']);
+  });
+
+  it('extracts calls from Razor code islands and explicit expressions', () => {
+    const source = `
+      @{
+        await Component.InvokeAsync("InBlock");
+        // @await Component.InvokeAsync("CommentedInBlock")
+        /* await Component.InvokeAsync("BlockComment") */
+      }
+      @if (true)
+      {
+        await Component.InvokeAsync("InIf");
+      }
+      @(await Component.InvokeAsync("Explicit"))
+    `;
+    expect(extractRazorViewComponentInvocations(source)).toEqual([
+      'InBlock',
+      'InIf',
+      'Explicit',
+    ]);
+  });
+
   it('extracts in-repo C# helper calls without matching SDK Task.InvokeAsync', () => {
     const source = `
       await Component.InvokeAsync("SessionSummaryBar");
       return ViewComponent("AccountMenu");
+      return this.ViewComponent("FromThis");
+      return base.ViewComponent("FromBase");
+      await this.Component.InvokeAsync("FromThisComponent");
       await Task.InvokeAsync("NotAComponent");
     `;
     expect(extractCsharpViewComponentInvocations(source)).toEqual([
       'SessionSummaryBar',
       'AccountMenu',
+      'FromThis',
+      'FromBase',
+      'FromThisComponent',
     ]);
   });
 
-  it('extracts positional, named, and qualified ViewComponent aliases', () => {
+  it('does not treat string literals as helper invocations', () => {
+    expect(
+      extractCsharpViewComponentInvocations(`
+        const string a = "ViewComponent(\\"DocsOnly\\")";
+        const string b = @"ViewComponent(""Verbatim"")";
+        const string c = """ViewComponent("Raw")""";
+        return ViewComponent("Visible");
+      `),
+    ).toEqual(['Visible']);
+  });
+
+  it('does not treat positional ViewComponent attributes as helper invocations', () => {
+    expect(
+      extractCsharpViewComponentInvocations(`
+        [ViewComponent("Alias")]
+        public class MenuViewComponent : ViewComponent {}
+      `),
+    ).toEqual([]);
+  });
+
+  it('extracts named and qualified ViewComponent aliases', () => {
     const source = `
       [ViewComponent(Name = "AccountMenu")]
       public sealed class MenuViewComponent : ViewComponent {}
 
-      [Microsoft.AspNetCore.Mvc.ViewComponentAttribute("Checkout")]
+      [Microsoft.AspNetCore.Mvc.ViewComponentAttribute(Name = "Checkout")]
       internal class CheckoutWidget : ViewComponent {}
     `;
     expect(extractViewComponentAliases(source)).toEqual(
@@ -68,9 +129,19 @@ describe('Razor ViewComponent convention extraction', () => {
     );
   });
 
+  it('extracts aliases from combined attribute lists', () => {
+    const source = `
+      [ApiController, ViewComponent(Name = "AccountMenu")]
+      public sealed class MenuViewComponent : ViewComponent {}
+    `;
+    expect(extractViewComponentAliases(source)).toEqual(
+      new Map([['MenuViewComponent', ['AccountMenu']]]),
+    );
+  });
+
   it('extracts aliases when comments sit between the attribute and the class', () => {
     const source = `
-      [ViewComponent("AccountMenu")]
+      [ViewComponent(Name = "AccountMenu")]
       // registered name overrides the suffix
       public class MenuViewComponent : ViewComponent {}
 
@@ -84,6 +155,26 @@ describe('Razor ViewComponent convention extraction', () => {
         ['CheckoutWidget', ['Checkout']],
       ]),
     );
+  });
+
+  it('does not treat positional constructor arguments as aliases', () => {
+    expect(
+      extractViewComponentAliases(`
+        [ViewComponent("AccountMenu")]
+        public class MenuViewComponent : ViewComponent {}
+      `),
+    ).toEqual(new Map());
+  });
+
+  it('binds aliases to the attributed class, not a same-named sibling', () => {
+    const binds = extractViewComponentAliasBinds(`
+      namespace A { [ViewComponent(Name = "AccountMenu")] class CardViewComponent {} }
+      namespace B { class CardViewComponent {} }
+    `);
+    const attributed = binds.filter((bind) => bind.aliases.includes('AccountMenu'));
+    expect(attributed).toHaveLength(1);
+    expect(attributed[0]?.className).toBe('CardViewComponent');
+    expect(binds.filter((bind) => bind.className === 'CardViewComponent')).toHaveLength(1);
   });
 
   it('ignores commented-out C# helper calls', () => {

--- a/gitnexus/test/unit/scope-resolution/csharp/razor-view-components.test.ts
+++ b/gitnexus/test/unit/scope-resolution/csharp/razor-view-components.test.ts
@@ -68,11 +68,7 @@ describe('Razor ViewComponent convention extraction', () => {
       }
       @(await Component.InvokeAsync("Explicit"))
     `;
-    expect(extractRazorViewComponentInvocations(source)).toEqual([
-      'InBlock',
-      'InIf',
-      'Explicit',
-    ]);
+    expect(extractRazorViewComponentInvocations(source)).toEqual(['InBlock', 'InIf', 'Explicit']);
   });
 
   it('extracts in-repo C# helper calls without matching SDK Task.InvokeAsync', () => {

--- a/gitnexus/test/unit/scope-resolution/csharp/razor-view-components.test.ts
+++ b/gitnexus/test/unit/scope-resolution/csharp/razor-view-components.test.ts
@@ -79,6 +79,8 @@ describe('Razor ViewComponent convention extraction', () => {
       return base.ViewComponent("FromBase");
       await this.Component.InvokeAsync("FromThisComponent");
       await Task.InvokeAsync("NotAComponent");
+      renderer.ViewComponent("UnrelatedRenderer");
+      await obj.Component.InvokeAsync("UnrelatedProperty");
     `;
     expect(extractCsharpViewComponentInvocations(source)).toEqual([
       'SessionSummaryBar',
@@ -132,6 +134,22 @@ describe('Razor ViewComponent convention extraction', () => {
     `;
     expect(extractViewComponentAliases(source)).toEqual(
       new Map([['MenuViewComponent', ['AccountMenu']]]),
+    );
+  });
+
+  it('extracts aliases from explicit record declarations', () => {
+    const source = `
+      [ViewComponent(Name = "AccountMenu")]
+      public record class MenuViewComponent : ViewComponent {}
+
+      [ViewComponent(Name = "Checkout")]
+      internal record CheckoutWidget : ViewComponent {}
+    `;
+    expect(extractViewComponentAliases(source)).toEqual(
+      new Map([
+        ['MenuViewComponent', ['AccountMenu']],
+        ['CheckoutWidget', ['Checkout']],
+      ]),
     );
   });
 

--- a/gitnexus/test/unit/scope-resolution/csharp/razor-view-components.test.ts
+++ b/gitnexus/test/unit/scope-resolution/csharp/razor-view-components.test.ts
@@ -116,13 +116,13 @@ describe('Razor ViewComponent convention extraction', () => {
       [ViewComponent(Name = "AccountMenu")]
       public sealed class MenuViewComponent : ViewComponent {}
 
-      [Microsoft.AspNetCore.Mvc.ViewComponentAttribute(Name = "Checkout")]
+      [Microsoft.AspNetCore.Mvc.ViewComponentAttribute(Name = "Admin.Checkout")]
       internal class CheckoutWidget : ViewComponent {}
     `;
     expect(extractViewComponentAliases(source)).toEqual(
       new Map([
         ['MenuViewComponent', ['AccountMenu']],
-        ['CheckoutWidget', ['Checkout']],
+        ['CheckoutWidget', ['Admin.Checkout']],
       ]),
     );
   });


### PR DESCRIPTION
## Summary
- Bind ASP.NET Razor string ViewComponent invocations (`Component.InvokeAsync("Foo")`, `ViewComponent("Foo")`, `<vc:foo>`) to **in-repo** `*ViewComponent` classes so `impact()` reports real callers instead of an empty set.
- Same bound as Spring Boot Java/Kotlin: hop only to workspace classes; never resolve into the SDK (`Microsoft.AspNetCore.Mvc.ViewComponent`, `IViewComponentHelper`, `InvokeAsync`). Ambiguous in-repo names fail closed (no edge).
- `.cshtml` stays File-only; C# `emitPostResolutionEdges` extracts invocations after comment stripping and emits `CALLS` File → Class (`confidence` 0.9, reason `aspnet-razor-view-component`). `[ViewComponent(Name=...)]` aliases replace the conventional suffix name.

Fixes #2991.

## Root cause
C# provider extensions are `.cs` only. Razor views are indexed as File nodes with no tree-sitter parse. String component names never became CALLS edges, so `impact("FooViewComponent")` returned 0 callers.

## Test plan
- [x] `cd gitnexus && npx vitest run test/unit/scope-resolution/csharp/razor-view-components.test.ts`
- [x] `cd gitnexus && npx tsc --noEmit`
- [x] Integration: `GITNEXUS_WORKER_READY_TIMEOUT_MS=60000 npx vitest run test/integration/csharp-razor-view-components.test.ts` (asserts pipeline CALLS, including C# `ViewComponent("Foo")`; does not treat UNKNOWN-vs-LOW as the merge gate)
- [ ] CI full suite on this PR


Made with [Cursor](https://cursor.com)

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a small, self-contained C# ingestion change focused on binding Razor ViewComponent names to in-repository classes, with accompanying unit and integration coverage.*

**🟢 LOW blast radius. A C# ingestion and scope resolution change for `Razor ViewComponent` names, reaching one direct dependent.**

The change is concentrated in the `Ingestion` module. It updates `loadCsharpResolutionConfig` and `CsharpResolutionConfig` in `gitnexus/src/core/ingestion/languages/csharp/resolution-config.ts`, along with `csharpScopeResolver` in `gitnexus/src/core/ingestion/languages/csharp/scope-resolver.ts` and the implementation in `gitnexus/src/core/ingestion/languages/csharp/razor-view-components.ts`.

Review `gitnexus/src/core/ingestion/languages/csharp/resolution-config.ts` and `gitnexus/src/core/ingestion/languages/csharp/scope-resolver.ts` first, then verify the behavior covered by `gitnexus/test/integration/csharp-razor-view-components.test.ts` and `gitnexus/test/unit/scope-resolution/csharp/razor-view-components.test.ts`. No affected execution flows or cross-repo consumers were identified.

_Added by GitNexus for PR #3104. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->