### PR TITLE
perf(resolution): avoid quadratic config walk queues

### DIFF
--- a/gitnexus/src/core/ingestion/import-resolvers/node-workspace-packages.ts
+++ b/gitnexus/src/core/ingestion/import-resolvers/node-workspace-packages.ts
@@ -340,16 +340,17 @@ export async function loadNodeWorkspacePackages(
   const scope = await loadWorkspaceScope(repoRoot);
   const byName = new Map<string, NodeWorkspacePackage>();
   const queue: { dir: string; depth: number }[] = [{ dir: repoRoot, depth: 0 }];
+  let queueHead = 0;
   let dirsScanned = 0;
 
-  while (queue.length > 0) {
+  while (queueHead < queue.length) {
     if (dirsScanned >= SCAN_MAX_DIRS) {
       logger.warn(
         `[node] package.json scan of ${repoRoot} hit the ${SCAN_MAX_DIRS}-directory cap; workspace packages below it will not resolve`,
       );
       break;
     }
-    const { dir, depth } = queue.shift()!;
+    const { dir, depth } = queue[queueHead++]!;
     dirsScanned++;
 
     let entries: import('fs').Dirent[];

--- a/gitnexus/src/core/ingestion/languages/typescript/tsconfig.ts
+++ b/gitnexus/src/core/ingestion/languages/typescript/tsconfig.ts
@@ -278,10 +278,11 @@ async function firstReadableConfig(base: string): Promise<string | null> {
 async function findTsconfigFiles(repoRoot: string): Promise<string[]> {
   const found: string[] = [];
   const queue: { dir: string; depth: number }[] = [{ dir: repoRoot, depth: 0 }];
+  let queueHead = 0;
   let dirsScanned = 0;
 
-  while (queue.length > 0 && dirsScanned < SCAN_MAX_DIRS) {
-    const { dir, depth } = queue.shift()!;
+  while (queueHead < queue.length && dirsScanned < SCAN_MAX_DIRS) {
+    const { dir, depth } = queue[queueHead++]!;
     dirsScanned++;
     let entries: import('fs').Dirent[];
     try {


### PR DESCRIPTION
## Summary

- replace `shift()` in the tsconfig and Node workspace breadth-first walks with a monotonic head index
- preserve FIFO traversal, directory caps, warning behavior, and resolution output

Closes #3230.

## Why

Both walks append children while draining a queue capped at 20,000 directories. Repeated `shift()` therefore moves the remaining frontier and makes dequeue work quadratic. A head index makes it linear without changing traversal order.

## Verification

- `npx vitest run test/unit/node-workspace-packages.test.ts test/unit/tsconfig-index.test.ts test/integration/resolvers/typescript-workspace-packages.test.ts --maxWorkers=1 --reporter=verbose` (48 passed across the focused runs)
- `node --expose-gc --import tsx bench/import-target/measure.mjs --check`
- `npx tsc --noEmit`
- `npx prettier --check src/core/ingestion/languages/typescript/tsconfig.ts src/core/ingestion/import-resolvers/node-workspace-packages.ts`
- `npx eslint src/core/ingestion/languages/typescript/tsconfig.ts src/core/ingestion/import-resolvers/node-workspace-packages.ts`
- `git diff --check`

Risk is limited to the queue cursor implementation; ordering and bounds are unchanged. Reverting the commit restores the prior behavior.

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a focused performance-oriented change in repository ingestion configuration discovery. Its reach is contained to direct dependents, with no traced execution flows or elevated file-risk findings.*

**🟠 HIGH blast radius. A core ingestion change to `loadNodeWorkspacePackages` and `findTsconfigFiles` reaches 4 direct dependents.**

The change is concentrated in TypeScript configuration handling and import resolution, specifically `gitnexus/src/core/ingestion/import-resolvers/node-workspace-packages.ts` and `gitnexus/src/core/ingestion/languages/typescript/tsconfig.ts`. Review the queue and traversal behavior in `loadNodeWorkspacePackages` and `findTsconfigFiles` first, since these are the only changed symbols and the former is the hottest changed file.

Impact lands across the human-named `Typescript`, `Import-resolvers`, and `Config` modules. The dependent reach is direct only, so review should focus on callers of these ingestion helpers and on preserving expected workspace-package and `tsconfig` discovery behavior.

_Added by GitNexus for PR #3237. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->