### PR TITLE
test(cli): prove detached refresh by ordering, not by wall clock

### DIFF
--- a/gitnexus/test/integration/cli/update-notice.test.ts
+++ b/gitnexus/test/integration/cli/update-notice.test.ts
@@ -127,12 +127,26 @@ describe('CLI update notice subprocess behavior', () => {
       'dir',
     );
 
+    // The refresh child parks inside fetch() until this test releases it. That
+    // orders the parent's exit against work that is provably still in flight,
+    // instead of racing it against a wall-clock budget: the child's real cost
+    // (node boot, tsx transpile, a lock acquisition that shells out to
+    // ps/powershell) has no bounded upper limit on a loaded CI runner.
+    const started = path.join(home, 'refresh-started');
+    const release = path.join(home, 'refresh-release');
     const preload = path.join(home, 'mock-refresh.mjs');
     fs.writeFileSync(
       preload,
-      `Object.defineProperty(process.stderr, 'isTTY', { value: true, configurable: true });
+      `import fs from 'node:fs';
+Object.defineProperty(process.stderr, 'isTTY', { value: true, configurable: true });
 globalThis.fetch = async () => {
-  await new Promise((resolve) => setTimeout(resolve, 750));
+  fs.writeFileSync(${JSON.stringify(started)}, '');
+  // Bounded so an abandoned child (test failed before releasing, temp home
+  // already deleted) still exits instead of spinning forever.
+  const deadline = Date.now() + 60_000;
+  while (!fs.existsSync(${JSON.stringify(release)}) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
   return new Response(JSON.stringify({ version: '99.0.0' }), {
     status: 200,
     headers: { 'content-type': 'application/json' },
@@ -141,7 +155,6 @@ globalThis.fetch = async () => {
 `,
     );
 
-    const startedAt = Date.now();
     await new Promise<void>((resolve, reject) => {
       const parent = spawn(
         process.execPath,
@@ -162,17 +175,20 @@ globalThis.fetch = async () => {
         else reject(new Error(`notifier parent exited ${String(code)}`));
       });
     });
-    const elapsed = Date.now() - startedAt;
 
-    expect(elapsed).toBeLessThan(1_800);
+    // The parent already exited above, so reaching a still-parked child proves
+    // the refresh outlived it and was never awaited.
     const cache = path.join(home, 'update-check.json');
+    await expect.poll(() => fs.existsSync(started), { timeout: 30_000, interval: 50 }).toBe(true);
     expect(fs.existsSync(cache)).toBe(false);
-    await expect.poll(() => fs.existsSync(cache), { timeout: 15_000, interval: 100 }).toBe(true);
+
+    fs.writeFileSync(release, '');
+    await expect.poll(() => fs.existsSync(cache), { timeout: 30_000, interval: 50 }).toBe(true);
     expect(JSON.parse(fs.readFileSync(cache, 'utf8'))).toMatchObject({
       latestVersion: '99.0.0',
       registry: 'https://registry.npmjs.org',
     });
-  }, 20_000);
+  }, 90_000);
 
   it('prints the localized notice on a forced-TTY stderr and keeps stdout clean', () => {
     const home = tempHome();


### PR DESCRIPTION
## Problem

`test/integration/cli/update-notice.test.ts > lets the parent exit without waiting for a detached refresh child` fails intermittently in the platform-sensitive matrix:

```
AssertionError: expected false to be true // Object.is equality
 ❯ test/integration/cli/update-notice.test.ts:170:87
Caused by: Error: Matcher did not succeed in time.
```

The test made two independent bets on absolute wall-clock budgets, and both are machine-speed dependent.

**Bet 1 — `expect(elapsed).toBeLessThan(1_800)`.** This bounds the *parent's* cold `node --import tsx` boot, and infers "did not wait for the child" from a 1050ms margin over the mock fetch's 750ms sleep. I reproduced it failing on Linux under 40-way CPU load: `parentElapsed: 1904`.

**Bet 2 — the 15s poll for the cache file.** That budget has to cover the entire detached child: node boot, a tsx transpile of 22 source files, an `acquireFileLock` that shells out (`ps` on POSIX, `powershell.exe -Command Get-CimInstance Win32_Process` on Windows), the mocked fetch, and the atomic write. Measured breakdown of that chain on an unloaded 24-core Linux box:

| phase | ms |
| --- | --- |
| node boot + tsx + full CLI graph | ~460 |
| `acquireFileLock` incl. `readProcessStartTime` | 16 |
| mocked fetch (the test's own `setTimeout`) | 750 |
| atomic write | ~0 |
| **total** | **~1020** |

Nothing in that chain has a bounded upper limit on a contended runner, and the Windows branch of `readProcessStartTime` spawns PowerShell and queries WMI per lock acquisition.

## Fix

Replace both budgets with an ordering proof. The preloaded mock `fetch` now parks the refresh child until the test releases it, so the asserted sequence is:

1. parent exits (awaited),
2. child is provably still mid-refresh — `refresh-started` marker present, cache absent,
3. test releases the child,
4. cache appears with the expected contents.

That is strictly stronger than inferring "did not wait" from elapsed time, and it holds at any machine speed. The remaining `expect.poll` timeouts no longer carry the assertion's meaning; they are only "is the child dead" safety nets. The mock's wait is bounded at 60s so an abandoned child (test failed before releasing, temp home already removed) exits instead of spinning forever.

Test-only change. No production behavior is touched.

## Why not just speed up the child

Considered, measured, insufficient:

- Bypassing commander/i18n in the `__update-check` child saves ~185ms of ~460ms boot here (22 transpiled source files vs 10), and would require changing the spawn contract the unit tests pin.
- The Windows `Get-CimInstance` call is the only term that can plausibly consume seconds, but it is the lock owner's PID-reuse identity, shared with the analyze/watch/auto-sync locks. Switching to `Get-Process` changes the `"O"` fractional precision, so an old holder plus a new reader would mismatch and steal each other's locks.
- Neither touches bet 1 at all, which bounds the parent, not the child.

A separate, safe win exists and is deliberately **not** in this PR: memoizing `readProcessStartTime(process.pid)`, since a process's own start time is immutable, so retry loops and `reclaimStaleLock` guards currently re-spawn PowerShell on Windows.

## Validation

- `npx vitest run --project default test/integration/cli/update-notice.test.ts` — 7/7 pass, 12.5s.
- 12 concurrent runs of the file — 12/12 pass.
- `detect_changes({scope: "all"})` — 0 changed symbols, risk low, not partial or truncated.