### PR TITLE
fix(detect-changes): map whole-file deletions to indexed symbols

### DIFF
--- a/gitnexus/src/storage/git.ts
+++ b/gitnexus/src/storage/git.ts
@@ -964,12 +964,16 @@ export function parseDiffHunksResult(diffOutput: string): DiffHunkParseResult {
   // `+++` after the first `@@` of a file is hunk body (`+` plus source text
   // that itself starts `++ …`), not another file header.
   let inHunk = false;
+  // A deleted file has no new-side coordinates. Its indexed symbols still use
+  // the pre-delete file, so map those hunks with the old-side range instead.
+  let currentFileDeleted = false;
   for (const line of diffOutput.split('\n')) {
     if (line.startsWith(DIFF_GIT_PREFIX)) {
       // Drop the previous file first: an unparsed header must not leave
       // `current` live for a later `@@` / quoted `+++` to steal.
       current = null;
       inHunk = false;
+      currentFileDeleted = false;
       const filePath = filePathFromGitHeader(line);
       if (filePath) {
         current = { filePath, hunks: [] };
@@ -985,6 +989,8 @@ export function parseDiffHunksResult(diffOutput: string): DiffHunkParseResult {
         current = { filePath, hunks: [] };
         files.push(current);
       }
+    } else if (!inHunk && line === '+++ /dev/null') {
+      currentFileDeleted = true;
     } else if (!inHunk && line.startsWith('+++ ')) {
       const filePath = pathFromPlusPlusPlus(line);
       if (!filePath) continue;
@@ -994,10 +1000,12 @@ export function parseDiffHunksResult(diffOutput: string): DiffHunkParseResult {
       }
     } else if (line.startsWith('@@') && current) {
       inHunk = true;
-      const match = line.match(/@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+      const match = line.match(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
       if (match) {
-        const start = parseInt(match[1], 10);
-        const count = match[2] !== undefined ? parseInt(match[2], 10) : 1;
+        const sideOffset = currentFileDeleted ? 1 : 3;
+        const start = parseInt(match[sideOffset], 10);
+        const rawCount = match[sideOffset + 1];
+        const count = rawCount !== undefined ? parseInt(rawCount, 10) : 1;
         if (count > 0) {
           current.hunks.push({ startLine: start, endLine: start + count - 1 });
         } else {

--- a/gitnexus/test/unit/parse-diff-hunks.test.ts
+++ b/gitnexus/test/unit/parse-diff-hunks.test.ts
@@ -93,6 +93,20 @@ describe('parseDiffHunks', () => {
     expect(result[0].hunks).toEqual([{ startLine: 1, endLine: 1 }]);
   });
 
+  it('maps a whole-file deletion to the old-side range', () => {
+    const diff = [
+      'diff --git a/src/deleted.ts b/src/deleted.ts',
+      'deleted file mode 100644',
+      '--- a/src/deleted.ts',
+      '+++ /dev/null',
+      '@@ -1,9 +0,0 @@',
+      '-export function removed() {}',
+    ].join('\n');
+    expect(parseDiffHunks(diff)).toEqual([
+      { filePath: 'src/deleted.ts', hunks: [{ startLine: 1, endLine: 9 }] },
+    ]);
+  });
+
   it('returns empty array for empty diff output', () => {
     expect(parseDiffHunks('')).toEqual([]);
   });


### PR DESCRIPTION
## Summary

- detect `+++ /dev/null` before parsing deletion hunks
- use the old-side range for whole-file deletions so indexed symbols remain addressable
- add a focused parser regression for the deletion-only diff shape

Closes #3268

## Validation

- `cd gitnexus && npx vitest run test/unit/parse-diff-hunks.test.ts` — 24 passed
- `cd gitnexus && npx tsc --noEmit` — passed
- `git diff --check` — passed

Prettier could not run in the fresh clone because the repository config imports `prettier-plugin-tailwindcss`, which is not installed by the CLI package setup.

## Risk

Low and limited to deletion-only hunks. Ordinary additions, edits, and partial deletions keep their existing new-side/anchor mapping.

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a focused storage and diff parsing change with a critical transitive reach into command line, server, local, integration, and MCP areas. Review should center on deleted file handling and the accompanying parser test coverage.*

**🔴 CRITICAL blast radius. A change to `parseDiffHunksResult` in `gitnexus/src/storage/git.ts` reaches outward through multiple caller layers despite touching only storage parsing code and its unit test.**

The change is concentrated in `gitnexus/src/storage/git.ts`, with coverage updated in `gitnexus/test/unit/parse-diff-hunks.test.ts`. Start by reviewing how `parseDiffHunksResult` maps deletion diff hunks to indexed symbols, then verify the test cases exercise the relevant deleted file ranges.

Its impact spans 18 dependents and 31 affected flows, landing most heavily in `Cli` and also reaching `Storage`, `Mcp`, `Server`, `Local`, and `Integration`. The file level risk is LOW, with no HIGH or CRITICAL risk files identified.

_Added by GitNexus for PR #3269. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->