### PR TITLE
fix(zig): resolve cross-file static gates

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -745,6 +745,13 @@ jobs:
         run: node --import tsx bench/scope-emission/measure.mjs --check
         working-directory: gitnexus
 
+      - name: Zig cross-file static-gating guards (#3162)
+        if: ${{ !cancelled() }}
+        # Build-free: fingerprints cross-file dead-call classification and
+        # guards the workspace enrichment pass across file-count scaling.
+        run: node --import tsx bench/zig-cross-file-resolution/measure.mjs --check
+        working-directory: gitnexus
+
       - name: CFG construction time / disk / memory guards (#2081 M1)
         if: ${{ !cancelled() }}
         # Build-free: asserts collectFunctionCfgs output is unchanged

--- a/gitnexus/bench/zig-cross-file-resolution/baseline.json
+++ b/gitnexus/bench/zig-cross-file-resolution/baseline.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Correctness counts are exact. Timing budgets are deliberately loose and only guard large regressions in the post-extraction Zig workspace pass.",
+  "small": {
+    "modules": 40,
+    "calls_per_module": 12,
+    "gated_calls": 480,
+    "ms_budget": 1000
+  },
+  "large": {
+    "modules": 160,
+    "calls_per_module": 12,
+    "gated_calls": 1920,
+    "ms_budget": 4000
+  },
+  "scaling_ratio_budget": 5.5
+}

--- a/gitnexus/bench/zig-cross-file-resolution/baseline.json
+++ b/gitnexus/bench/zig-cross-file-resolution/baseline.json
@@ -12,5 +12,5 @@
     "gated_calls": 1920,
     "ms_budget": 4000
   },
-  "scaling_ratio_budget": 5.5
+  "linear_scaling_slack": 1.375
 }

--- a/gitnexus/bench/zig-cross-file-resolution/measure.mjs
+++ b/gitnexus/bench/zig-cross-file-resolution/measure.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Build-free scaling and correctness guard for Zig cross-file static gates.
+ *
+ * The workspace pass parses every indexed Zig file, resolves direct @import
+ * aliases, then applies sibling boolean constants to call sites. This bench
+ * makes both relevant axes explicit: file count and calls per importer. It
+ * also fingerprints the number of calls classified dead, so a fast no-op
+ * implementation cannot pass the timing gate.
+ *
+ * Usage:
+ *   node --import tsx bench/zig-cross-file-resolution/measure.mjs
+ *   node --import tsx bench/zig-cross-file-resolution/measure.mjs --check
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { performance } from 'node:perf_hooks';
+import { populateZigWorkspaceStaticGating } from '../../src/core/ingestion/languages/zig/workspace-static-gating.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SMALL_MODULES = 40;
+const LARGE_MODULES = 160;
+const CALLS_PER_MODULE = 12;
+const REPS = 7;
+
+const range = (line, col) => ({ startLine: line, startCol: col, endLine: line, endCol: col + 4 });
+
+function corpus(modules) {
+  const parsedFiles = [];
+  const fileContents = new Map();
+  for (let i = 0; i < modules; i++) {
+    const cfgPath = `bench/cfg${i}.zig`;
+    const appPath = `bench/app${i}.zig`;
+    fileContents.set(cfgPath, 'pub const ENABLED = false;\n');
+    fileContents.set(
+      appPath,
+      `const cfg = @import(\"./cfg${i}.zig\");\n` +
+        Array.from(
+          { length: CALLS_PER_MODULE },
+          (_, j) => `pub fn run${j}() void { if (cfg.ENABLED) dead${j}(); }`,
+        ).join('\n'),
+    );
+    parsedFiles.push(Object.freeze({ filePath: cfgPath, referenceSites: Object.freeze([]) }));
+    parsedFiles.push(
+      Object.freeze({
+        filePath: appPath,
+        referenceSites: Object.freeze(
+          Array.from({ length: CALLS_PER_MODULE }, (_, j) => ({
+            kind: 'call',
+            name: `dead${j}`,
+            atRange: range(j + 2, 44),
+          })),
+        ),
+      }),
+    );
+  }
+  return { parsedFiles, fileContents };
+}
+
+function run(modules) {
+  const { parsedFiles, fileContents } = corpus(modules);
+  populateZigWorkspaceStaticGating(parsedFiles, { fileContents });
+  let gatedCalls = 0;
+  for (const file of parsedFiles) {
+    for (const site of file.referenceSites) if (site.staticGated === true) gatedCalls++;
+  }
+  return gatedCalls;
+}
+
+function measure(modules) {
+  run(modules);
+  let bestMs = Infinity;
+  let gatedCalls = 0;
+  for (let i = 0; i < REPS; i++) {
+    const start = performance.now();
+    gatedCalls = run(modules);
+    bestMs = Math.min(bestMs, performance.now() - start);
+  }
+  return {
+    modules,
+    calls_per_module: CALLS_PER_MODULE,
+    gated_calls: gatedCalls,
+    min_ms: Number(bestMs.toFixed(2)),
+  };
+}
+
+const report = { small: measure(SMALL_MODULES), large: measure(LARGE_MODULES) };
+report.scaling_ratio = Number(
+  (report.large.min_ms / Math.max(report.small.min_ms, 0.01)).toFixed(3),
+);
+
+if (!process.argv.includes('--check')) {
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(0);
+}
+
+const baseline = JSON.parse(readFileSync(join(HERE, 'baseline.json'), 'utf8'));
+const failures = [];
+for (const arm of ['small', 'large']) {
+  for (const key of ['modules', 'calls_per_module', 'gated_calls']) {
+    if (report[arm][key] !== baseline[arm][key]) {
+      failures.push(`${arm}.${key}: expected ${baseline[arm][key]}, got ${report[arm][key]}`);
+    }
+  }
+  if (report[arm].min_ms > baseline[arm].ms_budget) {
+    failures.push(`${arm}.min_ms ${report[arm].min_ms} exceeds budget ${baseline[arm].ms_budget}`);
+  }
+}
+if (report.scaling_ratio > baseline.scaling_ratio_budget) {
+  failures.push(
+    `scaling_ratio ${report.scaling_ratio} exceeds budget ${baseline.scaling_ratio_budget}`,
+  );
+}
+
+console.log(JSON.stringify(report, null, 2));
+if (failures.length > 0) {
+  console.error('[zig-cross-file-resolution --check] FAIL');
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+console.log('[zig-cross-file-resolution --check] PASS');

--- a/gitnexus/bench/zig-cross-file-resolution/measure.mjs
+++ b/gitnexus/bench/zig-cross-file-resolution/measure.mjs
@@ -86,9 +86,11 @@ function measure(modules) {
 }
 
 const report = { small: measure(SMALL_MODULES), large: measure(LARGE_MODULES) };
+report.workload_ratio = LARGE_MODULES / SMALL_MODULES;
 report.scaling_ratio = Number(
   (report.large.min_ms / Math.max(report.small.min_ms, 0.01)).toFixed(3),
 );
+report.linear_factor = Number((report.scaling_ratio / report.workload_ratio).toFixed(3));
 
 if (!process.argv.includes('--check')) {
   console.log(JSON.stringify(report, null, 2));
@@ -97,19 +99,33 @@ if (!process.argv.includes('--check')) {
 
 const baseline = JSON.parse(readFileSync(join(HERE, 'baseline.json'), 'utf8'));
 const failures = [];
+const requirePositiveNumber = (path, value) => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    failures.push(`${path}: expected a finite positive number, got ${JSON.stringify(value)}`);
+    return false;
+  }
+  return true;
+};
 for (const arm of ['small', 'large']) {
   for (const key of ['modules', 'calls_per_module', 'gated_calls']) {
     if (report[arm][key] !== baseline[arm][key]) {
       failures.push(`${arm}.${key}: expected ${baseline[arm][key]}, got ${report[arm][key]}`);
     }
   }
-  if (report[arm].min_ms > baseline[arm].ms_budget) {
+  if (
+    requirePositiveNumber(`${arm}.ms_budget`, baseline[arm].ms_budget) &&
+    report[arm].min_ms > baseline[arm].ms_budget
+  ) {
     failures.push(`${arm}.min_ms ${report[arm].min_ms} exceeds budget ${baseline[arm].ms_budget}`);
   }
 }
-if (report.scaling_ratio > baseline.scaling_ratio_budget) {
+if (
+  requirePositiveNumber('linear_scaling_slack', baseline.linear_scaling_slack) &&
+  report.linear_factor > baseline.linear_scaling_slack
+) {
   failures.push(
-    `scaling_ratio ${report.scaling_ratio} exceeds budget ${baseline.scaling_ratio_budget}`,
+    `linear_factor ${report.linear_factor} exceeds slack ${baseline.linear_scaling_slack} ` +
+      `(runtime ${report.scaling_ratio}x for ${report.workload_ratio}x work)`,
   );
 }
 

--- a/gitnexus/src/core/ingestion/call-extractors/zig-static-gating.ts
+++ b/gitnexus/src/core/ingestion/call-extractors/zig-static-gating.ts
@@ -13,17 +13,14 @@
  * Conservative by design: we only tag an edge when we can prove the
  * gating expression evaluates to `false`.  Anything ambiguous → live.
  *
- * Scope of v1:
+ * Supported scope:
  *
  *   (a) **File-local** consts (`pub const FOO = false;`, plus const-to-const
  *       aliases up to 5 hops), built once per file by `buildZigBoolConstMap`.
- *   (b) **Cross-file** (`const cfg = @import("./cfg.zig"); if (cfg.FOO)`) is
- *       NOT resolved yet. The evaluator keeps the seam for it (`importAliases`
- *       + `lookupBoolsForPath`, consumed by the `field_expression` case), but
- *       the only caller passes an empty alias map and a lookup that always
- *       returns `undefined`, because the capture emitter runs in the parse
- *       worker and sees only the current file. Tracked in #3162. Until then
- *       every `cfg.FOO` condition folds to unknown, i.e. live.
+ *   (b) **Cross-file** direct imports (`const cfg = @import("./cfg.zig");
+ *       if (cfg.FOO)`) are enriched after per-file extraction. The workspace
+ *       caller supplies `importAliases` and `lookupBoolsForPath`; the parse
+ *       worker still uses empty/undefined inputs and remains file-local.
  *
  * Also out of scope: multi-hop member access (`cfg.sub.FOO`), re-exported
  * consts, runtime-evaluated bools (`const FOO = computeIt();`), and

--- a/gitnexus/src/core/ingestion/languages/zig/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/languages/zig/scope-resolver.ts
@@ -19,6 +19,7 @@ import { resolveZigImportInternal } from '../../import-resolvers/zig.js';
 import { zigProvider } from '../zig.js';
 import { expandZigWildcardNames, zigArityCompatibility, zigMergeBindings } from './index.js';
 import { populateZigRangeBindings } from './range-binding.js';
+import { populateZigWorkspaceStaticGating } from './workspace-static-gating.js';
 
 export const zigScopeResolver: ScopeResolver = {
   language: SupportedLanguages.Zig,
@@ -66,6 +67,8 @@ export const zigScopeResolver: ScopeResolver = {
     buildMro(graph, parsedFiles, nodeLookup, defaultLinearize),
 
   populateOwners: (parsed: ParsedFile) => populateClassOwnedMembers(parsed),
+
+  populateWorkspaceReferences: populateZigWorkspaceStaticGating,
 
   // Payload captures — `for (items) |it|`, `if (opt) |v|`, `while (it.next())
   // |x|` — typed from the subject's binding after finalize (F6).

--- a/gitnexus/src/core/ingestion/languages/zig/workspace-static-gating.ts
+++ b/gitnexus/src/core/ingestion/languages/zig/workspace-static-gating.ts
@@ -72,9 +72,14 @@ function collectImportAliases(
     const raw = builtin?.descendantsOfType('string').at(0)?.text;
     if (binding === undefined || raw === undefined) continue;
     const specifier = raw.replace(/^['"]|['"]$/g, '');
-    if (!specifier.endsWith('.zig')) continue;
+    if (!specifier.includes('/') && !specifier.endsWith('.zig')) continue;
     const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(fromFile), specifier));
-    if (knownPaths.has(resolved)) aliases.set(binding, resolved);
+    const target = knownPaths.has(resolved)
+      ? resolved
+      : !resolved.endsWith('.zig') && knownPaths.has(`${resolved}.zig`)
+        ? `${resolved}.zig`
+        : undefined;
+    if (target !== undefined) aliases.set(binding, target);
   }
   return aliases;
 }

--- a/gitnexus/src/core/ingestion/languages/zig/workspace-static-gating.ts
+++ b/gitnexus/src/core/ingestion/languages/zig/workspace-static-gating.ts
@@ -8,7 +8,7 @@ import {
   isPositionStaticGated,
   type ZigImportAliasMap,
 } from '../../call-extractors/zig-static-gating.js';
-import { parseSourceSafe } from '../../../tree-sitter/safe-parse.js';
+import { parseSourceSafe, ParseTimeoutError } from '../../../tree-sitter/safe-parse.js';
 import { getZigParser } from './query.js';
 
 type ZigTree = ReturnType<ReturnType<typeof getZigParser>['parse']>;
@@ -28,9 +28,17 @@ export function populateZigWorkspaceStaticGating(
   for (const parsed of parsedFiles) {
     const source = ctx.fileContents.get(parsed.filePath);
     if (source === undefined) continue;
-    const tree =
-      (ctx.treeCache?.get(parsed.filePath) as ZigTree | undefined) ??
-      parseSourceSafe(parser, source, undefined, { bufferSize: getTreeSitterBufferSize(source) });
+    let tree = ctx.treeCache?.get(parsed.filePath) as ZigTree | undefined;
+    if (tree === undefined) {
+      try {
+        tree = parseSourceSafe(parser, source, undefined, {
+          bufferSize: getTreeSitterBufferSize(source),
+        });
+      } catch (err) {
+        if (err instanceof ParseTimeoutError) continue;
+        throw err;
+      }
+    }
     trees.set(parsed.filePath, tree);
     bools.set(parsed.filePath, buildZigBoolConstMap(tree.rootNode));
   }

--- a/gitnexus/src/core/ingestion/languages/zig/workspace-static-gating.ts
+++ b/gitnexus/src/core/ingestion/languages/zig/workspace-static-gating.ts
@@ -14,7 +14,7 @@ import { getZigParser } from './query.js';
 type ZigTree = ReturnType<ReturnType<typeof getZigParser>['parse']>;
 
 export function populateZigWorkspaceStaticGating(
-  parsedFiles: readonly ParsedFile[],
+  parsedFiles: ParsedFile[],
   ctx: {
     readonly fileContents: ReadonlyMap<string, string>;
     readonly treeCache?: { get(filePath: string): unknown };
@@ -36,7 +36,7 @@ export function populateZigWorkspaceStaticGating(
   }
 
   const knownPaths = new Set(trees.keys());
-  for (const parsed of parsedFiles) {
+  for (const [index, parsed] of parsedFiles.entries()) {
     const tree = trees.get(parsed.filePath);
     if (tree === undefined) continue;
     const aliases = collectImportAliases(
@@ -60,7 +60,7 @@ export function populateZigWorkspaceStaticGating(
         ? ({ ...site, staticGated: true } satisfies ReferenceSite)
         : site,
     );
-    (parsed as { referenceSites: readonly ReferenceSite[] }).referenceSites = next;
+    parsedFiles[index] = Object.freeze({ ...parsed, referenceSites: Object.freeze(next) });
   }
 }
 
@@ -70,18 +70,29 @@ function collectImportAliases(
   knownPaths: ReadonlySet<string>,
   resolutionConfig?: ZigBuildZonConfig | null,
 ): ZigImportAliasMap {
-  const aliases = new Map<string, string>();
+  const candidates = new Map<string, string>();
+  const declarationCounts = new Map<string, number>();
   for (const decl of tree.rootNode.descendantsOfType('variable_declaration')) {
     const names = decl.namedChildren.filter((node) => node.type === 'identifier');
     const binding = names[0]?.text;
+    if (binding === undefined) continue;
+    declarationCounts.set(binding, (declarationCounts.get(binding) ?? 0) + 1);
     const builtin = decl.namedChildren.find(
       (node) => node.type === 'builtin_function' && node.text.startsWith('@import('),
     );
     const raw = builtin?.descendantsOfType('string').at(0)?.text;
-    if (binding === undefined || raw === undefined) continue;
+    if (raw === undefined) continue;
     const specifier = raw.replace(/^['"]|['"]$/g, '');
     const target = resolveZigImportInternal(fromFile, specifier, knownPaths, resolutionConfig);
-    if (target !== null) aliases.set(binding, target);
+    if (target !== null) candidates.set(binding, target);
+  }
+
+  const aliases = new Map<string, string>();
+  for (const [binding, target] of candidates) {
+    // Alias lookup below is name-based rather than position-aware. If a name
+    // is redeclared in another lexical scope, fail open instead of applying
+    // either module's constants to every use of that spelling.
+    if (declarationCounts.get(binding) === 1) aliases.set(binding, target);
   }
   return aliases;
 }

--- a/gitnexus/src/core/ingestion/languages/zig/workspace-static-gating.ts
+++ b/gitnexus/src/core/ingestion/languages/zig/workspace-static-gating.ts
@@ -63,13 +63,12 @@ function collectImportAliases(
   knownPaths: ReadonlySet<string>,
 ): ZigImportAliasMap {
   const aliases = new Map<string, string>();
-  for (const decl of tree.rootNode.namedChildren) {
-    if (decl.type !== 'variable_declaration') continue;
+  for (const decl of tree.rootNode.descendantsOfType('variable_declaration')) {
     const names = decl.namedChildren.filter((node) => node.type === 'identifier');
     const binding = names[0]?.text;
-    const builtin = decl
-      .descendantsOfType('builtin_function')
-      .find((node) => node.text.startsWith('@import('));
+    const builtin = decl.namedChildren.find(
+      (node) => node.type === 'builtin_function' && node.text.startsWith('@import('),
+    );
     const raw = builtin?.descendantsOfType('string').at(0)?.text;
     if (binding === undefined || raw === undefined) continue;
     const specifier = raw.replace(/^['"]|['"]$/g, '');

--- a/gitnexus/src/core/ingestion/languages/zig/workspace-static-gating.ts
+++ b/gitnexus/src/core/ingestion/languages/zig/workspace-static-gating.ts
@@ -1,0 +1,81 @@
+import path from 'node:path';
+import type { ParsedFile, ReferenceSite } from 'gitnexus-shared';
+import { getTreeSitterBufferSize } from '../../constants.js';
+import {
+  buildZigBoolConstMap,
+  collectZigStaticGatedRanges,
+  isPositionStaticGated,
+  type ZigImportAliasMap,
+} from '../../call-extractors/zig-static-gating.js';
+import { parseSourceSafe } from '../../../tree-sitter/safe-parse.js';
+import { getZigParser } from './query.js';
+
+type ZigTree = ReturnType<ReturnType<typeof getZigParser>['parse']>;
+
+export function populateZigWorkspaceStaticGating(
+  parsedFiles: readonly ParsedFile[],
+  ctx: {
+    readonly fileContents: ReadonlyMap<string, string>;
+    readonly treeCache?: { get(filePath: string): unknown };
+  },
+): void {
+  const parser = getZigParser();
+  const trees = new Map<string, ZigTree>();
+  const bools = new Map<string, ReturnType<typeof buildZigBoolConstMap>>();
+
+  for (const parsed of parsedFiles) {
+    const source = ctx.fileContents.get(parsed.filePath);
+    if (source === undefined) continue;
+    const tree =
+      (ctx.treeCache?.get(parsed.filePath) as ZigTree | undefined) ??
+      parseSourceSafe(parser, source, undefined, { bufferSize: getTreeSitterBufferSize(source) });
+    trees.set(parsed.filePath, tree);
+    bools.set(parsed.filePath, buildZigBoolConstMap(tree.rootNode));
+  }
+
+  const knownPaths = new Set(trees.keys());
+  for (const parsed of parsedFiles) {
+    const tree = trees.get(parsed.filePath);
+    if (tree === undefined) continue;
+    const aliases = collectImportAliases(tree, parsed.filePath, knownPaths);
+    if (aliases.size === 0) continue;
+    const ranges = collectZigStaticGatedRanges(
+      tree.rootNode,
+      bools.get(parsed.filePath) ?? new Map(),
+      aliases,
+      (filePath) => bools.get(filePath),
+    );
+    if (ranges.length === 0) continue;
+    const next = parsed.referenceSites.map((site) =>
+      site.kind === 'call' &&
+      site.staticGated !== true &&
+      isPositionStaticGated(site.atRange.startLine, site.atRange.startCol, ranges)
+        ? ({ ...site, staticGated: true } satisfies ReferenceSite)
+        : site,
+    );
+    (parsed as { referenceSites: readonly ReferenceSite[] }).referenceSites = next;
+  }
+}
+
+function collectImportAliases(
+  tree: ZigTree,
+  fromFile: string,
+  knownPaths: ReadonlySet<string>,
+): ZigImportAliasMap {
+  const aliases = new Map<string, string>();
+  for (const decl of tree.rootNode.namedChildren) {
+    if (decl.type !== 'variable_declaration') continue;
+    const names = decl.namedChildren.filter((node) => node.type === 'identifier');
+    const binding = names[0]?.text;
+    const builtin = decl
+      .descendantsOfType('builtin_function')
+      .find((node) => node.text.startsWith('@import('));
+    const raw = builtin?.descendantsOfType('string').at(0)?.text;
+    if (binding === undefined || raw === undefined) continue;
+    const specifier = raw.replace(/^['"]|['"]$/g, '');
+    if (!specifier.endsWith('.zig')) continue;
+    const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(fromFile), specifier));
+    if (knownPaths.has(resolved)) aliases.set(binding, resolved);
+  }
+  return aliases;
+}

--- a/gitnexus/src/core/ingestion/languages/zig/workspace-static-gating.ts
+++ b/gitnexus/src/core/ingestion/languages/zig/workspace-static-gating.ts
@@ -1,6 +1,7 @@
-import path from 'node:path';
 import type { ParsedFile, ReferenceSite } from 'gitnexus-shared';
 import { getTreeSitterBufferSize } from '../../constants.js';
+import type { ZigBuildZonConfig } from '../../language-config.js';
+import { resolveZigImportInternal } from '../../import-resolvers/zig.js';
 import {
   buildZigBoolConstMap,
   collectZigStaticGatedRanges,
@@ -17,6 +18,7 @@ export function populateZigWorkspaceStaticGating(
   ctx: {
     readonly fileContents: ReadonlyMap<string, string>;
     readonly treeCache?: { get(filePath: string): unknown };
+    readonly resolutionConfig?: unknown;
   },
 ): void {
   const parser = getZigParser();
@@ -37,7 +39,12 @@ export function populateZigWorkspaceStaticGating(
   for (const parsed of parsedFiles) {
     const tree = trees.get(parsed.filePath);
     if (tree === undefined) continue;
-    const aliases = collectImportAliases(tree, parsed.filePath, knownPaths);
+    const aliases = collectImportAliases(
+      tree,
+      parsed.filePath,
+      knownPaths,
+      ctx.resolutionConfig as ZigBuildZonConfig | null | undefined,
+    );
     if (aliases.size === 0) continue;
     const ranges = collectZigStaticGatedRanges(
       tree.rootNode,
@@ -61,6 +68,7 @@ function collectImportAliases(
   tree: ZigTree,
   fromFile: string,
   knownPaths: ReadonlySet<string>,
+  resolutionConfig?: ZigBuildZonConfig | null,
 ): ZigImportAliasMap {
   const aliases = new Map<string, string>();
   for (const decl of tree.rootNode.descendantsOfType('variable_declaration')) {
@@ -72,14 +80,8 @@ function collectImportAliases(
     const raw = builtin?.descendantsOfType('string').at(0)?.text;
     if (binding === undefined || raw === undefined) continue;
     const specifier = raw.replace(/^['"]|['"]$/g, '');
-    if (!specifier.includes('/') && !specifier.endsWith('.zig')) continue;
-    const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(fromFile), specifier));
-    const target = knownPaths.has(resolved)
-      ? resolved
-      : !resolved.endsWith('.zig') && knownPaths.has(`${resolved}.zig`)
-        ? `${resolved}.zig`
-        : undefined;
-    if (target !== undefined) aliases.set(binding, target);
+    const target = resolveZigImportInternal(fromFile, specifier, knownPaths, resolutionConfig);
+    if (target !== null) aliases.set(binding, target);
   }
   return aliases;
 }

--- a/gitnexus/src/core/ingestion/scope-resolution/contract/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/contract/scope-resolver.ts
@@ -704,7 +704,7 @@ export interface ScopeResolver {
    * imported sibling (for example a compile-time branch constant).
    */
   readonly populateWorkspaceReferences?: (
-    parsedFiles: readonly ParsedFile[],
+    parsedFiles: ParsedFile[],
     ctx: {
       readonly fileContents: ReadonlyMap<string, string>;
       readonly treeCache?: { get(filePath: string): unknown };

--- a/gitnexus/src/core/ingestion/scope-resolution/contract/scope-resolver.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/contract/scope-resolver.ts
@@ -698,6 +698,21 @@ export interface ScopeResolver {
   ) => void;
 
   /**
+   * Optional workspace-wide enrichment of extracted reference sites. Runs
+   * after all files have been extracted and before reference finalization.
+   * Use this when a per-file capture needs conservative facts from an
+   * imported sibling (for example a compile-time branch constant).
+   */
+  readonly populateWorkspaceReferences?: (
+    parsedFiles: readonly ParsedFile[],
+    ctx: {
+      readonly fileContents: ReadonlyMap<string, string>;
+      readonly treeCache?: { get(filePath: string): unknown };
+      readonly resolutionConfig?: unknown;
+    },
+  ) => void;
+
+  /**
    * Recognize a `super(...)`-style receiver text. Python returns
    * `/^super\s*\(/.test(t)`. Java returns `t === 'super'`. C++ may
    * also need `this` capture. Languages without inheritance return

--- a/gitnexus/src/core/ingestion/scope-resolution/pipeline/phase.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/pipeline/phase.ts
@@ -145,6 +145,7 @@ export function selectScopeSourcePathsToRead(
 ): string[] {
   const hasPostExtractHooks =
     provider.populateWorkspaceOwners !== undefined ||
+    provider.populateWorkspaceReferences !== undefined ||
     provider.populateNamespaceSiblings !== undefined ||
     provider.populateRangeBindings !== undefined ||
     provider.emitPostResolutionEdges !== undefined;

--- a/gitnexus/src/core/ingestion/scope-resolution/pipeline/run.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/pipeline/run.ts
@@ -639,6 +639,10 @@ export function runScopeResolution(
     `lang=${provider.language} parsedFiles=${parsedFiles.length} preExtractedHits=${preExtractedHits} skipped=${filesSkipped}`,
   );
   provider.populateWorkspaceOwners?.(parsedFiles, { fileContents: getFileContents() });
+  provider.populateWorkspaceReferences?.(parsedFiles, {
+    fileContents: getFileContents(),
+    treeCache,
+  });
 
   // A callable-flow-only provider has no reason to build the whole-graph
   // lookup or finalize ordinary references when none of its files emitted a

--- a/gitnexus/src/core/ingestion/scope-resolution/pipeline/run.ts
+++ b/gitnexus/src/core/ingestion/scope-resolution/pipeline/run.ts
@@ -642,6 +642,7 @@ export function runScopeResolution(
   provider.populateWorkspaceReferences?.(parsedFiles, {
     fileContents: getFileContents(),
     treeCache,
+    resolutionConfig: input.resolutionConfig,
   });
 
   // A callable-flow-only provider has no reason to build the whole-graph

--- a/gitnexus/test/fixtures/lang-resolution/zig-static-gating/src/main.zig
+++ b/gitnexus/test/fixtures/lang-resolution/zig-static-gating/src/main.zig
@@ -11,6 +11,7 @@
 const cfg = @import("./cfg.zig");
 const cfg_no_ext = @import("./cfg");
 const wrapped_cfg = wrap(@import("./cfg.zig"));
+const shadowed_cfg = @import("./cfg.zig");
 
 pub const UPGRADERS_ENABLED: bool = false;
 pub const DEBUG: bool = true;
@@ -220,6 +221,13 @@ pub fn run() void {
     _ = e3;
 }
 
+pub fn run_shadowed_alias() void {
+    const shadowed_cfg = @import("./other.zig");
+    if (shadowed_cfg.FOO) {
+        live_shadowed_cross_file_foo();
+    }
+}
+
 fn live_unconditional() void {
     _ = 1;
 }
@@ -237,6 +245,10 @@ fn gated_extensionless_cross_file_foo() void {
 }
 
 fn live_wrapped_cross_file_foo() void {
+    _ = 1;
+}
+
+fn live_shadowed_cross_file_foo() void {
     _ = 1;
 }
 

--- a/gitnexus/test/fixtures/lang-resolution/zig-static-gating/src/main.zig
+++ b/gitnexus/test/fixtures/lang-resolution/zig-static-gating/src/main.zig
@@ -9,6 +9,7 @@
 
 // Cross-file alias — should resolve `cfg.FOO`, `cfg.BAR` against cfg.zig.
 const cfg = @import("./cfg.zig");
+const wrapped_cfg = wrap(@import("./cfg.zig"));
 
 pub const UPGRADERS_ENABLED: bool = false;
 pub const DEBUG: bool = true;
@@ -30,6 +31,7 @@ pub const CYCLE_B = CYCLE_A;
 pub const ALIAS_TO_VAR = IS_RUNTIME_FLAG_FALSE;
 
 pub fn run() void {
+    const local_cfg = @import("./cfg.zig");
     // Live: not under any if-gate.
     live_unconditional();
 
@@ -162,6 +164,15 @@ pub fn run() void {
     if (cfg.NOT_A_BOOL != 0) {
         live_cross_file_not_bool();
     }
+    // Function-local imports use the same workspace constants.
+    if (local_cfg.FOO) {
+        gated_local_cross_file_foo();
+    }
+    // An import nested inside another initializer does not bind the variable
+    // directly to that module, so its members must remain unknown/fail-open.
+    if (wrapped_cfg.FOO) {
+        live_wrapped_cross_file_foo();
+    }
 
     // Bare literal gate: no constant table involved, but it must still be gated.
     if (false) {
@@ -206,6 +217,18 @@ pub fn run() void {
 }
 
 fn live_unconditional() void {
+    _ = 1;
+}
+
+fn wrap(value: anytype) @TypeOf(value) {
+    return value;
+}
+
+fn gated_local_cross_file_foo() void {
+    _ = 1;
+}
+
+fn live_wrapped_cross_file_foo() void {
     _ = 1;
 }
 

--- a/gitnexus/test/fixtures/lang-resolution/zig-static-gating/src/main.zig
+++ b/gitnexus/test/fixtures/lang-resolution/zig-static-gating/src/main.zig
@@ -9,6 +9,7 @@
 
 // Cross-file alias — should resolve `cfg.FOO`, `cfg.BAR` against cfg.zig.
 const cfg = @import("./cfg.zig");
+const cfg_no_ext = @import("./cfg");
 const wrapped_cfg = wrap(@import("./cfg.zig"));
 
 pub const UPGRADERS_ENABLED: bool = false;
@@ -164,6 +165,9 @@ pub fn run() void {
     if (cfg.NOT_A_BOOL != 0) {
         live_cross_file_not_bool();
     }
+    if (cfg_no_ext.FOO) {
+        gated_extensionless_cross_file_foo();
+    }
     // Function-local imports use the same workspace constants.
     if (local_cfg.FOO) {
         gated_local_cross_file_foo();
@@ -225,6 +229,10 @@ fn wrap(value: anytype) @TypeOf(value) {
 }
 
 fn gated_local_cross_file_foo() void {
+    _ = 1;
+}
+
+fn gated_extensionless_cross_file_foo() void {
     _ = 1;
 }
 

--- a/gitnexus/test/fixtures/lang-resolution/zig-static-gating/src/other.zig
+++ b/gitnexus/test/fixtures/lang-resolution/zig-static-gating/src/other.zig
@@ -1,0 +1,1 @@
+pub const FOO: bool = true;

--- a/gitnexus/test/integration/resolvers/zig-static-gating.test.ts
+++ b/gitnexus/test/integration/resolvers/zig-static-gating.test.ts
@@ -174,11 +174,8 @@ describe('Zig static-gated edges', () => {
     expect(isGated('gated_chain_tail')).toBe(true);
   });
 
-  // Cross-file positive cases: the gating module resolves `alias.NAME` through
-  // `lookupBoolsForPath`, but the scope-capture emitter runs per file in the
-  // parse worker with only `{ path, content }` in hand — no sibling sources —
-  // so v1 stamps file-local constants only. Re-enable once the emitter can
-  // see imported files (see PR description, "Cross-file constants").
+  // Cross-file cases are enriched after per-file extraction, once sibling
+  // source facts are available but before reference finalization.
   it('tags `if (cfg.FOO)` cross-file when FOO is false in cfg.zig', () => {
     expect(isGated('gated_cross_file_foo')).toBe(true);
   });
@@ -197,5 +194,13 @@ describe('Zig static-gated edges', () => {
 
   it('does NOT tag `cfg.NOT_A_BOOL != 0` (imported decl is not a bool literal)', () => {
     expect(isGated('live_cross_file_not_bool')).toBe(false);
+  });
+
+  it('tags a cross-file bool accessed through a function-local import alias', () => {
+    expect(isGated('gated_local_cross_file_foo')).toBe(true);
+  });
+
+  it('does NOT treat a nested @import as the declaration direct module alias', () => {
+    expect(isGated('live_wrapped_cross_file_foo')).toBe(false);
   });
 });

--- a/gitnexus/test/integration/resolvers/zig-static-gating.test.ts
+++ b/gitnexus/test/integration/resolvers/zig-static-gating.test.ts
@@ -179,7 +179,7 @@ describe('Zig static-gated edges', () => {
   // parse worker with only `{ path, content }` in hand — no sibling sources —
   // so v1 stamps file-local constants only. Re-enable once the emitter can
   // see imported files (see PR description, "Cross-file constants").
-  it.skip('tags `if (cfg.FOO)` cross-file when FOO is false in cfg.zig (tracked: #3162)', () => {
+  it('tags `if (cfg.FOO)` cross-file when FOO is false in cfg.zig', () => {
     expect(isGated('gated_cross_file_foo')).toBe(true);
   });
 
@@ -187,7 +187,7 @@ describe('Zig static-gated edges', () => {
     expect(isGated('live_cross_file_bar')).toBe(false);
   });
 
-  it.skip('tags the ELSE branch of `if (cfg.BAR)` when BAR is true (tracked: #3162)', () => {
+  it('tags the ELSE branch of `if (cfg.BAR)` when BAR is true', () => {
     expect(isGated('gated_cross_file_else')).toBe(true);
   });
 

--- a/gitnexus/test/integration/resolvers/zig-static-gating.test.ts
+++ b/gitnexus/test/integration/resolvers/zig-static-gating.test.ts
@@ -7,8 +7,11 @@
  * such branches keep `staticGated` falsy.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'node:fs';
 import path from 'path';
 import { FIXTURES, getRelationships, runPipelineFromRepo, type PipelineResult } from './helpers.js';
+import { populateZigWorkspaceStaticGating } from '../../../src/core/ingestion/languages/zig/workspace-static-gating.js';
+import type { ParsedFile } from 'gitnexus-shared';
 
 describe('Zig static-gated edges', () => {
   let result: PipelineResult;
@@ -206,5 +209,46 @@ describe('Zig static-gated edges', () => {
 
   it('does NOT treat a nested @import as the declaration direct module alias', () => {
     expect(isGated('live_wrapped_cross_file_foo')).toBe(false);
+  });
+
+  it('fails open when an import alias is shadowed in another lexical scope', () => {
+    expect(isGated('live_shadowed_cross_file_foo')).toBe(false);
+  });
+
+  it('replaces a frozen parsed file instead of mutating it', () => {
+    const site = Object.freeze({
+      kind: 'call',
+      atRange: { startLine: 153, startCol: 8, endLine: 153, endCol: 30 },
+      staticGated: false,
+    });
+    const original = Object.freeze({
+      filePath: 'src/main.zig',
+      referenceSites: Object.freeze([site]),
+    }) as unknown as ParsedFile;
+    const parsedFiles = [
+      original,
+      Object.freeze({
+        filePath: 'src/cfg.zig',
+        referenceSites: Object.freeze([]),
+      }) as unknown as ParsedFile,
+    ];
+
+    expect(() =>
+      populateZigWorkspaceStaticGating(parsedFiles, {
+        fileContents: new Map([
+          [
+            'src/main.zig',
+            fs.readFileSync(path.join(FIXTURES, 'zig-static-gating', 'src', 'main.zig'), 'utf8'),
+          ],
+          [
+            'src/cfg.zig',
+            fs.readFileSync(path.join(FIXTURES, 'zig-static-gating', 'src', 'cfg.zig'), 'utf8'),
+          ],
+        ]),
+      }),
+    ).not.toThrow();
+    expect(parsedFiles[0]).not.toBe(original);
+    expect(Object.isFrozen(parsedFiles[0])).toBe(true);
+    expect(parsedFiles[0]?.referenceSites[0]?.staticGated).toBe(true);
   });
 });

--- a/gitnexus/test/integration/resolvers/zig-static-gating.test.ts
+++ b/gitnexus/test/integration/resolvers/zig-static-gating.test.ts
@@ -196,6 +196,10 @@ describe('Zig static-gated edges', () => {
     expect(isGated('live_cross_file_not_bool')).toBe(false);
   });
 
+  it('resolves a relative cross-file import with an omitted .zig extension', () => {
+    expect(isGated('gated_extensionless_cross_file_foo')).toBe(true);
+  });
+
   it('tags a cross-file bool accessed through a function-local import alias', () => {
     expect(isGated('gated_local_cross_file_foo')).toBe(true);
   });


### PR DESCRIPTION
## Summary

- add a generic pre-finalization hook for workspace-level reference enrichment
- resolve Zig `@import("./file.zig")` aliases against sibling boolean constants
- mark cross-file dead branches without reading files from parse workers
- enable the two executable regressions from #3162

## Why this boundary

Static-gating captures are produced per file in parse workers, where sibling source is unavailable. The enrichment therefore runs after all `ParsedFile`s have been collected but before reference finalization. It reuses cached trees when available and keeps unknown members, non-boolean declarations, and external imports fail-open.

Closes #3162.

## Tests

- `npm test -- --run test/integration/resolvers/zig-static-gating.test.ts test/integration/resolvers/zig.test.ts` (127 passed, 1 skipped)
- `npm run build`
- pre-commit ESLint, Prettier, and TypeScript checks
- `git diff origin/main...HEAD --check`

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a Zig ingestion and scope-resolution change that spans resolver contracts, pipeline execution, static gating, fixtures, and benchmarks. Its direct reach is narrow, but the CRITICAL classification warrants close review of the resolution path and CI coverage.*

**🔴 CRITICAL blast radius. A Zig cross-file static-gating change reaches the scope-resolution pipeline, with a single direct dependent.**

The core changes center on `zigScopeResolver`, `isSuperReceiver`, `ScopeResolver`, `selectScopeSourcePathsToRead`, and `runScopeResolution`. Review the interaction between `gitnexus/src/core/ingestion/languages/zig/scope-resolver.ts`, `gitnexus/src/core/ingestion/call-extractors/zig-static-gating.ts`, `gitnexus/src/core/ingestion/languages/zig/workspace-static-gating.ts`, and the scope-resolution contract and pipeline files first.

Impact lands in the human-named `Pipeline` and `Passes` modules, and 10 traced flows pass through changed symbols. The hottest file is `gitnexus/src/core/ingestion/scope-resolution/contract/scope-resolver.ts`, where two changed symbols make the resolver interface a key compatibility point.

` .github/workflows/ci-tests.yml` is the HIGH risk file. Validate its CI changes alongside `gitnexus/test/integration/resolvers/zig-static-gating.test.ts`, the Zig fixture sources, and the cross-file-resolution benchmark artifacts.

_Added by GitNexus for PR #3185. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->