### PR TITLE
fix(ci): stop gitleaks on Kotlin Actuator test canary

### DIFF
--- a/gitnexus/test/integration/spring-actuator-kotlin-runtime-pipeline.test.ts
+++ b/gitnexus/test/integration/spring-actuator-kotlin-runtime-pipeline.test.ts
@@ -241,7 +241,9 @@ class KotlinProperties {
       application: {
         positiveMatches: {
           'com.example.KotlinConfig#billingService': [{ message: SECRET_ENV_VALUE }],
-          'com.example.KotlinController$Companion#companionHandler': [{ message: SECRET_ENV_VALUE }],
+          'com.example.KotlinController$Companion#companionHandler': [
+            { message: SECRET_ENV_VALUE },
+          ],
           'com.example.NamedHolder$Factory#namedHandler': [{ message: SECRET_ENV_VALUE }],
         },
         negativeMatches: {},

--- a/gitnexus/test/integration/spring-actuator-kotlin-runtime-pipeline.test.ts
+++ b/gitnexus/test/integration/spring-actuator-kotlin-runtime-pipeline.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { GraphNode } from 'gitnexus-shared';
 import { runPipelineFromRepo } from '../../src/core/ingestion/pipeline.js';
 
-const SECRET = 'KOTLIN_ACTUATOR_SECRET_2418';
+const SECRET_ENV_VALUE = 'KOTLIN_ACTUATOR_ENV_CANARY_2418';
 
 function writeFixture(root: string, relativePath: string, content: string): void {
   const target = path.join(root, relativePath);
@@ -240,9 +240,9 @@ class KotlinProperties {
     contexts: {
       application: {
         positiveMatches: {
-          'com.example.KotlinConfig#billingService': [{ message: SECRET }],
-          'com.example.KotlinController$Companion#companionHandler': [{ message: SECRET }],
-          'com.example.NamedHolder$Factory#namedHandler': [{ message: SECRET }],
+          'com.example.KotlinConfig#billingService': [{ message: SECRET_ENV_VALUE }],
+          'com.example.KotlinController$Companion#companionHandler': [{ message: SECRET_ENV_VALUE }],
+          'com.example.NamedHolder$Factory#namedHandler': [{ message: SECRET_ENV_VALUE }],
         },
         negativeMatches: {},
       },
@@ -254,7 +254,7 @@ class KotlinProperties {
         beans: {
           kotlin: {
             prefix: 'app.kotlin',
-            inputs: { url: { value: SECRET, origin: SECRET } },
+            inputs: { url: { value: SECRET_ENV_VALUE, origin: SECRET_ENV_VALUE } },
           },
         },
       },
@@ -263,10 +263,10 @@ class KotlinProperties {
   writeJson(repo, 'actuator/env.json', {
     propertySources: [
       {
-        name: SECRET,
+        name: SECRET_ENV_VALUE,
         properties: {
-          'app.kotlin.url': { value: SECRET, origin: SECRET },
-          'app.kotlin.password': { value: SECRET, origin: SECRET },
+          'app.kotlin.url': { value: SECRET_ENV_VALUE, origin: SECRET_ENV_VALUE },
+          'app.kotlin.password': { value: SECRET_ENV_VALUE, origin: SECRET_ENV_VALUE },
         },
       },
     ],
@@ -380,7 +380,7 @@ describe('Spring Boot Actuator Kotlin runtime enrichment', () => {
       'Spring Actuator env runtime-confirmed',
     );
 
-    expect(JSON.stringify([...result.graph.iterNodes()])).not.toContain(SECRET);
+    expect(JSON.stringify([...result.graph.iterNodes()])).not.toContain(SECRET_ENV_VALUE);
     expect(nodes.some((node) => String(node.properties.filePath).includes('/actuator/'))).toBe(
       false,
     );


### PR DESCRIPTION
## Summary
- Gitleaks on `main` failed after #3107 with `generic-api-key` on `const SECRET = 'KOTLIN_ACTUATOR_SECRET_2418'` in the Kotlin Actuator pipeline test.
- Rename the fake credential to `SECRET_ENV_VALUE` / `KOTLIN_ACTUATOR_ENV_CANARY_2418`, matching the Java Actuator test that already passed the scanner.

## Test plan
- [ ] Confirm the Gitleaks workflow is green on this PR (PR diff scan) and after merge (`main` push scans the last commit).
- [ ] Optional: `cd gitnexus && npx vitest run test/integration/spring-actuator-kotlin-runtime-pipeline.test.ts` if workers are available.


Made with [Cursor](https://cursor.com)

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*A small, self-contained test-only CI change in the Kotlin Actuator integration canary, with a low and localized risk posture.*

**🟢 LOW blast radius. A test-only CI change in the Kotlin Actuator integration canary at `gitnexus/test/integration/spring-actuator-kotlin-runtime-pipeline.test.ts`, with no graph dependents.**

The change is concentrated in `kotlinRuntimeFixture` within the `Integration` module. Review that function and its surrounding canary setup first, particularly the gitleaks-related behavior indicated by the PR title.

The graph finds no affected execution flows and no cross-repo consumers.

_Added by GitNexus for PR #3123. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->