### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ The proxy strips `Origin` before forwarding, so the server's CSRF guard does not
 
 Indexing is memory-bound. If `gitnexus-server` runs out of memory on a large repo, raise its `plan`, which sets available RAM: `standard` is 2 GB, `pro` is 4 GB. Raise `sizeGB` only if the disk fills with clones and indexes.
 
+### Deploy to RepoCloud
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/gitnexus/)
+
 ## Two Ways to Use GitNexus
 
 |             | **CLI + MCP** (recommended)                                                        | **Web UI**                                                           |


### PR DESCRIPTION
Adds a RepoCloud one-click deploy button in a new "Deploy to RepoCloud" subsection, placed alongside the existing "Deploy to Render" section.

 - New `### Deploy to RepoCloud` subsection with deploy button
 - Button links to https://repocloud.io/details/gitnexus/
 - Matches existing deploy subsection format (Pattern 8)

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a small, self-contained documentation update with no indexed code or cross-repository reach.*

**🟢 LOW blast radius. A documentation change in `README.md` updates the `2. Connect your editors (one-time, auto-detects Claude Code, Cursor, Codex, …)` and `Two Ways to Use GitNexus` sections, with no dependents or affected flows.**

Review the content and placement of the deploy-button documentation in `README.md`, particularly how it fits alongside the editor connection guidance and the usage overview.

_Added by GitNexus for PR #3212. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->