### PR TITLE
fix(watch): await a watcher re-arm barrier so gitignore reloads cannot drop events

### DIFF
--- a/gitnexus/src/cli/analyze-watch.ts
+++ b/gitnexus/src/cli/analyze-watch.ts
@@ -257,6 +257,8 @@ export async function startWatchFileLoop(
 ): Promise<WatchFileLoop> {
   let ignorePath = await createWatchIgnorePredicate(repoPath);
   let ignoreControlValid = true;
+  let rearmPending = false;
+  let closed = false;
   const queue = new WatchRefreshQueue(
     async (paths) => {
       if (paths.some(isIgnoreControlPath) || !ignoreControlValid) {
@@ -264,7 +266,7 @@ export async function startWatchFileLoop(
         try {
           ignorePath = await createWatchIgnorePredicate(repoPath);
           ignoreControlValid = true;
-          watcher.add(repoPath);
+          rearmPending = true;
         } catch (error) {
           ignoreControlValid = false;
           throw new WatchControlReloadError(
@@ -279,6 +281,11 @@ export async function startWatchFileLoop(
           );
         }
       }
+      // Re-arm before refreshing, never after: the refresh reads the whole
+      // repository, so a write that lands while the replacement watcher is
+      // arming is still picked up by this refresh, and a write that lands
+      // afterwards is reported by the armed watcher.
+      if (rearmPending) await rearmWatcher();
       await refresh(paths);
     },
     onError,
@@ -291,44 +298,87 @@ export async function startWatchFileLoop(
     },
   );
 
-  const watcher: FSWatcher = watch(repoPath, {
-    ignoreInitial: true,
-    atomic: true,
-    followSymlinks: false,
-    awaitWriteFinish: { stabilityThreshold: 100, pollInterval: 20 },
-    ignored: (candidate, stats) => {
-      const relative = repoRelativeWatchPath(repoPath, candidate);
-      if (relative !== null && isAnalyzerOwnedWatchPath(relative)) return true;
-      if (relative !== null && (isIgnoreControlPath(relative) || isConfigControlPath(relative))) {
-        return false;
+  const createWatcher = (): FSWatcher => {
+    const created: FSWatcher = watch(repoPath, {
+      ignoreInitial: true,
+      atomic: true,
+      followSymlinks: false,
+      awaitWriteFinish: { stabilityThreshold: 100, pollInterval: 20 },
+      ignored: (candidate, stats) => {
+        const relative = repoRelativeWatchPath(repoPath, candidate);
+        if (relative !== null && isAnalyzerOwnedWatchPath(relative)) return true;
+        if (relative !== null && (isIgnoreControlPath(relative) || isConfigControlPath(relative))) {
+          return false;
+        }
+        return ignorePath(candidate, stats?.isDirectory() ?? false);
+      },
+    });
+    // Events from an instance being retired are kept: they overlap with the
+    // replacement's coverage and the queue coalesces the duplicates.
+    created.on('all', (event, changedPath) => {
+      if (event !== 'add' && event !== 'change' && event !== 'unlink') return;
+      const relative = repoRelativeWatchPath(repoPath, changedPath);
+      if (relative && isRelevantWatchPath(relative) && !isAnalyzerOwnedWatchPath(relative)) {
+        queue.enqueue(relative);
       }
-      return ignorePath(candidate, stats?.isDirectory() ?? false);
-    },
-  });
-  watcher.on('all', (event, changedPath) => {
-    if (event !== 'add' && event !== 'change' && event !== 'unlink') return;
-    const relative = repoRelativeWatchPath(repoPath, changedPath);
-    if (relative && isRelevantWatchPath(relative) && !isAnalyzerOwnedWatchPath(relative)) {
-      queue.enqueue(relative);
+    });
+    created.on('error', (error) => {
+      // A retired instance says nothing about live coverage, and a replacement
+      // that fails before the swap is reported through `waitUntilReady`.
+      if (created !== watcher) return;
+      // Chokidar can surface a transient EPERM on Windows while an ignored
+      // analyzer-owned path is replaced. Re-arm the watcher and force one
+      // bounded catch-up refresh so a missed event cannot leave the graph
+      // stale. Other watcher errors may mean coverage was lost and stay fatal.
+      if (TRANSIENT_WATCH_ERROR_CODES.has((error as NodeJS.ErrnoException).code ?? '')) {
+        rearmPending = true;
+        queue.enqueue(WATCH_FULL_REFRESH_PATH);
+        return;
+      }
+      onWatcherError(error);
+    });
+    return created;
+  };
+
+  let watcher: FSWatcher = createWatcher();
+
+  // Chokidar emits `ready` once per instance and `add()` returns before the
+  // rescan it starts has finished, with no signal for that completion. A file
+  // an ignore-rule reload has just unignored is therefore still unregistered
+  // when `add()` returns, and because `ignoreInitial` suppresses the `add` the
+  // rescan would emit, an immediate rewrite of that file is dropped for good
+  // (reproduced on chokidar 4 and 5). So re-arm by arming a replacement
+  // watcher and awaiting its `ready` instead. The outgoing instance keeps
+  // reporting until the replacement is armed, so the swap has no blind window,
+  // and a replacement that fails to arm leaves the working instance in place.
+  const rearmWatcher = async (): Promise<void> => {
+    rearmPending = false;
+    if (closed) return;
+    const replacement = createWatcher();
+    try {
+      await waitUntilReady(replacement);
+    } catch (error) {
+      rearmPending = true;
+      await replacement.close().catch(() => {});
+      throw new WatchControlReloadError(
+        new Error(
+          `Unable to re-arm the filesystem watcher: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
+        ),
+      );
     }
-  });
-  watcher.on('error', (error) => {
-    // Chokidar can surface a transient EPERM on Windows while an ignored
-    // analyzer-owned path is replaced. Re-arm the root and force one bounded
-    // catch-up refresh so a missed event cannot leave the graph stale. Other
-    // watcher errors may mean coverage was lost and remain fatal.
-    if (TRANSIENT_WATCH_ERROR_CODES.has((error as NodeJS.ErrnoException).code ?? '')) {
-      watcher.add(repoPath);
-      queue.enqueue(WATCH_FULL_REFRESH_PATH);
-      return;
-    }
-    onWatcherError(error);
-  });
+    const retired = watcher;
+    watcher = replacement;
+    await retired.close();
+    // `close()` can land between arming the replacement and the swap above.
+    if (closed) await replacement.close();
+  };
 
   try {
     await waitUntilReady(watcher);
     await queue.runInitial();
   } catch (error) {
+    closed = true;
     await watcher.close();
     await queue.close();
     throw error;
@@ -337,6 +387,7 @@ export async function startWatchFileLoop(
   return {
     waitForIdle: () => queue.waitForIdle(),
     close: async () => {
+      closed = true;
       await watcher.close();
       await queue.close();
     },

--- a/gitnexus/src/cli/analyze-watch.ts
+++ b/gitnexus/src/cli/analyze-watch.ts
@@ -323,8 +323,7 @@ export async function startWatchFileLoop(
       }
     });
     created.on('error', (error) => {
-      // A retired instance says nothing about live coverage, and a replacement
-      // that fails before the swap is reported through `waitUntilReady`.
+      // Replacement failures before the swap are reported through `waitUntilReady`.
       if (created !== watcher) return;
       // Chokidar can surface a transient EPERM on Windows while an ignored
       // analyzer-owned path is replaced. Re-arm the watcher and force one
@@ -359,12 +358,13 @@ export async function startWatchFileLoop(
       await waitUntilReady(replacement);
     } catch (error) {
       rearmPending = true;
-      await replacement.close().catch(() => {});
+      try {
+        await replacement.close();
+      } catch {
+        // The instance never became live; the arm error is the one to report.
+      }
       throw new WatchControlReloadError(
-        new Error(
-          `Unable to re-arm the filesystem watcher: ${error instanceof Error ? error.message : String(error)}`,
-          { cause: error },
-        ),
+        new Error('Unable to re-arm the filesystem watcher', { cause: error }),
       );
     }
     const retired = watcher;

--- a/gitnexus/test/integration/watch-filesystem.test.ts
+++ b/gitnexus/test/integration/watch-filesystem.test.ts
@@ -9,7 +9,19 @@ import { cleanupTempDir } from '../helpers/test-db.js';
 const tempDirs: string[] = [];
 const loops: WatchFileLoop[] = [];
 
-async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+// Busy CI runners can delay real filesystem watcher events (chokidar's
+// awaitWriteFinish polling plus scheduler contention) well past what a quiet
+// local machine sees. Budget more time under CI, matching the pattern used
+// by other timing-sensitive integration tests in this suite. Some tests
+// chain several waitFor calls, so also raise the per-test timeout to give
+// the full chain room under the larger per-call budget.
+const DEFAULT_WAIT_FOR_TIMEOUT_MS = process.env.CI ? 15_000 : 5_000;
+const TEST_TIMEOUT_MS = process.env.CI ? 90_000 : 30_000;
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = DEFAULT_WAIT_FOR_TIMEOUT_MS,
+): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!predicate()) {
     if (Date.now() >= deadline) throw new Error('timed out waiting for watcher event');
@@ -30,201 +42,231 @@ afterEach(async () => {
 });
 
 describe('watch filesystem integration', () => {
-  it('fails startup and closes the watcher when the initial analysis fails', async () => {
-    const repo = await makeRepo();
-    const onError = vi.fn();
+  it(
+    'fails startup and closes the watcher when the initial analysis fails',
+    async () => {
+      const repo = await makeRepo();
+      const onError = vi.fn();
 
-    await expect(
-      startWatchFileLoop(
+      await expect(
+        startWatchFileLoop(
+          repo,
+          25,
+          async () => {
+            throw new Error('initial analysis failed');
+          },
+          onError,
+        ),
+      ).rejects.toThrow('initial analysis failed');
+      expect(onError).not.toHaveBeenCalled();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'never enqueues analyzer-owned .gitnexus writes created by the initial refresh',
+    async () => {
+      const repo = await makeRepo();
+      const batches: string[][] = [];
+      const loop = await startWatchFileLoop(
         repo,
         25,
-        async () => {
-          throw new Error('initial analysis failed');
+        async (paths) => {
+          batches.push([...paths]);
+          if (paths.length === 0) {
+            await fs.mkdir(path.join(repo, '.gitnexus'), { recursive: true });
+            await fs.writeFile(path.join(repo, '.gitnexus', 'gitnexus.json'), '{}\n', 'utf8');
+            await fs.writeFile(path.join(repo, '.gitnexus', 'lbug'), 'index bytes', 'utf8');
+          }
         },
-        onError,
-      ),
-    ).rejects.toThrow('initial analysis failed');
-    expect(onError).not.toHaveBeenCalled();
-  });
+        (error) => {
+          throw error;
+        },
+      );
+      loops.push(loop);
 
-  it('never enqueues analyzer-owned .gitnexus writes created by the initial refresh', async () => {
-    const repo = await makeRepo();
-    const batches: string[][] = [];
-    const loop = await startWatchFileLoop(
-      repo,
-      25,
-      async (paths) => {
-        batches.push([...paths]);
-        if (paths.length === 0) {
-          await fs.mkdir(path.join(repo, '.gitnexus'), { recursive: true });
-          await fs.writeFile(path.join(repo, '.gitnexus', 'gitnexus.json'), '{}\n', 'utf8');
-          await fs.writeFile(path.join(repo, '.gitnexus', 'lbug'), 'index bytes', 'utf8');
-        }
-      },
-      (error) => {
-        throw error;
-      },
-    );
-    loops.push(loop);
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      await loop.waitForIdle();
 
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    await loop.waitForIdle();
+      expect(batches).toEqual([[]]);
+    },
+    TEST_TIMEOUT_MS,
+  );
 
-    expect(batches).toEqual([[]]);
-  });
+  it(
+    'coalesces indexed add/change/rename/delete events and stops cleanly',
+    async () => {
+      const repo = await makeRepo();
+      const batches: string[][] = [];
+      const loop = await startWatchFileLoop(
+        repo,
+        30,
+        async (paths) => batches.push([...paths]),
+        (error) => {
+          throw error;
+        },
+      );
+      loops.push(loop);
+      expect(batches).toEqual([[]]);
 
-  it('coalesces indexed add/change/rename/delete events and stops cleanly', async () => {
-    const repo = await makeRepo();
-    const batches: string[][] = [];
-    const loop = await startWatchFileLoop(
-      repo,
-      30,
-      async (paths) => batches.push([...paths]),
-      (error) => {
-        throw error;
-      },
-    );
-    loops.push(loop);
-    expect(batches).toEqual([[]]);
+      await fs.writeFile(path.join(repo, 'README.md'), '# One', 'utf8');
+      await fs.writeFile(path.join(repo, 'src.ts'), 'export const one = 1;', 'utf8');
+      await fs.writeFile(path.join(repo, 'src.ts'), 'export const one = 2;', 'utf8');
+      await waitFor(
+        () => batches.flat().includes('README.md') && batches.flat().includes('src.ts'),
+      );
 
-    await fs.writeFile(path.join(repo, 'README.md'), '# One', 'utf8');
-    await fs.writeFile(path.join(repo, 'src.ts'), 'export const one = 1;', 'utf8');
-    await fs.writeFile(path.join(repo, 'src.ts'), 'export const one = 2;', 'utf8');
-    await waitFor(() => batches.flat().includes('README.md') && batches.flat().includes('src.ts'));
+      await fs.rename(path.join(repo, 'src.ts'), path.join(repo, 'renamed.ts'));
+      await waitFor(() => batches.flat().includes('renamed.ts'));
+      await fs.rm(path.join(repo, 'renamed.ts'));
+      await waitFor(() => batches.flat().filter((entry) => entry === 'renamed.ts').length >= 2);
 
-    await fs.rename(path.join(repo, 'src.ts'), path.join(repo, 'renamed.ts'));
-    await waitFor(() => batches.flat().includes('renamed.ts'));
-    await fs.rm(path.join(repo, 'renamed.ts'));
-    await waitFor(() => batches.flat().filter((entry) => entry === 'renamed.ts').length >= 2);
+      expect(batches.flat()).toEqual(expect.arrayContaining(['README.md', 'src.ts', 'renamed.ts']));
+      await loop.close();
+      loops.pop();
+      const countAfterClose = batches.length;
+      await fs.writeFile(path.join(repo, 'after-close.ts'), 'export {};', 'utf8');
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(batches).toHaveLength(countAfterClose);
+    },
+    TEST_TIMEOUT_MS,
+  );
 
-    expect(batches.flat()).toEqual(expect.arrayContaining(['README.md', 'src.ts', 'renamed.ts']));
-    await loop.close();
-    loops.pop();
-    const countAfterClose = batches.length;
-    await fs.writeFile(path.join(repo, 'after-close.ts'), 'export {};', 'utf8');
-    await new Promise((resolve) => setTimeout(resolve, 150));
-    expect(batches).toHaveLength(countAfterClose);
-  });
+  it(
+    'queues edits during refresh, recovers after failure, and ignores external symlinks',
+    async () => {
+      const repo = await makeRepo();
+      const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-watch-outside-'));
+      tempDirs.push(outside);
+      await fs.symlink(
+        outside,
+        path.join(repo, 'external'),
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
+      const successful: string[][] = [];
+      const errors: string[][] = [];
+      let failNext = false;
+      let releaseRefresh: (() => void) | undefined;
+      const loop = await startWatchFileLoop(
+        repo,
+        25,
+        async (paths) => {
+          if (failNext) {
+            failNext = false;
+            throw new Error('injected refresh failure');
+          }
+          successful.push([...paths]);
+          if (paths.includes('first.ts')) {
+            await new Promise<void>((resolve) => {
+              releaseRefresh = resolve;
+            });
+          }
+        },
+        (_error, paths) => errors.push([...paths]),
+      );
+      loops.push(loop);
 
-  it('queues edits during refresh, recovers after failure, and ignores external symlinks', async () => {
-    const repo = await makeRepo();
-    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-watch-outside-'));
-    tempDirs.push(outside);
-    await fs.symlink(
-      outside,
-      path.join(repo, 'external'),
-      process.platform === 'win32' ? 'junction' : 'dir',
-    );
-    const successful: string[][] = [];
-    const errors: string[][] = [];
-    let failNext = false;
-    let releaseRefresh: (() => void) | undefined;
-    const loop = await startWatchFileLoop(
-      repo,
-      25,
-      async (paths) => {
-        if (failNext) {
-          failNext = false;
-          throw new Error('injected refresh failure');
-        }
-        successful.push([...paths]);
-        if (paths.includes('first.ts')) {
-          await new Promise<void>((resolve) => {
-            releaseRefresh = resolve;
-          });
-        }
-      },
-      (_error, paths) => errors.push([...paths]),
-    );
-    loops.push(loop);
+      await fs.writeFile(path.join(repo, 'first.ts'), 'export const first = 1;', 'utf8');
+      await waitFor(() => releaseRefresh !== undefined);
+      await fs.writeFile(path.join(repo, 'during.ts'), 'export const during = 1;', 'utf8');
+      releaseRefresh!();
+      await waitFor(() => successful.flat().includes('during.ts'));
 
-    await fs.writeFile(path.join(repo, 'first.ts'), 'export const first = 1;', 'utf8');
-    await waitFor(() => releaseRefresh !== undefined);
-    await fs.writeFile(path.join(repo, 'during.ts'), 'export const during = 1;', 'utf8');
-    releaseRefresh!();
-    await waitFor(() => successful.flat().includes('during.ts'));
+      failNext = true;
+      await fs.writeFile(path.join(repo, 'fails.ts'), 'export const fail = 1;', 'utf8');
+      await waitFor(() => errors.length === 1);
+      await waitFor(() => successful.flat().includes('fails.ts'));
+      await fs.writeFile(path.join(repo, 'retry.ts'), 'export const retry = 1;', 'utf8');
+      await waitFor(() => successful.flat().includes('retry.ts'));
 
-    failNext = true;
-    await fs.writeFile(path.join(repo, 'fails.ts'), 'export const fail = 1;', 'utf8');
-    await waitFor(() => errors.length === 1);
-    await waitFor(() => successful.flat().includes('fails.ts'));
-    await fs.writeFile(path.join(repo, 'retry.ts'), 'export const retry = 1;', 'utf8');
-    await waitFor(() => successful.flat().includes('retry.ts'));
+      const beforeExternal = successful.length + errors.length;
+      await fs.writeFile(path.join(outside, 'outside.ts'), 'export const outside = 1;', 'utf8');
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(successful.length + errors.length).toBe(beforeExternal);
+    },
+    TEST_TIMEOUT_MS,
+  );
 
-    const beforeExternal = successful.length + errors.length;
-    await fs.writeFile(path.join(outside, 'outside.ts'), 'export const outside = 1;', 'utf8');
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    expect(successful.length + errors.length).toBe(beforeExternal);
-  });
+  it(
+    'reloads gitignore rules before processing subsequent file events',
+    async () => {
+      const repo = await makeRepo();
+      await fs.writeFile(path.join(repo, '.gitignore'), 'blocked.ts\n', 'utf8');
+      const batches: string[][] = [];
+      const loop = await startWatchFileLoop(
+        repo,
+        25,
+        async (paths) => batches.push([...paths]),
+        (error) => {
+          throw error;
+        },
+      );
+      loops.push(loop);
 
-  it('reloads gitignore rules before processing subsequent file events', async () => {
-    const repo = await makeRepo();
-    await fs.writeFile(path.join(repo, '.gitignore'), 'blocked.ts\n', 'utf8');
-    const batches: string[][] = [];
-    const loop = await startWatchFileLoop(
-      repo,
-      25,
-      async (paths) => batches.push([...paths]),
-      (error) => {
-        throw error;
-      },
-    );
-    loops.push(loop);
+      await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 1;', 'utf8');
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(batches.flat()).not.toContain('blocked.ts');
 
-    await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 1;', 'utf8');
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    expect(batches.flat()).not.toContain('blocked.ts');
+      await fs.writeFile(path.join(repo, '.gitignore'), '', 'utf8');
+      await waitFor(() => batches.flat().includes('.gitignore'));
+      await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 2;', 'utf8');
+      await waitFor(() => batches.flat().includes('blocked.ts'));
+    },
+    TEST_TIMEOUT_MS,
+  );
 
-    await fs.writeFile(path.join(repo, '.gitignore'), '', 'utf8');
-    await waitFor(() => batches.flat().includes('.gitignore'));
-    await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 2;', 'utf8');
-    await waitFor(() => batches.flat().includes('blocked.ts'));
-  });
+  it(
+    'keeps the last valid ignore predicate after an oversized reload and later recovers',
+    async () => {
+      const repo = await makeRepo();
+      await fs.writeFile(path.join(repo, '.gitignore'), 'blocked.ts\n', 'utf8');
+      const batches: string[][] = [];
+      const errors: string[][] = [];
+      const loop = await startWatchFileLoop(
+        repo,
+        25,
+        async (paths) => batches.push([...paths]),
+        (_error, paths) => errors.push([...paths]),
+      );
+      loops.push(loop);
 
-  it('keeps the last valid ignore predicate after an oversized reload and later recovers', async () => {
-    const repo = await makeRepo();
-    await fs.writeFile(path.join(repo, '.gitignore'), 'blocked.ts\n', 'utf8');
-    const batches: string[][] = [];
-    const errors: string[][] = [];
-    const loop = await startWatchFileLoop(
-      repo,
-      25,
-      async (paths) => batches.push([...paths]),
-      (_error, paths) => errors.push([...paths]),
-    );
-    loops.push(loop);
+      await fs.writeFile(path.join(repo, '.gitignore'), 'x'.repeat(1024 * 1024 + 1), 'utf8');
+      await waitFor(() => errors.flat().includes('.gitignore'));
+      await waitFor(() => errors.length >= 2);
+      await fs.writeFile(path.join(repo, 'other.ts'), 'export const other = 1;', 'utf8');
+      await waitFor(() => errors.flat().includes('other.ts'));
+      expect(batches.flat()).not.toContain('other.ts');
+      await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 1;', 'utf8');
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(batches.flat()).not.toContain('blocked.ts');
 
-    await fs.writeFile(path.join(repo, '.gitignore'), 'x'.repeat(1024 * 1024 + 1), 'utf8');
-    await waitFor(() => errors.flat().includes('.gitignore'));
-    await waitFor(() => errors.length >= 2);
-    await fs.writeFile(path.join(repo, 'other.ts'), 'export const other = 1;', 'utf8');
-    await waitFor(() => errors.flat().includes('other.ts'));
-    expect(batches.flat()).not.toContain('other.ts');
-    await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 1;', 'utf8');
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    expect(batches.flat()).not.toContain('blocked.ts');
+      await fs.writeFile(path.join(repo, '.gitignore'), '', 'utf8');
+      await waitFor(() => batches.flat().includes('.gitignore'));
+      await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 2;', 'utf8');
+      await waitFor(() => batches.flat().includes('blocked.ts'));
+    },
+    TEST_TIMEOUT_MS,
+  );
 
-    await fs.writeFile(path.join(repo, '.gitignore'), '', 'utf8');
-    await waitFor(() => batches.flat().includes('.gitignore'));
-    await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 2;', 'utf8');
-    await waitFor(() => batches.flat().includes('blocked.ts'));
-  });
+  it(
+    'observes root control files even when gitignore excludes them',
+    async () => {
+      const repo = await makeRepo();
+      await fs.writeFile(path.join(repo, '.gitignore'), '.gitnexusrc\n', 'utf8');
+      const batches: string[][] = [];
+      const loop = await startWatchFileLoop(
+        repo,
+        25,
+        async (paths) => batches.push([...paths]),
+        (error) => {
+          throw error;
+        },
+      );
+      loops.push(loop);
 
-  it('observes root control files even when gitignore excludes them', async () => {
-    const repo = await makeRepo();
-    await fs.writeFile(path.join(repo, '.gitignore'), '.gitnexusrc\n', 'utf8');
-    const batches: string[][] = [];
-    const loop = await startWatchFileLoop(
-      repo,
-      25,
-      async (paths) => batches.push([...paths]),
-      (error) => {
-        throw error;
-      },
-    );
-    loops.push(loop);
-
-    await fs.writeFile(path.join(repo, '.gitnexusrc'), '{}\n', 'utf8');
-    await waitFor(() => batches.flat().includes('.gitnexusrc'));
-  });
+      await fs.writeFile(path.join(repo, '.gitnexusrc'), '{}\n', 'utf8');
+      await waitFor(() => batches.flat().includes('.gitnexusrc'));
+    },
+    TEST_TIMEOUT_MS,
+  );
 });

--- a/gitnexus/test/integration/watch-filesystem.test.ts
+++ b/gitnexus/test/integration/watch-filesystem.test.ts
@@ -9,19 +9,7 @@ import { cleanupTempDir } from '../helpers/test-db.js';
 const tempDirs: string[] = [];
 const loops: WatchFileLoop[] = [];
 
-// Busy CI runners can delay real filesystem watcher events (chokidar's
-// awaitWriteFinish polling plus scheduler contention) well past what a quiet
-// local machine sees. Budget more time under CI, matching FIRST_FRAME_BUDGET_MS
-// in mcp/server-startup.test.ts (15s/5s). Two tests chain five waitFor calls
-// (worst case 75s of waits), so the per-test ceiling is 90s under CI to leave
-// headroom for setup — a chain that hits it fails as a generic vitest timeout.
-const DEFAULT_WAIT_FOR_TIMEOUT_MS = process.env.CI ? 15_000 : 5_000;
-const TEST_TIMEOUT_MS = process.env.CI ? 90_000 : 30_000;
-
-async function waitFor(
-  predicate: () => boolean,
-  timeoutMs = DEFAULT_WAIT_FOR_TIMEOUT_MS,
-): Promise<void> {
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
   const startedAt = Date.now();
   const deadline = startedAt + timeoutMs;
   while (!predicate()) {
@@ -47,231 +35,235 @@ afterEach(async () => {
 });
 
 describe('watch filesystem integration', () => {
-  it(
-    'fails startup and closes the watcher when the initial analysis fails',
-    async () => {
-      const repo = await makeRepo();
-      const onError = vi.fn();
+  it('fails startup and closes the watcher when the initial analysis fails', async () => {
+    const repo = await makeRepo();
+    const onError = vi.fn();
 
-      await expect(
-        startWatchFileLoop(
-          repo,
-          25,
-          async () => {
-            throw new Error('initial analysis failed');
-          },
-          onError,
-        ),
-      ).rejects.toThrow('initial analysis failed');
-      expect(onError).not.toHaveBeenCalled();
-    },
-    TEST_TIMEOUT_MS,
-  );
-
-  it(
-    'never enqueues analyzer-owned .gitnexus writes created by the initial refresh',
-    async () => {
-      const repo = await makeRepo();
-      const batches: string[][] = [];
-      const loop = await startWatchFileLoop(
+    await expect(
+      startWatchFileLoop(
         repo,
         25,
-        async (paths) => {
-          batches.push([...paths]);
-          if (paths.length === 0) {
-            await fs.mkdir(path.join(repo, '.gitnexus'), { recursive: true });
-            await fs.writeFile(path.join(repo, '.gitnexus', 'gitnexus.json'), '{}\n', 'utf8');
-            await fs.writeFile(path.join(repo, '.gitnexus', 'lbug'), 'index bytes', 'utf8');
-          }
+        async () => {
+          throw new Error('initial analysis failed');
         },
-        (error) => {
-          throw error;
-        },
-      );
-      loops.push(loop);
+        onError,
+      ),
+    ).rejects.toThrow('initial analysis failed');
+    expect(onError).not.toHaveBeenCalled();
+  });
 
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      await loop.waitForIdle();
+  it('never enqueues analyzer-owned .gitnexus writes created by the initial refresh', async () => {
+    const repo = await makeRepo();
+    const batches: string[][] = [];
+    const loop = await startWatchFileLoop(
+      repo,
+      25,
+      async (paths) => {
+        batches.push([...paths]);
+        if (paths.length === 0) {
+          await fs.mkdir(path.join(repo, '.gitnexus'), { recursive: true });
+          await fs.writeFile(path.join(repo, '.gitnexus', 'gitnexus.json'), '{}\n', 'utf8');
+          await fs.writeFile(path.join(repo, '.gitnexus', 'lbug'), 'index bytes', 'utf8');
+        }
+      },
+      (error) => {
+        throw error;
+      },
+    );
+    loops.push(loop);
 
-      expect(batches).toEqual([[]]);
-    },
-    TEST_TIMEOUT_MS,
-  );
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    await loop.waitForIdle();
 
-  it(
-    'coalesces indexed add/change/rename/delete events and stops cleanly',
-    async () => {
-      const repo = await makeRepo();
-      const batches: string[][] = [];
-      const loop = await startWatchFileLoop(
-        repo,
-        30,
-        async (paths) => batches.push([...paths]),
-        (error) => {
-          throw error;
-        },
-      );
-      loops.push(loop);
-      expect(batches).toEqual([[]]);
+    expect(batches).toEqual([[]]);
+  });
 
-      await fs.writeFile(path.join(repo, 'README.md'), '# One', 'utf8');
-      await fs.writeFile(path.join(repo, 'src.ts'), 'export const one = 1;', 'utf8');
-      await fs.writeFile(path.join(repo, 'src.ts'), 'export const one = 2;', 'utf8');
-      await waitFor(
-        () => batches.flat().includes('README.md') && batches.flat().includes('src.ts'),
-      );
+  it('coalesces indexed add/change/rename/delete events and stops cleanly', async () => {
+    const repo = await makeRepo();
+    const batches: string[][] = [];
+    const loop = await startWatchFileLoop(
+      repo,
+      30,
+      async (paths) => batches.push([...paths]),
+      (error) => {
+        throw error;
+      },
+    );
+    loops.push(loop);
+    expect(batches).toEqual([[]]);
 
-      await fs.rename(path.join(repo, 'src.ts'), path.join(repo, 'renamed.ts'));
-      await waitFor(() => batches.flat().includes('renamed.ts'));
-      await fs.rm(path.join(repo, 'renamed.ts'));
-      await waitFor(() => batches.flat().filter((entry) => entry === 'renamed.ts').length >= 2);
+    await fs.writeFile(path.join(repo, 'README.md'), '# One', 'utf8');
+    await fs.writeFile(path.join(repo, 'src.ts'), 'export const one = 1;', 'utf8');
+    await fs.writeFile(path.join(repo, 'src.ts'), 'export const one = 2;', 'utf8');
+    await waitFor(() => batches.flat().includes('README.md') && batches.flat().includes('src.ts'));
 
-      expect(batches.flat()).toEqual(expect.arrayContaining(['README.md', 'src.ts', 'renamed.ts']));
-      await loop.close();
-      loops.pop();
-      const countAfterClose = batches.length;
-      await fs.writeFile(path.join(repo, 'after-close.ts'), 'export {};', 'utf8');
-      await new Promise((resolve) => setTimeout(resolve, 150));
-      expect(batches).toHaveLength(countAfterClose);
-    },
-    TEST_TIMEOUT_MS,
-  );
+    await fs.rename(path.join(repo, 'src.ts'), path.join(repo, 'renamed.ts'));
+    await waitFor(() => batches.flat().includes('renamed.ts'));
+    await fs.rm(path.join(repo, 'renamed.ts'));
+    await waitFor(() => batches.flat().filter((entry) => entry === 'renamed.ts').length >= 2);
 
-  it(
-    'queues edits during refresh, recovers after failure, and ignores external symlinks',
-    async () => {
-      const repo = await makeRepo();
-      const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-watch-outside-'));
-      tempDirs.push(outside);
-      await fs.symlink(
-        outside,
-        path.join(repo, 'external'),
-        process.platform === 'win32' ? 'junction' : 'dir',
-      );
-      const successful: string[][] = [];
-      const errors: string[][] = [];
-      let failNext = false;
-      let releaseRefresh: (() => void) | undefined;
-      const loop = await startWatchFileLoop(
-        repo,
-        25,
-        async (paths) => {
-          if (failNext) {
-            failNext = false;
-            throw new Error('injected refresh failure');
-          }
-          successful.push([...paths]);
-          if (paths.includes('first.ts')) {
-            await new Promise<void>((resolve) => {
-              releaseRefresh = resolve;
-            });
-          }
-        },
-        (_error, paths) => errors.push([...paths]),
-      );
-      loops.push(loop);
+    expect(batches.flat()).toEqual(expect.arrayContaining(['README.md', 'src.ts', 'renamed.ts']));
+    await loop.close();
+    loops.pop();
+    const countAfterClose = batches.length;
+    await fs.writeFile(path.join(repo, 'after-close.ts'), 'export {};', 'utf8');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(batches).toHaveLength(countAfterClose);
+  });
 
-      await fs.writeFile(path.join(repo, 'first.ts'), 'export const first = 1;', 'utf8');
-      await waitFor(() => releaseRefresh !== undefined);
-      await fs.writeFile(path.join(repo, 'during.ts'), 'export const during = 1;', 'utf8');
-      releaseRefresh!();
-      await waitFor(() => successful.flat().includes('during.ts'));
+  it('queues edits during refresh, recovers after failure, and ignores external symlinks', async () => {
+    const repo = await makeRepo();
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-watch-outside-'));
+    tempDirs.push(outside);
+    await fs.symlink(
+      outside,
+      path.join(repo, 'external'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+    const successful: string[][] = [];
+    const errors: string[][] = [];
+    let failNext = false;
+    let releaseRefresh: (() => void) | undefined;
+    const loop = await startWatchFileLoop(
+      repo,
+      25,
+      async (paths) => {
+        if (failNext) {
+          failNext = false;
+          throw new Error('injected refresh failure');
+        }
+        successful.push([...paths]);
+        if (paths.includes('first.ts')) {
+          await new Promise<void>((resolve) => {
+            releaseRefresh = resolve;
+          });
+        }
+      },
+      (_error, paths) => errors.push([...paths]),
+    );
+    loops.push(loop);
 
-      failNext = true;
-      await fs.writeFile(path.join(repo, 'fails.ts'), 'export const fail = 1;', 'utf8');
-      await waitFor(() => errors.length === 1);
-      await waitFor(() => successful.flat().includes('fails.ts'));
-      await fs.writeFile(path.join(repo, 'retry.ts'), 'export const retry = 1;', 'utf8');
-      await waitFor(() => successful.flat().includes('retry.ts'));
+    await fs.writeFile(path.join(repo, 'first.ts'), 'export const first = 1;', 'utf8');
+    await waitFor(() => releaseRefresh !== undefined);
+    await fs.writeFile(path.join(repo, 'during.ts'), 'export const during = 1;', 'utf8');
+    releaseRefresh!();
+    await waitFor(() => successful.flat().includes('during.ts'));
 
-      const beforeExternal = successful.length + errors.length;
-      await fs.writeFile(path.join(outside, 'outside.ts'), 'export const outside = 1;', 'utf8');
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      expect(successful.length + errors.length).toBe(beforeExternal);
-    },
-    TEST_TIMEOUT_MS,
-  );
+    failNext = true;
+    await fs.writeFile(path.join(repo, 'fails.ts'), 'export const fail = 1;', 'utf8');
+    await waitFor(() => errors.length === 1);
+    await waitFor(() => successful.flat().includes('fails.ts'));
+    await fs.writeFile(path.join(repo, 'retry.ts'), 'export const retry = 1;', 'utf8');
+    await waitFor(() => successful.flat().includes('retry.ts'));
 
-  it(
-    'reloads gitignore rules before processing subsequent file events',
-    async () => {
-      const repo = await makeRepo();
-      await fs.writeFile(path.join(repo, '.gitignore'), 'blocked.ts\n', 'utf8');
-      const batches: string[][] = [];
-      const loop = await startWatchFileLoop(
-        repo,
-        25,
-        async (paths) => batches.push([...paths]),
-        (error) => {
-          throw error;
-        },
-      );
-      loops.push(loop);
+    const beforeExternal = successful.length + errors.length;
+    await fs.writeFile(path.join(outside, 'outside.ts'), 'export const outside = 1;', 'utf8');
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(successful.length + errors.length).toBe(beforeExternal);
+  });
 
-      await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 1;', 'utf8');
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      expect(batches.flat()).not.toContain('blocked.ts');
+  it('reloads gitignore rules before processing subsequent file events', async () => {
+    const repo = await makeRepo();
+    await fs.writeFile(path.join(repo, '.gitignore'), 'blocked.ts\n', 'utf8');
+    const batches: string[][] = [];
+    const loop = await startWatchFileLoop(
+      repo,
+      25,
+      async (paths) => batches.push([...paths]),
+      (error) => {
+        throw error;
+      },
+    );
+    loops.push(loop);
 
-      await fs.writeFile(path.join(repo, '.gitignore'), '', 'utf8');
-      await waitFor(() => batches.flat().includes('.gitignore'));
-      await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 2;', 'utf8');
-      await waitFor(() => batches.flat().includes('blocked.ts'));
-    },
-    TEST_TIMEOUT_MS,
-  );
+    await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 1;', 'utf8');
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(batches.flat()).not.toContain('blocked.ts');
 
-  it(
-    'keeps the last valid ignore predicate after an oversized reload and later recovers',
-    async () => {
-      const repo = await makeRepo();
-      await fs.writeFile(path.join(repo, '.gitignore'), 'blocked.ts\n', 'utf8');
-      const batches: string[][] = [];
-      const errors: string[][] = [];
-      const loop = await startWatchFileLoop(
-        repo,
-        25,
-        async (paths) => batches.push([...paths]),
-        (_error, paths) => errors.push([...paths]),
-      );
-      loops.push(loop);
+    await fs.writeFile(path.join(repo, '.gitignore'), '', 'utf8');
+    await waitFor(() => batches.flat().includes('.gitignore'));
+    await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 2;', 'utf8');
+    await waitFor(() => batches.flat().includes('blocked.ts'));
+  });
 
-      await fs.writeFile(path.join(repo, '.gitignore'), 'x'.repeat(1024 * 1024 + 1), 'utf8');
-      await waitFor(() => errors.flat().includes('.gitignore'));
-      await waitFor(() => errors.length >= 2);
-      await fs.writeFile(path.join(repo, 'other.ts'), 'export const other = 1;', 'utf8');
-      await waitFor(() => errors.flat().includes('other.ts'));
-      expect(batches.flat()).not.toContain('other.ts');
-      await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 1;', 'utf8');
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      expect(batches.flat()).not.toContain('blocked.ts');
+  it('reports writes issued the instant a gitignore reload re-arms the watcher', async () => {
+    const repo = await makeRepo();
+    await fs.writeFile(path.join(repo, '.gitignore'), 'blocked.ts\n', 'utf8');
+    await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 1;', 'utf8');
+    await fs.writeFile(path.join(repo, 'tracked.ts'), 'export const tracked = 1;', 'utf8');
+    const batches: string[][] = [];
+    let rewritten = false;
+    const loop = await startWatchFileLoop(
+      repo,
+      25,
+      async (paths) => {
+        batches.push([...paths]);
+        // Writing from inside the refresh puts these rewrites right after the
+        // re-arm returns. Polling from the test body instead would leave enough
+        // slack for a watcher that is not armed yet to look armed.
+        if (paths.includes('.gitignore') && !rewritten) {
+          rewritten = true;
+          await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 2;', 'utf8');
+          await fs.writeFile(path.join(repo, 'tracked.ts'), 'export const tracked = 2;', 'utf8');
+        }
+      },
+      (error) => {
+        throw error;
+      },
+    );
+    loops.push(loop);
 
-      await fs.writeFile(path.join(repo, '.gitignore'), '', 'utf8');
-      await waitFor(() => batches.flat().includes('.gitignore'));
-      await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 2;', 'utf8');
-      await waitFor(() => batches.flat().includes('blocked.ts'));
-    },
-    TEST_TIMEOUT_MS,
-  );
+    await fs.writeFile(path.join(repo, '.gitignore'), '', 'utf8');
+    // The newly unignored file must be picked up, and the swap must not drop
+    // the file the retired watcher was already tracking.
+    await waitFor(() => batches.flat().includes('blocked.ts'));
+    await waitFor(() => batches.flat().includes('tracked.ts'));
+  });
 
-  it(
-    'observes root control files even when gitignore excludes them',
-    async () => {
-      const repo = await makeRepo();
-      await fs.writeFile(path.join(repo, '.gitignore'), '.gitnexusrc\n', 'utf8');
-      const batches: string[][] = [];
-      const loop = await startWatchFileLoop(
-        repo,
-        25,
-        async (paths) => batches.push([...paths]),
-        (error) => {
-          throw error;
-        },
-      );
-      loops.push(loop);
+  it('keeps the last valid ignore predicate after an oversized reload and later recovers', async () => {
+    const repo = await makeRepo();
+    await fs.writeFile(path.join(repo, '.gitignore'), 'blocked.ts\n', 'utf8');
+    const batches: string[][] = [];
+    const errors: string[][] = [];
+    const loop = await startWatchFileLoop(
+      repo,
+      25,
+      async (paths) => batches.push([...paths]),
+      (_error, paths) => errors.push([...paths]),
+    );
+    loops.push(loop);
 
-      await fs.writeFile(path.join(repo, '.gitnexusrc'), '{}\n', 'utf8');
-      await waitFor(() => batches.flat().includes('.gitnexusrc'));
-    },
-    TEST_TIMEOUT_MS,
-  );
+    await fs.writeFile(path.join(repo, '.gitignore'), 'x'.repeat(1024 * 1024 + 1), 'utf8');
+    await waitFor(() => errors.flat().includes('.gitignore'));
+    await waitFor(() => errors.length >= 2);
+    await fs.writeFile(path.join(repo, 'other.ts'), 'export const other = 1;', 'utf8');
+    await waitFor(() => errors.flat().includes('other.ts'));
+    expect(batches.flat()).not.toContain('other.ts');
+    await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 1;', 'utf8');
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(batches.flat()).not.toContain('blocked.ts');
+
+    await fs.writeFile(path.join(repo, '.gitignore'), '', 'utf8');
+    await waitFor(() => batches.flat().includes('.gitignore'));
+    await fs.writeFile(path.join(repo, 'blocked.ts'), 'export const blocked = 2;', 'utf8');
+    await waitFor(() => batches.flat().includes('blocked.ts'));
+  });
+
+  it('observes root control files even when gitignore excludes them', async () => {
+    const repo = await makeRepo();
+    await fs.writeFile(path.join(repo, '.gitignore'), '.gitnexusrc\n', 'utf8');
+    const batches: string[][] = [];
+    const loop = await startWatchFileLoop(
+      repo,
+      25,
+      async (paths) => batches.push([...paths]),
+      (error) => {
+        throw error;
+      },
+    );
+    loops.push(loop);
+
+    await fs.writeFile(path.join(repo, '.gitnexusrc'), '{}\n', 'utf8');
+    await waitFor(() => batches.flat().includes('.gitnexusrc'));
+  });
 });

--- a/gitnexus/test/integration/watch-filesystem.test.ts
+++ b/gitnexus/test/integration/watch-filesystem.test.ts
@@ -10,13 +10,10 @@ const tempDirs: string[] = [];
 const loops: WatchFileLoop[] = [];
 
 async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
-  const startedAt = Date.now();
-  const deadline = startedAt + timeoutMs;
+  const deadline = Date.now() + timeoutMs;
   while (!predicate()) {
     if (Date.now() >= deadline) {
-      throw new Error(
-        `timed out waiting for watcher event after ${timeoutMs}ms (elapsed ${Date.now() - startedAt}ms)`,
-      );
+      throw new Error(`timed out waiting for watcher event after ${timeoutMs}ms`);
     }
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
@@ -214,10 +211,9 @@ describe('watch filesystem integration', () => {
     loops.push(loop);
 
     await fs.writeFile(path.join(repo, '.gitignore'), '', 'utf8');
-    // The newly unignored file must be picked up, and the swap must not drop
-    // the file the retired watcher was already tracking.
-    await waitFor(() => batches.flat().includes('blocked.ts'));
-    await waitFor(() => batches.flat().includes('tracked.ts'));
+    await waitFor(
+      () => batches.flat().includes('blocked.ts') && batches.flat().includes('tracked.ts'),
+    );
   });
 
   it('keeps the last valid ignore predicate after an oversized reload and later recovers', async () => {

--- a/gitnexus/test/integration/watch-filesystem.test.ts
+++ b/gitnexus/test/integration/watch-filesystem.test.ts
@@ -11,10 +11,10 @@ const loops: WatchFileLoop[] = [];
 
 // Busy CI runners can delay real filesystem watcher events (chokidar's
 // awaitWriteFinish polling plus scheduler contention) well past what a quiet
-// local machine sees. Budget more time under CI, matching the pattern used
-// by other timing-sensitive integration tests in this suite. Some tests
-// chain several waitFor calls, so also raise the per-test timeout to give
-// the full chain room under the larger per-call budget.
+// local machine sees. Budget more time under CI, matching FIRST_FRAME_BUDGET_MS
+// in mcp/server-startup.test.ts (15s/5s). Two tests chain five waitFor calls
+// (worst case 75s of waits), so the per-test ceiling is 90s under CI to leave
+// headroom for setup — a chain that hits it fails as a generic vitest timeout.
 const DEFAULT_WAIT_FOR_TIMEOUT_MS = process.env.CI ? 15_000 : 5_000;
 const TEST_TIMEOUT_MS = process.env.CI ? 90_000 : 30_000;
 
@@ -22,9 +22,14 @@ async function waitFor(
   predicate: () => boolean,
   timeoutMs = DEFAULT_WAIT_FOR_TIMEOUT_MS,
 ): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
+  const startedAt = Date.now();
+  const deadline = startedAt + timeoutMs;
   while (!predicate()) {
-    if (Date.now() >= deadline) throw new Error('timed out waiting for watcher event');
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `timed out waiting for watcher event after ${timeoutMs}ms (elapsed ${Date.now() - startedAt}ms)`,
+      );
+    }
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
 }


### PR DESCRIPTION
Replaces #3156 (Copilot stacked that PR on Dependabot #3141 and GitHub refused to change the base).

`test/integration/watch-filesystem.test.ts` intermittently failed in CI with `Error: timed out waiting for watcher event`, most recently in `reloads gitignore rules before processing subsequent file events`. **This turned out to be a production bug in watch mode, not CI event latency**, so this PR now fixes the watcher instead of raising the timeout.

## Root cause

After an ignore-rule reload, `startWatchFileLoop` re-armed the watcher with `watcher.add(repoPath)`. That call returns before the rescan it starts has finished, and chokidar exposes no signal for that completion — `ready` fires exactly once per instance and is replaced with a no-op afterwards, so a post-ready `add()` is fire-and-forget.

A file the reload had just unignored is therefore still unregistered when `add()` returns. Worse, the miss is permanent rather than merely late: the in-flight rescan discovers the file, but `ignoreInitial: true` suppresses the `add` event it would emit, while the scan still records the file with its post-write stats. The rewrite is swallowed and no later event replays it.

A standalone reproduction (write immediately after the re-arm, then wait 2s for any event) missed:

| chokidar | delay after `add()` | missed |
|---|---|---|
| 4.0.3 | 0 ms | 40/40 |
| 4.0.3 | 10 ms | 0/40 |
| 5.0.0 | 0 ms | 40/40 |
| 5.0.0 | 10 ms | 0/40 |

That 10 ms is exactly what CI was flipping on: `waitFor` polls every 25 ms, so the test's own polling normally supplied enough slack to hide the unarmed watcher, and only lost the race when the runner was busy. Raising the timeout would have made the flake rarer without fixing the dropped event.

## Fix

`gitnexus/src/cli/analyze-watch.ts`:

- **Awaited re-arm barrier.** Re-arming now builds a replacement watcher and awaits its `ready` — the only completion signal chokidar offers. The outgoing instance keeps reporting until the swap, so the transition has no blind window, and a replacement that fails to arm leaves the working instance in place for the queue to retry with backoff (a re-arm failure is a `WatchControlReloadError`, matching how a failed ignore-control reload is already handled).
- **Ordering invariant.** The re-arm runs *before* the refresh, never after. The refresh reads the whole repository, so a write landing while the replacement arms is still picked up by that refresh, and a write landing afterwards is reported by the armed watcher. No state can fall between them.
- **Transient watcher errors** (the Windows `EPERM` path) now request the same awaited re-arm ahead of their bounded catch-up refresh, instead of re-arming inline with the same fire-and-forget `add()`.

## Test

`reports writes issued the instant a gitignore reload re-arms the watcher` issues its rewrites from *inside* the refresh callback, so they land immediately after the re-arm returns with none of the polling slack that hid the bug. It asserts both that the newly unignored file is reported and that the swap does not drop a file the retired watcher was already tracking.

Verified to fail deterministically against the pre-fix watcher (`timed out waiting for watcher event after 5000ms`) and to pass with the fix, 10/10 consecutive runs of the file.

## Dropped from #3156

The CI timeout inflation (`waitFor` 15s and a 90s per-test ceiling) and the reindentation it required are reverted — the test is not slow, so the budget does not need to grow. The one piece kept is `waitFor` reporting its budget and elapsed ms, which is how the failure above was read.

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*A focused CLI watcher change with its implementation and integration test concentrated in the same area. The blast level is critical because the affected watch lifecycle participates in multiple execution flows, despite the change remaining localized to two files.*

**🔴 CRITICAL blast radius. A TypeScript CLI watcher change in `gitnexus/src/cli/analyze-watch.ts`, with one direct dependent and a single integration test updated alongside it.**

The implementation centers on `startWatchFileLoop`, `ignored`, `waitForIdle`, `close`, `watchCommandWithRunnerIdentity`, and `reportIgnoredConfig` in the `Cli` module. Review the watcher re-arm and shutdown paths first, particularly how `waitForIdle` and `close` coordinate with gitignore reload handling.

The corresponding test change is `waitFor` in `gitnexus/test/integration/watch-filesystem.test.ts`. The changed watcher symbols participate in 6 affected flows, so the key review concern is whether the re-arm barrier consistently preserves filesystem events across those paths.

_Added by GitNexus for PR #3159. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->