### PR TITLE
fix(embeddings): send Voyage output dimensions

### DIFF
--- a/gitnexus/src/core/embeddings/http-client.ts
+++ b/gitnexus/src/core/embeddings/http-client.ts
@@ -364,11 +364,10 @@ const countMismatchMessage = (
  * @param model - Model name for the request body
  * @param apiKey - Bearer token (only used in Authorization header)
  * @param batchIndex - Logical batch number (for error context)
- * @param dimensions - Optional output-vector size. When provided, sent as
- *   the `dimensions` field in the request body. Endpoints that implement
- *   Matryoshka truncation (OpenAI text-embedding-3-*, Cohere embed-v3,
- *   Voyage) return a truncated vector at that size; endpoints that do not
- *   recognise the field may ignore it or return 400. Set
+ * @param dimensions - Optional output-vector size. Voyage uses its
+ *   `output_dimension` field; other OpenAI-compatible endpoints use
+ *   `dimensions`. Endpoints that do not recognise the field may ignore it or
+ *   return 400. Set
  *   `GITNEXUS_EMBEDDING_REQUEST_DIMS=omit` for strict backends while keeping
  *   `GITNEXUS_EMBEDDING_DIMS` set to the returned vector size.
  */
@@ -385,12 +384,27 @@ const httpEmbedBatch = async (
   minIntervalMs = 0,
   timeoutMs = DEFAULT_HTTP_TIMEOUT_MS,
 ): Promise<EmbeddingItem[]> => {
-  const requestBody: { input: string[]; model: string; dimensions?: number } = {
+  const requestBody: {
+    input: string[];
+    model: string;
+    dimensions?: number;
+    output_dimension?: number;
+  } = {
     input: batch,
     model,
   };
   if (dimensions !== undefined) {
-    requestBody.dimensions = dimensions;
+    let hostname = '';
+    try {
+      hostname = new URL(url).hostname.toLowerCase().replace(/\.$/, '');
+    } catch {
+      // Fetch below owns malformed-URL reporting.
+    }
+    if (hostname === 'voyageai.com' || hostname.endsWith('.voyageai.com')) {
+      requestBody.output_dimension = dimensions;
+    } else {
+      requestBody.dimensions = dimensions;
+    }
   }
 
   // Built on demand, not up front. Both describe faults, so in a healthy run —

--- a/gitnexus/test/unit/http-embedder.test.ts
+++ b/gitnexus/test/unit/http-embedder.test.ts
@@ -168,6 +168,56 @@ describe('HTTP embedding backend', () => {
       expect(result.length).toBe(1024);
     });
 
+    it('uses output_dimension for Voyage document batches', async () => {
+      process.env.GITNEXUS_EMBEDDING_URL = 'https://api.voyageai.com/v1';
+      process.env.GITNEXUS_EMBEDDING_MODEL = 'voyage-code-3';
+      process.env.GITNEXUS_EMBEDDING_API_KEY = 'test-key';
+      process.env.GITNEXUS_EMBEDDING_DIMS = '2048';
+
+      const vec2048 = Array.from({ length: 2048 }, (_, i) => i / 2048);
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ data: [{ embedding: vec2048 }] }),
+        }),
+      );
+
+      const { embedText } = await import('../../src/core/embeddings/embedder.js');
+      const result = await embedText('test text');
+
+      const body = JSON.parse((fetch as any).mock.calls[0][1].body);
+      expect(body).toMatchObject({
+        input: ['test text'],
+        model: 'voyage-code-3',
+        output_dimension: 2048,
+      });
+      expect(body.dimensions).toBeUndefined();
+      expect(result.length).toBe(2048);
+    });
+
+    it('does not treat a voyageai.com lookalike host as Voyage', async () => {
+      process.env.GITNEXUS_EMBEDDING_URL = 'https://voyageai.com.example/v1';
+      process.env.GITNEXUS_EMBEDDING_MODEL = 'test-model';
+      process.env.GITNEXUS_EMBEDDING_DIMS = '512';
+
+      const vec512 = Array.from({ length: 512 }, (_, i) => i / 512);
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ data: [{ embedding: vec512 }] }),
+        }),
+      );
+
+      const { embedText } = await import('../../src/core/embeddings/embedder.js');
+      await embedText('test text');
+
+      const body = JSON.parse((fetch as any).mock.calls[0][1].body);
+      expect(body.dimensions).toBe(512);
+      expect(body.output_dimension).toBeUndefined();
+    });
+
     it('can validate custom dims without forwarding dimensions to strict backends', async () => {
       process.env.GITNEXUS_EMBEDDING_URL = 'http://test:8080/v1';
       process.env.GITNEXUS_EMBEDDING_MODEL = 'bge-m3';
@@ -212,6 +262,30 @@ describe('HTTP embedding backend', () => {
       const body = JSON.parse((fetch as any).mock.calls[0][1].body);
       expect(body.dimensions).toBe(512);
       expect(result.length).toBe(512);
+    });
+
+    it('uses output_dimension for Voyage on the single-query path', async () => {
+      process.env.GITNEXUS_EMBEDDING_URL = 'https://voyageai.com/v1';
+      process.env.GITNEXUS_EMBEDDING_MODEL = 'voyage-code-3';
+      process.env.GITNEXUS_EMBEDDING_API_KEY = 'test-key';
+      process.env.GITNEXUS_EMBEDDING_DIMS = '2048';
+
+      const vec2048 = Array.from({ length: 2048 }, (_, i) => i / 2048);
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ data: [{ embedding: vec2048 }] }),
+        }),
+      );
+
+      const mod = await import('../../src/mcp/core/embedder.js');
+      const result = await mod.embedQuery('query text');
+
+      const body = JSON.parse((fetch as any).mock.calls[0][1].body);
+      expect(body.output_dimension).toBe(2048);
+      expect(body.dimensions).toBeUndefined();
+      expect(result.length).toBe(2048);
     });
 
     it('can omit dimensions on the single-query path while validating custom dims', async () => {


### PR DESCRIPTION
## Summary

Send configured embedding dimensions as `output_dimension` for Voyage endpoints. Keep the existing `dimensions` field for other OpenAI-compatible endpoints.

## Motivation / context

[Voyage's embedding API](https://docs.voyageai.com/reference/embeddings-api-1) names this parameter `output_dimension`. The shared HTTP client currently sends `dimensions`, so explicitly requesting a supported output width fails against Voyage. Omitting the field remains a workaround when the provider's default width is suitable.

## Areas touched

- [x] `gitnexus/` — HTTP embedding request builder and its unit tests

## Scope & constraints

This changes only the outbound parameter name for the exact `voyageai.com` hostname and its subdomains. Generic endpoints and lookalike hosts retain `dimensions`. Existing request-dimensions omission is unchanged. No new environment variable, provider proxy, dependency, credential handling, index schema or CLI flag is added.

## Implementation notes

Document batches and single-query embeddings share the same request builder. The tests cover both Voyage paths and a lookalike hostname; existing tests retain generic-provider and omission coverage.

## Testing & verification

- Tests added first on the unchanged base: two expected Voyage failures, 66 passes.
- `cd gitnexus && npx vitest run test/unit/http-embedder.test.ts --maxWorkers=4`: 68/68 pass after the fix.
- Normal pre-commit hook: ESLint, repository Prettier and `tsc --noEmit` passed.
- `git diff --check`: passed.
- Independent scoped semantic review: no verified findings.
- Full package/integration and platform validation is left to upstream CI; no live-provider acceptance claim is made by these unit tests.

## Risk & rollout

The behavior change is limited to Voyage endpoints with explicitly included request dimensions. Reverting this commit restores the prior request shape. No index migration or release action is required by this PR.

## Checklist

- [x] Focused, test-backed change
- [x] No secrets, private repository content or machine-specific paths
- [x] No dependency changes or unrelated refactoring

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a focused embeddings HTTP client change with test coverage updates, but it sits on a critical execution surface with broad downstream flow involvement. Review should center on request and response handling in the embedding client.*

**🔴 CRITICAL blast radius. An embeddings networking change in `gitnexus/src/core/embeddings/http-client.ts` reaches 8 dependents across the `Embeddings` module.**

The change is concentrated in `httpEmbedBatch`, `unparseableMessage`, and `unexpectedShapeMessage` within `gitnexus/src/core/embeddings/http-client.ts`, with `vec512` updated in `gitnexus/test/unit/http-embedder.test.ts`. The implementation file is the hottest changed file and is the primary review target.

Impact lands in the human-named `Embeddings` module and spans 11 affected flows. Inspect the dimension-related behavior around `httpEmbedBatch` first, then verify that the updated parsing and unexpected-shape message paths remain aligned with the unit test coverage.

_Added by GitNexus for PR #3223. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->