### PR TITLE
fix(lbug): await evict-then-reopen so it can't race the checkpoint

### DIFF
--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -224,7 +224,33 @@ function ensureIdleTimer(): void {
     for (const [repoId, entry] of pool) {
       if (pinnedRepos.has(repoId)) continue;
       if (now - entry.lastUsed > IDLE_TIMEOUT_MS && entry.checkedOut === 0) {
-        closeOne(repoId);
+        // Routed through the same mutex as initLbug (not awaited here — this
+        // sweep is periodic best-effort cleanup with nothing waiting on it).
+        // closeOne now removes the pool entry before its awaited db.close(),
+        // so an unsynchronized idle close racing a concurrent initLbug for
+        // the same repoId would let that init treat the repo as absent and
+        // open a fresh native handle on the same file while the idle close's
+        // checkpoint is still in flight — reopening the exact race this pool
+        // rework exists to close, just via the idle path instead of LRU
+        // eviction (review finding on PR #3187). withPoolLock serializes it
+        // against every initLbug call the same way evictLRU already is.
+        //
+        // This callback can now sit queued behind an in-progress initLbug
+        // before its turn comes, and that init's existing-entry path (or a
+        // concurrent touchRepo()) can refresh lastUsed in the meantime — so
+        // the repo may no longer be idle by the time this actually runs.
+        // Re-check inside the lock, right before closing, instead of trusting
+        // the snapshot taken above (second review finding on PR #3187).
+        withPoolLock(async () => {
+          const current = pool.get(repoId);
+          if (
+            current &&
+            Date.now() - current.lastUsed > IDLE_TIMEOUT_MS &&
+            current.checkedOut === 0
+          ) {
+            await closeOne(repoId);
+          }
+        });
       }
     }
   }, 60_000);
@@ -304,7 +330,7 @@ export const getMaxResidentRepos = (): number => MAX_POOL_SIZE;
  * entry is pinned, no eviction occurs and the pool transiently exceeds
  * MAX_POOL_SIZE (see the pinnedRepos docstring).
  */
-function evictLRU(): void {
+async function evictLRU(): Promise<void> {
   if (pool.size < MAX_POOL_SIZE) return;
 
   let oldestId: string | null = null;
@@ -317,7 +343,12 @@ function evictLRU(): void {
     }
   }
   if (oldestId) {
-    closeOne(oldestId);
+    // Awaited: the caller opens a new connection right after evicting one, and
+    // closeOne's db.close() below triggers a checkpoint. A fire-and-forget close
+    // here let that new open race the still-in-flight checkpoint of the evicted
+    // repo, surfacing as "Cannot open database in read-only mode while checkpoint
+    // is in progress" on the read path.
+    await closeOne(oldestId);
   }
 }
 
@@ -326,7 +357,7 @@ function evictLRU(): void {
  * shared Database ref.  Only closes the Database when no other repoIds
  * reference it (refCount === 0).
  */
-function closeOne(repoId: string): void {
+async function closeOne(repoId: string): Promise<void> {
   const entry = pool.get(repoId);
   if (!entry) return;
 
@@ -358,6 +389,27 @@ function closeOne(repoId: string): void {
   // Checked-out connections can't be closed here — they're in-flight.
   // The checkin() function detects entry.closed and closes them on return.
 
+  // Remove the entry — and clear its pin, and notify listeners — BEFORE the
+  // possible await below. `available` is already empty and `closed` is
+  // already set, so nothing further to lose; but `shared.db.close()` can
+  // suspend, and until this repoId is actually gone from `pool`,
+  // `isLbugReady(repoId)` (a bare `pool.has`) still reports true. A
+  // concurrent same-repo `initLbug`/query during that window would see a
+  // "ready" pool entry with no available connections and no in-flight
+  // open — a zombie that `checkout` can only fail on with a misleading
+  // "pool integrity error" instead of just reopening. Deleting first makes
+  // that window disappear: any concurrent caller instead sees "not
+  // initialized" and takes the normal fresh-open path.
+  pool.delete(repoId);
+  pinnedRepos.delete(repoId);
+  for (const listener of poolCloseListeners) {
+    try {
+      listener(repoId);
+    } catch {
+      // Isolate listener failures — teardown must complete.
+    }
+  }
+
   // Only close the Database when no other repoIds reference it.
   // External databases (injected via initLbugWithDb) are never closed here —
   // the core adapter owns them and handles their lifecycle.
@@ -374,26 +426,13 @@ function closeOne(repoId: string): void {
         shared.vectorLoaded = false;
         shared.vectorLoadPromise = undefined;
       } else {
-        shared.db.close().catch(() => {});
+        // Awaited (unlike the per-connection closes above): this is the shared
+        // Database handle whose close() drives the checkpoint that the caller's
+        // subsequent reopen (evictLRU / the "idle & changed" path below) must not
+        // race. See the awaited call site in evictLRU for the full rationale.
+        await shared.db.close().catch(() => {});
         dbCache.delete(entry.dbPath);
       }
-    }
-  }
-
-  pool.delete(repoId);
-
-  // Clear any eviction pin — the entry is gone, so the pin is meaningless and
-  // would otherwise leak across operations in a long-lived process. Teardown
-  // is authoritative: an explicit close always wins over a pin.
-  pinnedRepos.delete(repoId);
-
-  // Notify listeners AFTER the pool entry is gone so any cache-invalidation
-  // they perform is consistent with `isLbugReady(repoId) === false`.
-  for (const listener of poolCloseListeners) {
-    try {
-      listener(repoId);
-    } catch {
-      // Isolate listener failures — teardown must complete.
     }
   }
 
@@ -650,15 +689,14 @@ async function tryQuarantineAndReopen(dbPath: string, repoId: string): Promise<l
   return await openReadOnlyDatabase(dbPath);
 }
 
-/** Deduplicates concurrent initLbug calls for the same repoId */
-const initPromises = new Map<string, Promise<void>>();
-
 /**
  * Initialize (or reuse) a Database + connection pool for a specific repo.
  * Retries on lock errors (e.g., when `gitnexus analyze` is running).
  *
- * Concurrent calls for the same repoId are deduplicated — the second caller
- * awaits the first's in-progress init rather than starting a redundant one.
+ * Concurrent calls (for the same repoId or different ones) serialize on
+ * poolLock below, so a second caller for a repo already being initialized
+ * simply waits its turn and then hits the "existing" fast path once its turn
+ * comes — no separate per-repoId dedup needed on top of that.
  */
 /**
  * Returns `true` when this call (re)opened a fresh handle onto the current
@@ -667,7 +705,27 @@ const initPromises = new Map<string, Promise<void>>();
  * bookkeeping on "did the pool actually roll over" (LocalBackend) use the
  * return value; callers that only need the pool ready can ignore it.
  */
-export const initLbug = async (repoId: string, dbPath: string): Promise<boolean> => {
+// Serializes the whole initLbug body across concurrent callers. Awaiting
+// closeOne/evictLRU (above) closes the race within a single call, but two
+// concurrent initLbug() calls for two different repoIds can still each evict
+// their own LRU victim and open their own new connection at the same time,
+// racing each other's checkpoint on whatever global lock the native engine
+// holds. This mutex makes pool mutations (evict + reopen, for any repo)
+// mutually exclusive across all callers, closing that cross-request race too.
+let poolLock: Promise<unknown> = Promise.resolve();
+function withPoolLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = poolLock.then(fn, fn);
+  poolLock = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+export const initLbug = (repoId: string, dbPath: string): Promise<boolean> =>
+  withPoolLock(() => initLbugInner(repoId, dbPath));
+
+const initLbugInner = async (repoId: string, dbPath: string): Promise<boolean> => {
   const existing = pool.get(repoId);
   if (existing) {
     existing.lastUsed = Date.now();
@@ -688,25 +746,11 @@ export const initLbug = async (repoId: string, dbPath: string): Promise<boolean>
     // freshness THROUGH initLbug (rather than calling closeLbug directly) get
     // this guard for free; that is why LocalBackend delegates here (#2614).
     if (existing.checkedOut > 0) return false;
-    closeOne(repoId); // idle & changed → evict, then fall through to reopen the new file
+    // Awaited: see the rationale on the evictLRU call site in doInitLbug below.
+    await closeOne(repoId); // idle & changed → evict, then fall through to reopen the new file
   }
 
-  // Deduplicate concurrent init calls for the same repoId —
-  // prevents double-init race when multiple parallel tool calls
-  // trigger initialization for the same repo simultaneously.
-  const pending = initPromises.get(repoId);
-  if (pending) {
-    await pending;
-    return true;
-  }
-
-  const promise = doInitLbug(repoId, dbPath);
-  initPromises.set(repoId, promise);
-  try {
-    await promise;
-  } finally {
-    initPromises.delete(repoId);
-  }
+  await doInitLbug(repoId, dbPath);
   return true;
 };
 
@@ -723,7 +767,12 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
     throw new Error(`LadybugDB not found at ${dbPath}. Run: gitnexus analyze`);
   }
 
-  evictLRU();
+  // Awaited: without this, the connection opened just below could race the
+  // checkpoint from the LRU victim's still-in-flight close (see evictLRU /
+  // closeOne). initLbug's outer poolLock keeps this whole function exclusive
+  // across concurrent repos too, so this await only needs to cover this call's
+  // own evict-then-reopen — not other callers.
+  await evictLRU();
 
   // Reuse an existing native Database if another repoId already opened this path.
   // This prevents buffer manager exhaustion from multiple mmap regions on the same file.
@@ -1223,13 +1272,24 @@ export const executeParameterized = async (
  */
 export const closeLbug = async (repoId?: string): Promise<void> => {
   if (repoId) {
-    closeOne(repoId);
+    // Awaited: closeOne is now async (see evictLRU's rationale); callers of
+    // closeLbug rely on pool.delete() having already run — e.g. isLbugReady()
+    // returning false — by the time this promise resolves.
+    await closeOne(repoId);
     return;
   }
 
-  for (const id of [...pool.keys()]) {
-    closeOne(id);
-  }
+  // Locked (unlike the per-repoId branch above): without this, an initLbug
+  // that runs while this loop is mid-await (closeOne yields during the
+  // native close) can register a fresh pool entry after `pool.keys()` was
+  // already snapshotted, so a caller expecting closeLbug() to mean "pool is
+  // now empty" would find that new entry still resident (review finding on
+  // PR #3187).
+  await withPoolLock(async () => {
+    for (const id of [...pool.keys()]) {
+      await closeOne(id);
+    }
+  });
 
   if (idleTimer) {
     clearInterval(idleTimer);

--- a/gitnexus/test/unit/lbug-pool-evict-reopen-race.test.ts
+++ b/gitnexus/test/unit/lbug-pool-evict-reopen-race.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+
+// Regression test: closeOne() used to close the evicted repo's shared Database
+// with a fire-and-forget `db.close().catch(() => {})` (no await), and evictLRU
+// (plus the "idle & changed" reopen path in initLbug) proceeded to open the
+// next repo's connection immediately after, without waiting for that close —
+// and the checkpoint it triggers — to finish. On the real LadybugDB engine
+// this surfaces as: "Runtime exception: Cannot open database in read-only
+// mode while checkpoint is in progress. Please retry later." on the very next
+// read against ANY repo, not just the one being evicted.
+//
+// The native engine isn't mockable down to that exact error, so this test
+// instead asserts the ordering guarantee the fix provides: the evicted repo's
+// close() must fully resolve before the caller that triggered the eviction
+// (initLbug for a new, distinct repo) itself resolves. Mock setup mirrors
+// lbug-pool-pinning.test.ts (same native/adapter/sidecar-recovery mocks),
+// driving the real initLbug -> evictLRU -> closeOne path.
+
+const { loadFTSExtensionMock, loadVectorExtensionMock } = vi.hoisted(() => ({
+  loadFTSExtensionMock: vi.fn(),
+  loadVectorExtensionMock: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('@ladybugdb/core', () => ({
+  default: {
+    Database: vi.fn(),
+    Connection: vi.fn(function (this: any) {
+      this.query = vi.fn().mockResolvedValue({
+        getAll: vi.fn().mockResolvedValue([]),
+        close: vi.fn(),
+      });
+      this.close = vi.fn().mockResolvedValue(undefined);
+    }),
+  },
+}));
+
+vi.mock('../../src/core/lbug/lbug-adapter.js', () => ({
+  isReadOnlyDbError: vi.fn(() => false),
+  loadFTSExtension: loadFTSExtensionMock,
+  loadVectorExtension: loadVectorExtensionMock,
+}));
+
+vi.mock('../../src/core/lbug/lbug-config.js', () => ({
+  createLbugDatabase: vi.fn(() => ({
+    init: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  })),
+  toNativeSafePath: vi.fn((p: string) => p),
+  isWalCorruptionError: vi.fn(() => false),
+  WAL_RECOVERY_SUGGESTION: '',
+}));
+
+vi.mock('../../src/core/lbug/sidecar-recovery.js', () => ({
+  preflightLbugSidecars: vi.fn().mockResolvedValue(undefined),
+  guardWalQuarantine: vi.fn().mockResolvedValue(undefined),
+  isMissingFsError: vi.fn(() => false),
+  isMissingShadowSidecarError: vi.fn(() => false),
+  isReadOnlyShadowReplayError: vi.fn(() => false),
+  quarantineWalForMissingShadow: vi.fn().mockResolvedValue(''),
+  quarantineSidecarsForDirtyRecovery: vi
+    .fn()
+    .mockResolvedValue({ moved: [], removed: [], failed: [] }),
+  renameFailureMessage: vi.fn((p: string) => `rename failed for ${p}`),
+  statIfExists: vi.fn().mockResolvedValue(null),
+}));
+
+const { initLbug, closeLbug, isLbugReady, unpinRepo } =
+  await import('../../src/core/lbug/pool-adapter.js');
+const { createLbugDatabase } = await import('../../src/core/lbug/lbug-config.js');
+
+describe('pool-adapter evict-then-reopen race (fire-and-forget close fix)', () => {
+  let tmpDir: string;
+  const touched = new Set<string>();
+
+  const dbPathFor = (repoId: string): string => {
+    const p = path.join(tmpDir, `${repoId}.lbug`);
+    writeFileSync(p, '');
+    return p;
+  };
+
+  const init = async (repoId: string): Promise<void> => {
+    touched.add(repoId);
+    await initLbug(repoId, dbPathFor(repoId));
+  };
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'gn-evict-race-test-'));
+    loadFTSExtensionMock.mockResolvedValue(true);
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await closeLbug().catch(() => {});
+    for (const id of touched) unpinRepo(id);
+    touched.clear();
+    loadFTSExtensionMock.mockReset();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("evictLRU awaits the evicted repo's close() before the triggering initLbug settles", async () => {
+    // MAX_POOL_SIZE is 5; repo-1 is the first (and, once repo-6 inits, the
+    // LRU-oldest unpinned) entry, so it is the eviction victim below.
+    // Give repo-1's shared Database a close() gated on a real (short) delay,
+    // simulating a slow checkpoint, and record the relative order of "close
+    // finished" vs. "the repo-6 init that triggered the eviction finished".
+    const order: string[] = [];
+
+    vi.mocked(createLbugDatabase).mockImplementationOnce(() => ({
+      init: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        order.push('repo1-close-end');
+      }),
+    }));
+
+    for (let i = 1; i <= 5; i++) await init(`repo-${i}`);
+
+    await init('repo-6');
+    order.push('repo6-init-done');
+
+    // With the fix: evictLRU awaits closeOne's close(), so the 20ms-delayed
+    // close of the evicted repo-1 must finish BEFORE initLbug('repo-6', ...)
+    // itself resolves — 'repo1-close-end' precedes 'repo6-init-done'.
+    // Without the fix (fire-and-forget close), repo-6's own (near-instant,
+    // mock-driven) init finishes well before the unrelated 20ms delay elapses,
+    // so the order is reversed.
+    expect(order).toEqual(['repo1-close-end', 'repo6-init-done']);
+    expect(isLbugReady('repo-1')).toBe(false);
+    expect(isLbugReady('repo-6')).toBe(true);
+  });
+
+  it('closeLbug(repoId) awaits the underlying close() before its own promise resolves', async () => {
+    // Regression guard for a second-order effect of making closeOne async:
+    // closeLbug must still await it, or its promise can resolve before the
+    // real (here, delayed-mock) close() has actually finished. Gate the
+    // mock's close() on a real short delay, like the first test, so an
+    // implementation that drops the await is caught regardless of how fast
+    // the mock itself would otherwise resolve.
+    const order: string[] = [];
+
+    vi.mocked(createLbugDatabase).mockImplementationOnce(() => ({
+      init: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        order.push('close-end');
+      }),
+    }));
+
+    await init('repo-solo');
+    expect(isLbugReady('repo-solo')).toBe(true);
+
+    await closeLbug('repo-solo');
+    order.push('closeLbug-done');
+
+    expect(order).toEqual(['close-end', 'closeLbug-done']);
+    expect(isLbugReady('repo-solo')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`closeOne()`/`evictLRU()` close the evicted repo's LadybugDB connection with a fire-and-forget `db.close().catch(() => {})` (no `await`); the caller then opens the next repo's connection immediately, racing the still-in-flight checkpoint. Fixes that, plus serializes `initLbug` across concurrent callers so two different repos can't race each other's evict-then-reopen either, plus fixes a zombie-pool-entry window that review caught in the first version of this fix (see below).

## Motivation / context

Related to #3186 (does not close it — see that issue for why). Self-hosted `gitnexus serve` deployments with more than `MAX_POOL_SIZE` (5) actively-used repos hit `"Runtime exception: Cannot open database in read-only mode while checkpoint is in progress. Please retry later."` on `/api/graph` and other pool-backed reads, routinely.

## Areas touched

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- `gitnexus/src/core/lbug/pool-adapter.ts`: make `closeOne`/`evictLRU` async and await the two evict-then-reopen call sites (`doInitLbug`'s `evictLRU()`, and the "idle & changed" reopen in `initLbug`).
- Wrap the exported `initLbug` in a small async mutex (`initLbugInner` does the real work) so concurrent calls for different repos serialize instead of racing each other's pool mutations.
- Also await `closeOne()` at `closeLbug`'s two call sites — required once `closeOne` is async, or `closeLbug` can resolve before `pool.delete()` actually ran (caught by the existing `lbug-pool-pinning.test.ts` "explicit close beats the pin" test).
- `closeOne` now removes the pool entry (`pool.delete`, pin clear, listener notify) **before** the newly-awaited `db.close()`, not after. Review found that the previous order left the closed entry reachable via `pool.get(repoId)` — `isLbugReady(repoId)` still `true` — for the duration of that await, so a same-repo query/init landing in that window would hit a `Connection pool integrity error` in `checkout()` instead of just reopening.

**Explicitly out of scope / not done here**

- `MAX_POOL_SIZE` itself is unchanged (still hardcoded to 5). Raising it or making it configurable would reduce how often eviction happens but doesn't address either bug; left as a separate discussion.
- The second, deeper issue noted in #3186 (a repo that has gone through one evict+reopen cycle sometimes becomes permanently unable to reopen for reads, identically with and without this fix) — did not reproduce with mocks, not root-caused, intentionally not attempted here. Further investigation (version bisection, native-engine-vs-JS isolation) is tracked on that issue, not this PR.

## Implementation notes

The idle-timer sweep's `closeOne(repoId)` call is still fire-and-forget on purpose: it's periodic best-effort cleanup with nothing waiting on its completion, unlike the two paths this PR fixes (which are immediately followed by opening a new connection) and unlike `closeLbug` (whose callers observably depend on the close having completed).

## Testing & verification

- [x] `cd gitnexus && npm test` — full unit suite green; the handful of failures seen on an earlier run (`run-analyze.test.ts`, `run-analyze-fts-repair.test.ts`) are pre-existing analyzer-identity flakiness under full-suite parallel load, reproduced identically against `main` with this change reverted.
- [x] `cd gitnexus && npx tsc --noEmit` — clean.
- [x] `test/unit/lbug-pool-evict-reopen-race.test.ts` (mocks `@ladybugdb/core` the same way as `lbug-pool-pinning.test.ts`), two tests:
  - Asserts the evicted repo's `close()` (gated on a controllable delay) completes before the `initLbug` call that triggered the eviction settles. Confirmed it fails against `main` (repo-6's init resolves before the gated close finishes) and passes with this fix.
  - Asserts `closeLbug(repoId)`'s own promise doesn't resolve before the underlying (delay-gated) `close()` does. Confirmed it fails when the corresponding `await` is dropped.
- [x] Manual A/B against the compiled/published bundle: built `ghcr.io/abhigyanpatwari/gitnexus:1.6.10` into a Docker image, indexed 7 tiny local repos, fired genuinely concurrent (not sequential) `/api/graph?...&stream=true` requests across all 7. Without this fix (stock image): 7/7 fail. With this fix applied to the compiled output: 7/7 succeed, on a freshly-analyzed pool. (Sequential requests against tiny repos don't reproduce it — the fire-and-forget close finishes before the next request arrives regardless of the bug; only genuine concurrency, or a large enough repo that the checkpoint takes measurable time, exposes it.)

## Risk & rollout

No behavior change for the common case (pool under `MAX_POOL_SIZE`, no eviction). For the eviction path, callers now wait a bit longer for `initLbug`/`closeLbug` to resolve (bounded by however long the evicted repo's `close()`/checkpoint takes) instead of racing it — strictly safer, no data-shape or API change. No new `GITNEXUS_*` env var.

## Checklist

- [x] PR body meets repo minimum length
- [ ] N/A — no `AGENTS.md`/overlay changes
- [x] No secrets, tokens, or machine-specific paths committed

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary
*This appears to be a concentrated data-layer and connection-pool lifecycle change with broad transitive reach. The implementation footprint is small, but the critical blast level warrants close review of asynchronous eviction, reopening, and checkpoint ordering.*

**🔴 CRITICAL blast radius. A change to the Lbug pool adapter in `gitnexus/src/core/lbug/pool-adapter.ts` reaches 133 dependents despite being confined to two files.**

The change is concentrated in 14 symbols in `gitnexus/src/core/lbug/pool-adapter.ts`, including `ensureIdleTimer`, `touchRepo`, `closeOne`, `initLbug`, `doInitLbug`, `isLbugReady`, `closeLbug`, `executeParameterized`, `executeQuery`, and `withTimeout`. Review the ordering and lifecycle interactions among these pool initialization, eviction, close, and query paths first, alongside the focused coverage in `gitnexus/test/unit/lbug-pool-evict-reopen-race.test.ts`.

Impact is strongest in `Local`, with additional graph reach through `Wiki`, `Lbug`, `Cli`, `Group`, `Integration`, `Search`, `Cfg`, `Graph`, `Embeddings`, `Mcp`, and `Server`. The report traces 41 affected flows, so review should follow callers through those areas rather than treating this as an isolated adapter change.

No HIGH or CRITICAL risk files and no cross-repo consumers were identified.

_Added by GitNexus for PR #3187. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->