### PR TITLE
refactor(fts): share skip-FTS helpers and capability defaults

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -1452,7 +1452,8 @@ const analyzeCommandImpl = async (
       console.error = origError;
       bar.stop();
       console.log('  Already up to date\n');
-      if (result.ftsSkipped) console.log(`  ${FTS_DISABLED_MESSAGE}\n`);
+      if (isExplicitFtsDisablement(result.ftsSkipReason))
+        console.log(`  ${FTS_DISABLED_MESSAGE}\n`);
       if (runOptions.registryName) {
         console.log(`  Registry name: ${result.repoName}\n`);
       }

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -709,7 +709,9 @@ const runSchemaCreationQueries = async (dbPath: string): Promise<unknown | null>
   return null;
 };
 
-export const initLbug = async (dbPath: string, options: { skipFts?: boolean } = {}) => {
+type LbugInitOptions = { readOnly?: boolean; skipFts?: boolean };
+
+export const initLbug = async (dbPath: string, options: LbugInitOptions = {}) => {
   return runWithSessionLock(() => ensureLbugInitialized(dbPath, options));
 };
 
@@ -724,7 +726,7 @@ export const initLbug = async (dbPath: string, options: { skipFts?: boolean } = 
 export const withLbugDb = async <T>(
   dbPath: string,
   operation: () => Promise<T>,
-  options: { readOnly?: boolean; skipFts?: boolean } = {},
+  options: LbugInitOptions = {},
 ): Promise<T> => {
   let lastError: unknown;
   const readOnly = options.readOnly === true;
@@ -764,10 +766,7 @@ export const withLbugDb = async <T>(
 
 let currentDbSkipFts = false;
 
-const ensureLbugInitialized = async (
-  dbPath: string,
-  options: { readOnly?: boolean; skipFts?: boolean } = {},
-) => {
+const ensureLbugInitialized = async (dbPath: string, options: LbugInitOptions = {}) => {
   const readOnly = options.readOnly === true;
   const skipFts = options.skipFts === true;
   if (
@@ -782,10 +781,7 @@ const ensureLbugInitialized = async (
   return { db, conn };
 };
 
-const doInitLbug = async (
-  dbPath: string,
-  options: { readOnly?: boolean; skipFts?: boolean } = {},
-) => {
+const doInitLbug = async (dbPath: string, options: LbugInitOptions = {}) => {
   const readOnly = options.readOnly === true;
   const skipFts = options.skipFts === true;
   // Different database requested — close the old one first
@@ -3701,7 +3697,7 @@ export const ensureEmbeddingRowDmlSafe = async (
  */
 export const ensureFtsRowDmlSafe = async (
   indexRows?: IndexCatalogSnapshot,
-  options: { skipFts?: boolean } = {},
+  options: LbugInitOptions = {},
 ): Promise<boolean> => {
   // Unconditional precondition, same regression as the VECTOR twin's (#2841
   // review §5.B): a caller-supplied snapshot must not let a closed DB be

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -711,7 +711,7 @@ const runSchemaCreationQueries = async (dbPath: string): Promise<unknown | null>
 
 type LbugInitOptions = { readOnly?: boolean; skipFts?: boolean };
 
-export const initLbug = async (dbPath: string, options: LbugInitOptions = {}) => {
+export const initLbug = async (dbPath: string, options: { skipFts?: boolean } = {}) => {
   return runWithSessionLock(() => ensureLbugInitialized(dbPath, options));
 };
 
@@ -3697,7 +3697,7 @@ export const ensureEmbeddingRowDmlSafe = async (
  */
 export const ensureFtsRowDmlSafe = async (
   indexRows?: IndexCatalogSnapshot,
-  options: LbugInitOptions = {},
+  options: { skipFts?: boolean } = {},
 ): Promise<boolean> => {
   // Unconditional precondition, same regression as the VECTOR twin's (#2841
   // review §5.B): a caller-supplied snapshot must not let a closed DB be

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -709,8 +709,6 @@ const runSchemaCreationQueries = async (dbPath: string): Promise<unknown | null>
   return null;
 };
 
-type LbugInitOptions = { readOnly?: boolean; skipFts?: boolean };
-
 export const initLbug = async (dbPath: string, options: { skipFts?: boolean } = {}) => {
   return runWithSessionLock(() => ensureLbugInitialized(dbPath, options));
 };
@@ -726,7 +724,7 @@ export const initLbug = async (dbPath: string, options: { skipFts?: boolean } = 
 export const withLbugDb = async <T>(
   dbPath: string,
   operation: () => Promise<T>,
-  options: LbugInitOptions = {},
+  options: { readOnly?: boolean; skipFts?: boolean } = {},
 ): Promise<T> => {
   let lastError: unknown;
   const readOnly = options.readOnly === true;
@@ -766,7 +764,10 @@ export const withLbugDb = async <T>(
 
 let currentDbSkipFts = false;
 
-const ensureLbugInitialized = async (dbPath: string, options: LbugInitOptions = {}) => {
+const ensureLbugInitialized = async (
+  dbPath: string,
+  options: { readOnly?: boolean; skipFts?: boolean } = {},
+) => {
   const readOnly = options.readOnly === true;
   const skipFts = options.skipFts === true;
   if (
@@ -781,7 +782,10 @@ const ensureLbugInitialized = async (dbPath: string, options: LbugInitOptions = 
   return { db, conn };
 };
 
-const doInitLbug = async (dbPath: string, options: LbugInitOptions = {}) => {
+const doInitLbug = async (
+  dbPath: string,
+  options: { readOnly?: boolean; skipFts?: boolean } = {},
+) => {
   const readOnly = options.readOnly === true;
   const skipFts = options.skipFts === true;
   // Different database requested — close the old one first

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -15,6 +15,8 @@ import {
   getFtsDisabledReason,
   withExplicitFtsDisablement,
   FTS_DISABLED_MESSAGE,
+  DEFAULT_GRAPH_CAPABILITY,
+  DEFAULT_VECTOR_SEARCH_CAPABILITY,
   type FtsSkipReason,
 } from './search/fts-policy.js';
 import { PDG_EDGE_TYPES } from './lbug/pdg-emit-sink.js';
@@ -519,6 +521,12 @@ function recordLiveIndexMutationRisk(error: unknown): void {
   if ((typeof error === 'object' && error !== null) || typeof error === 'function') {
     liveIndexMutationRisks.add(error);
   }
+}
+
+function formatMetaWriteFailureReason(err: unknown): string {
+  return isReadOnlyFilesystemError(err)
+    ? `${(err as Error).message} — storage may be read-only (#1549)`
+    : (err as Error).message;
 }
 
 /** Whether a failed analyze may already have changed the live DB. */
@@ -1352,16 +1360,9 @@ async function runFullAnalysisInner(
         await saveMeta(metaDir, {
           ...latestMeta,
           capabilities: {
-            graph: latestMeta.capabilities?.graph ?? {
-              provider: 'ladybugdb',
-              status: 'available',
-            },
+            graph: latestMeta.capabilities?.graph ?? DEFAULT_GRAPH_CAPABILITY,
             fts: { provider: 'ladybugdb-fts', status: 'available' },
-            vectorSearch: latestMeta.capabilities?.vectorSearch ?? {
-              provider: 'exact-scan',
-              status: 'unavailable',
-              exactScanLimit: 0,
-            },
+            vectorSearch: latestMeta.capabilities?.vectorSearch ?? DEFAULT_VECTOR_SEARCH_CAPABILITY,
           },
         });
       } catch (err) {
@@ -1914,11 +1915,8 @@ async function runFullAnalysisInner(
             // EACCES/EPERM also arise from ownership problems and transient
             // Windows locks, so keep the real error visible alongside the
             // #1549 read-only hint instead of replacing it.
-            const reason = isReadOnlyFilesystemError(err)
-              ? `${(err as Error).message} — storage may be read-only (#1549)`
-              : (err as Error).message;
             log(
-              `Warning: could not restamp the workspace branch label (${reason}); will retry on the next run.`,
+              `Warning: could not restamp the workspace branch label (${formatMetaWriteFailureReason(err)}); will retry on the next run.`,
             );
           }
         } else if (ftsDisabledReason && ftsDisabledReason !== previousFtsDisabledReason) {
@@ -1927,11 +1925,8 @@ async function runFullAnalysisInner(
           try {
             await saveMeta(metaDir, existingMeta);
           } catch (err) {
-            const reason = isReadOnlyFilesystemError(err)
-              ? `${(err as Error).message} — storage may be read-only (#1549)`
-              : (err as Error).message;
             log(
-              `Warning: could not restamp the FTS skip reason (${reason}); will retry on the next run.`,
+              `Warning: could not restamp the FTS skip reason (${formatMetaWriteFailureReason(err)}); will retry on the next run.`,
             );
           }
         }
@@ -2716,9 +2711,9 @@ async function runFullAnalysisInner(
       // creates or drops an index.
       const indexCatalogRows = await readIndexCatalogSnapshot();
       const embeddingRowDmlSafe = await ensureEmbeddingRowDmlSafe(indexCatalogRows);
-      const ftsRowDmlSafe = ftsDisabledReason
-        ? await ensureFtsRowDmlSafe(indexCatalogRows, { skipFts: true })
-        : await ensureFtsRowDmlSafe(indexCatalogRows);
+      const ftsRowDmlSafe = await ensureFtsRowDmlSafe(indexCatalogRows, {
+        skipFts: Boolean(ftsDisabledReason),
+      });
       const extensionForcedRebuild = !embeddingRowDmlSafe || !ftsRowDmlSafe;
       // `!options.dropEmbeddings` (H1): this rescue reads the rows back OUT of
       // the DB, so it must never fire on the one path whose entire purpose is to

--- a/gitnexus/src/core/search/fts-policy.ts
+++ b/gitnexus/src/core/search/fts-policy.ts
@@ -5,12 +5,12 @@ export type FtsSkipReason = FtsDisabledReason | 'extension-unavailable' | 'build
 
 type RepoCapabilities = NonNullable<RepoMeta['capabilities']>;
 
-const DEFAULT_GRAPH_CAPABILITY: RepoCapabilities['graph'] = {
+export const DEFAULT_GRAPH_CAPABILITY: RepoCapabilities['graph'] = {
   provider: 'ladybugdb',
   status: 'available',
 };
 
-const DEFAULT_VECTOR_SEARCH_CAPABILITY: RepoCapabilities['vectorSearch'] = {
+export const DEFAULT_VECTOR_SEARCH_CAPABILITY: RepoCapabilities['vectorSearch'] = {
   provider: 'exact-scan',
   status: 'unavailable',
   exactScanLimit: 0,

--- a/gitnexus/src/server/api.ts
+++ b/gitnexus/src/server/api.ts
@@ -735,8 +735,12 @@ async function loadFtsSession(storagePath: string): Promise<{
   return {
     meta,
     ftsDisabledReason,
-    ...(ftsDisabledReason ? { skipFts: true as const } : {}),
+    ...skipFtsOption(Boolean(ftsDisabledReason)),
   };
+}
+
+function skipFtsOption(skipFts?: boolean): { skipFts?: true } {
+  return skipFts ? { skipFts: true } : {};
 }
 
 function readOnlyFtsOptions(skipFts?: true): { readOnly: true; skipFts?: true } {
@@ -2039,7 +2043,7 @@ export const createServer = async (port: number, host: string = '127.0.0.1') => 
                 );
                 await saveMeta(entry.storagePath, embeddingMeta);
               },
-              { ...(ftsSession.skipFts ? { skipFts: true } : {}) },
+              skipFtsOption(ftsSession.skipFts),
             );
 
             // Don't overwrite 'failed' if the job was cancelled while the pipeline was running

--- a/gitnexus/test/unit/analyze-api.test.ts
+++ b/gitnexus/test/unit/analyze-api.test.ts
@@ -611,7 +611,7 @@ describe('POST /api/embed route wiring (#2790)', () => {
     const head = source.match(/await withLbugDb\(\s*lbugPath,\s*async \(\) => \{/);
     expect(head).not.toBeNull();
     const start = head!.index!;
-    const end = source.indexOf('{ ...(ftsSession.skipFts', start);
+    const end = source.indexOf('skipFtsOption(ftsSession.skipFts)', start);
     expect(end).toBeGreaterThan(start);
     return source.slice(start, end);
   };


### PR DESCRIPTION
## Summary

Share the skip-FTS option object and graph/vector capability defaults so analyze, `--repair-fts`, and HTTP opens cannot stamp or open with drifted copies.

## Motivation / context

Follow-up cleanup after #3205 (`feat(analyze): add explicit FTS opt-out`). The first implementation repeated the same capability literals, `#1549` restamp error text, and `skipFts` option objects across analyze / adapter / HTTP.

## Areas touched

- [x] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [ ] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [ ] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- Export and reuse `DEFAULT_GRAPH_CAPABILITY` / `DEFAULT_VECTOR_SEARCH_CAPABILITY`
- One `ensureFtsRowDmlSafe` call with `skipFts: Boolean(ftsDisabledReason)`
- Shared `#1549` meta-write failure formatter
- Shared `skipFtsOption` + `LbugInitOptions`
- Fast-path CLI message uses `isExplicitFtsDisablement`

**Explicitly out of scope / not done here**

- Pool-adapter `skipFts` threading
- Caching `loadFtsSession`, skipping stemmer/CJK init, BM25 `!enrich` short-circuit
- Moving `loadFtsSession` into MCP or dropping the pre-import BM25 guard
- `FtsSkipReason` on repo-meta / hybridSearch API shape changes

## Implementation notes

Behavior-preserving aliases and helpers only. `readOnlyFtsOptions` stays the pinned `{ readOnly: true }` ternary so the source-scan contract in `api-readonly-wiring.test.ts` is unchanged.

## Testing & verification

- [x] `cd gitnexus && npx tsc --noEmit`
- [x] `npx vitest run test/unit/fts-policy.test.ts test/unit/api-readonly-wiring.test.ts test/unit/api-query-readonly-wiring.test.ts test/unit/api-fts-mode.test.ts test/unit/analyze-api.test.ts`
- [ ] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [ ] `cd gitnexus-web && npm test` *(if web changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*

Local parse-worker cases that spawn the analyze pool hit the existing 5s ready timeout; they are unrelated to these helper moves.

## Risk & rollout

No flag, meta schema, or HTTP contract change. Existing skip-FTS indexes keep the same open options. No index refresh required.

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a cross-cutting refactor of full-text search skip helpers and capability defaults across CLI, analysis, database adapter, and server API paths. Its CRITICAL posture comes from the breadth of connected execution paths, although no individual file is flagged as high risk.*

**🔴 CRITICAL blast radius. This appears to be a full-text search refactor across `gitnexus/src/cli/analyze.ts`, core analysis code, and `gitnexus/src/server/api.ts`, reaching direct and transitive dependents.**

The densest review point is `gitnexus/src/core/lbug/lbug-adapter.ts`, with 5 changed symbols: `readOnly`, `initLbug`, `withLbugDb`, `ensureLbugInitialized`, and `doInitLbug`. Review how those adapter lifecycle and read-only paths interact with `analyzeCommandImpl` in `gitnexus/src/cli/analyze.ts`, plus `AnalyzeResult`, `analyzeFailureMayHaveMutatedLiveIndex`, and `runFullAnalysisInner` in `gitnexus/src/core/run-analyze.ts`.

The impact spans `Cli`, `Lbug`, `Server`, `Incremental`, and `Tree-sitter`, with 30 affected flows. Pay particular attention to how `DEFAULT_GRAPH_CAPABILITY` and `DEFAULT_VECTOR_SEARCH_CAPABILITY` in `gitnexus/src/core/search/fts-policy.ts` are consumed through `loadFtsSession`, `readOnlyFtsOptions`, `handleQueryRequest`, and `createServer` in `gitnexus/src/server/api.ts`, then validated by `insideWithLbugDb` in `gitnexus/test/unit/analyze-api.test.ts`.

_Added by GitNexus for PR #3263. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->