### PR TITLE
perf(lock): probe this process's own start time once

### DIFF
--- a/gitnexus/src/core/auto-sync/starter.ts
+++ b/gitnexus/src/core/auto-sync/starter.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { acquireFileLock, FileLockBusyError } from '../../storage/file-lock.js';
 import { getGlobalDir } from '../../storage/repo-manager.js';
-import { isProcessAlive, readProcessStartTime } from '../../utils/process-identity.js';
+import { isProcessAlive, readProcessStartTimeCached } from '../../utils/process-identity.js';
 import { loadAutoSyncConfig } from './config.js';
 import { runAutoSyncOnce } from './runner.js';
 import { getAutoSyncMutexPath, getAutoSyncWatchDir } from './state.js';
@@ -632,7 +632,7 @@ function resolveWatchDeps(deps: Partial<AutoSyncWatchControlDeps> = {}): AutoSyn
           return undefined;
         }
       }),
-    readProcessStartTime: deps.readProcessStartTime ?? readProcessStartTime,
+    readProcessStartTime: deps.readProcessStartTime ?? readProcessStartTimeCached,
     sleep:
       deps.sleep ??
       ((ms) =>

--- a/gitnexus/src/storage/file-lock.ts
+++ b/gitnexus/src/storage/file-lock.ts
@@ -46,7 +46,9 @@ export async function acquireFileLock(
     pid,
     ownerId: crypto.randomUUID(),
     processStartTime:
-      options.processStartTime ?? (options.readProcessStartTime ?? readProcessStartTimeCached)(pid) ?? '',
+      options.processStartTime ??
+      (options.readProcessStartTime ?? readProcessStartTimeCached)(pid) ??
+      '',
     hostname: options.hostname ?? HOSTNAME,
   };
   if (!owner.processStartTime) {

--- a/gitnexus/src/storage/file-lock.ts
+++ b/gitnexus/src/storage/file-lock.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { isProcessAlive, readProcessStartTime } from '../utils/process-identity.js';
+import { isProcessAlive, readProcessStartTimeCached } from '../utils/process-identity.js';
 
 const HOSTNAME = os.hostname();
 
@@ -46,7 +46,7 @@ export async function acquireFileLock(
     pid,
     ownerId: crypto.randomUUID(),
     processStartTime:
-      options.processStartTime ?? (options.readProcessStartTime ?? readProcessStartTime)(pid) ?? '',
+      options.processStartTime ?? (options.readProcessStartTime ?? readProcessStartTimeCached)(pid) ?? '',
     hostname: options.hostname ?? HOSTNAME,
   };
   if (!owner.processStartTime) {
@@ -69,7 +69,7 @@ export async function acquireFileLock(
             resolvedPath,
             owner,
             options.isProcessAlive ?? isProcessAlive,
-            options.readProcessStartTime ?? readProcessStartTime,
+            options.readProcessStartTime ?? readProcessStartTimeCached,
           )
         ) {
           continue;

--- a/gitnexus/src/utils/process-identity.ts
+++ b/gitnexus/src/utils/process-identity.ts
@@ -38,3 +38,22 @@ export function readProcessStartTime(pid: number): string | undefined {
     return undefined;
   }
 }
+
+let ownStartTime: string | undefined;
+
+/**
+ * `readProcessStartTime`, except this process's own start time is probed once.
+ * It cannot change while we are running, and every `acquireFileLock` — plus
+ * each retry attempt and each stale-lock reclaim guard — stamps the owner file
+ * with it. On Windows that probe is a `powershell.exe` spawn and a WMI query,
+ * so a process taking several locks pays it several times for one constant.
+ *
+ * A foreign pid is never cached: that process can exit and its pid can be
+ * reused, which is the very thing the stamp exists to detect. A failed probe
+ * is not cached either — one transient failure would otherwise leave the
+ * process unable to take a lock for its whole lifetime.
+ */
+export function readProcessStartTimeCached(pid: number): string | undefined {
+  if (pid !== process.pid) return readProcessStartTime(pid);
+  return (ownStartTime ??= readProcessStartTime(pid));
+}

--- a/gitnexus/test/unit/process-identity.test.ts
+++ b/gitnexus/test/unit/process-identity.test.ts
@@ -4,7 +4,23 @@ import { isProcessAlive, readProcessStartTime } from '../../src/utils/process-id
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.doUnmock('node:child_process');
+  vi.resetModules();
 });
+
+/**
+ * Loads a fresh copy of the module (fresh memo) over a counted `execFileSync`,
+ * so "how many times did we actually shell out" is observable. `doMock` is not
+ * hoisted, so the statically imported functions used by the other tests keep
+ * the real implementation.
+ */
+async function withCountedProbe(probe: () => string) {
+  const execFileSync = vi.fn(probe);
+  vi.doMock('node:child_process', () => ({ execFileSync }));
+  vi.resetModules();
+  const identity = await import('../../src/utils/process-identity.js');
+  return { execFileSync, readProcessStartTimeCached: identity.readProcessStartTimeCached };
+}
 
 describe('process identity', () => {
   it('treats only ESRCH as a dead process', () => {
@@ -39,4 +55,33 @@ describe('process identity', () => {
       }
     },
   );
+
+  it('probes this process once and re-probes a foreign pid every time', async () => {
+    const { execFileSync, readProcessStartTimeCached } = await withCountedProbe(() => 'STAMP\n');
+
+    expect(readProcessStartTimeCached(process.pid)).toBe('STAMP');
+    expect(readProcessStartTimeCached(process.pid)).toBe('STAMP');
+    // On Windows each probe is a powershell.exe spawn plus a WMI query.
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+
+    // A foreign process can exit and its pid be reused — caching that stamp
+    // would blind the reuse check the stamp exists for.
+    expect(readProcessStartTimeCached(process.pid + 1)).toBe('STAMP');
+    expect(readProcessStartTimeCached(process.pid + 1)).toBe('STAMP');
+    expect(execFileSync).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries after a failed self probe instead of caching the failure', async () => {
+    const { execFileSync, readProcessStartTimeCached } = await withCountedProbe(() => 'STAMP\n');
+    execFileSync.mockImplementationOnce(() => {
+      throw new Error('probe unavailable');
+    });
+
+    // A cached failure would leave acquireFileLock throwing "Unable to
+    // determine process start time" for the rest of the process's life.
+    expect(readProcessStartTimeCached(process.pid)).toBeUndefined();
+    expect(readProcessStartTimeCached(process.pid)).toBe('STAMP');
+    expect(readProcessStartTimeCached(process.pid)).toBe('STAMP');
+    expect(execFileSync).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## What

`acquireFileLock` stamps the owner file with the acquiring process's start time, so a later reclaimer can tell a live owner from pid reuse. That value is immutable for the process's lifetime, but it was re-probed on every acquisition — each retry attempt and each `reclaimStaleLock` guard included.

The probe is not cheap. On POSIX it is `ps -p <pid> -o lstart=` (~7ms measured here). On Windows it is:

```
powershell.exe -NoProfile -NonInteractive -Command "$p = Get-CimInstance Win32_Process -Filter ..."
```

a PowerShell spawn plus a WMI query — the single most expensive step in taking an uncontended lock, paid once per acquisition for a constant.

## Change

New `readProcessStartTimeCached`, used as the default reader in `acquireFileLock` and `resolveWatchDeps`. Only this process's own pid is cached:

- **Foreign pids are always re-probed.** That process can exit and its pid be reused, which is precisely what the stamp exists to detect. Caching it would blind the reuse check.
- **A failed probe is not cached.** `acquireFileLock` throws `Unable to determine process start time` on an empty value, so caching one transient failure would leave the process unable to take a lock for the rest of its life.

`readProcessStartTime` itself is untouched and still probes on every call. That was deliberate: putting the memo inside it would have made the existing timezone-pinning regression test (`renders the same start time regardless of the ambient timezone`) pass vacuously, since its second call would never reach `ps`.

Behavior is otherwise identical — same probe, same string, same stamp. Injected readers (`options.readProcessStartTime`) are unaffected.

## Tests

Two new cases in `test/unit/process-identity.test.ts`, both counting actual `execFileSync` calls over a freshly loaded module so "did we really shell out" is observable rather than inferred:

- self pid probed once across repeated calls; a foreign pid re-probed every call;
- a failed self probe is retried, not cached.

## Validation

- `test/unit/{process-identity,file-lock,auto-sync-runner,cli-update-notice,update-check}.test.ts` — 116 passed.
- `test/unit/{auto-sync,pool-wal-recovery,sidecar-recovery}.test.ts` + `test/integration/lbug-core-adapter.test.ts` — passed.
- `test/unit/incremental-dirty-recovery.test.ts` fails on this host with a worker-pool startup ready-timeout. Pre-existing: it fails identically with these changes stashed, and nothing here touches the parse path.
- `tsc --noEmit`, `eslint` on all four files — clean.
- `impact({target: "acquireFileLock", direction: "upstream"})` — HIGH, 10 upstream / 4 direct, `update-check.run` process. Flagged and reviewed: the edit is a default-argument swap, no logic change inside the lock.
- `detect_changes({scope: "all"})` — 4 changed symbols, medium, 2 affected processes, both via `acquireFileLock` step 2. Not partial, not truncated.

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a performance-focused change around process identity and file locking, reaching into auto-sync startup behavior. The blast radius is critical because the changed functions sit on several traced execution paths, though no changed file is individually rated high risk.*

**🔴 CRITICAL blast radius. A performance-focused change to `acquireFileLock` and `resolveWatchDeps` reaches lock handling and auto-sync startup code with transitive dependents.**

Review `gitnexus/src/storage/file-lock.ts` and `gitnexus/src/utils/process-identity.ts` first, focusing on how process start time is obtained and used by `acquireFileLock`. Then check `gitnexus/src/core/auto-sync/starter.ts`, where `resolveWatchDeps` places the change in the `Auto-sync` module and the hottest changed file.

The impact is concentrated in `Auto-sync`, `Storage`, and `Net`, with 8 affected flows. `gitnexus/test/unit/process-identity.test.ts` is the focused test coverage to compare against the updated process identity behavior.

_Added by GitNexus for PR #3222. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->