### PR TITLE
fix(parse-cache): retire a chunk whose durable generation could not be reset

### DIFF
--- a/gitnexus/scripts/cross-platform-tests.ts
+++ b/gitnexus/scripts/cross-platform-tests.ts
@@ -290,6 +290,11 @@ const NATIVE_ADDON_SMOKE = [
 // Filesystem behavior tests — exercise operations that vary across
 // platforms (CRLF, symlinks, permissions, temp dirs)
 const FILESYSTEM = [
+  // The durable ParsedFile store's prune tolerates a chunk directory it cannot
+  // delete (#3204). The failures that motivate it — held handles, read-only
+  // mounts — are Windows- and macOS-flavored, and the permission-based case
+  // skips itself where chmod cannot block a delete, so run it everywhere.
+  'test/unit/parsedfile-store.test.ts',
   'test/integration/filesystem-walker.test.ts',
   'test/integration/watch-filesystem.test.ts',
   'test/integration/markdown-processor-crlf.test.ts',

--- a/gitnexus/src/core/ingestion/pipeline-phases/parse-impl.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/parse-impl.ts
@@ -937,6 +937,22 @@ export async function runChunkedParseAndResolve(
      */
     const durablePrepareFailures = new Set<string>();
 
+    /**
+     * Retire a chunk hash this run cannot vouch for (#3204). Skipping the
+     * parse-cache write is not enough on its own: the hash is already in
+     * `usedKeys` from the lookup, so `saveParseCache` would copy a
+     * pre-existing `.v8` forward and the durable prune — which keeps exactly
+     * the saved keys — would retain the directory it belongs to.
+     */
+    const retireChunkHash = (chunkHash: string): void => {
+      if (!parseCache) return;
+      (parseCache.staleKeys ??= new Set<string>()).add(chunkHash);
+      // `loadParseCacheChunk` reads these two, so clear them as well: a second
+      // lookup of the same hash in this run must not serve the old shard.
+      parseCache.entries.delete(chunkHash);
+      parseCache.onDiskKeys?.delete(chunkHash);
+    };
+
     const roundByteBudget = resolveParseRoundByteBudget(options);
     let roundEntries: RoundEntry[] = [];
     /**
@@ -1073,7 +1089,11 @@ export async function runChunkedParseAndResolve(
       // Persist raw results for this chunk hash (skipping when any chunk file
       // was worker-quarantined, so the narrower rawResults isn't cached under
       // the full-chunk key — see the original inline note / U20.U2).
-      if (parseCache && p.chunkHash && rawResults.length > 0) {
+      // `rawResults.length > 0` guards the WRITE only. A quarantined chunk
+      // often returns nothing at all (the worker died on it), and that chunk
+      // still has to be retired — otherwise its pre-existing `.v8` is copied
+      // forward at save time (#3204).
+      if (parseCache && p.chunkHash) {
         const quarantineSet = new Set(workerPool?.getQuarantinedPaths?.() ?? []);
         const chunkHadQuarantine = p.chunkFiles.some((f) => quarantineSet.has(f.path));
         const durableGenerationStale = durablePrepareFailures.has(p.chunkHash);
@@ -1084,6 +1104,10 @@ export async function runChunkedParseAndResolve(
               'so its shards may be stale; next run will re-dispatch it',
           );
         } else if (chunkHadQuarantine) {
+          // Same retirement as a failed reset: skipping the write leaves any
+          // pre-existing `.v8` to be copied forward, and its durable directory
+          // now holds only this run's narrower shards (#3204).
+          retireChunkHash(p.chunkHash);
           if (isDev) {
             const quarantinedInChunk = p.chunkFiles.filter((f) => quarantineSet.has(f.path)).length;
             logger.info(
@@ -1092,7 +1116,7 @@ export async function runChunkedParseAndResolve(
                 `next run will rediscover (${p.chunkHash.slice(0, 8)})`,
             );
           }
-        } else {
+        } else if (rawResults.length > 0) {
           await persistParseCacheChunk(parseCache, p.chunkHash, rawResults);
           if (isDev) {
             logger.info(
@@ -1142,6 +1166,10 @@ export async function runChunkedParseAndResolve(
             // directory on write, so at worst the old generation lingers.
             // Caught per chunk so one failure cannot abort the others.
             durablePrepareFailures.add(miss.chunkHash);
+            // Retire here, not at finalize: that branch sits behind
+            // `rawResults.length > 0`, so a chunk whose worker round returns
+            // nothing would keep its stale entry.
+            retireChunkHash(miss.chunkHash);
             logger.warn(
               { err, chunkHash: miss.chunkHash.slice(0, 8) },
               'parsedfile-cache: could not reset durable chunk generation; ' +

--- a/gitnexus/src/core/ingestion/pipeline-phases/parse-impl.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/parse-impl.ts
@@ -934,9 +934,10 @@ export async function runChunkedParseAndResolve(
      * Chunk hashes whose durable ParsedFile directory could not be reset. The
      * old generation's shards are still on disk, so a warm hit would union
      * stale shards with the new ones. Treated exactly like a quarantined chunk:
-     * skip the parse-cache write AND retire the hash (#3204), so neither the
-     * old `.v8` nor the durable directory survives the save and the next run
-     * re-dispatches into a clean directory. Kept as its own set rather than
+     * skip the parse-cache write AND, when shards from that generation are
+     * still on disk, retire the hash (#3204): the old `.v8` is not carried
+     * forward and the directory is dropped from the durable index, so the next
+     * run re-dispatches. Kept as its own set rather than
      * read back off `staleKeys`, which is a superset — it is what selects the
      * warn below over the quarantine branch's dev-only log.
      */

--- a/gitnexus/src/core/ingestion/pipeline-phases/parse-impl.ts
+++ b/gitnexus/src/core/ingestion/pipeline-phases/parse-impl.ts
@@ -26,6 +26,7 @@ import {
   computeChunkHash,
   loadParseCacheChunk,
   persistParseCacheChunk,
+  markParseCacheChunkStale,
   PARSE_CACHE_VERSION,
   packParseCacheChunks,
 } from '../../../storage/parse-cache.js';
@@ -37,6 +38,7 @@ import {
   loadDurableParsedFileIndex,
   prepareDurableParsedFileChunk,
   durableChunkHasShards,
+  durableChunkHasStaleShards,
 } from '../../../storage/parsedfile-store.js';
 import type { ParseWorkerResult } from '../workers/parse-worker.js';
 import { DEFAULT_PDG_MAX_FUNCTION_LINES } from '../cfg/collect.js';
@@ -932,26 +934,13 @@ export async function runChunkedParseAndResolve(
      * Chunk hashes whose durable ParsedFile directory could not be reset. The
      * old generation's shards are still on disk, so a warm hit would union
      * stale shards with the new ones. Treated exactly like a quarantined chunk:
-     * skip the parse-cache write so the next run re-dispatches into a clean
-     * directory rather than trusting a generation we could not clear.
+     * skip the parse-cache write AND retire the hash (#3204), so neither the
+     * old `.v8` nor the durable directory survives the save and the next run
+     * re-dispatches into a clean directory. Kept as its own set rather than
+     * read back off `staleKeys`, which is a superset — it is what selects the
+     * warn below over the quarantine branch's dev-only log.
      */
     const durablePrepareFailures = new Set<string>();
-
-    /**
-     * Retire a chunk hash this run cannot vouch for (#3204). Skipping the
-     * parse-cache write is not enough on its own: the hash is already in
-     * `usedKeys` from the lookup, so `saveParseCache` would copy a
-     * pre-existing `.v8` forward and the durable prune — which keeps exactly
-     * the saved keys — would retain the directory it belongs to.
-     */
-    const retireChunkHash = (chunkHash: string): void => {
-      if (!parseCache) return;
-      (parseCache.staleKeys ??= new Set<string>()).add(chunkHash);
-      // `loadParseCacheChunk` reads these two, so clear them as well: a second
-      // lookup of the same hash in this run must not serve the old shard.
-      parseCache.entries.delete(chunkHash);
-      parseCache.onDiskKeys?.delete(chunkHash);
-    };
 
     const roundByteBudget = resolveParseRoundByteBudget(options);
     let roundEntries: RoundEntry[] = [];
@@ -1104,10 +1093,10 @@ export async function runChunkedParseAndResolve(
               'so its shards may be stale; next run will re-dispatch it',
           );
         } else if (chunkHadQuarantine) {
-          // Same retirement as a failed reset: skipping the write leaves any
-          // pre-existing `.v8` to be copied forward, and its durable directory
-          // now holds only this run's narrower shards (#3204).
-          retireChunkHash(p.chunkHash);
+          // This chunk's durable directory now holds only this run's NARROWER
+          // shards, so a warm hit would replay the full-coverage `.v8` over
+          // partial ParsedFiles (#3204).
+          markParseCacheChunkStale(parseCache, p.chunkHash);
           if (isDev) {
             const quarantinedInChunk = p.chunkFiles.filter((f) => quarantineSet.has(f.path)).length;
             logger.info(
@@ -1166,10 +1155,22 @@ export async function runChunkedParseAndResolve(
             // directory on write, so at worst the old generation lingers.
             // Caught per chunk so one failure cannot abort the others.
             durablePrepareFailures.add(miss.chunkHash);
-            // Retire here, not at finalize: that branch sits behind
+            // Retire ONLY when a generation nobody cleared is still on disk.
+            // `prepareDurableParsedFileChunk` is rm-then-mkdir: an rm failure
+            // leaves the old shards to be unioned into a warm hit, but an rm
+            // that succeeded before a failing mkdir leaves nothing — the
+            // workers recreate the directory and write a clean generation, so
+            // retiring there would discard a good `.v8` for no safety gain
+            // (and a correlated burst would discard the whole shared cache).
+            // Retire here rather than at finalize: that branch sits behind
             // `rawResults.length > 0`, so a chunk whose worker round returns
             // nothing would keep its stale entry.
-            retireChunkHash(miss.chunkHash);
+            if (
+              parseCache &&
+              (await durableChunkHasStaleShards(durableParsedFileDir, miss.chunkHash))
+            ) {
+              markParseCacheChunkStale(parseCache, miss.chunkHash);
+            }
             logger.warn(
               { err, chunkHash: miss.chunkHash.slice(0, 8) },
               'parsedfile-cache: could not reset durable chunk generation; ' +

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -4304,9 +4304,10 @@ async function runFullAnalysisInner(
       // Prune the durable ParsedFile store to EXACTLY the parse cache's
       // surviving keys (#2038 warm-cache coverage), so the two content-addressed
       // stores stay coherent: a chunk is "cached" iff both its parse-cache shard
-      // and its durable shards exist. A quarantined chunk (in usedKeys but with
-      // no parse-cache shard) drops its durable subdir here and re-dispatches
-      // next run. Same try/catch — a durable-store write failure must never
+      // and its durable shards exist. A retired chunk — worker-quarantined, or
+      // one whose durable generation could not be reset (#3204) — is filtered
+      // out of `savedKeys`, so it drops its durable subdir here and
+      // re-dispatches next run. Same try/catch — a durable-store write must never
       // break an otherwise successful run (next run treats it as a miss).
       await mergeStagedDurableParsedFileStore(
         storagePath,

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -4305,9 +4305,10 @@ async function runFullAnalysisInner(
       // surviving keys (#2038 warm-cache coverage), so the two content-addressed
       // stores stay coherent: a chunk is "cached" iff both its parse-cache shard
       // and its durable shards exist. A retired chunk — worker-quarantined, or
-      // one whose durable generation could not be reset (#3204) — is filtered
-      // out of `savedKeys`, so it drops its durable subdir here and
-      // re-dispatches next run. Same try/catch — a durable-store write must never
+      // one whose failed durable reset left an uncleared generation behind
+      // (#3204) — is filtered out of `savedKeys`, so it drops out of the
+      // durable index here and re-dispatches next run. Same try/catch — a
+      // durable-store write must never
       // break an otherwise successful run (next run treats it as a miss).
       await mergeStagedDurableParsedFileStore(
         storagePath,

--- a/gitnexus/src/storage/parse-cache.ts
+++ b/gitnexus/src/storage/parse-cache.ts
@@ -1135,6 +1135,24 @@ export const persistParseCacheChunk = async (
   cache.entries.set(chunkHash, slim);
 };
 
+/**
+ * Retire a chunk this run cannot vouch for — its durable ParsedFile generation
+ * could not be reset, or its chunk was worker-quarantined (#3204).
+ *
+ * `saveParseCache` refuses a stale key, so no pre-existing `.v8` is copied
+ * forward and the durable store — pruned to exactly the keys that save
+ * returns — drops the chunk in the same step. The two deletes matter because
+ * `loadParseCacheChunk` reads `entries` and `onDiskKeys` and does NOT consult
+ * `staleKeys`: without them a second lookup of the same hash inside this run
+ * would still serve the retired shard.
+ */
+export const markParseCacheChunkStale = (cache: ParseCache, chunkHash: string): void => {
+  cache.staleKeys ??= new Set<string>();
+  cache.staleKeys.add(chunkHash);
+  cache.entries.delete(chunkHash);
+  cache.onDiskKeys?.delete(chunkHash);
+};
+
 const loadLegacyParseCache = async (storagePath: string): Promise<ParseCache> => {
   const cachePath = getLegacyCachePath(storagePath);
   try {

--- a/gitnexus/src/storage/parse-cache.ts
+++ b/gitnexus/src/storage/parse-cache.ts
@@ -897,6 +897,16 @@ export interface ParseCache {
    */
   usedKeys: Set<string>;
   /**
+   * Hashes this run decided it cannot vouch for — its durable generation could
+   * not be reset, or its chunk was worker-quarantined (#3204). `saveParseCache`
+   * refuses them, so neither a pre-existing `.v8` nor the chunk's durable
+   * directory survives into the next run. Kept separate from `usedKeys`
+   * because the orchestrator re-adds keys to that set after the parse phase
+   * (#2106 sibling fold), which would undo a deletion.
+   * Transient — never serialized to disk.
+   */
+  staleKeys?: Set<string>;
+  /**
    * When set, chunk payloads are loaded from / flushed to sharded files on
    * demand instead of retaining every chunk in `entries` for the whole run
    * (#1983 — Linux kernel OOM from duplicate in-memory cache + graph).
@@ -1210,7 +1220,14 @@ export const saveParseCache = async (storagePath: string, cache: ParseCache): Pr
   await fs.rm(tmpDir, { recursive: true, force: true });
   await fs.mkdir(tmpDir, { recursive: true });
 
-  const keys = [...cache.usedKeys].filter(isValidChunkCacheKey).sort();
+  // A stale key is dropped here rather than at the failure site: the
+  // orchestrator folds sibling-branch keys back into `usedKeys` after the parse
+  // phase (#2106), so this is the last point that sees the final key set. The
+  // exclusion also reaches the durable store, which prunes to the keys this
+  // function returns — both stores drop the chunk together (#3204).
+  const keys = [...cache.usedKeys]
+    .filter((key) => isValidChunkCacheKey(key) && !cache.staleKeys?.has(key))
+    .sort();
   // Track hashes whose shard was actually written/copied this save. A hash can
   // be in `usedKeys` without a backing shard — its in-memory serialize threw, or
   // its on-disk copy failed/was-absent (e.g. a worker-quarantined chunk added to

--- a/gitnexus/src/storage/parsedfile-store.ts
+++ b/gitnexus/src/storage/parsedfile-store.ts
@@ -771,7 +771,20 @@ export const pruneAndSaveDurableParsedFileStore = async (
         /* not a readable dir → drop below */
       }
     }
-    await fs.rm(full, { recursive: true, force: true });
+    // The causes that break `prepareDurableParsedFileChunk` — permissions, a
+    // locked file, a read-only mount — break this rm too (#3204). Dropping the
+    // entry from the index is what makes the chunk unreachable; losing the
+    // directory is a cleanup bonus. Never let one of them abort the loop and
+    // cost every remaining chunk its index entry.
+    try {
+      await fs.rm(full, { recursive: true, force: true });
+    } catch (err) {
+      logger.warn(
+        { err, chunkHash: name },
+        'parsedfile-cache: could not remove a pruned durable chunk directory; ' +
+          'it is excluded from the index and will be re-attempted next run',
+      );
+    }
   }
   const idx: DurableParsedFileIndex = { version, entries: survivors };
   const tmp = path.join(durableDir, `${DURABLE_INDEX_FILENAME}.tmp`);

--- a/gitnexus/src/storage/parsedfile-store.ts
+++ b/gitnexus/src/storage/parsedfile-store.ts
@@ -620,6 +620,22 @@ export const prepareDurableParsedFileChunk = async (
 };
 
 /**
+ * Does this chunk still hold shards from a generation nobody cleared?
+ *
+ * Asked only after {@link prepareDurableParsedFileChunk} rejected, to tell its
+ * two failure modes apart (#3204). The `rm` failing leaves the previous
+ * generation in place, and a warm hit would union it with whatever this run's
+ * workers write — that chunk must be retired. The `rm` succeeding and the
+ * `mkdir` then failing leaves NO directory: the workers recreate it and write
+ * a clean generation, so retiring would throw away a good cache entry for
+ * nothing. Absent or empty ⇒ nothing to distrust.
+ */
+export const durableChunkHasStaleShards = async (
+  durableDir: string,
+  chunkHash: string,
+): Promise<boolean> => (await listV8Shards(durableChunkDir(durableDir, chunkHash))).length > 0;
+
+/**
  * Synchronous durable-shard writer for use INSIDE a parse worker, alongside
  * {@link persistParsedFileShardSync}. Writes the SAME bytes to a content-addressed
  * durable location keyed by the parse chunk hash so a future warm hit can reuse
@@ -728,8 +744,9 @@ export const loadDurableParsedFileIndex = async (
  * Prune the durable store to `keepKeys` and rewrite its index. `keepKeys` must
  * be the parse cache's surviving on-disk keys (so the two stores stay coherent:
  * a chunk is "cached" iff BOTH its parse-cache shard and its durable shards
- * exist; a quarantined chunk — no parse-cache shard — drops its durable subdir
- * here and re-dispatches next run). Only chunks whose envelopes all validate
+ * exist; a chunk retired by `markParseCacheChunkStale` — worker-quarantined, or
+ * holding a durable generation that could not be reset — is absent from
+ * `keepKeys`, so it drops its durable subdir here and re-dispatches next run). Only chunks whose envelopes all validate
  * are indexed, together with their exact persisted path coverage (never vouch
  * for a missing/corrupt shard). The index write is tmp+rename atomic.
  */
@@ -745,6 +762,8 @@ export const pruneAndSaveDurableParsedFileStore = async (
     return; // nothing written this run
   }
   const survivors: Record<string, string[]> = {};
+  const undeletable: string[] = [];
+  let firstRemoveError: unknown;
   for (const name of entries) {
     if (name === DURABLE_INDEX_FILENAME) continue;
     const full = path.join(durableDir, name);
@@ -779,12 +798,21 @@ export const pruneAndSaveDurableParsedFileStore = async (
     try {
       await fs.rm(full, { recursive: true, force: true });
     } catch (err) {
-      logger.warn(
-        { err, chunkHash: name },
-        'parsedfile-cache: could not remove a pruned durable chunk directory; ' +
-          'it is excluded from the index and will be re-attempted next run',
-      );
+      // `name` reached the drop branch precisely because it is not a live
+      // chunk key, so it may be any stray directory — report it as an entry.
+      undeletable.push(name);
+      firstRemoveError ??= err;
     }
+  }
+  if (undeletable.length > 0) {
+    // One line per RUN, not per directory: a store-wide cause (read-only mount,
+    // wrong ownership) hits every non-survivor, and thousands of warns would
+    // bury the message that matters.
+    logger.warn(
+      { err: firstRemoveError, count: undeletable.length, firstEntry: undeletable[0] },
+      'parsedfile-cache: could not remove pruned durable chunk directories; ' +
+        'they are excluded from the index and will be re-attempted next run',
+    );
   }
   const idx: DurableParsedFileIndex = { version, entries: survivors };
   const tmp = path.join(durableDir, `${DURABLE_INDEX_FILENAME}.tmp`);
@@ -823,7 +851,20 @@ export const mergeStagedDurableParsedFileStore = async (
     if (name === DURABLE_INDEX_FILENAME) continue;
     const from = path.join(stagedDir, name);
     const to = path.join(liveDir, name);
-    await replaceDurableChunkDir(from, to);
+    // Same reasoning as the prune's per-entry guard, on the loop that runs
+    // BEFORE it (#3204): this overlay targets the same live chunk directories,
+    // so the causes that break a reset break a replacement too. Letting one
+    // throw here would skip the prune entirely — the durable index would not be
+    // rewritten this run, and a retired chunk would keep its directory.
+    try {
+      await replaceDurableChunkDir(from, to);
+    } catch (err) {
+      logger.warn(
+        { err, entry: name },
+        'parsedfile-cache: could not publish a staged durable chunk; ' +
+          'it stays uncached and will re-dispatch next run',
+      );
+    }
   }
   await pruneAndSaveDurableParsedFileStore(liveDir, version, keepKeys);
 };
@@ -837,7 +878,9 @@ const replaceDurableChunkDir = async (from: string, to: string): Promise<void> =
     /* dest exists, or the rename is cross-device */
   }
   const backup = `${to}.replacing`;
-  await fs.rm(backup, { recursive: true, force: true });
+  // Best-effort: a leftover backup that cannot be deleted must not fail an
+  // otherwise-publishable replacement — the rename below overwrites it (#3204).
+  await fs.rm(backup, { recursive: true, force: true }).catch(() => {});
   let backedUp = false;
   try {
     await fs.rename(to, backup);
@@ -860,6 +903,8 @@ const replaceDurableChunkDir = async (from: string, to: string): Promise<void> =
     throw err;
   }
   if (backedUp) {
-    await fs.rm(backup, { recursive: true, force: true });
+    // The new generation is already in place; an undeletable backup is litter,
+    // not a failure. The next prune re-attempts it.
+    await fs.rm(backup, { recursive: true, force: true }).catch(() => {});
   }
 };

--- a/gitnexus/src/storage/parsedfile-store.ts
+++ b/gitnexus/src/storage/parsedfile-store.ts
@@ -878,9 +878,13 @@ const replaceDurableChunkDir = async (from: string, to: string): Promise<void> =
     /* dest exists, or the rename is cross-device */
   }
   const backup = `${to}.replacing`;
-  // Best-effort: a leftover backup that cannot be deleted must not fail an
-  // otherwise-publishable replacement — the rename below overwrites it (#3204).
-  await fs.rm(backup, { recursive: true, force: true }).catch(() => {});
+  // Deliberately NOT best-effort. If a non-empty backup survives, the
+  // `fs.rename(to, backup)` below cannot overwrite it and is swallowed as
+  // "dest was missing", so the `fs.cp` fallback would merge the staged
+  // generation INTO the live directory — manufacturing exactly the old+new
+  // union this fix exists to prevent. Let it throw; the caller's per-entry
+  // guard keeps one such chunk from costing the others their prune.
+  await fs.rm(backup, { recursive: true, force: true });
   let backedUp = false;
   try {
     await fs.rename(to, backup);

--- a/gitnexus/test/integration/parse-impl-quarantine-cache-skip.test.ts
+++ b/gitnexus/test/integration/parse-impl-quarantine-cache-skip.test.ts
@@ -78,6 +78,7 @@ import {
   fileContentHash,
   packParseCacheChunks,
 } from '../../src/storage/parse-cache.js';
+import type { ParseCache } from '../../src/storage/parse-cache.js';
 import type { ParseWorkerResult } from '../../src/core/ingestion/workers/parse-worker.js';
 
 /**
@@ -257,7 +258,7 @@ describe('U20: parse-impl quarantine + chunk-cache integration (PR #1693 Codex f
 
     const expectedChunkHash = hashPacks(scanned).poison;
 
-    const parseCache = {
+    const parseCache: ParseCache = {
       version: 'test',
       entries: new Map<string, ParseWorkerResult[]>(),
       usedKeys: new Set<string>(),
@@ -323,6 +324,9 @@ describe('U20: parse-impl quarantine + chunk-cache integration (PR #1693 Codex f
     // against a fresh-quarantine pool.
     expect(parseCache.entries.has(expectedChunkHash)).toBe(false);
     expect(parseCache.usedKeys.has(expectedChunkHash)).toBe(true);
+    // #3204: `usedKeys` alone would let `saveParseCache` copy a pre-existing
+    // shard forward, so the skipped chunk is also retired from the save.
+    expect(parseCache.staleKeys?.has(expectedChunkHash)).toBe(true);
     for (const hash of hashPacks(scanned).others) {
       expect(parseCache.entries.has(hash)).toBe(true);
     }
@@ -338,7 +342,7 @@ describe('U20: parse-impl quarantine + chunk-cache integration (PR #1693 Codex f
     }));
     const expectedChunkHash = hashPacks(scanned).poison;
 
-    const parseCache = {
+    const parseCache: ParseCache = {
       version: 'test',
       entries: new Map<string, ParseWorkerResult[]>(),
       usedKeys: new Set<string>(),

--- a/gitnexus/test/unit/parse-impl-warm-cache-parsedfile-coverage.test.ts
+++ b/gitnexus/test/unit/parse-impl-warm-cache-parsedfile-coverage.test.ts
@@ -662,9 +662,19 @@ describe('parse-impl warm-cache ParsedFile coverage (#2038)', () => {
     expect(warm.staleKeys?.has(aHash)).toBe(true);
     expect(warm.staleKeys?.has(bHash) ?? false).toBe(false);
 
-    const third = (await loadParseCache(storageDir)) as ParseCache;
-    expect(third.onDiskKeys?.has(aHash)).toBe(false);
-    expect(third.onDiskKeys?.has(bHash)).toBe(true);
+    // Actually perform the next run. An index entry alone does not exercise the
+    // warm-hit/coherence path, so the claim in the title has to be paid for.
+    // Run each chunk on its own so the single global spawn marker is
+    // unambiguous about WHICH chunk re-dispatched.
+    const bOnly = (await loadParseCache(storageDir)) as ParseCache;
+    fs.rmSync(markerPath, { force: true });
+    await run(bOnly, [b], 1);
+    expect(fs.existsSync(markerPath)).toBe(false); // sibling served warm
+
+    const aOnly = (await loadParseCache(storageDir)) as ParseCache;
+    fs.rmSync(markerPath, { force: true });
+    await run(aOnly, [a], 1);
+    expect(fs.existsSync(markerPath)).toBe(true); // retired chunk re-parsed
   });
 
   it('retains worker ParsedFiles when the main-thread run-store write fails', async () => {

--- a/gitnexus/test/unit/parse-impl-warm-cache-parsedfile-coverage.test.ts
+++ b/gitnexus/test/unit/parse-impl-warm-cache-parsedfile-coverage.test.ts
@@ -34,8 +34,10 @@ import { pathToFileURL } from 'node:url';
 
 // Partial mock: lets one test make prepareDurableParsedFileChunk fail without
 // touching the worker-side persist path (which shares the same directory).
+// Receives the chunk hash so a test can fail the reset for ONE chunk while its
+// siblings reset normally — the shape a correlated-vs-isolated failure needs.
 const prepareOverride = vi.hoisted(() => ({
-  impl: undefined as undefined | (() => Promise<void>),
+  impl: undefined as undefined | ((durableDir: string, chunkHash: string) => Promise<void>),
 }));
 const persistOverride = vi.hoisted(() => ({
   impl: undefined as undefined | (() => Promise<boolean>),
@@ -46,7 +48,7 @@ vi.mock('../../src/storage/parsedfile-store.js', async (importOriginal) => {
     ...real,
     prepareDurableParsedFileChunk: (durableDir: string, chunkHash: string) =>
       prepareOverride.impl
-        ? prepareOverride.impl()
+        ? prepareOverride.impl(durableDir, chunkHash)
         : real.prepareDurableParsedFileChunk(durableDir, chunkHash),
     persistParsedFileChunk: (
       storagePath: string,
@@ -78,6 +80,7 @@ import {
   clearParsedFileStore,
 } from '../../src/storage/parsedfile-store.js';
 import type { ParseWorkerResult } from '../../src/core/ingestion/workers/parse-worker.js';
+import type { ParseCache } from '../../src/storage/parse-cache.js';
 import type { ParsedFile } from 'gitnexus-shared';
 
 // A structurally-minimal ParsedFile. `loadParsedFilesForPaths` keys on
@@ -309,7 +312,7 @@ describe('parse-impl warm-cache ParsedFile coverage (#2038)', () => {
     return { path: rel, size: fs.statSync(full).size };
   };
 
-  const newCache = () => ({
+  const newCache = (): ParseCache => ({
     version: PARSE_CACHE_VERSION,
     entries: new Map<string, ParseWorkerResult[]>(),
     usedKeys: new Set<string>(),
@@ -485,7 +488,14 @@ describe('parse-impl warm-cache ParsedFile coverage (#2038)', () => {
       'export function readded() { return 1; }\n',
     );
 
+    // Model both merges: the sibling fold re-adds the key, and the
+    // unreadable-meta fallback unions `entries.keys()` back into `usedKeys`.
+    // Either one would resurrect the chunk if invalidation were a deletion
+    // from `usedKeys` instead of a filter at save time.
     warm.usedKeys.add(chunkHash);
+    warm.entries.set(chunkHash, [] as unknown as ParseWorkerResult[]);
+    warm.onDiskKeys?.add(chunkHash);
+    for (const key of warm.entries.keys()) warm.usedKeys.add(key);
 
     const { saveParseCache } = await import('../../src/storage/parse-cache.js');
     const saved = await saveParseCache(storageDir, warm);
@@ -494,18 +504,75 @@ describe('parse-impl warm-cache ParsedFile coverage (#2038)', () => {
     expect(readSavedIndexKeys()).not.toContain(chunkHash);
   });
 
-  it('marks the chunk stale at reset-failure time, not at parse-cache write time', async () => {
-    // The write guard is `if (parseCache && p.chunkHash && rawResults.length > 0)`,
-    // so a failed chunk whose worker round returns nothing would never be marked
-    // there. The marking belongs at the failure site, which always runs.
+  it('retires the chunk when the failed reset left the old generation on disk', async () => {
     const { chunkHash, warm } = await seedThenFailReset(
       'src/stale-marking-site.ts',
       'export function marked() { return 1; }\n',
     );
 
     expect(warm.staleKeys?.has(chunkHash)).toBe(true);
-    expect(warm.entries.has(chunkHash)).toBe(false);
-    expect(warm.onDiskKeys.has(chunkHash)).toBe(false);
+    // `onDiskKeys` carried this hash from the loaded index, so clearing it is
+    // observable; `entries` is empty on the sharded path, which is why the
+    // in-memory half is proved by the legacy-cache case below instead.
+    expect(warm.onDiskKeys?.has(chunkHash)).toBe(false);
+  });
+
+  it('clears an in-memory entry for a retired chunk', async () => {
+    // `markParseCacheChunkStale` also drops `entries`, which only matters for a
+    // legacy (non-sharded) cache whose payloads live in memory. Drive the
+    // helper directly — the sharded pipeline never populates `entries`, so the
+    // pipeline test above cannot observe this half.
+    const { markParseCacheChunkStale, saveParseCache } =
+      await import('../../src/storage/parse-cache.js');
+    const cache = newCache();
+    const chunkHash = 'a'.repeat(64);
+    cache.entries.set(chunkHash, [] as unknown as ParseWorkerResult[]);
+    cache.onDiskKeys?.add(chunkHash);
+    cache.usedKeys.add(chunkHash);
+
+    markParseCacheChunkStale(cache, chunkHash);
+
+    expect(cache.entries.has(chunkHash)).toBe(false);
+    expect(cache.onDiskKeys?.has(chunkHash)).toBe(false);
+    expect(await saveParseCache(storageDir, cache)).not.toContain(chunkHash);
+  });
+
+  it('does NOT retire a chunk when the failed reset left no old generation', async () => {
+    // `prepareDurableParsedFileChunk` is rm-then-mkdir. When the rm succeeded
+    // and the mkdir failed there is nothing stale to protect against — the
+    // workers recreate the directory and write a clean generation — so
+    // retiring would throw away a good cache entry. Only an rm failure, which
+    // leaves shards behind, justifies retirement.
+    const source = 'export function mkdirOnly() { return 1; }\n';
+    const file = writeFile('src/mkdir-only.ts', source);
+    const chunkHash = computeChunkHash([
+      { filePath: file.path, contentHash: fileContentHash(source) },
+    ]);
+    const cold = newCache();
+    await run(cold, [file]);
+    await persistCaches(cold);
+
+    // Corrupt a shard so the coherence gate re-dispatches, then model the
+    // rm-succeeded/mkdir-failed shape: the directory is gone when prepare throws.
+    const chunkDir = path.join(getDurableParsedFileDir(storageDir), chunkHash);
+    const shard = fs.readdirSync(chunkDir).find((name) => name.endsWith('.v8'));
+    if (!shard) throw new Error('expected a durable shard to corrupt');
+    fs.writeFileSync(path.join(chunkDir, shard), Buffer.from([0, 1, 2]));
+
+    const { loadParseCache, saveParseCache } = await import('../../src/storage/parse-cache.js');
+    const warm = (await loadParseCache(storageDir)) as ParseCache;
+    prepareOverride.impl = async (durableDir, hash) => {
+      fs.rmSync(path.join(durableDir, hash), { recursive: true, force: true });
+      throw new Error('EMFILE: simulated mkdir failure after a clean rm');
+    };
+    try {
+      await run(warm, [file]);
+    } finally {
+      prepareOverride.impl = undefined;
+    }
+
+    expect(warm.staleKeys?.has(chunkHash) ?? false).toBe(false);
+    expect(await saveParseCache(storageDir, warm)).toContain(chunkHash);
   });
 
   it('still saves a chunk whose durable generation reset succeeded', async () => {
@@ -524,6 +591,17 @@ describe('parse-impl warm-cache ParsedFile coverage (#2038)', () => {
 
     expect(saved).toContain(chunkHash);
     expect(cache.staleKeys?.has(chunkHash) ?? false).toBe(false);
+    expect(fs.existsSync(path.join(storageDir, 'parse-cache', `${chunkHash}.v8`))).toBe(true);
+    const { loadDurableParsedFileIndex: loadIdx } =
+      await import('../../src/storage/parsedfile-store.js');
+    await pruneAndSaveDurableParsedFileStore(
+      getDurableParsedFileDir(storageDir),
+      PARSE_CACHE_VERSION,
+      new Set(saved),
+    );
+    expect(
+      (await loadIdx(getDurableParsedFileDir(storageDir), PARSE_CACHE_VERSION)).has(chunkHash),
+    ).toBe(true);
   });
 
   it('re-dispatches on the run after a failed reset instead of taking a warm hit', async () => {
@@ -541,6 +619,52 @@ describe('parse-impl warm-cache ParsedFile coverage (#2038)', () => {
     await run(third, [file]);
 
     expect(fs.existsSync(markerPath)).toBe(true);
+  });
+
+  it('retires only the failing chunk — a sibling chunk stays warm through the next run', async () => {
+    // The single-chunk tests cannot tell "retires the failing chunk" from
+    // "retires everything": one chunk plus a global spawn marker look the same
+    // either way. Two chunks, one failure, and a per-chunk assertion can.
+    const aSrc = 'export function a() { return 1; }\n';
+    const bSrc = 'export function b() { return 2; }\n';
+    const a = writeFile('src/a.ts', aSrc);
+    const b = writeFile('src/b.ts', bSrc);
+    const hashOf = (rel: string, src: string): string =>
+      computeChunkHash([{ filePath: rel, contentHash: fileContentHash(src) }]);
+    const aHash = hashOf(a.path, aSrc);
+    const bHash = hashOf(b.path, bSrc);
+
+    // chunkByteBudget 1 forces one file per chunk, so a and b hash distinctly.
+    const cold = newCache();
+    await run(cold, [a, b], 1);
+    await persistCaches(cold);
+
+    // Corrupt only a's durable shard: a re-dispatches, b still hits warm.
+    const aDir = path.join(getDurableParsedFileDir(storageDir), aHash);
+    const aShard = fs.readdirSync(aDir).find((name) => name.endsWith('.v8'));
+    if (!aShard) throw new Error('expected a durable shard for a');
+    fs.writeFileSync(path.join(aDir, aShard), Buffer.from([0, 1, 2]));
+
+    const { loadParseCache } = await import('../../src/storage/parse-cache.js');
+    const warm = (await loadParseCache(storageDir)) as ParseCache;
+    prepareOverride.impl = (_durableDir, hash) =>
+      hash === aHash
+        ? Promise.reject(new Error('EACCES: simulated cache failure'))
+        : Promise.resolve();
+    try {
+      await run(warm, [a, b], 1);
+    } finally {
+      prepareOverride.impl = undefined;
+    }
+    await persistCaches(warm);
+
+    // b survived the save; only a was retired.
+    expect(warm.staleKeys?.has(aHash)).toBe(true);
+    expect(warm.staleKeys?.has(bHash) ?? false).toBe(false);
+
+    const third = (await loadParseCache(storageDir)) as ParseCache;
+    expect(third.onDiskKeys?.has(aHash)).toBe(false);
+    expect(third.onDiskKeys?.has(bHash)).toBe(true);
   });
 
   it('retains worker ParsedFiles when the main-thread run-store write fails', async () => {

--- a/gitnexus/test/unit/parse-impl-warm-cache-parsedfile-coverage.test.ts
+++ b/gitnexus/test/unit/parse-impl-warm-cache-parsedfile-coverage.test.ts
@@ -401,6 +401,148 @@ describe('parse-impl warm-cache ParsedFile coverage (#2038)', () => {
     expect(cache.onDiskKeys.size + cache.entries.size).toBe(0);
   });
 
+  // #3204: the chunk above had no prior generation. When one EXISTS, skipping
+  // the write is not enough — `saveParseCache` copies the pre-existing `.v8`
+  // forward from `usedKeys`, and the durable prune then keeps the mixed
+  // directory because it prunes to exactly those saved keys.
+  const seedThenFailReset = async (
+    rel: string,
+    source: string,
+  ): Promise<{
+    file: { path: string; size: number };
+    chunkHash: string;
+    warm: ReturnType<typeof newCache>;
+  }> => {
+    const file = writeFile(rel, source);
+    const chunkHash = computeChunkHash([
+      { filePath: file.path, contentHash: fileContentHash(source) },
+    ]);
+    const cold = newCache();
+    await run(cold, [file]); // miss → populates the parse cache + durable shards
+    await persistCaches(cold);
+
+    // Corrupt (do not delete) one durable shard: the coherence gate then
+    // re-dispatches while the previous generation stays on disk, which is the
+    // only way a chunk is both a live `.v8` entry and a miss in one run.
+    const chunkDir = path.join(getDurableParsedFileDir(storageDir), chunkHash);
+    const shard = fs.readdirSync(chunkDir).find((name) => name.endsWith('.v8'));
+    if (!shard) throw new Error('expected a durable shard to corrupt');
+    fs.writeFileSync(path.join(chunkDir, shard), Buffer.from([0, 1, 2]));
+
+    const { loadParseCache } = await import('../../src/storage/parse-cache.js');
+    const warm = (await loadParseCache(storageDir)) as ReturnType<typeof newCache>;
+    expect(warm.onDiskKeys.has(chunkHash)).toBe(true); // the old generation is live
+    fs.rmSync(markerPath, { force: true });
+
+    prepareOverride.impl = () => Promise.reject(new Error('EACCES: simulated cache failure'));
+    try {
+      await run(warm, [file]);
+    } finally {
+      prepareOverride.impl = undefined;
+    }
+    expect(fs.existsSync(markerPath)).toBe(true); // the gate did fall through
+    return { file, chunkHash, warm };
+  };
+
+  const readSavedIndexKeys = (): string[] => {
+    const raw = fs.readFileSync(path.join(storageDir, 'parse-cache', 'index.json'), 'utf-8');
+    return (JSON.parse(raw) as { keys: string[] }).keys;
+  };
+
+  it('drops a pre-existing cache entry when the durable generation could not be reset', async () => {
+    const { chunkHash, warm } = await seedThenFailReset(
+      'src/stale-carryforward.ts',
+      'export function carried() { return 1; }\n',
+    );
+
+    const { saveParseCache, pruneCache } = await import('../../src/storage/parse-cache.js');
+    pruneCache(warm, warm.usedKeys);
+    const saved = await saveParseCache(storageDir, warm);
+
+    expect(saved).not.toContain(chunkHash);
+    expect(readSavedIndexKeys()).not.toContain(chunkHash);
+    expect(fs.existsSync(path.join(storageDir, 'parse-cache', `${chunkHash}.v8`))).toBe(false);
+
+    await pruneAndSaveDurableParsedFileStore(
+      getDurableParsedFileDir(storageDir),
+      PARSE_CACHE_VERSION,
+      new Set(saved),
+    );
+    const { loadDurableParsedFileIndex } = await import('../../src/storage/parsedfile-store.js');
+    const durable = await loadDurableParsedFileIndex(
+      getDurableParsedFileDir(storageDir),
+      PARSE_CACHE_VERSION,
+    );
+    expect(durable.has(chunkHash)).toBe(false);
+  });
+
+  it('keeps the chunk excluded when a post-parse merge re-adds its key', async () => {
+    // run-analyze folds sibling-branch keys into usedKeys AFTER the parse phase
+    // (#2106), and retains every loaded key when a sibling meta is unreadable.
+    // Invalidation has to outlive both, which is why it is filtered at save.
+    const { chunkHash, warm } = await seedThenFailReset(
+      'src/stale-readd.ts',
+      'export function readded() { return 1; }\n',
+    );
+
+    warm.usedKeys.add(chunkHash);
+
+    const { saveParseCache } = await import('../../src/storage/parse-cache.js');
+    const saved = await saveParseCache(storageDir, warm);
+
+    expect(saved).not.toContain(chunkHash);
+    expect(readSavedIndexKeys()).not.toContain(chunkHash);
+  });
+
+  it('marks the chunk stale at reset-failure time, not at parse-cache write time', async () => {
+    // The write guard is `if (parseCache && p.chunkHash && rawResults.length > 0)`,
+    // so a failed chunk whose worker round returns nothing would never be marked
+    // there. The marking belongs at the failure site, which always runs.
+    const { chunkHash, warm } = await seedThenFailReset(
+      'src/stale-marking-site.ts',
+      'export function marked() { return 1; }\n',
+    );
+
+    expect(warm.staleKeys?.has(chunkHash)).toBe(true);
+    expect(warm.entries.has(chunkHash)).toBe(false);
+    expect(warm.onDiskKeys.has(chunkHash)).toBe(false);
+  });
+
+  it('still saves a chunk whose durable generation reset succeeded', async () => {
+    const f = writeFile('src/healthy.ts', 'export function healthy() { return 1; }\n');
+    const chunkHash = computeChunkHash([
+      {
+        filePath: f.path,
+        contentHash: fileContentHash('export function healthy() { return 1; }\n'),
+      },
+    ]);
+    const cache = newCache();
+
+    await run(cache, [f]);
+    const { saveParseCache } = await import('../../src/storage/parse-cache.js');
+    const saved = await saveParseCache(storageDir, cache);
+
+    expect(saved).toContain(chunkHash);
+    expect(cache.staleKeys?.has(chunkHash) ?? false).toBe(false);
+  });
+
+  it('re-dispatches on the run after a failed reset instead of taking a warm hit', async () => {
+    const { file, chunkHash, warm } = await seedThenFailReset(
+      'src/stale-nextrun.ts',
+      'export function nextRun() { return 1; }\n',
+    );
+    await persistCaches(warm);
+
+    const { loadParseCache } = await import('../../src/storage/parse-cache.js');
+    const third = (await loadParseCache(storageDir)) as ReturnType<typeof newCache>;
+    expect(third.onDiskKeys.has(chunkHash)).toBe(false);
+    fs.rmSync(markerPath, { force: true });
+
+    await run(third, [file]);
+
+    expect(fs.existsSync(markerPath)).toBe(true);
+  });
+
   it('retains worker ParsedFiles when the main-thread run-store write fails', async () => {
     const f = writeFile(
       'src/persist-fallback.ts',

--- a/gitnexus/test/unit/parsedfile-store.test.ts
+++ b/gitnexus/test/unit/parsedfile-store.test.ts
@@ -18,6 +18,7 @@ import {
   prepareDurableParsedFileChunk,
   pruneAndSaveDurableParsedFileStore,
   mergeStagedDurableParsedFileStore,
+  loadDurableParsedFileIndex,
 } from '../../src/storage/parsedfile-store.js';
 
 /**
@@ -904,6 +905,39 @@ describe('parsedfile-store receiverChain sanitation', () => {
       expect(await persistParsedFileChunk(dir, 'ok', [makeParsedFile('a.c')])).toBe(false);
       expect((await loadParsedFilesForPaths(dir, new Set(['a.c']))).size).toBe(0);
     } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps pruning and still writes the index when one chunk directory cannot be removed', async () => {
+    // #3204: the non-survivor delete targets the same directory whose reset
+    // may have failed, so the causes that break the reset (permissions, a
+    // locked file, a read-only mount) break this rm too. One undeletable
+    // directory must not cost every other chunk its index entry.
+    const dir = await mkdtemp(path.join(tmpdir(), 'pf-rm-fail-'));
+    const durableDir = getDurableParsedFileDir(dir);
+    const undeletable = '3'.repeat(64);
+    const keep = '4'.repeat(64);
+    try {
+      await prepareDurableParsedFileChunk(durableDir, undeletable);
+      persistDurableParsedFileShardSync(durableDir, undeletable, 1, 0, [makeParsedFile('gone.c')]);
+      await prepareDurableParsedFileChunk(durableDir, keep);
+      persistDurableParsedFileShardSync(durableDir, keep, 1, 0, [makeParsedFile('keep.c')]);
+
+      // Clearing write permission on the chunk directory makes its shards
+      // un-unlinkable, so the recursive rm of that directory rejects while the
+      // store root stays writable for the index rewrite.
+      const doomed = path.join(durableDir, undeletable);
+      await nodeFsPromises.chmod(doomed, 0o555);
+      await expect(
+        pruneAndSaveDurableParsedFileStore(durableDir, 'v-test', new Set([keep])),
+      ).resolves.toBeUndefined();
+
+      const index = await loadDurableParsedFileIndex(durableDir, 'v-test');
+      expect(index.has(keep)).toBe(true);
+      expect(index.has(undeletable)).toBe(false);
+    } finally {
+      await nodeFsPromises.chmod(path.join(durableDir, undeletable), 0o755).catch(() => {});
       await rm(dir, { recursive: true, force: true });
     }
   });

--- a/gitnexus/test/unit/parsedfile-store.test.ts
+++ b/gitnexus/test/unit/parsedfile-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { promises as nodeFsPromises } from 'node:fs';
+import { promises as nodeFsPromises, existsSync } from 'node:fs';
 import v8 from 'node:v8';
 import { mkdtemp, rm, readdir, readFile, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
@@ -909,38 +909,51 @@ describe('parsedfile-store receiverChain sanitation', () => {
     }
   });
 
-  it('keeps pruning and still writes the index when one chunk directory cannot be removed', async () => {
-    // #3204: the non-survivor delete targets the same directory whose reset
-    // may have failed, so the causes that break the reset (permissions, a
-    // locked file, a read-only mount) break this rm too. One undeletable
-    // directory must not cost every other chunk its index entry.
-    const dir = await mkdtemp(path.join(tmpdir(), 'pf-rm-fail-'));
-    const durableDir = getDurableParsedFileDir(dir);
-    const undeletable = '3'.repeat(64);
-    const keep = '4'.repeat(64);
-    try {
-      await prepareDurableParsedFileChunk(durableDir, undeletable);
-      persistDurableParsedFileShardSync(durableDir, undeletable, 1, 0, [makeParsedFile('gone.c')]);
-      await prepareDurableParsedFileChunk(durableDir, keep);
-      persistDurableParsedFileShardSync(durableDir, keep, 1, 0, [makeParsedFile('keep.c')]);
+  // chmod is the only lever that makes a real `fs.rm` reject here, and root
+  // ignores directory write permission while Windows treats the mode bits as a
+  // near no-op. Skipping is honest; a green vacuous run is not.
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'keeps pruning and still writes the index when one chunk directory cannot be removed',
+    async () => {
+      // #3204: the non-survivor delete targets the same directory whose reset
+      // may have failed, so the causes that break the reset (permissions, a
+      // locked file, a read-only mount) break this rm too. One undeletable
+      // directory must not cost every other chunk its index entry.
+      const dir = await mkdtemp(path.join(tmpdir(), 'pf-rm-fail-'));
+      const durableDir = getDurableParsedFileDir(dir);
+      const undeletable = '3'.repeat(64);
+      const keep = '4'.repeat(64);
+      try {
+        await prepareDurableParsedFileChunk(durableDir, undeletable);
+        persistDurableParsedFileShardSync(durableDir, undeletable, 1, 0, [
+          makeParsedFile('gone.c'),
+        ]);
+        await prepareDurableParsedFileChunk(durableDir, keep);
+        persistDurableParsedFileShardSync(durableDir, keep, 1, 0, [makeParsedFile('keep.c')]);
 
-      // Clearing write permission on the chunk directory makes its shards
-      // un-unlinkable, so the recursive rm of that directory rejects while the
-      // store root stays writable for the index rewrite.
-      const doomed = path.join(durableDir, undeletable);
-      await nodeFsPromises.chmod(doomed, 0o555);
-      await expect(
-        pruneAndSaveDurableParsedFileStore(durableDir, 'v-test', new Set([keep])),
-      ).resolves.toBeUndefined();
+        // Clearing write permission on the chunk directory makes its shards
+        // un-unlinkable, so the recursive rm of that directory rejects while the
+        // store root stays writable for the index rewrite.
+        const doomed = path.join(durableDir, undeletable);
+        await nodeFsPromises.chmod(doomed, 0o555);
+        await expect(
+          pruneAndSaveDurableParsedFileStore(durableDir, 'v-test', new Set([keep])),
+        ).resolves.toBeUndefined();
 
-      const index = await loadDurableParsedFileIndex(durableDir, 'v-test');
-      expect(index.has(keep)).toBe(true);
-      expect(index.has(undeletable)).toBe(false);
-    } finally {
-      await nodeFsPromises.chmod(path.join(durableDir, undeletable), 0o755).catch(() => {});
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
+        // Assert the premise: the directory SURVIVED, i.e. the rm really did
+        // reject. Without this the test passes wherever the delete succeeds and
+        // would stay green if the try/catch were reverted.
+        expect(existsSync(doomed)).toBe(true);
+
+        const index = await loadDurableParsedFileIndex(durableDir, 'v-test');
+        expect(index.has(keep)).toBe(true);
+        expect(index.has(undeletable)).toBe(false);
+      } finally {
+        await nodeFsPromises.chmod(path.join(durableDir, undeletable), 0o755).catch(() => {});
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it('overlays staged durable chunks onto the live store without dropping live-only keys', async () => {
     const live = await mkdtemp(path.join(tmpdir(), 'pf-live-'));


### PR DESCRIPTION
Closes #3204.

## The defect

PR #3200 made a parse chunk uncacheable when `prepareDurableParsedFileChunk` fails, but it only skipped the parse-cache **write**. The chunk hash was already in `parseCache.usedKeys` from the lookup, so at shutdown `saveParseCache` copied the **pre-existing** `.v8` shard forward from the live cache directory, and the durable store — pruned to exactly the keys `saveParseCache` returns — kept the mixed directory and re-indexed it.

The state is reachable because a chunk can be a live `.v8` entry **and** a re-dispatched miss in the same run: the coherence gate re-dispatches when a cached chunk's durable shards are missing or unreadable. The next run then serves a warm hit out of a directory the previous run had already decided it could not account for.

## The fix

- `ParseCache.staleKeys` (transient, never serialized). `markParseCacheChunkStale` marks the hash and drops it from `entries`/`onDiskKeys`, which is what `loadParseCacheChunk` reads.
- `saveParseCache` filters stale keys out of its key list. That one filter reaches **both** stores, because the durable prune keeps exactly the keys this function returns. It sits at save time deliberately: `run-analyze` re-adds keys to `usedKeys` after the parse phase (the #2106 sibling fold and the unreadable-meta retention fallback), so an invalidation applied earlier would be undone.
- Retirement is conditional on evidence. `prepareDurableParsedFileChunk` is rm-then-mkdir; only an **rm** failure leaves a generation nobody cleared. An rm that succeeded before a failing mkdir leaves no directory at all, and retiring there would discard a good cache entry for nothing — and under a correlated failure would discard a great many at once.
- Worker-quarantined chunks get the same retirement: they reach the save with no in-memory entry, which is the same copy-forward path.
- The durable prune's per-entry `fs.rm` and the staged→live overlay's `replaceDurableChunkDir` are both guarded. The causes that break a reset break those deletes too, and either one aborting its loop skipped the durable index rewrite for every remaining chunk.

## Verification

Written test-first; each new test was observed failing for its intended reason before the fix. The prune test reproduced the original defect directly — `EACCES` propagating out of `pruneAndSaveDurableParsedFileStore` with the index never written.

- `npx vitest run test/unit/parse-impl-warm-cache-parsedfile-coverage.test.ts test/unit/parsedfile-store.test.ts test/unit/incremental-parse-cache.test.ts test/integration/parse-impl-quarantine-cache-skip.test.ts` — 108 passing.
- `npx tsc --noEmit -p tsconfig.json` — clean.
- Full unit suite: failures are identical with and without this change (13 files / 56 tests, verified by running the same set against a stashed tree). They are pre-existing in this environment — native-DB project tests, env-dependent config tests, and worker-startup timeouts.

No `PARSE_CACHE_VERSION` bump: `staleKeys` is transient, both index shapes are unchanged, and the change only ever removes keys, so version skew is safe in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a broad cache lifecycle change spanning durable parsed-file storage and the ingestion pipeline. The file-level risk is low, but the critical blast level reflects reach into analysis and cache handling paths.*

**🔴 CRITICAL blast radius. This change updates parse-cache and durable parsed-file handling across the analysis pipeline, with impact extending through callers and transitive dependents.**

The core review area is `gitnexus/src/storage/parse-cache.ts`, which contains 5 changed symbols, alongside `gitnexus/src/storage/parsedfile-store.ts`. Focus on the interactions between `loadLegacyParseCache`, `loadShardedParseCache`, `saveParseCache`, `persistDurableParsedFileShardSync`, `pruneAndSaveDurableParsedFileStore`, and `mergeStagedDurableParsedFileStore`.

The change also reaches parsing orchestration through `runChunkedParseAndResolve`, `finalizeWorkerChunk`, `startRound`, and `progressForRound` in `gitnexus/src/core/ingestion/pipeline-phases/parse-impl.ts`, plus `runFullAnalysisInner` in `gitnexus/src/core/run-analyze.ts`. Its 66 dependents and 12 affected flows make cache persistence, chunk finalization, and analysis entry points the most important review path.

Impact is concentrated in the `Storage`, `Pipeline-phases`, `Cli`, `Incremental`, and `Tree-sitter` modules. The accompanying coverage in `gitnexus/test/integration/parse-impl-quarantine-cache-skip.test.ts`, `gitnexus/test/unit/parse-impl-warm-cache-parsedfile-coverage.test.ts`, and `gitnexus/test/unit/parsedfile-store.test.ts` is the first place to validate the revised cache and durable-store behavior.

_Added by GitNexus for PR #3271. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->